### PR TITLE
Add Ordo Missae feature with both Ordinary and Extraordinary Forms

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,6 +31,7 @@
 /office/[hour]          -> Prayer Flow (dynamic route for morning/evening/compline)
 /plan/                  -> Plan of Life (green wall overview + stats + practice checklist)
 /plan/[practiceId]      -> Individual practice detail with its own green wall + stats
+/mass                   -> Ordo Missae (static reference, OF/EF toggle, bilingual prayers)
 /settings/              -> Settings (reading progress, translation picker, theme toggle)
 /settings/books         -> Mark books as already read (checklist of 73 books)
 /settings/position      -> Change reading position (query param: type=ot|nt|catechism)

--- a/docs/features/mass.md
+++ b/docs/features/mass.md
@@ -1,0 +1,57 @@
+# Ordo Missae — Holy Mass Feature
+
+## Overview
+
+Static reference screen displaying the fixed/ordinary parts of the Catholic Mass. Users can follow along during Mass with beautifully rendered bilingual (Latin + English) prayer texts.
+
+## Forms Supported
+
+- **Ordinary Form (Novus Ordo)** — Roman Missal, Third Edition (2011 ICEL translation)
+- **Extraordinary Form (Traditional Latin Mass)** — 1962 Roman Missal
+
+Users toggle between forms via a segmented control. The selected form persists across sessions via `preferencesStore`.
+
+## Content Structure
+
+Mass content lives in `src/assets/mass/` as JSON files:
+- `ordinary-form.json` — Novus Ordo ordinary
+- `extraordinary-form.json` — TLM ordinary
+
+### Section Types
+
+| Type | Purpose |
+|------|---------|
+| `heading` | Major liturgical division (e.g., "Liturgy of the Eucharist") |
+| `subheading` | Sub-section within a division |
+| `rubric` | Liturgical instruction text |
+| `prayer` | Bilingual prayer with `speaker` (priest/people/all), `latin`, `english` |
+| `proper` | Placeholder slot for variable texts (introit, collect, readings, etc.) |
+| `options` | Multiple alternatives (e.g., Eucharistic Prayers I-IV, Penitential Act forms) |
+| `divider` | Ornamental rule between major sections |
+
+### Extensibility
+
+- Every prayer and proper has a unique `id` for future reference
+- `proper` sections include a `slot` field (e.g., `"introit"`, `"collect"`) for future lectionary integration
+- `options` type supports nested sections, allowing complex alternatives (e.g., full Eucharistic Prayers)
+- `speaker` field enables future "highlight my responses" mode
+
+## UI
+
+- Single scrollable screen at `/mass`
+- Reuses existing components: `ManuscriptFrame`, `PrayerText`, `DropCap`, `RubricLabel`, `OrnamentalRule`, `PageBreakOrnament`
+- People's responses styled with bold weight and `R.` indicator
+- Proper slots shown as dashed-border placeholders
+- Options rendered with horizontal pill selector
+
+## Navigation
+
+Accessible from home screen via `NavigationMedallion` (cross icon, "Holy Mass" / "Santa Missa").
+
+## Future Enhancements
+
+- Fill proper slots with daily readings from a lectionary API
+- Multiple preface options
+- "Highlight my responses" toggle (filter by `speaker: 'people'`)
+- Audio/chant mode for Latin texts
+- Requiem Mass, Nuptial Mass variants

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -107,6 +107,21 @@ Implementation tasks for Ember MVP, ordered by dependency. Each phase builds on 
 - [x] Office completion status for today (icons showing which hours are done)
 - [x] Quick reading progress summary
 
