### PR TITLE
Fix UNIQUE constraint error when creating practices

### DIFF
--- a/src/db/repositories/practices.ts
+++ b/src/db/repositories/practices.ts
@@ -18,7 +18,7 @@ export async function createPractice(data: {
   customDesc?: string
 }): Promise<void> {
   await getDb().runAsync(
-    'INSERT INTO user_practices (practice_id, custom_name, custom_icon, custom_desc) VALUES (?, ?, ?, ?)',
+    'INSERT OR IGNORE INTO user_practices (practice_id, custom_name, custom_icon, custom_desc) VALUES (?, ?, ?, ?)',
     [data.id, data.customName ?? null, data.customIcon ?? null, data.customDesc ?? null],
   )
 }
@@ -65,7 +65,7 @@ export async function createPracticeWithSlot(
   let slotKey = ''
   await db.withTransactionAsync(async () => {
     await db.runAsync(
-      'INSERT INTO user_practices (practice_id, custom_name, custom_icon, custom_desc) VALUES (?, ?, ?, ?)',
+      'INSERT OR IGNORE INTO user_practices (practice_id, custom_name, custom_icon, custom_desc) VALUES (?, ?, ?, ?)',
       [
         practice.id,
         practice.customName ?? null,


### PR DESCRIPTION
Use INSERT OR IGNORE in createPractice() and createPracticeWithSlot() so
that re-adding an existing practice_id no longer crashes. The practice row
is silently skipped if it already exists, allowing the slot creation to
proceed normally.

https://claude.ai/code/session_01XkDiaDMs7bLPB4KsJZFheK