### PR TITLE
Set default Bible translation based on app language

### DIFF
--- a/src/lib/bolls.ts
+++ b/src/lib/bolls.ts
@@ -141,6 +141,12 @@ export const suggestedTranslations: Translation[] = [
   },
 ]
 
+// Default Bible translation per app language
+export const defaultTranslationForLanguage: Record<string, string> = {
+  en: 'RSV2CE',
+  'pt-BR': 'CNBB',
+}
+
 export async function fetchAllTranslations(): Promise<BollsLanguageEntry[]> {
   const res = await fetch(`${baseUrl}/static/bolls/app/views/languages.json`)
   if (!res.ok) {

--- a/src/stores/preferencesStore.ts
+++ b/src/stores/preferencesStore.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 import { create } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
 
+import { defaultTranslationForLanguage } from '@/lib/bolls'
 import i18n from '@/lib/i18n'
 
 type PsalterCycle = '30-day'
@@ -19,7 +20,7 @@ type PreferencesState = {
 
 export const usePreferencesStore = create<PreferencesState>()(
   immer((set) => ({
-    translation: 'DRB',
+    translation: 'RSV2CE',
     psalterCycle: '30-day',
     language: 'en',
     hydrated: false,
@@ -39,10 +40,13 @@ export const usePreferencesStore = create<PreferencesState>()(
     },
 
     setLanguage: (language) => {
+      const defaultTranslation = defaultTranslationForLanguage[language]
       set((state) => {
         state.language = language
+        if (defaultTranslation) state.translation = defaultTranslation
       })
       AsyncStorage.setItem('language', language)
+      if (defaultTranslation) AsyncStorage.setItem('translation', defaultTranslation)
       i18n.changeLanguage(language)
     },
 


### PR DESCRIPTION
## Summary
This PR implements language-specific default Bible translations, ensuring users get an appropriate translation when they change their app language.

## Key Changes
- Added `defaultTranslationForLanguage` mapping in `bolls.ts` to define default translations per language (English → RSV2CE, Portuguese (Brazil) → CNBB)
- Updated the default translation in `preferencesStore` from 'DRB' to 'RSV2CE'
- Modified `setLanguage` action to automatically update the Bible translation when the app language changes, using the language-specific default if available
- Persists both language and translation changes to AsyncStorage for consistency

## Implementation Details
The `setLanguage` function now:
1. Looks up the default translation for the selected language
2. Updates both the language and translation state if a default exists
3. Persists both values to AsyncStorage to maintain consistency across app sessions

https://claude.ai/code/session_01Ua7zhRcsUQ9GGAJLoMWEcZ