+## Phase 9a: Ordo Missae ✅
+
+- [x] Bundle Extraordinary Form (TLM 1962) ordinary prayers as JSON in `src/assets/mass/`
+- [x] Bundle Ordinary Form (Novus Ordo, 2011 translation) ordinary prayers as JSON
+- [x] Content model with heading, prayer, rubric, proper (slot), options types
+- [x] `src/features/mass/` — content loader, MassScreen, MassSection components
+- [x] `/mass` route with form toggle (OF/EF), persisted via preferencesStore
+- [x] Bilingual rendering (English primary, Latin italic secondary)
+- [x] People's responses styled distinctly (bold, `R.` indicator)
+- [x] Proper slots as dashed-border placeholders for future lectionary integration
+- [x] Options selector for Eucharistic Prayers, Penitential Act forms, etc.
+- [x] Home screen NavigationMedallion entry ("Holy Mass" / "Santa Missa")
+- [x] i18n keys for en + pt-BR
+- [x] Feature doc at `docs/features/mass.md`
+
 ## Phase 9: Polish
 
 - [ ] Animations (Moti) — fade transitions between screens, subtle checkbox toggle animation, green wall cell fade-in with staggered delay

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -93,7 +93,7 @@ export default function HomeScreen() {
           <AppShortcuts />
         </FadeInView>
 
-        {/* 4. Today's Plan of Life */}
+        {/* 3. Today's Plan of Life */}
         {todayPractices.length > 0 && (
           <YStack gap="$md">
             {activeBlocks.map(({ block, def }, i) => {

--- a/src/app/mass.tsx
+++ b/src/app/mass.tsx
@@ -1,0 +1,5 @@
+import { MassScreen } from '@/features/mass'
+
+export default function MassRoute() {
+  return <MassScreen />
+}

--- a/src/assets/mass/extraordinary-form.json
+++ b/src/assets/mass/extraordinary-form.json
@@ -1,0 +1,842 @@
+{
+	"id": "extraordinary-form",
+	"title": "Ordo Missæ",
+	"subtitle": "Missale Romanum 1962",
+	"sections": [
+		{ "type": "heading", "id": "ef-foot-of-altar", "text": "Prayers at the Foot of the Altar" },
+		{
+			"type": "prayer",
+			"id": "ef-sign-of-cross",
+			"speaker": "priest",
+			"latin": "In nómine Patris, ✠ et Fílii, et Spíritus Sancti. Amen.",
+			"english": "In the name of the Father, ✠ and of the Son, and of the Holy Spirit. Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-introibo",
+			"speaker": "priest",
+			"latin": "Introíbo ad altáre Dei.",
+			"english": "I will go unto the altar of God."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-introibo-r",
+			"speaker": "people",
+			"latin": "Ad Deum qui lætíficat juventútem meam.",
+			"english": "To God, who gives joy to my youth."
+		},
+		{ "type": "subheading", "id": "ef-ps42", "text": "Psalm 42" },
+		{
+			"type": "prayer",
+			"id": "ef-judica-me",
+			"speaker": "priest",
+			"latin": "Júdica me, Deus, et discérne causam meam de gente non sancta:\nab hómine iníquo et dolóso érue me.",
+			"english": "Judge me, O God, and distinguish my cause from the nation that is not holy:\ndeliver me from the unjust and deceitful man."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-judica-r1",
+			"speaker": "people",
+			"latin": "Quia tu es, Deus, fortitúdo mea:\nquare me repulísti, et quare tristis incédo, dum afflígit me inimícus?",
+			"english": "For Thou, O God, art my strength:\nwhy hast Thou cast me off? And why do I go sorrowful whilst the enemy afflicts me?"
+		},
+		{
+			"type": "prayer",
+			"id": "ef-judica-v2",
+			"speaker": "priest",
+			"latin": "Emítte lucem tuam et veritátem tuam:\nipsa me deduxérunt et adduxérunt in montem sanctum tuum et in tabernácula tua.",
+			"english": "Send forth Thy light and Thy truth:\nthey have led me and brought me unto Thy holy mount, and into Thy tabernacles."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-judica-r2",
+			"speaker": "people",
+			"latin": "Et introíbo ad altáre Dei:\nad Deum qui lætíficat juventútem meam.",
+			"english": "And I will go unto the altar of God:\nunto God, who gives joy to my youth."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-judica-v3",
+			"speaker": "priest",
+			"latin": "Confitébor tibi in cíthara, Deus, Deus meus:\nquare tristis es, ánima mea, et quare contúrbas me?",
+			"english": "I will praise Thee upon the harp, O God, my God:\nwhy art thou sad, O my soul, and why dost thou disquiet me?"
+		},
+		{
+			"type": "prayer",
+			"id": "ef-judica-r3",
+			"speaker": "people",
+			"latin": "Spera in Deo, quóniam adhuc confitébor illi:\nsalutáre vultus mei, et Deus meus.",
+			"english": "Hope thou in God, for I will yet praise Him:\nthe salvation of my countenance, and my God."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-gloria-patri",
+			"speaker": "priest",
+			"latin": "Glória Patri, et Fílio, et Spirítui Sancto.",
+			"english": "Glory be to the Father, and to the Son, and to the Holy Spirit."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-gloria-patri-r",
+			"speaker": "people",
+			"latin": "Sicut erat in princípio, et nunc, et semper,\net in sǽcula sæculórum. Amen.",
+			"english": "As it was in the beginning, is now, and ever shall be,\nworld without end. Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-introibo-repeat",
+			"speaker": "priest",
+			"latin": "Introíbo ad altáre Dei.",
+			"english": "I will go unto the altar of God."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-introibo-repeat-r",
+			"speaker": "people",
+			"latin": "Ad Deum qui lætíficat juventútem meam.",
+			"english": "To God, who gives joy to my youth."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-adjutorium",
+			"speaker": "priest",
+			"latin": "Adjutórium nostrum ✠ in nómine Dómini.",
+			"english": "Our help ✠ is in the name of the Lord."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-adjutorium-r",
+			"speaker": "people",
+			"latin": "Qui fecit cælum et terram.",
+			"english": "Who made heaven and earth."
+		},
+		{ "type": "subheading", "id": "ef-confiteor-section", "text": "Confiteor" },
+		{
+			"type": "prayer",
+			"id": "ef-confiteor-priest",
+			"speaker": "priest",
+			"latin": "Confíteor Deo omnipoténti, beátæ Maríæ semper Vírgini, beáto Michaéli Archángelo, beáto Joánni Baptístæ, sanctis Apóstolis Petro et Paulo, ómnibus Sanctis, et vobis, fratres: quia peccávi nimis cogitatióne, verbo, et ópere: mea culpa, mea culpa, mea máxima culpa. Ideo precor beátam Maríam semper Vírginem, beátum Michaélem Archángelum, beátum Joánnem Baptístam, sanctos Apóstolos Petrum et Paulum, omnes Sanctos, et vos, fratres, oráre pro me ad Dóminum Deum nostrum.",
+			"english": "I confess to almighty God, to blessed Mary ever Virgin, to blessed Michael the Archangel, to blessed John the Baptist, to the holy Apostles Peter and Paul, to all the Saints, and to you, brethren: that I have sinned exceedingly, in thought, word, and deed: through my fault, through my fault, through my most grievous fault. Therefore I beseech blessed Mary ever Virgin, blessed Michael the Archangel, blessed John the Baptist, the holy Apostles Peter and Paul, all the Saints, and you, brethren, to pray for me to the Lord our God."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-misereatur-server",
+			"speaker": "people",
+			"latin": "Misereátur tui omnípotens Deus, et dimíssis peccátis tuis, perdúcat te ad vitam ætérnam.",
+			"english": "May almighty God have mercy on you, forgive you your sins, and bring you to everlasting life."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-misereatur-amen",
+			"speaker": "priest",
+			"latin": "Amen.",
+			"english": "Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-confiteor-server",
+			"speaker": "people",
+			"latin": "Confíteor Deo omnipoténti, beátæ Maríæ semper Vírgini, beáto Michaéli Archángelo, beáto Joánni Baptístæ, sanctis Apóstolis Petro et Paulo, ómnibus Sanctis, et tibi, pater: quia peccávi nimis cogitatióne, verbo, et ópere: mea culpa, mea culpa, mea máxima culpa. Ideo precor beátam Maríam semper Vírginem, beátum Michaélem Archángelum, beátum Joánnem Baptístam, sanctos Apóstolos Petrum et Paulum, omnes Sanctos, et te, pater, oráre pro me ad Dóminum Deum nostrum.",
+			"english": "I confess to almighty God, to blessed Mary ever Virgin, to blessed Michael the Archangel, to blessed John the Baptist, to the holy Apostles Peter and Paul, to all the Saints, and to you, Father: that I have sinned exceedingly, in thought, word, and deed: through my fault, through my fault, through my most grievous fault. Therefore I beseech blessed Mary ever Virgin, blessed Michael the Archangel, blessed John the Baptist, the holy Apostles Peter and Paul, all the Saints, and you, Father, to pray for me to the Lord our God."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-misereatur-priest",
+			"speaker": "priest",
+			"latin": "Misereátur vestri omnípotens Deus, et dimíssis peccátis vestris, perdúcat vos ad vitam ætérnam.",
+			"english": "May almighty God have mercy on you, forgive you your sins, and bring you to everlasting life."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-misereatur-priest-amen",
+			"speaker": "people",
+			"latin": "Amen.",
+			"english": "Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-indulgentiam",
+			"speaker": "priest",
+			"latin": "Indulgéntiam, ✠ absolutiónem, et remissiónem peccatórum nostrórum, tríbuat nobis omnípotens et miséricors Dóminus.",
+			"english": "May the almighty and merciful Lord grant us ✠ pardon, absolution, and remission of our sins."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-indulgentiam-amen",
+			"speaker": "people",
+			"latin": "Amen.",
+			"english": "Amen."
+		},
+		{ "type": "subheading", "id": "ef-versicles", "text": "Versicles" },
+		{
+			"type": "prayer",
+			"id": "ef-deus-tu",
+			"speaker": "priest",
+			"latin": "Deus, tu convérsus vivificábis nos.",
+			"english": "Thou wilt turn, O God, and bring us to life."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-deus-tu-r",
+			"speaker": "people",
+			"latin": "Et plebs tua lætábitur in te.",
+			"english": "And Thy people shall rejoice in Thee."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-ostende",
+			"speaker": "priest",
+			"latin": "Osténde nobis, Dómine, misericórdiam tuam.",
+			"english": "Show us, O Lord, Thy mercy."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-ostende-r",
+			"speaker": "people",
+			"latin": "Et salutáre tuum da nobis.",
+			"english": "And grant us Thy salvation."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-domine-exaudi",
+			"speaker": "priest",
+			"latin": "Dómine, exáudi oratiónem meam.",
+			"english": "O Lord, hear my prayer."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-domine-exaudi-r",
+			"speaker": "people",
+			"latin": "Et clamor meus ad te véniat.",
+			"english": "And let my cry come unto Thee."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-dominus-vobiscum-1",
+			"speaker": "priest",
+			"latin": "Dóminus vobíscum.",
+			"english": "The Lord be with you."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-dominus-vobiscum-1r",
+			"speaker": "people",
+			"latin": "Et cum spíritu tuo.",
+			"english": "And with thy spirit."
+		},
+		{ "type": "rubric", "text": "The priest ascends to the altar." },
+		{
+			"type": "prayer",
+			"id": "ef-aufer",
+			"speaker": "priest",
+			"latin": "Aufer a nobis, quǽsumus, Dómine, iniquitátes nostras: ut ad Sancta sanctórum puris mereámur méntibus introíre. Per Christum Dóminum nostrum. Amen.",
+			"english": "Take away from us our iniquities, we beseech Thee, O Lord: that we may be worthy to enter with pure minds into the Holy of Holies. Through Christ our Lord. Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-oramus-te",
+			"speaker": "priest",
+			"latin": "Orámus te, Dómine, per mérita Sanctórum tuórum, quorum relíquiæ hic sunt, et ómnium Sanctórum: ut indulgére dignéris ómnia peccáta mea. Amen.",
+			"english": "We beseech Thee, O Lord, by the merits of Thy Saints whose relics are here, and of all the Saints: that Thou wouldst vouchsafe to forgive me all my sins. Amen."
+		},
+		{ "type": "divider" },
+		{ "type": "proper", "id": "ef-introit", "slot": "introit", "description": "Introit of the day" },
+		{ "type": "divider" },
+		{ "type": "heading", "id": "ef-kyrie-section", "text": "Kyrie" },
+		{
+			"type": "prayer",
+			"id": "ef-kyrie",
+			"speaker": "priest",
+			"latin": "Kýrie, eléison.",
+			"english": "Lord, have mercy."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-kyrie-r1",
+			"speaker": "people",
+			"latin": "Kýrie, eléison.",
+			"english": "Lord, have mercy."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-kyrie-3",
+			"speaker": "priest",
+			"latin": "Kýrie, eléison.",
+			"english": "Lord, have mercy."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-christe-1",
+			"speaker": "people",
+			"latin": "Christe, eléison.",
+			"english": "Christ, have mercy."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-christe-2",
+			"speaker": "priest",
+			"latin": "Christe, eléison.",
+			"english": "Christ, have mercy."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-christe-3",
+			"speaker": "people",
+			"latin": "Christe, eléison.",
+			"english": "Christ, have mercy."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-kyrie-4",
+			"speaker": "priest",
+			"latin": "Kýrie, eléison.",
+			"english": "Lord, have mercy."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-kyrie-5",
+			"speaker": "people",
+			"latin": "Kýrie, eléison.",
+			"english": "Lord, have mercy."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-kyrie-6",
+			"speaker": "priest",
+			"latin": "Kýrie, eléison.",
+			"english": "Lord, have mercy."
+		},
+		{ "type": "divider" },
+		{ "type": "heading", "id": "ef-gloria-section", "text": "Gloria" },
+		{ "type": "rubric", "text": "The priest intones:" },
+		{
+			"type": "prayer",
+			"id": "ef-gloria",
+			"speaker": "priest",
+			"latin": "Glória in excélsis Deo.",
+			"english": "Glory to God in the highest."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-gloria-cont",
+			"speaker": "all",
+			"latin": "Et in terra pax homínibus bonæ voluntátis. Laudámus te. Benedícimus te. Adorámus te. Glorificámus te. Grátias ágimus tibi propter magnam glóriam tuam. Dómine Deus, Rex cæléstis, Deus Pater omnípotens. Dómine Fili unigénite, Jesu Christe. Dómine Deus, Agnus Dei, Fílius Patris. Qui tollis peccáta mundi, miserére nobis. Qui tollis peccáta mundi, súscipe deprecatiónem nostram. Qui sedes ad déxteram Patris, miserére nobis. Quóniam tu solus Sanctus. Tu solus Dóminus. Tu solus Altíssimus, Jesu Christe. Cum Sancto Spíritu, ✠ in glória Dei Patris. Amen.",
+			"english": "And on earth peace to men of good will. We praise Thee. We bless Thee. We adore Thee. We glorify Thee. We give Thee thanks for Thy great glory. O Lord God, heavenly King, God the Father almighty. O Lord Jesus Christ, the only-begotten Son. O Lord God, Lamb of God, Son of the Father. Thou who takest away the sins of the world, have mercy on us. Thou who takest away the sins of the world, receive our prayer. Thou who sittest at the right hand of the Father, have mercy on us. For Thou alone art holy. Thou alone art the Lord. Thou alone art the Most High, Jesus Christ. Together with the Holy Spirit, ✠ in the glory of God the Father. Amen."
+		},
+		{ "type": "divider" },
+		{ "type": "proper", "id": "ef-collect", "slot": "collect", "description": "Collect of the day" },
+		{ "type": "divider" },
+		{ "type": "heading", "id": "ef-liturgy-word", "text": "Liturgy of the Word" },
+		{ "type": "proper", "id": "ef-epistle", "slot": "epistle", "description": "Epistle of the day" },
+		{ "type": "proper", "id": "ef-gradual", "slot": "gradual", "description": "Gradual / Alleluia / Tract of the day" },
+		{ "type": "subheading", "id": "ef-gospel-section", "text": "Gospel" },
+		{
+			"type": "prayer",
+			"id": "ef-munda-cor",
+			"speaker": "priest",
+			"latin": "Munda cor meum ac lábia mea, omnípotens Deus, qui lábia Isaíæ Prophétæ cálculo mundásti igníto: ita me tua grata miseratióne dignáre mundáre, ut sanctum Evangélium tuum digne váleam nuntiáre. Per Christum Dóminum nostrum. Amen.",
+			"english": "Cleanse my heart and my lips, O almighty God, who didst cleanse the lips of the Prophet Isaiah with a burning coal: so by Thy gracious mercy deign to cleanse me that I may worthily proclaim Thy holy Gospel. Through Christ our Lord. Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-dominus-vobiscum-gospel",
+			"speaker": "priest",
+			"latin": "Dóminus vobíscum.",
+			"english": "The Lord be with you."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-dominus-vobiscum-gospel-r",
+			"speaker": "people",
+			"latin": "Et cum spíritu tuo.",
+			"english": "And with thy spirit."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-sequentia",
+			"speaker": "priest",
+			"latin": "✠ Sequéntia sancti Evangélii secúndum N.",
+			"english": "✠ The continuation of the holy Gospel according to N."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-sequentia-r",
+			"speaker": "people",
+			"latin": "Glória tibi, Dómine.",
+			"english": "Glory be to Thee, O Lord."
+		},
+		{ "type": "proper", "id": "ef-gospel", "slot": "gospel", "description": "Gospel of the day" },
+		{
+			"type": "prayer",
+			"id": "ef-gospel-end-r",
+			"speaker": "people",
+			"latin": "Laus tibi, Christe.",
+			"english": "Praise be to Thee, O Christ."
+		},
+		{ "type": "divider" },
+		{ "type": "heading", "id": "ef-credo-section", "text": "Credo" },
+		{
+			"type": "prayer",
+			"id": "ef-credo",
+			"speaker": "all",
+			"latin": "Credo in unum Deum, Patrem omnipoténtem, factórem cæli et terræ, visibílium ómnium et invisibílium.\nEt in unum Dóminum Jesum Christum, Fílium Dei unigénitum.\nEt ex Patre natum ante ómnia sǽcula.\nDeum de Deo, Lumen de Lúmine, Deum verum de Deo vero.\nGénitum, non factum, consubstantiálem Patri: per quem ómnia facta sunt.\nQui propter nos hómines et propter nostram salútem descéndit de cælis.\nEt incarnátus est de Spíritu Sancto ex María Vírgine: et homo factus est.\nCrucifíxus étiam pro nobis: sub Póntio Piláto passus, et sepúltus est.\nEt resurréxit tértia die, secúndum Scriptúras.\nEt ascéndit in cælum: sedet ad déxteram Patris.\nEt íterum ventúrus est cum glória judicáre vivos et mórtuos: cujus regni non erit finis.\nEt in Spíritum Sanctum, Dóminum et vivificántem: qui ex Patre Filióque procédit.\nQui cum Patre et Fílio simul adorátur et conglorificátur: qui locútus est per Prophétas.\nEt unam, sanctam, cathólicam et apostólicam Ecclésiam.\nConfíteor unum baptísma in remissiónem peccatórum.\nEt exspécto resurrectiónem mortuórum.\nEt vitam ✠ ventúri sǽculi. Amen.",
+			"english": "I believe in one God, the Father almighty, maker of heaven and earth, and of all things visible and invisible.\nAnd in one Lord Jesus Christ, the only-begotten Son of God.\nBorn of the Father before all ages.\nGod of God, Light of Light, true God of true God.\nBegotten, not made, consubstantial with the Father: by whom all things were made.\nWho for us men and for our salvation came down from heaven.\nAnd was incarnate by the Holy Spirit of the Virgin Mary: and was made man.\nHe was crucified also for us: suffered under Pontius Pilate, and was buried.\nAnd the third day He rose again according to the Scriptures.\nAnd ascended into heaven: He sits at the right hand of the Father.\nAnd He shall come again with glory to judge the living and the dead: of His kingdom there shall be no end.\nAnd in the Holy Spirit, the Lord and giver of life: who proceeds from the Father and the Son.\nWho together with the Father and the Son is adored and glorified: who spoke through the Prophets.\nAnd one, holy, catholic and apostolic Church.\nI confess one baptism for the remission of sins.\nAnd I await the resurrection of the dead.\nAnd the life ✠ of the world to come. Amen."
+		},
+		{ "type": "divider" },
+		{ "type": "proper", "id": "ef-offertory-verse", "slot": "offertory", "description": "Offertory verse of the day" },
+		{ "type": "heading", "id": "ef-offertory-section", "text": "Offertory" },
+		{
+			"type": "prayer",
+			"id": "ef-suscipe-pater",
+			"speaker": "priest",
+			"latin": "Súscipe, sancte Pater, omnípotens ætérne Deus, hanc immaculátam hóstiam, quam ego indígnus fámulus tuus óffero tibi, Deo meo vivo et vero, pro innumerabílibus peccátis, et offensiónibus, et negligéntiis meis, et pro ómnibus circumstántibus, sed et pro ómnibus fidélibus christiánis vivis atque defúnctis: ut mihi et illis profíciat ad salútem in vitam ætérnam. Amen.",
+			"english": "Accept, O holy Father, almighty and eternal God, this unspotted host, which I, Thy unworthy servant, offer unto Thee, my living and true God, for my innumerable sins, offenses, and negligences, and for all here present; as also for all faithful Christians, both living and dead, that it may avail both me and them unto salvation and life everlasting. Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-deus-qui-humanae",
+			"speaker": "priest",
+			"latin": "Deus, qui humánæ substántiæ dignitátem mirabíliter condidísti, et mirabílius reformásti: da nobis per hujus aquæ et vini mystérium, ejus divinitátis esse consórtes, qui humanitátis nostræ fíeri dignátus est párticeps, Jesus Christus, Fílius tuus, Dóminus noster: Qui tecum vivit et regnat in unitáte Spíritus Sancti, Deus: per ómnia sǽcula sæculórum. Amen.",
+			"english": "O God, who in creating human nature, didst wonderfully dignify it, and still more wonderfully restore it: grant that by the mystery of this water and wine, we may be made partakers of His divinity, who vouchsafed to become partaker of our humanity, Jesus Christ, Thy Son, our Lord: Who with Thee liveth and reigneth in the unity of the Holy Spirit, God: world without end. Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-offerimus",
+			"speaker": "priest",
+			"latin": "Offérimus tibi, Dómine, cálicem salutáris, tuam deprecántes cleméntiam: ut in conspéctu divínæ majestátis tuæ, pro nostra et totíus mundi salúte, cum odóre suavitátis ascéndat. Amen.",
+			"english": "We offer unto Thee, O Lord, the chalice of salvation, entreating Thy clemency: that in the sight of Thy divine majesty, it may ascend with the odor of sweetness, for our salvation and for that of the whole world. Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-in-spiritu",
+			"speaker": "priest",
+			"latin": "In spíritu humilitátis et in ánimo contríto suscipiámur a te, Dómine: et sic fiat sacrifícium nostrum in conspéctu tuo hódie, ut pláceat tibi, Dómine Deus.",
+			"english": "In the spirit of humility and with a contrite heart, may we be received by Thee, O Lord: and may our sacrifice be so offered in Thy sight this day as to please Thee, O Lord God."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-veni-sanctificator",
+			"speaker": "priest",
+			"latin": "Veni, sanctificátor omnípotens ætérne Deus: et bénedic ✠ hoc sacrifícium, tuo sancto nómini præparátum.",
+			"english": "Come, O sanctifier, almighty and eternal God: and bless ✠ this sacrifice prepared for Thy holy name."
+		},
+		{ "type": "subheading", "id": "ef-lavabo-section", "text": "Lavabo" },
+		{
+			"type": "prayer",
+			"id": "ef-lavabo",
+			"speaker": "priest",
+			"latin": "Lavábo inter innocéntes manus meas: et circúmdabo altáre tuum, Dómine.\nUt áudiam vocem laudis: et enárrem univérsa mirabília tua.\nDómine, diléxi decórem domus tuæ: et locum habitatiónis glóriæ tuæ.\nNe perdas cum ímpiis, Deus, ánimam meam: et cum viris sánguinum vitam meam.\nIn quorum mánibus iniquitátes sunt: déxtera eórum repléta est munéribus.\nEgo autem in innocéntia mea ingréssus sum: rédime me, et miserére mei.\nPes meus stetit in dirécto: in ecclésiis benedícam te, Dómine.\nGlória Patri, et Fílio, et Spirítui Sancto.\nSicut erat in princípio, et nunc, et semper, et in sǽcula sæculórum. Amen.",
+			"english": "I will wash my hands among the innocent: and will encompass Thy altar, O Lord.\nThat I may hear the voice of praise: and tell of all Thy wondrous works.\nO Lord, I have loved the beauty of Thy house: and the place where Thy glory dwells.\nTake not away my soul, O God, with the wicked: nor my life with men of blood.\nIn whose hands are iniquities: their right hand is filled with gifts.\nBut as for me, I have walked in my innocence: redeem me, and have mercy on me.\nMy foot has stood on the right path: in the churches I will bless Thee, O Lord.\nGlory be to the Father, and to the Son, and to the Holy Spirit.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-suscipe-trinitas",
+			"speaker": "priest",
+			"latin": "Súscipe, sancta Trínitas, hanc oblatiónem, quam tibi offérimus ob memóriam passiónis, resurrectiónis, et ascensiónis Jesu Christi Dómini nostri: et in honórem beátæ Maríæ semper Vírginis, et beáti Joánnis Baptístæ, et sanctórum Apostolórum Petri et Pauli, et istórum, et ómnium Sanctórum: ut illis profíciat ad honórem, nobis autem ad salútem: et illi pro nobis intercédere dignéntur in cælis, quorum memóriam ágimus in terris. Per eúndem Christum Dóminum nostrum. Amen.",
+			"english": "Receive, O holy Trinity, this oblation which we make to Thee in memory of the passion, resurrection, and ascension of our Lord Jesus Christ: and in honor of blessed Mary ever Virgin, of blessed John the Baptist, of the holy Apostles Peter and Paul, of these and of all the Saints: that it may avail to their honor and our salvation: and may they whom we commemorate here on earth deign to intercede for us in heaven. Through the same Christ our Lord. Amen."
+		},
+		{ "type": "subheading", "id": "ef-orate-fratres", "text": "Orate Fratres" },
+		{
+			"type": "prayer",
+			"id": "ef-orate",
+			"speaker": "priest",
+			"latin": "Oráte, fratres: ut meum ac vestrum sacrifícium acceptábile fiat apud Deum Patrem omnipoténtem.",
+			"english": "Pray, brethren: that my sacrifice and yours may be acceptable to God the Father almighty."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-suscipiat",
+			"speaker": "people",
+			"latin": "Suscípiat Dóminus sacrifícium de mánibus tuis ad laudem et glóriam nóminis sui, ad utilitátem quoque nostram, totiúsque Ecclésiæ suæ sanctæ.",
+			"english": "May the Lord receive the sacrifice from thy hands, to the praise and glory of His name, for our benefit and for that of all His holy Church."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-orate-amen",
+			"speaker": "priest",
+			"latin": "Amen.",
+			"english": "Amen."
+		},
+		{ "type": "proper", "id": "ef-secret", "slot": "secret", "description": "Secret of the day" },
+		{ "type": "divider" },
+		{ "type": "heading", "id": "ef-preface-section", "text": "Preface" },
+		{
+			"type": "prayer",
+			"id": "ef-per-omnia-1",
+			"speaker": "priest",
+			"latin": "Per ómnia sǽcula sæculórum.",
+			"english": "World without end."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-per-omnia-1r",
+			"speaker": "people",
+			"latin": "Amen.",
+			"english": "Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-dominus-vobiscum-preface",
+			"speaker": "priest",
+			"latin": "Dóminus vobíscum.",
+			"english": "The Lord be with you."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-dominus-vobiscum-preface-r",
+			"speaker": "people",
+			"latin": "Et cum spíritu tuo.",
+			"english": "And with thy spirit."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-sursum-corda",
+			"speaker": "priest",
+			"latin": "Sursum corda.",
+			"english": "Lift up your hearts."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-sursum-corda-r",
+			"speaker": "people",
+			"latin": "Habémus ad Dóminum.",
+			"english": "We have them lifted up to the Lord."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-gratias-agamus",
+			"speaker": "priest",
+			"latin": "Grátias agámus Dómino Deo nostro.",
+			"english": "Let us give thanks to the Lord our God."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-gratias-agamus-r",
+			"speaker": "people",
+			"latin": "Dignum et justum est.",
+			"english": "It is right and just."
+		},
+		{ "type": "proper", "id": "ef-preface-text", "slot": "preface", "description": "Preface of the day" },
+		{ "type": "subheading", "id": "ef-sanctus-section", "text": "Sanctus" },
+		{
+			"type": "prayer",
+			"id": "ef-sanctus",
+			"speaker": "all",
+			"latin": "Sanctus, Sanctus, Sanctus, Dóminus Deus Sábaoth.\nPleni sunt cæli et terra glória tua.\nHosánna in excélsis.\nBenedíctus qui venit in nómine Dómini.\nHosánna in excélsis.",
+			"english": "Holy, Holy, Holy, Lord God of Hosts.\nHeaven and earth are full of Thy glory.\nHosanna in the highest.\nBlessed is He who comes in the name of the Lord.\nHosanna in the highest."
+		},
+		{ "type": "divider" },
+		{ "type": "heading", "id": "ef-canon-section", "text": "Canon of the Mass" },
+		{
+			"type": "prayer",
+			"id": "ef-te-igitur",
+			"speaker": "priest",
+			"latin": "Te ígitur, clementíssime Pater, per Jesum Christum Fílium tuum, Dóminum nostrum, súpplices rogámus ac pétimus, uti accépta hábeas, et benedícas hæc ✠ dona, hæc ✠ múnera, hæc ✠ sancta sacrifícia illibáta: in primis quæ tibi offérimus pro Ecclésia tua sancta cathólica; quam pacificáre, custodíre, adunáre, et régere dignéris toto orbe terrárum: una cum fámulo tuo Papa nostro N., et Antístite nostro N., et ómnibus orthodóxis, atque cathólicæ et apostólicæ fídei cultóribus.",
+			"english": "Therefore, most merciful Father, through Jesus Christ Thy Son, our Lord, we humbly pray and beseech Thee to accept and bless these ✠ gifts, these ✠ offerings, these ✠ holy and unblemished sacrifices: which in the first place we offer Thee for Thy holy Catholic Church; that Thou wouldst deign to give her peace, to preserve, unite, and govern her throughout the whole world: together with Thy servant N. our Pope, and N. our Bishop, and all the orthodox, and those who profess the Catholic and apostolic faith."
+		},
+		{ "type": "subheading", "id": "ef-memento-living", "text": "Memento of the Living" },
+		{
+			"type": "prayer",
+			"id": "ef-memento-vivorum",
+			"speaker": "priest",
+			"latin": "Meménto, Dómine, famulórum famularúmque tuárum N. et N., et ómnium circumstántium, quorum tibi fides cógnita est et nota devótio: pro quibus tibi offérimus, vel qui tibi ófferunt hoc sacrifícium laudis, pro se suísque ómnibus, pro redemptióne animárum suárum, pro spe salútis et incolumitátis suæ: tibíque reddunt vota sua ætérno Deo, vivo et vero.",
+			"english": "Remember, O Lord, Thy servants and handmaids N. and N., and all here present, whose faith and devotion are known unto Thee: for whom we offer, or who offer to Thee this sacrifice of praise for themselves and all their own, for the redemption of their souls, for the hope of their salvation and safety: and who pay their vows to Thee, the eternal, living and true God."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-communicantes",
+			"speaker": "priest",
+			"latin": "Communicántes, et memóriam venerántes, in primis gloriósæ semper Vírginis Maríæ, Genitrícis Dei et Dómini nostri Jesu Christi: sed et beáti Joseph, ejúsdem Vírginis Sponsi, et beatórum Apostolórum ac Mártyrum tuórum, Petri et Pauli, Andréæ, Jacóbi, Joánnis, Thomæ, Jacóbi, Philíppi, Bartholomǽi, Matthǽi, Simónis et Thaddǽi, Lini, Cleti, Cleméntis, Xysti, Cornélii, Cypriáni, Lauréntii, Chrysógoni, Joánnis et Pauli, Cosmæ et Damiáni, et ómnium Sanctórum tuórum; quorum méritis precibúsque concédas, ut in ómnibus protectiónis tuæ muniámur auxílio. Per eúndem Christum Dóminum nostrum. Amen.",
+			"english": "In union with the whole Church, we honor the memory, first of all, of the glorious ever Virgin Mary, Mother of our God and Lord Jesus Christ: and also of blessed Joseph, Spouse of the same Virgin, and of Thy blessed Apostles and Martyrs, Peter and Paul, Andrew, James, John, Thomas, James, Philip, Bartholomew, Matthew, Simon and Thaddeus, Linus, Cletus, Clement, Sixtus, Cornelius, Cyprian, Lawrence, Chrysogonus, John and Paul, Cosmas and Damian, and of all Thy Saints; by whose merits and prayers, grant that in all things we may be defended by the help of Thy protection. Through the same Christ our Lord. Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-hanc-igitur",
+			"speaker": "priest",
+			"latin": "Hanc ígitur oblatiónem servitútis nostræ, sed et cunctæ famíliæ tuæ, quǽsumus, Dómine, ut placátus accípias: diésque nostros in tua pace dispónas, atque ab ætérna damnatióne nos éripi, et in electórum tuórum júbeas grege numerári. Per Christum Dóminum nostrum. Amen.",
+			"english": "We therefore beseech Thee, O Lord, graciously to accept this oblation of our service, and of Thy whole household: order our days in Thy peace, and command that we be delivered from eternal damnation, and numbered in the flock of Thine elect. Through Christ our Lord. Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-quam-oblationem",
+			"speaker": "priest",
+			"latin": "Quam oblatiónem tu, Deus, in ómnibus, quǽsumus, benedíctam ✠, adscríptam ✠, ratam ✠, rationábilem, acceptabilémque fácere dignéris: ut nobis Corpus ✠ et Sanguis ✠ fiat dilectíssimi Fílii tui Dómini nostri Jesu Christi.",
+			"english": "Which oblation do Thou, O God, vouchsafe in all respects to make blessed ✠, approved ✠, ratified ✠, reasonable and acceptable: that it may become for us the Body ✠ and Blood ✠ of Thy most beloved Son, our Lord Jesus Christ."
+		},
+		{ "type": "subheading", "id": "ef-consecration", "text": "Consecration" },
+		{
+			"type": "prayer",
+			"id": "ef-qui-pridie",
+			"speaker": "priest",
+			"latin": "Qui prídie quam paterétur, accépit panem in sanctas ac venerábiles manus suas, et elevátis óculis in cælum, ad te Deum Patrem suum omnipoténtem, tibi grátias agens, benedíxit ✠, fregit, dedítque discípulis suis, dicens: Accípite et manducáte ex hoc omnes:\nHOC EST ENIM CORPUS MEUM.",
+			"english": "Who, the day before He suffered, took bread into His holy and venerable hands, and with His eyes raised to heaven, unto Thee, God, His almighty Father, giving thanks to Thee, He blessed ✠ it, broke it, and gave it to His disciples, saying: Take and eat ye all of this:\nFOR THIS IS MY BODY."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-simili-modo",
+			"speaker": "priest",
+			"latin": "Símili modo postquam cenátum est, accípiens et hunc præclárum Cálicem in sanctas ac venerábiles manus suas: item tibi grátias agens, benedíxit ✠, dedítque discípulis suis, dicens: Accípite et bíbite ex eo omnes:\nHIC EST ENIM CALIX SÁNGUINIS MEI, NOVI ET ÆTÉRNI TESTAMÉNTI: MYSTÉRIUM FÍDEI: QUI PRO VOBIS ET PRO MULTIS EFFUNDÉTUR IN REMISSIÓNEM PECCATÓRUM.\nHæc quotiescúmque fecéritis, in mei memóriam faciétis.",
+			"english": "In like manner, after He had supped, taking also this excellent Chalice into His holy and venerable hands, and giving thanks to Thee, He blessed ✠ it, and gave it to His disciples, saying: Take and drink ye all of this:\nFOR THIS IS THE CHALICE OF MY BLOOD, OF THE NEW AND ETERNAL TESTAMENT: THE MYSTERY OF FAITH: WHICH SHALL BE SHED FOR YOU AND FOR MANY UNTO THE REMISSION OF SINS.\nAs often as ye do these things, ye shall do them in remembrance of Me."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-unde-et-memores",
+			"speaker": "priest",
+			"latin": "Unde et mémores, Dómine, nos servi tui, sed et plebs tua sancta, ejúsdem Christi Fílii tui Dómini nostri tam beátæ passiónis, nec non et ab ínferis resurrectiónis, sed et in cælos gloriósæ ascensiónis: offérimus præcláræ majestáti tuæ de tuis donis ac datis, hóstiam ✠ puram, hóstiam ✠ sanctam, hóstiam ✠ immaculátam, Panem ✠ sanctum vitæ ætérnæ, et Cálicem ✠ salútis perpétuæ.",
+			"english": "Wherefore, O Lord, we Thy servants, as also Thy holy people, calling to mind the blessed passion of the same Christ Thy Son our Lord, His resurrection from the dead, and His glorious ascension into heaven: do offer unto Thy most excellent majesty of Thine own gifts and bounty, a pure ✠ victim, a holy ✠ victim, an unspotted ✠ victim, the holy ✠ Bread of eternal life, and the Chalice ✠ of everlasting salvation."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-supra-quae",
+			"speaker": "priest",
+			"latin": "Supra quæ propítio ac seréno vultu respícere dignéris: et accépta habére, sícuti accépta habére dignátus es múnera púeri tui justi Abel, et sacrifícium Patriárchæ nostri Ábrahæ: et quod tibi óbtulit summus sacérdos tuus Melchísedech, sanctum sacrifícium, immaculátam hóstiam.",
+			"english": "Upon which vouchsafe to look with a propitious and serene countenance: and to accept them, as Thou wert graciously pleased to accept the gifts of Thy just servant Abel, and the sacrifice of our Patriarch Abraham: and that which Thy high priest Melchisedech offered to Thee, a holy sacrifice, an unspotted victim."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-supplices",
+			"speaker": "priest",
+			"latin": "Súpplices te rogámus, omnípotens Deus: jube hæc perférri per manus sancti Ángeli tui in sublíme altáre tuum, in conspéctu divínæ majestátis tuæ: ut quotquot ex hac altáris participatióne, sacrosánctum Fílii tui Corpus ✠ et Sánguinem ✠ sumpsérimus, omni benedictióne cælésti et grátia repleámur. Per eúndem Christum Dóminum nostrum. Amen.",
+			"english": "We most humbly beseech Thee, almighty God: command these things to be borne by the hands of Thy holy Angel to Thine altar on high, in the sight of Thy divine majesty: that as many of us as shall, by partaking at this altar, receive the most sacred Body ✠ and Blood ✠ of Thy Son, may be filled with every heavenly blessing and grace. Through the same Christ our Lord. Amen."
+		},
+		{ "type": "subheading", "id": "ef-memento-dead", "text": "Memento of the Dead" },
+		{
+			"type": "prayer",
+			"id": "ef-memento-defunctorum",
+			"speaker": "priest",
+			"latin": "Meménto étiam, Dómine, famulórum famularúmque tuárum N. et N., qui nos præcessérunt cum signo fídei, et dórmiunt in somno pacis. Ipsis, Dómine, et ómnibus in Christo quiescéntibus, locum refrigérii, lucis et pacis, ut indúlgeas, deprecámur. Per eúndem Christum Dóminum nostrum. Amen.",
+			"english": "Remember also, O Lord, Thy servants and handmaids N. and N., who have gone before us with the sign of faith, and rest in the sleep of peace. To these, O Lord, and to all who rest in Christ, grant, we beseech Thee, a place of refreshment, light and peace. Through the same Christ our Lord. Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-nobis-quoque",
+			"speaker": "priest",
+			"latin": "Nobis quoque peccatóribus fámulis tuis, de multitúdine miseratiónum tuárum sperántibus, partem áliquam et societátem donáre dignéris, cum tuis sanctis Apóstolis et Martýribus: cum Joánne, Stéphano, Matthía, Bárnaba, Ignátio, Alexándro, Marcellíno, Petro, Felicitáte, Perpétua, Ágatha, Lúcia, Agnéte, Cæcília, Anastásia, et ómnibus Sanctis tuis: intra quorum nos consórtium, non æstimátor mériti, sed véniæ, quǽsumus, largítor admítte. Per Christum Dóminum nostrum.",
+			"english": "To us also, Thy sinful servants, trusting in the multitude of Thy mercies, vouchsafe to grant some part and fellowship with Thy holy Apostles and Martyrs: with John, Stephen, Matthias, Barnabas, Ignatius, Alexander, Marcellinus, Peter, Felicity, Perpetua, Agatha, Lucy, Agnes, Cecilia, Anastasia, and all Thy Saints: into whose company, we beseech Thee, not as appraiser of merit, but as bestower of pardon, to admit us. Through Christ our Lord."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-per-quem",
+			"speaker": "priest",
+			"latin": "Per quem hæc ómnia, Dómine, semper bona creas, sanctí ✠ ficas, viví ✠ ficas, bene ✠ dícis, et præstas nobis.",
+			"english": "Through whom, O Lord, Thou dost always create, sanctify ✠, quicken ✠, bless ✠ and bestow upon us all these good things."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-per-ipsum",
+			"speaker": "priest",
+			"latin": "Per ip ✠ sum, et cum ip ✠ so, et in ip ✠ so, est tibi Deo Patri ✠ omnipoténti, in unitáte Spíritus ✠ Sancti, omnis honor et glória.",
+			"english": "Through Him ✠, and with Him ✠, and in Him ✠, is unto Thee, God the Father ✠ almighty, in the unity of the Holy ✠ Spirit, all honor and glory."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-per-omnia-canon",
+			"speaker": "priest",
+			"latin": "Per ómnia sǽcula sæculórum.",
+			"english": "World without end."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-per-omnia-canon-r",
+			"speaker": "people",
+			"latin": "Amen.",
+			"english": "Amen."
+		},
+		{ "type": "divider" },
+		{ "type": "heading", "id": "ef-communion-rite", "text": "Communion Rite" },
+		{ "type": "subheading", "id": "ef-pater-noster-section", "text": "Pater Noster" },
+		{
+			"type": "prayer",
+			"id": "ef-pater-noster",
+			"speaker": "priest",
+			"latin": "Pater noster, qui es in cælis: sanctificétur nomen tuum: advéniat regnum tuum: fiat volúntas tua, sicut in cælo, et in terra.\nPanem nostrum quotidiánum da nobis hódie: et dimítte nobis débita nostra, sicut et nos dimíttimus debitóribus nostris. Et ne nos indúcas in tentatiónem.",
+			"english": "Our Father, who art in heaven: hallowed be Thy name: Thy kingdom come: Thy will be done on earth as it is in heaven.\nGive us this day our daily bread: and forgive us our trespasses, as we forgive those who trespass against us. And lead us not into temptation."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-pater-noster-r",
+			"speaker": "people",
+			"latin": "Sed líbera nos a malo.",
+			"english": "But deliver us from evil."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-pater-amen",
+			"speaker": "priest",
+			"latin": "Amen.",
+			"english": "Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-libera-nos",
+			"speaker": "priest",
+			"latin": "Líbera nos, quǽsumus, Dómine, ab ómnibus malis, prætéritis, præséntibus, et futúris: et intercedénte beáta et gloriósa semper Vírgine Dei Genitrícis María, cum beátis Apóstolis tuis Petro et Paulo, atque Andréa, et ómnibus Sanctis, da propítius pacem in diébus nostris: ut ope misericórdiæ tuæ adjúti, et a peccáto simus semper líberi, et ab omni perturbatióne secúri. Per eúndem Dóminum nostrum Jesum Christum Fílium tuum. Qui tecum vivit et regnat in unitáte Spíritus Sancti, Deus, per ómnia sǽcula sæculórum.",
+			"english": "Deliver us, we beseech Thee, O Lord, from all evils, past, present, and to come: and by the intercession of the blessed and glorious ever Virgin Mary, Mother of God, together with Thy blessed Apostles Peter and Paul, and Andrew, and all the Saints, graciously give peace in our days: that by the help of Thy mercy we may be always free from sin, and secure from all disturbance. Through the same our Lord Jesus Christ Thy Son. Who with Thee liveth and reigneth in the unity of the Holy Spirit, God, world without end."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-libera-nos-r",
+			"speaker": "people",
+			"latin": "Amen.",
+			"english": "Amen."
+		},
+		{ "type": "subheading", "id": "ef-pax-section", "text": "Pax Domini" },
+		{
+			"type": "prayer",
+			"id": "ef-pax-domini",
+			"speaker": "priest",
+			"latin": "Pax ✠ Dómini sit ✠ semper vobís ✠ cum.",
+			"english": "May the peace ✠ of the Lord ✠ be always ✠ with you."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-pax-domini-r",
+			"speaker": "people",
+			"latin": "Et cum spíritu tuo.",
+			"english": "And with thy spirit."
+		},
+		{ "type": "subheading", "id": "ef-agnus-section", "text": "Agnus Dei" },
+		{
+			"type": "prayer",
+			"id": "ef-agnus-dei",
+			"speaker": "all",
+			"latin": "Agnus Dei, qui tollis peccáta mundi: miserére nobis.\nAgnus Dei, qui tollis peccáta mundi: miserére nobis.\nAgnus Dei, qui tollis peccáta mundi: dona nobis pacem.",
+			"english": "Lamb of God, who takest away the sins of the world: have mercy on us.\nLamb of God, who takest away the sins of the world: have mercy on us.\nLamb of God, who takest away the sins of the world: grant us peace."
+		},
+		{ "type": "subheading", "id": "ef-communion-prayers", "text": "Communion Prayers" },
+		{
+			"type": "prayer",
+			"id": "ef-domine-jesu-pax",
+			"speaker": "priest",
+			"latin": "Dómine Jesu Christe, qui dixísti Apóstolis tuis: Pacem relínquo vobis, pacem meam do vobis: ne respícias peccáta mea, sed fidem Ecclésiæ tuæ: eámque secúndum voluntátem tuam pacificáre et coadunáre dignéris: Qui vivis et regnas, Deus, per ómnia sǽcula sæculórum. Amen.",
+			"english": "O Lord Jesus Christ, who said to Thy Apostles: Peace I leave with you, My peace I give unto you: regard not my sins, but the faith of Thy Church: and deign to give her peace and unity according to Thy will: Who livest and reignest, God, world without end. Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-domine-jesu-fili",
+			"speaker": "priest",
+			"latin": "Dómine Jesu Christe, Fili Dei vivi, qui ex voluntáte Patris, cooperánte Spíritu Sancto, per mortem tuam mundum vivificásti: líbera me per hoc sacrosánctum Corpus et Sánguinem tuum ab ómnibus iniquitátibus meis et univérsis malis: et fac me tuis semper inhærére mandátis, et a te numquam separári permíttas: Qui cum eódem Deo Patre et Spíritu Sancto vivis et regnas, Deus, in sǽcula sæculórum. Amen.",
+			"english": "O Lord Jesus Christ, Son of the living God, who by the will of the Father, with the cooperation of the Holy Spirit, hast by Thy death given life to the world: deliver me by this Thy most sacred Body and Blood from all my iniquities and from all evils: and make me always cleave to Thy commandments, and never permit me to be separated from Thee: Who with the same God the Father and the Holy Spirit livest and reignest, God, world without end. Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-domine-non-sum-dignus",
+			"speaker": "priest",
+			"latin": "Dómine, non sum dignus, ut intres sub tectum meum: sed tantum dic verbo, et sanábitur ánima mea.\nDómine, non sum dignus, ut intres sub tectum meum: sed tantum dic verbo, et sanábitur ánima mea.\nDómine, non sum dignus, ut intres sub tectum meum: sed tantum dic verbo, et sanábitur ánima mea.",
+			"english": "Lord, I am not worthy that Thou shouldst enter under my roof: but only say the word, and my soul shall be healed.\nLord, I am not worthy that Thou shouldst enter under my roof: but only say the word, and my soul shall be healed.\nLord, I am not worthy that Thou shouldst enter under my roof: but only say the word, and my soul shall be healed."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-corpus-domini",
+			"speaker": "priest",
+			"latin": "Corpus Dómini nostri Jesu Christi custódiat ánimam meam in vitam ætérnam. Amen.",
+			"english": "May the Body of our Lord Jesus Christ preserve my soul unto life everlasting. Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-sanguis-domini",
+			"speaker": "priest",
+			"latin": "Sanguis Dómini nostri Jesu Christi custódiat ánimam meam in vitam ætérnam. Amen.",
+			"english": "May the Blood of our Lord Jesus Christ preserve my soul unto life everlasting. Amen."
+		},
+		{ "type": "proper", "id": "ef-communion-antiphon", "slot": "communion", "description": "Communion antiphon of the day" },
+		{ "type": "proper", "id": "ef-postcommunion", "slot": "postcommunion", "description": "Postcommunion prayer of the day" },
+		{ "type": "divider" },
+		{ "type": "heading", "id": "ef-dismissal-section", "text": "Dismissal" },
+		{
+			"type": "prayer",
+			"id": "ef-dominus-vobiscum-dismiss",
+			"speaker": "priest",
+			"latin": "Dóminus vobíscum.",
+			"english": "The Lord be with you."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-dominus-vobiscum-dismiss-r",
+			"speaker": "people",
+			"latin": "Et cum spíritu tuo.",
+			"english": "And with thy spirit."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-ite-missa-est",
+			"speaker": "priest",
+			"latin": "Ite, Missa est.",
+			"english": "Go, the Mass is ended."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-ite-r",
+			"speaker": "people",
+			"latin": "Deo grátias.",
+			"english": "Thanks be to God."
+		},
+		{ "type": "subheading", "id": "ef-blessing-section", "text": "Blessing" },
+		{
+			"type": "prayer",
+			"id": "ef-placeat",
+			"speaker": "priest",
+			"latin": "Pláceat tibi, sancta Trínitas, obséquium servitútis meæ: et præsta; ut sacrifícium, quod óculis tuæ majestátis indígnus óbtuli, tibi sit acceptábile, mihíque, et ómnibus pro quibus illud óbtuli, sit, te miseránte, propitiábile. Per Christum Dóminum nostrum. Amen.",
+			"english": "May the tribute of my homage be pleasing to Thee, O holy Trinity: and grant that the sacrifice which I, though unworthy, have offered in the sight of Thy majesty, may be acceptable to Thee, and through Thy mercy be a propitiation for me and for all those for whom I have offered it. Through Christ our Lord. Amen."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-benedicat",
+			"speaker": "priest",
+			"latin": "Benedícat vos omnípotens Deus, Pater, et Fílius, ✠ et Spíritus Sanctus.",
+			"english": "May almighty God bless you, the Father, and the Son, ✠ and the Holy Spirit."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-benedicat-r",
+			"speaker": "people",
+			"latin": "Amen.",
+			"english": "Amen."
+		},
+		{ "type": "divider" },
+		{ "type": "heading", "id": "ef-last-gospel-section", "text": "Last Gospel" },
+		{ "type": "rubric", "text": "John 1:1-14" },
+		{
+			"type": "prayer",
+			"id": "ef-dominus-vobiscum-lg",
+			"speaker": "priest",
+			"latin": "Dóminus vobíscum.",
+			"english": "The Lord be with you."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-dominus-vobiscum-lg-r",
+			"speaker": "people",
+			"latin": "Et cum spíritu tuo.",
+			"english": "And with thy spirit."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-initium",
+			"speaker": "priest",
+			"latin": "✠ Inítium sancti Evangélii secúndum Joánnem.",
+			"english": "✠ The beginning of the holy Gospel according to John."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-initium-r",
+			"speaker": "people",
+			"latin": "Glória tibi, Dómine.",
+			"english": "Glory be to Thee, O Lord."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-last-gospel",
+			"speaker": "priest",
+			"latin": "In princípio erat Verbum, et Verbum erat apud Deum, et Deus erat Verbum. Hoc erat in princípio apud Deum. Ómnia per ipsum facta sunt: et sine ipso factum est nihil, quod factum est: in ipso vita erat, et vita erat lux hóminum: et lux in ténebris lucet, et ténebræ eam non comprehendérunt.\nFuit homo missus a Deo, cui nomen erat Joánnes. Hic venit in testimónium, ut testimónium perhibéret de lúmine, ut omnes créderent per illum. Non erat ille lux, sed ut testimónium perhibéret de lúmine.\nErat lux vera, quæ illúminat omnem hóminem veniéntem in hunc mundum. In mundo erat, et mundus per ipsum factus est, et mundus eum non cognóvit. In própria venit, et sui eum non recepérunt. Quotquot autem recepérunt eum, dedit eis potestátem fílios Dei fíeri, his qui credunt in nómine ejus: qui non ex sanguínibus, neque ex voluntáte carnis, neque ex voluntáte viri, sed ex Deo nati sunt.\nET VERBUM CARO FACTUM EST, et habitávit in nobis: et vídimus glóriam ejus, glóriam quasi Unigéniti a Patre, plenum grátiæ et veritátis.",
+			"english": "In the beginning was the Word, and the Word was with God, and the Word was God. The same was in the beginning with God. All things were made by Him: and without Him was made nothing that was made: in Him was life, and the life was the light of men: and the light shineth in darkness, and the darkness did not comprehend it.\nThere was a man sent from God, whose name was John. This man came for a witness, to give testimony of the light, that all men might believe through him. He was not the light, but was to give testimony of the light.\nThat was the true light, which enlighteneth every man that cometh into this world. He was in the world, and the world was made by Him, and the world knew Him not. He came unto His own, and His own received Him not. But as many as received Him, He gave them power to be made the sons of God, to them that believe in His name: who are born, not of blood, nor of the will of the flesh, nor of the will of man, but of God.\nAND THE WORD WAS MADE FLESH, and dwelt among us: and we saw His glory, the glory as it were of the only-begotten of the Father, full of grace and truth."
+		},
+		{
+			"type": "prayer",
+			"id": "ef-last-gospel-r",
+			"speaker": "people",
+			"latin": "Deo grátias.",
+			"english": "Thanks be to God."
+		}
+	]
+}

--- a/src/assets/mass/ordinary-form.json
+++ b/src/assets/mass/ordinary-form.json
@@ -1,0 +1,769 @@
+{
+	"id": "ordinary-form",
+	"title": "The Order of Mass",
+	"subtitle": "Roman Missal, Third Edition",
+	"sections": [
+		{ "type": "heading", "id": "of-introductory-rites", "text": "Introductory Rites" },
+		{
+			"type": "prayer",
+			"id": "of-sign-of-cross",
+			"speaker": "priest",
+			"latin": "In nómine Patris, et Fílii, et Spíritus Sancti.",
+			"english": "In the name of the Father, and of the Son, and of the Holy Spirit."
+		},
+		{
+			"type": "prayer",
+			"id": "of-sign-of-cross-r",
+			"speaker": "people",
+			"latin": "Amen.",
+			"english": "Amen."
+		},
+		{
+			"type": "options",
+			"id": "of-greeting",
+			"label": "Greeting",
+			"options": [
+				{
+					"id": "of-greeting-a",
+					"label": "Form A",
+					"sections": [
+						{
+							"type": "prayer",
+							"id": "of-greeting-a-v",
+							"speaker": "priest",
+							"latin": "Grátia Dómini nostri Jesu Christi, et cáritas Dei, et communicátio Sancti Spíritus sit cum ómnibus vobis.",
+							"english": "The grace of our Lord Jesus Christ, and the love of God, and the communion of the Holy Spirit be with you all."
+						},
+						{
+							"type": "prayer",
+							"id": "of-greeting-a-r",
+							"speaker": "people",
+							"latin": "Et cum spíritu tuo.",
+							"english": "And with your spirit."
+						}
+					]
+				},
+				{
+					"id": "of-greeting-b",
+					"label": "Form B",
+					"sections": [
+						{
+							"type": "prayer",
+							"id": "of-greeting-b-v",
+							"speaker": "priest",
+							"latin": "Grátia vobis et pax a Deo Patre nostro et Dómino Jesu Christo.",
+							"english": "Grace to you and peace from God our Father and the Lord Jesus Christ."
+						},
+						{
+							"type": "prayer",
+							"id": "of-greeting-b-r",
+							"speaker": "people",
+							"latin": "Et cum spíritu tuo.",
+							"english": "And with your spirit."
+						}
+					]
+				},
+				{
+					"id": "of-greeting-c",
+					"label": "Form C",
+					"sections": [
+						{
+							"type": "prayer",
+							"id": "of-greeting-c-v",
+							"speaker": "priest",
+							"latin": "Dóminus vobíscum.",
+							"english": "The Lord be with you."
+						},
+						{
+							"type": "prayer",
+							"id": "of-greeting-c-r",
+							"speaker": "people",
+							"latin": "Et cum spíritu tuo.",
+							"english": "And with your spirit."
+						}
+					]
+				}
+			]
+		},
+		{
+			"type": "options",
+			"id": "of-penitential-act",
+			"label": "Penitential Act",
+			"options": [
+				{
+					"id": "of-penit-a",
+					"label": "Form A: Confiteor",
+					"sections": [
+						{
+							"type": "prayer",
+							"id": "of-confiteor",
+							"speaker": "all",
+							"latin": "Confíteor Deo omnipoténti et vobis, fratres, quia peccávi nimis cogitatióne, verbo, ópere et omissióne: mea culpa, mea culpa, mea máxima culpa. Ideo precor beátam Maríam semper Vírginem, omnes Ángelos et Sanctos, et vos, fratres, oráre pro me ad Dóminum Deum nostrum.",
+							"english": "I confess to almighty God and to you, my brothers and sisters, that I have greatly sinned, in my thoughts and in my words, in what I have done and in what I have failed to do, through my fault, through my fault, through my most grievous fault; therefore I ask blessed Mary ever-Virgin, all the Angels and Saints, and you, my brothers and sisters, to pray for me to the Lord our God."
+						},
+						{
+							"type": "prayer",
+							"id": "of-absolution",
+							"speaker": "priest",
+							"latin": "Misereátur nostri omnípotens Deus et, dimíssis peccátis nostris, perdúcat nos ad vitam ætérnam.",
+							"english": "May almighty God have mercy on us, forgive us our sins, and bring us to everlasting life."
+						},
+						{
+							"type": "prayer",
+							"id": "of-absolution-r",
+							"speaker": "people",
+							"latin": "Amen.",
+							"english": "Amen."
+						}
+					]
+				},
+				{
+					"id": "of-penit-b",
+					"label": "Form B",
+					"sections": [
+						{
+							"type": "prayer",
+							"id": "of-penit-b-v1",
+							"speaker": "priest",
+							"latin": "Miserére nostri, Dómine.",
+							"english": "Have mercy on us, O Lord."
+						},
+						{
+							"type": "prayer",
+							"id": "of-penit-b-r1",
+							"speaker": "people",
+							"latin": "Quia peccávimus tibi.",
+							"english": "For we have sinned against you."
+						},
+						{
+							"type": "prayer",
+							"id": "of-penit-b-v2",
+							"speaker": "priest",
+							"latin": "Osténde nobis, Dómine, misericórdiam tuam.",
+							"english": "Show us, O Lord, your mercy."
+						},
+						{
+							"type": "prayer",
+							"id": "of-penit-b-r2",
+							"speaker": "people",
+							"latin": "Et salutáre tuum da nobis.",
+							"english": "And grant us your salvation."
+						},
+						{
+							"type": "prayer",
+							"id": "of-penit-b-abs",
+							"speaker": "priest",
+							"latin": "Misereátur nostri omnípotens Deus et, dimíssis peccátis nostris, perdúcat nos ad vitam ætérnam.",
+							"english": "May almighty God have mercy on us, forgive us our sins, and bring us to everlasting life."
+						},
+						{
+							"type": "prayer",
+							"id": "of-penit-b-abs-r",
+							"speaker": "people",
+							"latin": "Amen.",
+							"english": "Amen."
+						}
+					]
+				},
+				{
+					"id": "of-penit-c",
+					"label": "Form C: Tropes",
+					"sections": [
+						{
+							"type": "prayer",
+							"id": "of-trope-1v",
+							"speaker": "priest",
+							"latin": "Qui missus es sanáre contrítos corde: Kýrie, eléison.",
+							"english": "You were sent to heal the contrite of heart: Lord, have mercy."
+						},
+						{ "type": "prayer", "id": "of-trope-1r", "speaker": "people", "latin": "Kýrie, eléison.", "english": "Lord, have mercy." },
+						{
+							"type": "prayer",
+							"id": "of-trope-2v",
+							"speaker": "priest",
+							"latin": "Qui ad déxteram Patris sedes, ad interpellándum pro nobis: Christe, eléison.",
+							"english": "You are seated at the right hand of the Father to intercede for us: Christ, have mercy."
+						},
+						{ "type": "prayer", "id": "of-trope-2r", "speaker": "people", "latin": "Christe, eléison.", "english": "Christ, have mercy." },
+						{
+							"type": "prayer",
+							"id": "of-trope-3v",
+							"speaker": "priest",
+							"latin": "Qui íterum ventúrus es judicáre vivos et mórtuos: Kýrie, eléison.",
+							"english": "You will come again to judge the living and the dead: Lord, have mercy."
+						},
+						{ "type": "prayer", "id": "of-trope-3r", "speaker": "people", "latin": "Kýrie, eléison.", "english": "Lord, have mercy." },
+						{
+							"type": "prayer",
+							"id": "of-trope-abs",
+							"speaker": "priest",
+							"latin": "Misereátur nostri omnípotens Deus et, dimíssis peccátis nostris, perdúcat nos ad vitam ætérnam.",
+							"english": "May almighty God have mercy on us, forgive us our sins, and bring us to everlasting life."
+						},
+						{ "type": "prayer", "id": "of-trope-abs-r", "speaker": "people", "latin": "Amen.", "english": "Amen." }
+					]
+				}
+			]
+		},
+		{ "type": "subheading", "id": "of-kyrie-section", "text": "Kyrie" },
+		{ "type": "rubric", "text": "Unless included in the Penitential Act:" },
+		{
+			"type": "prayer",
+			"id": "of-kyrie-v1",
+			"speaker": "priest",
+			"latin": "Kýrie, eléison.",
+			"english": "Lord, have mercy."
+		},
+		{ "type": "prayer", "id": "of-kyrie-r1", "speaker": "people", "latin": "Kýrie, eléison.", "english": "Lord, have mercy." },
+		{ "type": "prayer", "id": "of-christe-v", "speaker": "priest", "latin": "Christe, eléison.", "english": "Christ, have mercy." },
+		{ "type": "prayer", "id": "of-christe-r", "speaker": "people", "latin": "Christe, eléison.", "english": "Christ, have mercy." },
+		{ "type": "prayer", "id": "of-kyrie-v2", "speaker": "priest", "latin": "Kýrie, eléison.", "english": "Lord, have mercy." },
+		{ "type": "prayer", "id": "of-kyrie-r2", "speaker": "people", "latin": "Kýrie, eléison.", "english": "Lord, have mercy." },
+		{ "type": "subheading", "id": "of-gloria-section", "text": "Gloria" },
+		{
+			"type": "prayer",
+			"id": "of-gloria",
+			"speaker": "all",
+			"latin": "Glória in excélsis Deo et in terra pax homínibus bonæ voluntátis.\nLaudámus te, benedícimus te, adorámus te, glorificámus te, grátias ágimus tibi propter magnam glóriam tuam, Dómine Deus, Rex cæléstis, Deus Pater omnípotens.\nDómine Fili Unigénite, Jesu Christe, Dómine Deus, Agnus Dei, Fílius Patris, qui tollis peccáta mundi, miserére nobis; qui tollis peccáta mundi, súscipe deprecatiónem nostram. Qui sedes ad déxteram Patris, miserére nobis.\nQuóniam tu solus Sanctus, tu solus Dóminus, tu solus Altíssimus, Jesu Christe, cum Sancto Spíritu: in glória Dei Patris. Amen.",
+			"english": "Glory to God in the highest, and on earth peace to people of good will.\nWe praise you, we bless you, we adore you, we glorify you, we give you thanks for your great glory, Lord God, heavenly King, O God, almighty Father.\nLord Jesus Christ, Only Begotten Son, Lord God, Lamb of God, Son of the Father, you take away the sins of the world, have mercy on us; you take away the sins of the world, receive our prayer; you are seated at the right hand of the Father, have mercy on us.\nFor you alone are the Holy One, you alone are the Lord, you alone are the Most High, Jesus Christ, with the Holy Spirit, in the glory of God the Father. Amen."
+		},
+		{ "type": "proper", "id": "of-collect", "slot": "collect", "description": "Collect of the day" },
+		{ "type": "divider" },
+		{ "type": "heading", "id": "of-liturgy-word", "text": "Liturgy of the Word" },
+		{ "type": "proper", "id": "of-first-reading", "slot": "first-reading", "description": "First Reading" },
+		{
+			"type": "prayer",
+			"id": "of-reading-end",
+			"speaker": "priest",
+			"latin": "Verbum Dómini.",
+			"english": "The word of the Lord."
+		},
+		{
+			"type": "prayer",
+			"id": "of-reading-end-r",
+			"speaker": "people",
+			"latin": "Deo grátias.",
+			"english": "Thanks be to God."
+		},
+		{ "type": "proper", "id": "of-responsorial-psalm", "slot": "responsorial-psalm", "description": "Responsorial Psalm" },
+		{ "type": "proper", "id": "of-second-reading", "slot": "second-reading", "description": "Second Reading (Sundays and Solemnities)" },
+		{ "type": "subheading", "id": "of-gospel-section", "text": "Gospel" },
+		{
+			"type": "prayer",
+			"id": "of-gospel-accl",
+			"speaker": "people",
+			"latin": "Allelúia.",
+			"english": "Alleluia."
+		},
+		{ "type": "proper", "id": "of-gospel-verse", "slot": "gospel-verse", "description": "Gospel Acclamation verse" },
+		{
+			"type": "prayer",
+			"id": "of-dominus-vobiscum-gospel",
+			"speaker": "priest",
+			"latin": "Dóminus vobíscum.",
+			"english": "The Lord be with you."
+		},
+		{
+			"type": "prayer",
+			"id": "of-dominus-vobiscum-gospel-r",
+			"speaker": "people",
+			"latin": "Et cum spíritu tuo.",
+			"english": "And with your spirit."
+		},
+		{
+			"type": "prayer",
+			"id": "of-lectio-evangelii",
+			"speaker": "priest",
+			"latin": "Léctio sancti Evangélii secúndum N.",
+			"english": "A reading from the holy Gospel according to N."
+		},
+		{
+			"type": "prayer",
+			"id": "of-lectio-evangelii-r",
+			"speaker": "people",
+			"latin": "Glória tibi, Dómine.",
+			"english": "Glory to you, O Lord."
+		},
+		{ "type": "proper", "id": "of-gospel", "slot": "gospel", "description": "Gospel of the day" },
+		{
+			"type": "prayer",
+			"id": "of-verbum-domini-gospel",
+			"speaker": "priest",
+			"latin": "Verbum Dómini.",
+			"english": "The Gospel of the Lord."
+		},
+		{
+			"type": "prayer",
+			"id": "of-verbum-domini-gospel-r",
+			"speaker": "people",
+			"latin": "Laus tibi, Christe.",
+			"english": "Praise to you, Lord Jesus Christ."
+		},
+		{ "type": "proper", "id": "of-homily", "slot": "homily", "description": "Homily" },
+		{ "type": "subheading", "id": "of-creed-section", "text": "Profession of Faith" },
+		{
+			"type": "options",
+			"id": "of-creed",
+			"label": "Creed",
+			"options": [
+				{
+					"id": "of-nicene",
+					"label": "Nicene Creed",
+					"sections": [
+						{
+							"type": "prayer",
+							"id": "of-nicene-creed",
+							"speaker": "all",
+							"latin": "Credo in unum Deum, Patrem omnipoténtem, factórem cæli et terræ, visibílium ómnium et invisibílium.\nEt in unum Dóminum Jesum Christum, Fílium Dei Unigénitum, et ex Patre natum ante ómnia sǽcula. Deum de Deo, lumen de lúmine, Deum verum de Deo vero, génitum, non factum, consubstantiálem Patri: per quem ómnia facta sunt. Qui propter nos hómines et propter nostram salútem descéndit de cælis. Et incarnátus est de Spíritu Sancto ex María Vírgine, et homo factus est. Crucifíxus étiam pro nobis sub Póntio Piláto; passus et sepúltus est, et resurréxit tértia die, secúndum Scriptúras, et ascéndit in cælum, sedet ad déxteram Patris. Et íterum ventúrus est cum glória, judicáre vivos et mórtuos, cujus regni non erit finis.\nEt in Spíritum Sanctum, Dóminum et vivificántem: qui ex Patre Filióque procédit. Qui cum Patre et Fílio simul adorátur et conglorificátur: qui locútus est per prophétas. Et unam, sanctam, cathólicam et apostólicam Ecclésiam. Confíteor unum baptísma in remissiónem peccatórum. Et exspécto resurrectiónem mortuórum, et vitam ventúri sǽculi. Amen.",
+							"english": "I believe in one God, the Father almighty, maker of heaven and earth, of all things visible and invisible.\nI believe in one Lord Jesus Christ, the Only Begotten Son of God, born of the Father before all ages. God from God, Light from Light, true God from true God, begotten, not made, consubstantial with the Father; through him all things were made. For us men and for our salvation he came down from heaven, and by the Holy Spirit was incarnate of the Virgin Mary, and became man. For our sake he was crucified under Pontius Pilate, he suffered death and was buried, and rose again on the third day in accordance with the Scriptures. He ascended into heaven and is seated at the right hand of the Father. He will come again in glory to judge the living and the dead and his kingdom will have no end.\nI believe in the Holy Spirit, the Lord, the giver of life, who proceeds from the Father and the Son, who with the Father and the Son is adored and glorified, who has spoken through the prophets. I believe in one, holy, catholic and apostolic Church. I confess one Baptism for the forgiveness of sins and I look forward to the resurrection of the dead and the life of the world to come. Amen."
+						}
+					]
+				},
+				{
+					"id": "of-apostles",
+					"label": "Apostles' Creed",
+					"sections": [
+						{
+							"type": "prayer",
+							"id": "of-apostles-creed",
+							"speaker": "all",
+							"latin": "Credo in Deum Patrem omnipoténtem, Creatórem cæli et terræ, et in Jesum Christum, Fílium Ejus únicum, Dóminum nostrum, qui concéptus est de Spíritu Sancto, natus ex María Vírgine, passus sub Póntio Piláto, crucifíxus, mórtuus, et sepúltus, descéndit ad ínferos, tértia die resurréxit a mórtuis, ascéndit ad cælos, sedet ad déxteram Dei Patris omnipoténtis, inde ventúrus est judicáre vivos et mórtuos. Credo in Spíritum Sanctum, sanctam Ecclésiam cathólicam, sanctórum communiónem, remissiónem peccatórum, carnis resurrectiónem, vitam ætérnam. Amen.",
+							"english": "I believe in God, the Father almighty, Creator of heaven and earth, and in Jesus Christ, his only Son, our Lord, who was conceived by the Holy Spirit, born of the Virgin Mary, suffered under Pontius Pilate, was crucified, died and was buried; he descended into hell; on the third day he rose again from the dead; he ascended into heaven, and is seated at the right hand of God the Father almighty; from there he will come to judge the living and the dead. I believe in the Holy Spirit, the holy catholic Church, the communion of saints, the forgiveness of sins, the resurrection of the body, and life everlasting. Amen."
+						}
+					]
+				}
+			]
+		},
+		{ "type": "proper", "id": "of-universal-prayer", "slot": "universal-prayer", "description": "Prayer of the Faithful" },
+		{ "type": "divider" },
+		{ "type": "heading", "id": "of-liturgy-eucharist", "text": "Liturgy of the Eucharist" },
+		{ "type": "subheading", "id": "of-preparation-gifts", "text": "Preparation of the Gifts" },
+		{
+			"type": "prayer",
+			"id": "of-blessed-bread",
+			"speaker": "priest",
+			"latin": "Benedíctus es, Dómine, Deus univérsi, quia de tua largitáte accépimus panem, quem tibi offérimus, fructum terræ et óperis mánuum hóminum: ex quo nobis fiet panis vitæ.",
+			"english": "Blessed are you, Lord God of all creation, for through your goodness we have received the bread we offer you: fruit of the earth and work of human hands, it will become for us the bread of life."
+		},
+		{
+			"type": "prayer",
+			"id": "of-blessed-bread-r",
+			"speaker": "people",
+			"latin": "Benedíctus Deus in sǽcula.",
+			"english": "Blessed be God for ever."
+		},
+		{
+			"type": "prayer",
+			"id": "of-per-mysterium",
+			"speaker": "priest",
+			"latin": "Per hujus aquæ et vini mystérium ejus efficiámur divinitátis consórtes, qui humanitátis nostræ fíeri dignátus est párticeps.",
+			"english": "By the mystery of this water and wine may we come to share in the divinity of Christ who humbled himself to share in our humanity."
+		},
+		{
+			"type": "prayer",
+			"id": "of-blessed-wine",
+			"speaker": "priest",
+			"latin": "Benedíctus es, Dómine, Deus univérsi, quia de tua largitáte accépimus vinum, quod tibi offérimus, fructum vitis et óperis mánuum hóminum: ex quo nobis fiet potus spiritális.",
+			"english": "Blessed are you, Lord God of all creation, for through your goodness we have received the wine we offer you: fruit of the vine and work of human hands, it will become our spiritual drink."
+		},
+		{
+			"type": "prayer",
+			"id": "of-blessed-wine-r",
+			"speaker": "people",
+			"latin": "Benedíctus Deus in sǽcula.",
+			"english": "Blessed be God for ever."
+		},
+		{
+			"type": "prayer",
+			"id": "of-in-spiritu",
+			"speaker": "priest",
+			"latin": "In spíritu humilitátis et in ánimo contríto suscipiámur a te, Dómine; et sic fiat sacrifícium nostrum in conspéctu tuo hódie, ut pláceat tibi, Dómine Deus.",
+			"english": "With humble spirit and contrite heart may we be accepted by you, O Lord, and may our sacrifice in your sight this day be pleasing to you, Lord God."
+		},
+		{
+			"type": "prayer",
+			"id": "of-lavabo",
+			"speaker": "priest",
+			"latin": "Lava me, Dómine, ab iniquitáte mea, et a peccáto meo munda me.",
+			"english": "Wash me, O Lord, from my iniquity and cleanse me from my sin."
+		},
+		{
+			"type": "prayer",
+			"id": "of-orate-fratres",
+			"speaker": "priest",
+			"latin": "Oráte, fratres: ut meum ac vestrum sacrifícium acceptábile fiat apud Deum Patrem omnipoténtem.",
+			"english": "Pray, brethren, that my sacrifice and yours may be acceptable to God, the almighty Father."
+		},
+		{
+			"type": "prayer",
+			"id": "of-suscipiat",
+			"speaker": "people",
+			"latin": "Suscípiat Dóminus sacrifícium de mánibus tuis ad laudem et glóriam nóminis sui, ad utilitátem quoque nostram totiúsque Ecclésiæ suæ sanctæ.",
+			"english": "May the Lord accept the sacrifice at your hands for the praise and glory of his name, for our good and the good of all his holy Church."
+		},
+		{ "type": "proper", "id": "of-prayer-offerings", "slot": "prayer-over-offerings", "description": "Prayer over the Offerings" },
+		{ "type": "subheading", "id": "of-preface-section", "text": "Preface Dialogue" },
+		{
+			"type": "prayer",
+			"id": "of-dominus-vobiscum-preface",
+			"speaker": "priest",
+			"latin": "Dóminus vobíscum.",
+			"english": "The Lord be with you."
+		},
+		{ "type": "prayer", "id": "of-et-cum-preface", "speaker": "people", "latin": "Et cum spíritu tuo.", "english": "And with your spirit." },
+		{
+			"type": "prayer",
+			"id": "of-sursum-corda",
+			"speaker": "priest",
+			"latin": "Sursum corda.",
+			"english": "Lift up your hearts."
+		},
+		{ "type": "prayer", "id": "of-habemus", "speaker": "people", "latin": "Habémus ad Dóminum.", "english": "We lift them up to the Lord." },
+		{
+			"type": "prayer",
+			"id": "of-gratias-agamus",
+			"speaker": "priest",
+			"latin": "Grátias agámus Dómino Deo nostro.",
+			"english": "Let us give thanks to the Lord our God."
+		},
+		{ "type": "prayer", "id": "of-dignum", "speaker": "people", "latin": "Dignum et justum est.", "english": "It is right and just." },
+		{ "type": "proper", "id": "of-preface-text", "slot": "preface", "description": "Preface of the day" },
+		{
+			"type": "prayer",
+			"id": "of-sanctus",
+			"speaker": "all",
+			"latin": "Sanctus, Sanctus, Sanctus Dóminus Deus Sábaoth.\nPleni sunt cæli et terra glória tua.\nHosánna in excélsis.\nBenedíctus qui venit in nómine Dómini.\nHosánna in excélsis.",
+			"english": "Holy, Holy, Holy Lord God of hosts.\nHeaven and earth are full of your glory.\nHosanna in the highest.\nBlessed is he who comes in the name of the Lord.\nHosanna in the highest."
+		},
+		{ "type": "divider" },
+		{
+			"type": "options",
+			"id": "of-eucharistic-prayer",
+			"label": "Eucharistic Prayer",
+			"options": [
+				{
+					"id": "of-ep2",
+					"label": "EP II",
+					"sections": [
+						{ "type": "rubric", "text": "Eucharistic Prayer II has its own Preface, but may also be used with other Prefaces." },
+						{
+							"type": "prayer",
+							"id": "of-ep2-vere-sanctus",
+							"speaker": "priest",
+							"latin": "Vere Sanctus es, Dómine, fons omnis sanctitátis.",
+							"english": "You are indeed Holy, O Lord, the fount of all holiness."
+						},
+						{
+							"type": "prayer",
+							"id": "of-ep2-epiclesis",
+							"speaker": "priest",
+							"latin": "Hæc ergo dona, quǽsumus, Spíritus tui rore sanctífica, ut nobis Corpus et Sanguis fiant Dómini nostri Jesu Christi.",
+							"english": "Make holy, therefore, these gifts, we pray, by sending down your Spirit upon them like the dewfall, so that they may become for us the Body and Blood of our Lord Jesus Christ."
+						},
+						{
+							"type": "prayer",
+							"id": "of-ep2-institution-bread",
+							"speaker": "priest",
+							"latin": "Qui cum Passióni voluntárie traderétur, accépit panem et, grátias agens, fregit, dedítque discípulis suis, dicens:\nACCÍPITE ET MANDUCÁTE EX HOC OMNES:\nHOC EST ENIM CORPUS MEUM,\nQUOD PRO VOBIS TRADÉTUR.",
+							"english": "At the time he was betrayed and entered willingly into his Passion, he took bread and, giving thanks, broke it, and gave it to his disciples, saying:\nTAKE THIS, ALL OF YOU, AND EAT OF IT,\nFOR THIS IS MY BODY,\nWHICH WILL BE GIVEN UP FOR YOU."
+						},
+						{
+							"type": "prayer",
+							"id": "of-ep2-institution-cup",
+							"speaker": "priest",
+							"latin": "Símili modo, postquam cenátum est, accípiens et cálicem, íterum grátias agens, dedit discípulis suis, dicens:\nACCÍPITE ET BÍBITE EX EO OMNES:\nHIC EST ENIM CALIX SÁNGUINIS MEI\nNOVI ET ÆTÉRNI TESTAMÉNTI,\nQUI PRO VOBIS ET PRO MULTIS EFFUNDÉTUR\nIN REMISSIÓNEM PECCATÓRUM.\nHOC FÁCITE IN MEAM COMMEMORATIÓNEM.",
+							"english": "In a similar way, when supper was ended, he took the chalice and, once more giving thanks, he gave it to his disciples, saying:\nTAKE THIS, ALL OF YOU, AND DRINK FROM IT,\nFOR THIS IS THE CHALICE OF MY BLOOD,\nTHE BLOOD OF THE NEW AND ETERNAL COVENANT,\nWHICH WILL BE POURED OUT FOR YOU AND FOR MANY\nFOR THE FORGIVENESS OF SINS.\nDO THIS IN REMEMBRANCE OF ME."
+						},
+						{
+							"type": "prayer",
+							"id": "of-ep2-mysterium",
+							"speaker": "priest",
+							"latin": "Mystérium fídei.",
+							"english": "The mystery of faith."
+						},
+						{
+							"type": "options",
+							"id": "of-memorial-accl",
+							"label": "Memorial Acclamation",
+							"options": [
+								{
+									"id": "of-memorial-a",
+									"label": "A",
+									"sections": [{
+										"type": "prayer",
+										"id": "of-memorial-a-text",
+										"speaker": "people",
+										"latin": "Mortem tuam annuntiámus, Dómine, et tuam resurrectiónem confitémur, donec vénias.",
+										"english": "We proclaim your Death, O Lord, and profess your Resurrection until you come again."
+									}]
+								},
+								{
+									"id": "of-memorial-b",
+									"label": "B",
+									"sections": [{
+										"type": "prayer",
+										"id": "of-memorial-b-text",
+										"speaker": "people",
+										"latin": "Quotiescúmque manducámus panem hunc et cálicem bíbimus, mortem tuam annuntiámus, Dómine, donec vénias.",
+										"english": "When we eat this Bread and drink this Cup, we proclaim your Death, O Lord, until you come again."
+									}]
+								},
+								{
+									"id": "of-memorial-c",
+									"label": "C",
+									"sections": [{
+										"type": "prayer",
+										"id": "of-memorial-c-text",
+										"speaker": "people",
+										"latin": "Salvátor mundi, salva nos, qui per crucem et resurrectiónem tuam liberásti nos.",
+										"english": "Save us, Saviour of the world, for by your Cross and Resurrection you have set us free."
+									}]
+								}
+							]
+						},
+						{
+							"type": "prayer",
+							"id": "of-ep2-anamnesis",
+							"speaker": "priest",
+							"latin": "Mémores ígitur mortis et resurrectiónis ejus, tibi, Dómine, panem vitæ et cálicem salútis offérimus, grátias agéntes quia nos dignos habuísti astáre coram te et tibi ministráre.",
+							"english": "Therefore, as we celebrate the memorial of his Death and Resurrection, we offer you, Lord, the Bread of life and the Chalice of salvation, giving thanks that you have held us worthy to be in your presence and minister to you."
+						},
+						{
+							"type": "prayer",
+							"id": "of-ep2-epiclesis-2",
+							"speaker": "priest",
+							"latin": "Et súpplices deprecámur ut Córporis et Sánguinis Christi partícipes a Spíritu Sancto congregémur in unum.",
+							"english": "Humbly we pray that, partaking of the Body and Blood of Christ, we may be gathered into one by the Holy Spirit."
+						},
+						{
+							"type": "prayer",
+							"id": "of-ep2-intercessions",
+							"speaker": "priest",
+							"latin": "Recordáre, Dómine, Ecclésiæ tuæ toto orbe diffúsæ, ut eam in caritáte perfícias una cum Papa nostro N. et Epíscopo nostro N. et univérso clero.\nMeménto étiam fratrum nostrórum, qui in spe resurrectiónis dormiérunt, omniúmque in tua miseratióne defunctórum, et eos in lumen vultus tui admítte.\nOmnium nostrum, quǽsumus, miserére, ut cum beáta Dei Genitrícce Vírgine María, beátis Apóstolis et ómnibus Sanctis, qui tibi a sǽculo placuérunt, ætérnæ vitæ mereámur esse consórtes, et te laudémus et glorificémus per Fílium tuum Jesum Christum.",
+							"english": "Remember, Lord, your Church, spread throughout the world, and bring her to the fullness of charity, together with N. our Pope and N. our Bishop and all the clergy.\nRemember also our brothers and sisters who have fallen asleep in the hope of the resurrection, and all who have died in your mercy: welcome them into the light of your face.\nHave mercy on us all, we pray, that with the Blessed Virgin Mary, Mother of God, with the blessed Apostles, and all the Saints who have pleased you throughout the ages, we may merit to be coheirs to eternal life, and may praise and glorify you through your Son, Jesus Christ."
+						},
+						{
+							"type": "prayer",
+							"id": "of-ep2-doxology",
+							"speaker": "priest",
+							"latin": "Per ipsum, et cum ipso, et in ipso, est tibi Deo Patri omnipoténti, in unitáte Spíritus Sancti, omnis honor et glória per ómnia sǽcula sæculórum.",
+							"english": "Through him, and with him, and in him, O God, almighty Father, in the unity of the Holy Spirit, all glory and honor is yours, for ever and ever."
+						},
+						{ "type": "prayer", "id": "of-ep2-amen", "speaker": "people", "latin": "Amen.", "english": "Amen." }
+					]
+				},
+				{
+					"id": "of-ep3",
+					"label": "EP III",
+					"sections": [
+						{
+							"type": "prayer",
+							"id": "of-ep3-vere-sanctus",
+							"speaker": "priest",
+							"latin": "Vere Sanctus es, Dómine, et mérito te laudat omnis a te cóndita creatúra, quia per Fílium tuum, Dóminum nostrum Jesum Christum, Spíritus Sancti operánte virtúte, vivíficas et sanctíficas univérsa, et pópulum tibi congregáre non désinis, ut a solis ortu usque ad occásum oblátio munda offerátur nómini tuo.",
+							"english": "You are indeed Holy, O Lord, and all you have created rightly gives you praise, for through your Son our Lord Jesus Christ, by the power and working of the Holy Spirit, you give life to all things and make them holy, and you never cease to gather a people to yourself, so that from the rising of the sun to its setting a pure sacrifice may be offered to your name."
+						},
+						{
+							"type": "prayer",
+							"id": "of-ep3-epiclesis",
+							"speaker": "priest",
+							"latin": "Súpplices ergo te, Dómine, deprecámur, ut hæc múnera, quæ tibi sacránda detúlimus, eódem Spíritu sanctificáre dignéris, ut Corpus et Sanguis fiant Fílii tui Dómini nostri Jesu Christi, cujus mandáto hæc mystéria celebrámus.",
+							"english": "Therefore, O Lord, we humbly implore you: by the same Spirit graciously make holy these gifts we have brought to you for consecration, that they may become the Body and Blood of your Son our Lord Jesus Christ, at whose command we celebrate these mysteries."
+						},
+						{
+							"type": "prayer",
+							"id": "of-ep3-institution-bread",
+							"speaker": "priest",
+							"latin": "Ipse enim in qua nocte tradebátur accépit panem et tibi grátias agens benedíxit, fregit, dedítque discípulis suis, dicens:\nACCÍPITE ET MANDUCÁTE EX HOC OMNES:\nHOC EST ENIM CORPUS MEUM,\nQUOD PRO VOBIS TRADÉTUR.",
+							"english": "For on the night he was betrayed he himself took bread, and, giving you thanks, he said the blessing, broke the bread and gave it to his disciples, saying:\nTAKE THIS, ALL OF YOU, AND EAT OF IT,\nFOR THIS IS MY BODY,\nWHICH WILL BE GIVEN UP FOR YOU."
+						},
+						{
+							"type": "prayer",
+							"id": "of-ep3-institution-cup",
+							"speaker": "priest",
+							"latin": "Símili modo, postquam cenátum est, accípiens cálicem, et tibi grátias agens benedíxit, dedítque discípulis suis, dicens:\nACCÍPITE ET BÍBITE EX EO OMNES:\nHIC EST ENIM CALIX SÁNGUINIS MEI\nNOVI ET ÆTÉRNI TESTAMÉNTI,\nQUI PRO VOBIS ET PRO MULTIS EFFUNDÉTUR\nIN REMISSIÓNEM PECCATÓRUM.\nHOC FÁCITE IN MEAM COMMEMORATIÓNEM.",
+							"english": "In a similar way, when supper was ended, he took the chalice, and, giving you thanks, he said the blessing, and gave the chalice to his disciples, saying:\nTAKE THIS, ALL OF YOU, AND DRINK FROM IT,\nFOR THIS IS THE CHALICE OF MY BLOOD,\nTHE BLOOD OF THE NEW AND ETERNAL COVENANT,\nWHICH WILL BE POURED OUT FOR YOU AND FOR MANY\nFOR THE FORGIVENESS OF SINS.\nDO THIS IN REMEMBRANCE OF ME."
+						},
+						{
+							"type": "prayer",
+							"id": "of-ep3-mysterium",
+							"speaker": "priest",
+							"latin": "Mystérium fídei.",
+							"english": "The mystery of faith."
+						},
+						{ "type": "rubric", "text": "Memorial Acclamation (as above)" },
+						{
+							"type": "prayer",
+							"id": "of-ep3-anamnesis",
+							"speaker": "priest",
+							"latin": "Mémores ígitur, Dómine, ejúsdem Fílii tui salutíferæ passiónis necnon et ab ínferis resurrectiónis, sed et in cælos gloriósæ ascensiónis, offérimus tibi, grátias referéntes, hoc sacrifícium vivum et sanctum.",
+							"english": "Therefore, O Lord, as we celebrate the memorial of the saving Passion of your Son, his wondrous Resurrection and Ascension into heaven, and as we look forward to his second coming, we offer you in thanksgiving this holy and living sacrifice."
+						},
+						{
+							"type": "prayer",
+							"id": "of-ep3-epiclesis-2",
+							"speaker": "priest",
+							"latin": "Réspice, quǽsumus, in oblatiónem Ecclésiæ tuæ et, agnóscens Hóstiam, cujus voluísti immolatióne placári, concéde, ut qui Córpore et Sánguine Fílii tui refícimur, Spíritu ejus Sancto repléti, unum corpus et unus spíritus inveniámur in Christo.",
+							"english": "Look, we pray, upon the oblation of your Church, and, recognizing the sacrificial Victim by whose death you willed to reconcile us to yourself, grant that we, who are nourished by the Body and Blood of your Son and filled with his Holy Spirit, may become one body, one spirit in Christ."
+						},
+						{
+							"type": "prayer",
+							"id": "of-ep3-intercessions",
+							"speaker": "priest",
+							"latin": "Ipse nos tibi perfíciat munus ætérnum, ut cum eléctis tuis hereditátem cónsequi valeámus, in primis cum beatíssima Vírgine, Dei Genitrícce, María, cum beátis Apóstolis tuis et gloriósis Martýribus et ómnibus Sanctis, quorum intercessióne perpétuo apud te confídimus adjuvári.\nHæc Hóstia nostræ reconciliatiónis profíciat, quǽsumus, Dómine, ad totíus mundi pacem atque salútem. Ecclésiam tuam, peregrinántem in terra, in fide et caritáte firmáre dignéris cum fámulo tuo Papa nostro N. et Epíscopo nostro N., cum episcopáli órdine et univérso clero et omni pópulo acquisitiónis tuæ.\nMeménto étiam fratrum nostrórum, qui in spe resurrectiónis dormiérunt, omniúmque in tua miseratióne defunctórum, et eos in lumen vultus tui admítte. Omnium nostrum, quǽsumus, miserére, ut cum beáta Dei Genetrícce Vírgine María, beátis Apóstolis et ómnibus Sanctis, qui tibi a sǽculo placuérunt, ætérnæ vitæ mereámur esse consórtes, et te laudémus et glorificémus per Fílium tuum Jesum Christum.",
+							"english": "May he make of us an eternal offering to you, so that we may obtain an inheritance with your elect, especially with the most Blessed Virgin Mary, Mother of God, with your blessed Apostles and glorious Martyrs and with all the Saints, on whose constant intercession in your presence we rely for unfailing help.\nMay this Sacrifice of our reconciliation, we pray, O Lord, advance the peace and salvation of all the world. Be pleased to confirm in faith and charity your pilgrim Church on earth, with your servant N. our Pope and N. our Bishop, the Order of Bishops, all the clergy, and the entire people you have gained for your own.\nRemember also our brothers and sisters who have fallen asleep in the hope of the resurrection, and all who have died in your mercy: welcome them into the light of your face. Have mercy on us all, we pray, that with the Blessed Virgin Mary, Mother of God, with the blessed Apostles, and all the Saints who have pleased you throughout the ages, we may merit to be coheirs to eternal life, and may praise and glorify you through your Son, Jesus Christ."
+						},
+						{
+							"type": "prayer",
+							"id": "of-ep3-doxology",
+							"speaker": "priest",
+							"latin": "Per ipsum, et cum ipso, et in ipso, est tibi Deo Patri omnipoténti, in unitáte Spíritus Sancti, omnis honor et glória per ómnia sǽcula sæculórum.",
+							"english": "Through him, and with him, and in him, O God, almighty Father, in the unity of the Holy Spirit, all glory and honor is yours, for ever and ever."
+						},
+						{ "type": "prayer", "id": "of-ep3-amen", "speaker": "people", "latin": "Amen.", "english": "Amen." }
+					]
+				},
+				{
+					"id": "of-ep1",
+					"label": "EP I (Roman Canon)",
+					"sections": [
+						{ "type": "rubric", "text": "The Roman Canon — the most ancient Eucharistic Prayer of the Roman Rite. Same text as in the Extraordinary Form." },
+						{ "type": "proper", "id": "of-ep1-full", "slot": "ep1", "description": "See Extraordinary Form for the full text of the Roman Canon (Te igitur through Per ipsum)." }
+					]
+				},
+				{
+					"id": "of-ep4",
+					"label": "EP IV",
+					"sections": [
+						{ "type": "rubric", "text": "Eucharistic Prayer IV has a fixed Preface and provides a broad summary of salvation history. It may not be used with another Preface." },
+						{ "type": "proper", "id": "of-ep4-full", "slot": "ep4", "description": "Eucharistic Prayer IV (with its own Preface)" }
+					]
+				}
+			]
+		},
+		{ "type": "divider" },
+		{ "type": "heading", "id": "of-communion-rite", "text": "Communion Rite" },
+		{ "type": "subheading", "id": "of-pater-noster-section", "text": "The Lord's Prayer" },
+		{
+			"type": "prayer",
+			"id": "of-pater-noster",
+			"speaker": "all",
+			"latin": "Pater noster, qui es in cælis:\nsanctificétur nomen tuum;\nadvéniat regnum tuum;\nfiat volúntas tua, sicut in cælo, et in terra.\nPanem nostrum cotidiánum da nobis hódie;\net dimítte nobis débita nostra,\nsicut et nos dimíttimus debitóribus nostris;\net ne nos indúcas in tentatiónem;\nsed líbera nos a malo.",
+			"english": "Our Father, who art in heaven,\nhallowed be thy name;\nthy kingdom come,\nthy will be done on earth as it is in heaven.\nGive us this day our daily bread,\nand forgive us our trespasses,\nas we forgive those who trespass against us;\nand lead us not into temptation,\nbut deliver us from evil."
+		},
+		{
+			"type": "prayer",
+			"id": "of-embolism",
+			"speaker": "priest",
+			"latin": "Líbera nos, quǽsumus, Dómine, ab ómnibus malis, da propítius pacem in diébus nostris, ut, ope misericórdiæ tuæ adjúti, et a peccáto simus semper líberi et ab omni perturbatióne secúri: exspectántes beátam spem et advéntum Salvatóris nostri Jesu Christi.",
+			"english": "Deliver us, Lord, we pray, from every evil, graciously grant peace in our days, that, by the help of your mercy, we may be always free from sin and safe from all distress, as we await the blessed hope and the coming of our Saviour, Jesus Christ."
+		},
+		{
+			"type": "prayer",
+			"id": "of-doxology",
+			"speaker": "people",
+			"latin": "Quia tuum est regnum, et potéstas, et glória in sǽcula.",
+			"english": "For the kingdom, the power and the glory are yours now and for ever."
+		},
+		{ "type": "subheading", "id": "of-peace-section", "text": "Sign of Peace" },
+		{
+			"type": "prayer",
+			"id": "of-peace-prayer",
+			"speaker": "priest",
+			"latin": "Dómine Jesu Christe, qui dixísti Apóstolis tuis: Pacem relínquo vobis, pacem meam do vobis: ne respícias peccáta nostra, sed fidem Ecclésiæ tuæ; eámque secúndum voluntátem tuam pacificáre et coadunáre dignéris. Qui vivis et regnas in sǽcula sæculórum.",
+			"english": "Lord Jesus Christ, who said to your Apostles: Peace I leave you, my peace I give you, look not on our sins, but on the faith of your Church, and graciously grant her peace and unity in accordance with your will. Who live and reign for ever and ever."
+		},
+		{ "type": "prayer", "id": "of-peace-amen", "speaker": "people", "latin": "Amen.", "english": "Amen." },
+		{
+			"type": "prayer",
+			"id": "of-pax-domini",
+			"speaker": "priest",
+			"latin": "Pax Dómini sit semper vobíscum.",
+			"english": "The peace of the Lord be with you always."
+		},
+		{ "type": "prayer", "id": "of-pax-r", "speaker": "people", "latin": "Et cum spíritu tuo.", "english": "And with your spirit." },
+		{ "type": "rubric", "text": "The Deacon, or the Priest, may add: Let us offer each other the sign of peace." },
+		{ "type": "subheading", "id": "of-agnus-section", "text": "Agnus Dei" },
+		{
+			"type": "prayer",
+			"id": "of-agnus-dei",
+			"speaker": "all",
+			"latin": "Agnus Dei, qui tollis peccáta mundi: miserére nobis.\nAgnus Dei, qui tollis peccáta mundi: miserére nobis.\nAgnus Dei, qui tollis peccáta mundi: dona nobis pacem.",
+			"english": "Lamb of God, you take away the sins of the world, have mercy on us.\nLamb of God, you take away the sins of the world, have mercy on us.\nLamb of God, you take away the sins of the world, grant us peace."
+		},
+		{ "type": "subheading", "id": "of-communion-section", "text": "Communion" },
+		{
+			"type": "prayer",
+			"id": "of-ecce-agnus",
+			"speaker": "priest",
+			"latin": "Ecce Agnus Dei, ecce qui tollit peccáta mundi. Beáti qui ad cenam Agni vocáti sunt.",
+			"english": "Behold the Lamb of God, behold him who takes away the sins of the world. Blessed are those called to the supper of the Lamb."
+		},
+		{
+			"type": "prayer",
+			"id": "of-domine-non-sum-dignus",
+			"speaker": "all",
+			"latin": "Dómine, non sum dignus, ut intres sub tectum meum: sed tantum dic verbo, et sanábitur ánima mea.",
+			"english": "Lord, I am not worthy that you should enter under my roof, but only say the word and my soul shall be healed."
+		},
+		{ "type": "proper", "id": "of-communion-antiphon", "slot": "communion", "description": "Communion Antiphon" },
+		{ "type": "proper", "id": "of-prayer-after-communion", "slot": "prayer-after-communion", "description": "Prayer after Communion" },
+		{ "type": "divider" },
+		{ "type": "heading", "id": "of-concluding-rites", "text": "Concluding Rites" },
+		{
+			"type": "prayer",
+			"id": "of-dominus-vobiscum-end",
+			"speaker": "priest",
+			"latin": "Dóminus vobíscum.",
+			"english": "The Lord be with you."
+		},
+		{ "type": "prayer", "id": "of-et-cum-end", "speaker": "people", "latin": "Et cum spíritu tuo.", "english": "And with your spirit." },
+		{
+			"type": "prayer",
+			"id": "of-blessing",
+			"speaker": "priest",
+			"latin": "Benedícat vos omnípotens Deus, Pater, et Fílius, ✠ et Spíritus Sanctus.",
+			"english": "May almighty God bless you, the Father, and the Son, ✠ and the Holy Spirit."
+		},
+		{ "type": "prayer", "id": "of-blessing-r", "speaker": "people", "latin": "Amen.", "english": "Amen." },
+		{
+			"type": "options",
+			"id": "of-dismissal",
+			"label": "Dismissal",
+			"options": [
+				{
+					"id": "of-dismiss-a",
+					"label": "Form A",
+					"sections": [
+						{ "type": "prayer", "id": "of-dismiss-a-v", "speaker": "priest", "latin": "Ite, ad Evangélium Dómini annuntiándum.", "english": "Go and announce the Gospel of the Lord." },
+						{ "type": "prayer", "id": "of-dismiss-a-r", "speaker": "people", "latin": "Deo grátias.", "english": "Thanks be to God." }
+					]
+				},
+				{
+					"id": "of-dismiss-b",
+					"label": "Form B",
+					"sections": [
+						{ "type": "prayer", "id": "of-dismiss-b-v", "speaker": "priest", "latin": "Ite in pace, glorificándo vita vestra Dóminum.", "english": "Go in peace, glorifying the Lord by your life." },
+						{ "type": "prayer", "id": "of-dismiss-b-r", "speaker": "people", "latin": "Deo grátias.", "english": "Thanks be to God." }
+					]
+				},
+				{
+					"id": "of-dismiss-c",
+					"label": "Form C",
+					"sections": [
+						{ "type": "prayer", "id": "of-dismiss-c-v", "speaker": "priest", "latin": "Ite in pace.", "english": "Go in peace." },
+						{ "type": "prayer", "id": "of-dismiss-c-r", "speaker": "people", "latin": "Deo grátias.", "english": "Thanks be to God." }
+					]
+				},
+				{
+					"id": "of-dismiss-d",
+					"label": "Form D",
+					"sections": [
+						{ "type": "prayer", "id": "of-dismiss-d-v", "speaker": "priest", "latin": "Ite, missa est.", "english": "Go forth, the Mass is ended." },
+						{ "type": "prayer", "id": "of-dismiss-d-r", "speaker": "people", "latin": "Deo grátias.", "english": "Thanks be to God." }
+					]
+				}
+			]
+		}
+	]
+}

--- a/src/components/TasselPull.tsx
+++ b/src/components/TasselPull.tsx
@@ -16,6 +16,7 @@ import { mediumTap } from '@/lib/haptics'
 const sections = [
   { path: '/', labelKey: 'nav.home', color: '#C9A84C' },
   { path: '/office', labelKey: 'nav.divineOffice', color: '#6B1D2A' },
+  { path: '/mass', labelKey: 'nav.holyMass', color: '#8B6914' },
   { path: '/plan', labelKey: 'nav.planOfLife', color: '#2D6A4F' },
   { path: '/bible', labelKey: 'nav.sacredScripture', color: '#1B3A5C' },
   { path: '/catechism', labelKey: 'nav.catechism', color: '#7B2D3B' },

--- a/src/features/home/components/AppShortcuts.tsx
+++ b/src/features/home/components/AppShortcuts.tsx
@@ -9,6 +9,7 @@ type IconName = 'sunrise' | 'book' | 'rosary' | 'moon' | 'quill' | 'cross'
 
 const shortcuts = [
   { icon: 'book' as IconName, labelKey: 'home.divineOffice', route: '/office' },
+  { icon: 'cross' as IconName, labelKey: 'home.holyMass', route: '/mass' },
   { icon: 'cross' as IconName, labelKey: 'home.sacredScripture', route: '/bible' },
   { icon: 'book' as IconName, labelKey: 'home.catechism', route: '/catechism' },
   { icon: 'quill' as IconName, labelKey: 'home.planOfLife', route: '/plan' },

--- a/src/features/mass/components/MassScreen.tsx
+++ b/src/features/mass/components/MassScreen.tsx
@@ -1,0 +1,113 @@
+// biome-ignore-all lint/suspicious/noArrayIndexKey: static mass sections never reorder
+import { useRouter } from 'expo-router'
+import { ChevronLeft } from 'lucide-react-native'
+import { useTranslation } from 'react-i18next'
+import { Pressable } from 'react-native'
+import { Text, useTheme, XStack, YStack } from 'tamagui'
+
+import { AnimatedPressable, HeaderFlourish, ManuscriptFrame, ScreenLayout } from '@/components'
+import { useReadingMargin } from '@/hooks/useReadingStyle'
+import { usePreferencesStore } from '@/stores/preferencesStore'
+import { getMassData, type MassForm } from '../content'
+import { MassSectionBlock } from './MassSection'
+
+export function MassScreen() {
+  const { t } = useTranslation()
+  const router = useRouter()
+  const theme = useTheme()
+  const readingMargin = useReadingMargin()
+
+  const massForm = usePreferencesStore((s) => s.massForm)
+  const setMassForm = usePreferencesStore((s) => s.setMassForm)
+  const data = getMassData(massForm)
+
+  return (
+    <ScreenLayout>
+      <YStack gap="$lg" paddingVertical="$md">
+        <Pressable onPress={() => router.back()}>
+          <XStack alignItems="center" gap="$sm">
+            <ChevronLeft size={20} color={theme.accent.val} />
+            <Text fontFamily="$body" fontSize="$2" color="$accent">
+              {t('nav.home')}
+            </Text>
+          </XStack>
+        </Pressable>
+
+        <ManuscriptFrame>
+          <YStack
+            alignItems="center"
+            gap="$xs"
+            paddingVertical="$md"
+            paddingHorizontal={readingMargin}
+          >
+            <HeaderFlourish />
+            <Text fontFamily="$display" fontSize={36} lineHeight={42} color="$colorBurgundy">
+              {data.title}
+            </Text>
+            <Text fontFamily="$script" fontSize="$3" color="$colorSecondary">
+              {data.subtitle}
+            </Text>
+          </YStack>
+
+          <FormToggle value={massForm} onChange={setMassForm} />
+
+          <YStack gap="$md" paddingHorizontal={readingMargin} paddingBottom="$lg">
+            {data.sections.map((section, i) => (
+              <MassSectionBlock key={`${section.type}-${i}`} section={section} />
+            ))}
+          </YStack>
+        </ManuscriptFrame>
+      </YStack>
+    </ScreenLayout>
+  )
+}
+
+function FormToggle({ value, onChange }: { value: MassForm; onChange: (form: MassForm) => void }) {
+  const { t } = useTranslation()
+
+  return (
+    <XStack gap="$xs" justifyContent="center" paddingVertical="$md" paddingHorizontal="$md">
+      <FormToggleButton
+        label={t('mass.ordinaryForm')}
+        active={value === 'ordinary'}
+        onPress={() => onChange('ordinary')}
+      />
+      <FormToggleButton
+        label={t('mass.extraordinaryForm')}
+        active={value === 'extraordinary'}
+        onPress={() => onChange('extraordinary')}
+      />
+    </XStack>
+  )
+}
+
+function FormToggleButton({
+  label,
+  active,
+  onPress,
+}: {
+  label: string
+  active: boolean
+  onPress: () => void
+}) {
+  return (
+    <AnimatedPressable onPress={onPress}>
+      <YStack
+        paddingHorizontal="$md"
+        paddingVertical="$sm"
+        borderRadius="$md"
+        borderWidth={1}
+        borderColor={active ? '$accent' : '$borderColor'}
+        backgroundColor={active ? '$accent' : 'transparent'}
+      >
+        <Text
+          fontFamily="$heading"
+          fontSize="$1"
+          color={active ? '$background' : '$colorSecondary'}
+        >
+          {label}
+        </Text>
+      </YStack>
+    </AnimatedPressable>
+  )
+}

--- a/src/features/mass/components/MassSection.tsx
+++ b/src/features/mass/components/MassSection.tsx
@@ -1,0 +1,193 @@
+// biome-ignore-all lint/suspicious/noArrayIndexKey: static prayer text lines never reorder
+import { useState } from 'react'
+import { Text, XStack, YStack } from 'tamagui'
+
+import {
+  AnimatedPressable,
+  DropCap,
+  OrnamentalRule,
+  PageBreakOrnament,
+  PrayerText,
+  RubricLabel,
+} from '@/components'
+import type { MassOption, MassSection as MassSectionType } from '../content'
+
+export function MassSectionBlock({ section }: { section: MassSectionType }) {
+  switch (section.type) {
+    case 'heading':
+      return (
+        <YStack gap="$sm" paddingTop="$md">
+          <PageBreakOrnament />
+          <Text
+            fontFamily="$display"
+            fontSize={24}
+            lineHeight={30}
+            color="$colorBurgundy"
+            textAlign="center"
+          >
+            {section.text}
+          </Text>
+        </YStack>
+      )
+
+    case 'subheading':
+      return (
+        <Text
+          fontFamily="$heading"
+          fontSize="$3"
+          color="$colorBurgundy"
+          letterSpacing={0.5}
+          paddingTop="$sm"
+        >
+          {section.text}
+        </Text>
+      )
+
+    case 'rubric':
+      return <RubricLabel>{section.text}</RubricLabel>
+
+    case 'prayer':
+      return (
+        <PrayerBlock speaker={section.speaker} latin={section.latin} english={section.english} />
+      )
+
+    case 'proper':
+      return <ProperSlot description={section.description} />
+
+    case 'options':
+      return <OptionsBlock id={section.id} label={section.label} options={section.options} />
+
+    case 'divider':
+      return <OrnamentalRule />
+
+    default:
+      return undefined
+  }
+}
+
+function PrayerBlock({
+  speaker,
+  latin,
+  english,
+}: {
+  speaker: 'priest' | 'people' | 'all'
+  latin: string
+  english: string
+}) {
+  const englishLines = english.split('\n')
+  const latinLines = latin.split('\n')
+  const isPeople = speaker === 'people'
+
+  return (
+    <YStack gap="$xs" paddingLeft={isPeople ? '$md' : 0}>
+      {isPeople && (
+        <Text
+          fontFamily="$heading"
+          fontSize="$1"
+          color="$accent"
+          letterSpacing={1.5}
+          textTransform="uppercase"
+        >
+          R.
+        </Text>
+      )}
+      {englishLines.length > 0 && englishLines[0].length > 80 && !isPeople ? (
+        <>
+          <DropCap text={englishLines[0]} />
+          {englishLines.slice(1).map((line, i) => (
+            <PrayerText
+              key={`en-${i}-${line.slice(0, 20)}`}
+              fontWeight={isPeople ? '600' : undefined}
+            >
+              {line}
+            </PrayerText>
+          ))}
+        </>
+      ) : (
+        englishLines.map((line, i) => (
+          <PrayerText
+            key={`en-${i}-${line.slice(0, 20)}`}
+            fontWeight={isPeople ? '600' : undefined}
+          >
+            {line}
+          </PrayerText>
+        ))
+      )}
+      <YStack gap="$xs" opacity={0.6} paddingTop="$xs">
+        {latinLines.map((line, i) => (
+          <Text
+            key={`la-${i}-${line.slice(0, 20)}`}
+            fontFamily="$body"
+            fontSize="$2"
+            fontStyle="italic"
+            color="$colorSecondary"
+          >
+            {line}
+          </Text>
+        ))}
+      </YStack>
+    </YStack>
+  )
+}
+
+function ProperSlot({ description }: { description: string }) {
+  return (
+    <YStack
+      backgroundColor="$backgroundSurface"
+      borderRadius="$md"
+      borderWidth={1}
+      borderColor="$borderColor"
+      borderStyle="dashed"
+      padding="$md"
+      alignItems="center"
+    >
+      <Text fontFamily="$body" fontSize="$2" fontStyle="italic" color="$colorSecondary">
+        {description}
+      </Text>
+    </YStack>
+  )
+}
+
+function OptionsBlock({ label, options }: { id: string; label: string; options: MassOption[] }) {
+  const [selected, setSelected] = useState(0)
+  const current = options[selected]
+
+  return (
+    <YStack gap="$sm">
+      <Text fontFamily="$heading" fontSize="$2" color="$accent" letterSpacing={0.5}>
+        {label}
+      </Text>
+
+      <XStack gap="$xs" flexWrap="wrap">
+        {options.map((opt, i) => (
+          <AnimatedPressable key={opt.id} onPress={() => setSelected(i)}>
+            <YStack
+              paddingHorizontal="$sm"
+              paddingVertical="$xs"
+              borderRadius="$sm"
+              borderWidth={1}
+              borderColor={i === selected ? '$accent' : '$borderColor'}
+              backgroundColor={i === selected ? '$accent' : 'transparent'}
+            >
+              <Text
+                fontFamily="$heading"
+                fontSize="$1"
+                color={i === selected ? '$background' : '$colorSecondary'}
+              >
+                {opt.label}
+              </Text>
+            </YStack>
+          </AnimatedPressable>
+        ))}
+      </XStack>
+
+      {current && (
+        <YStack gap="$sm">
+          {current.sections.map((s, i) => (
+            <MassSectionBlock key={`${current.id}-${i}`} section={s} />
+          ))}
+        </YStack>
+      )}
+    </YStack>
+  )
+}

--- a/src/features/mass/components/index.ts
+++ b/src/features/mass/components/index.ts
@@ -1,0 +1,1 @@
+export { MassScreen } from './MassScreen'

--- a/src/features/mass/content.ts
+++ b/src/features/mass/content.ts
@@ -1,0 +1,36 @@
+export type MassSection =
+  | { type: 'heading'; id: string; text: string }
+  | { type: 'subheading'; id: string; text: string }
+  | { type: 'rubric'; text: string }
+  | {
+      type: 'prayer'
+      id: string
+      speaker: 'priest' | 'people' | 'all'
+      latin: string
+      english: string
+    }
+  | { type: 'proper'; id: string; slot: string; description: string }
+  | { type: 'options'; id: string; label: string; options: MassOption[] }
+  | { type: 'divider' }
+
+export type MassOption = {
+  id: string
+  label: string
+  sections: MassSection[]
+}
+
+export type MassForm = 'ordinary' | 'extraordinary'
+
+type MassData = {
+  id: string
+  title: string
+  subtitle: string
+  sections: MassSection[]
+}
+
+const efData: MassData = require('@/assets/mass/extraordinary-form.json')
+const ofData: MassData = require('@/assets/mass/ordinary-form.json')
+
+export function getMassData(form: MassForm): MassData {
+  return form === 'extraordinary' ? efData : ofData
+}

--- a/src/features/mass/index.ts
+++ b/src/features/mass/index.ts
@@ -1,0 +1,2 @@
+export { MassScreen } from './components'
+export { getMassData, type MassForm, type MassOption, type MassSection } from './content'

--- a/src/lib/i18n/locales/en.ts
+++ b/src/lib/i18n/locales/en.ts
@@ -11,6 +11,8 @@ export default {
     sacredScriptureSub: 'Read the Bible',
     catechism: 'Catechism',
     catechismSub: 'Read the CCC',
+    holyMass: 'Holy Mass',
+    holyMassSub: 'Ordo Missæ',
     fidelity: 'Fidelity',
     begin: 'Begin',
     nextPractice: 'Your next practice',
@@ -205,12 +207,21 @@ export default {
       'Hail Mary, full of grace, the Lord is with thee. Blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus. Holy Mary, Mother of God, pray for us sinners, now and at the hour of our death. Amen.',
   },
 
+  mass: {
+    title: 'Holy Mass',
+    subtitle: 'Ordo Missæ',
+    ordinaryForm: 'Ordinary Form',
+    extraordinaryForm: 'Extraordinary Form',
+    proper: 'Proper of the day',
+  },
+
   nav: {
     home: 'Home',
     divineOffice: 'Divine Office',
     planOfLife: 'Plan of Life',
     sacredScripture: 'Sacred Scripture',
     catechism: 'Catechism',
+    holyMass: 'Holy Mass',
     saints: 'Saints',
     settings: 'Settings',
   },

--- a/src/lib/i18n/locales/pt-BR.ts
+++ b/src/lib/i18n/locales/pt-BR.ts
@@ -11,6 +11,8 @@ export default {
     sacredScriptureSub: 'Ler a B\u00edblia',
     catechism: 'Catecismo',
     catechismSub: 'Ler o CIC',
+    holyMass: 'Santa Missa',
+    holyMassSub: 'Ordo Missæ',
     fidelity: 'Fidelidade',
     begin: 'Come\u00e7ar',
     nextPractice: 'Sua pr\u00f3xima pr\u00e1tica',
@@ -207,12 +209,21 @@ export default {
       'Ave Maria, cheia de gra\u00e7a, o Senhor \u00e9 convosco. Bendita sois v\u00f3s entre as mulheres, e bendito \u00e9 o fruto do vosso ventre, Jesus. Santa Maria, M\u00e3e de Deus, rogai por n\u00f3s, pecadores, agora e na hora da nossa morte. Am\u00e9m.',
   },
 
+  mass: {
+    title: 'Santa Missa',
+    subtitle: 'Ordo Miss\u00e6',
+    ordinaryForm: 'Forma Ordin\u00e1ria',
+    extraordinaryForm: 'Forma Extraordin\u00e1ria',
+    proper: 'Pr\u00f3prio do dia',
+  },
+
   nav: {
     home: 'In\u00edcio',
     divineOffice: 'Of\u00edcio Divino',
     planOfLife: 'Plano de Vida',
     sacredScripture: 'Sagrada Escritura',
     catechism: 'Catecismo',
+    holyMass: 'Santa Missa',
     saints: 'Santos',
     settings: 'Configura\u00e7\u00f5es',
   },

--- a/src/stores/preferencesStore.ts
+++ b/src/stores/preferencesStore.ts
@@ -3,6 +3,7 @@ import { create } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
 
 import { defaultTranslationForLanguage } from '@/lib/bolls'
+import type { MassForm } from '@/features/mass/content'
 import i18n from '@/lib/i18n'
 
 type PsalterCycle = '30-day'
@@ -11,10 +12,12 @@ type PreferencesState = {
   translation: string
   psalterCycle: PsalterCycle
   language: string
+  massForm: MassForm
   hydrated: boolean
   setTranslation: (translation: string) => void
   setPsalterCycle: (cycle: PsalterCycle) => void
   setLanguage: (language: string) => void
+  setMassForm: (form: MassForm) => void
   hydrate: () => Promise<void>
 }
 
@@ -23,6 +26,7 @@ export const usePreferencesStore = create<PreferencesState>()(
     translation: 'RSV2CE',
     psalterCycle: '30-day',
     language: 'en',
+    massForm: 'ordinary' as MassForm,
     hydrated: false,
 
     setTranslation: (translation) => {
@@ -50,16 +54,25 @@ export const usePreferencesStore = create<PreferencesState>()(
       i18n.changeLanguage(language)
     },
 
+    setMassForm: (form) => {
+      set((state) => {
+        state.massForm = form
+      })
+      AsyncStorage.setItem('mass-form', form)
+    },
+
     hydrate: async () => {
-      const [translation, psalterCycle, language] = await Promise.all([
+      const [translation, psalterCycle, language, massForm] = await Promise.all([
         AsyncStorage.getItem('translation'),
         AsyncStorage.getItem('psalter-cycle'),
         AsyncStorage.getItem('language'),
+        AsyncStorage.getItem('mass-form'),
       ])
       set((state) => {
         if (translation) state.translation = translation
         if (psalterCycle === '30-day') state.psalterCycle = psalterCycle
         if (language) state.language = language
+        if (massForm === 'ordinary' || massForm === 'extraordinary') state.massForm = massForm
         state.hydrated = true
       })
       if (language) {


### PR DESCRIPTION
Static reference screen for following along at Mass, with bilingual
(Latin + English) prayer texts for both the Novus Ordo (2011 ICEL
translation) and the Traditional Latin Mass (1962 Missal). Includes
form toggle persisted in preferences, options selector for Eucharistic
Prayers/Penitential Act/dismissal forms, proper slots for future
lectionary integration, and home screen navigation entry.

https://claude.ai/code/session_01Cup3QM28wdRDSnyeV54jxj