### PR TITLE
Support canticles as prayer references in library flows

### DIFF
--- a/apps/app/src/app/library/[libraryId].tsx
+++ b/apps/app/src/app/library/[libraryId].tsx
@@ -18,6 +18,7 @@ import {
   getAllChapterManifestsForLibrary,
   getManifest,
   qualifyId,
+  resolveCanticle,
   resolvePrayer,
 } from '@/content/registry'
 import type { Library } from '@/content/sources/filesystem'
@@ -73,7 +74,7 @@ export default function LibraryDetailScreen() {
   const prayerList: PrayerPreview[] = useMemo(() => {
     if (library) {
       return library.prayers.map((pid) => {
-        const asset = resolvePrayer(pid, library.id)
+        const asset = resolvePrayer(pid, library.id) ?? resolveCanticle(pid)
         return { id: pid, title: asset?.title ?? { 'en-US': pid } }
       })
     }
@@ -172,7 +173,7 @@ export default function LibraryDetailScreen() {
 
   const selectedPrayerData = useMemo(() => {
     if (!selectedPrayer || !isInstalled) return undefined
-    const asset = resolvePrayer(selectedPrayer, library?.id)
+    const asset = resolvePrayer(selectedPrayer, library?.id) ?? resolveCanticle(selectedPrayer)
     if (!asset) return undefined
     const bil = (text: Record<string, string>): BilingualText =>
       localizeBilingual(text, contentLanguage, secondaryLanguage)

--- a/content/libraries/base/practices/morning-offering/flow.json
+++ b/content/libraries/base/practices/morning-offering/flow.json
@@ -45,7 +45,7 @@
 		},
 		{
 			"type": "prayer",
-			"ref": "prayer-st-michael"
+			"ref": "st-michael"
 		},
 		{
 			"type": "prayer",


### PR DESCRIPTION
## Summary
This change enables canticles to be referenced as prayers in library flow definitions by updating the prayer resolution logic to fall back to canticle resolution when a prayer ID is not found.

## Key Changes
- **Import `resolveCanticle`** from the content registry in the library detail screen
- **Update prayer resolution logic** in two locations to use a fallback pattern: `resolvePrayer(pid, library.id) ?? resolveCanticle(pid)`
  - Applied to the prayer list generation
  - Applied to the selected prayer data resolution
- **Update morning offering flow** to reference "st-michael" instead of "prayer-st-michael", allowing it to resolve as a canticle

## Implementation Details
The change uses the nullish coalescing operator (`??`) to attempt prayer resolution first, then fall back to canticle resolution if the prayer is not found. This maintains backward compatibility with existing prayer references while enabling canticles to be used interchangeably in flow definitions.

https://claude.ai/code/session_01TZydtKs512kSdXZmnkD8Gq