### PR TITLE
Add source stack documentation for Catechism of Pius X

### DIFF
--- a/docs/features/catechism-pius-x/README.md
+++ b/docs/features/catechism-pius-x/README.md
@@ -1,0 +1,80 @@
+# Catechism of Pius X — Catechetical Formation Track
+
+A 90-day formation practice teaching the Catechism of Pius X (1912) through one daily session per topical cluster, anchored by a sacred-art image and a pastoral commentary adapted from Aquinas's Naples Lent sermons (1273).
+
+Format inspired by Pe. Eugênio Fornasari's *Na Escola de Jesus* — image + Q&A + pastoral teaching + Scripture + closing — but built from public-domain sources only.
+
+## Spine
+
+**Catecismo da Doutrina Cristã (1912)** — Pius X's universal catechism, 433 Qs, four pillars: Creed, Sacraments, Decalogue, Lord's Prayer (+ virtues).
+
+PT-BR canonical text: Montfort. See `sources/README.md`.
+
+## 90 sessions
+
+| Pillar | Sessions | Pius X Qs |
+|---|---|---|
+| Lição Preliminar | 2 | ~8 |
+| Credo | 32 | ~170 |
+| Mandamentos | 18 | ~80 |
+| Sacramentos | 22 | ~110 |
+| Pai Nosso + Ave Maria | 10 | ~35 |
+| Virtudes + conclusão | 6 | ~30 |
+| **Total** | **90** | **~433** |
+
+Every Pius X Q is covered. Sessions cluster adjacent Qs by topical focus, following Pius X's own section structure.
+
+## Daily session shape
+
+| Element | Length | Source |
+|---|---|---|
+| Image | full-bleed | PD sacred art (Wikimedia / museum APIs) |
+| Image ekphrasis | ~50 words | Ours |
+| Pius X Qs (cluster) | ~50 words | Pius X 1912 verbatim |
+| Pastoral commentary | ~250 words | Aquinas Naples sermons (adapted) |
+| Scripture | ~30 words | Pius X's footnoted citations |
+| Closing | ~30 words | Ours |
+
+Authorial surface across the whole track: ~80 words/session × 90 ≈ 7,200 words. The doctrinal substance is borrowed; the pastoral framing is ours.
+
+Optional deep-dive layer (later): full Trent passages, Spirago excerpts, Catecismo Maggiore (1905) parallels.
+
+## Commentary source per pillar
+
+| Pillar | Source | Status |
+|---|---|---|
+| Credo | Aquinas, *On the Apostles' Creed* (Collins 1939) | **In scope** |
+| Mandamentos | Aquinas, *On the Ten Commandments* (Collins 1939) | **In scope** |
+| Pai Nosso | Aquinas, *On the Lord's Prayer* (Collins 1939) | **In scope** |
+| Ave Maria | Aquinas, *On the Angelic Salutation* (Collins 1939) | **In scope** |
+| Sacramentos | TBD — Aquinas's Naples cycle has no sacramental sermons | **Deferred** |
+| Virtudes | TBD — no committed source yet | **Deferred** |
+
+Aquinas covers ~62 of the 90 sessions in the confirmed scope. Sacraments and Virtues commentary will be addressed later.
+
+## Phases
+
+1. **Phase 0 — Source assembly.** All PD downloads. See `sources/README.md`.
+2. **Phase 1 — Clustering.** Map Pius X's 433 Qs into 90 topical sessions following Pius X's own section structure. Produces `clustering.md`.
+3. **Phase 2 — Pilot.** One end-to-end session (Creed Article 1, *I believe in God*) — image, ekphrasis, commentary, Scripture, closing, EN + PT-BR. Surfaces every format decision.
+4. **Phase 3 — Resolve deferred gaps.** Sacraments + Virtues commentary sourcing.
+5. **Phase 4 — Four more pilot sessions.** One per pillar, format stress-tested.
+6. **Phase 5 — Theological review of pilots.** Find a competent reviewer; iterate.
+7. **Phase 6 — Full authoring.** ~7–10 sessions/week.
+8. **Phase 7 — Image curation.** ~90 PD images, parallel with Phase 6.
+9. **Phase 8 — Spec + engineering.** `flow.json`, deep-dive toggle, library packaging.
+10. **Phase 9 — Beta + iterate.**
+
+## Status
+
+- ✅ Spine + commentary sources for ~62 sessions identified
+- ✅ PT-BR Pius X 1912 chosen (Montfort)
+- ⏳ Sacraments commentary — deferred
+- ⏳ Virtues commentary — deferred
+- ⏳ Phase 1 clustering — next concrete step
+
+## Files
+
+- `README.md` — this file
+- `sources/README.md` — verified PD sources, URLs, license status
+- `clustering.md` — Pius X → 90-session map (not yet written)

--- a/docs/features/catechism-pius-x/sources/README.md
+++ b/docs/features/catechism-pius-x/sources/README.md
@@ -1,0 +1,207 @@
+# Catechism of Pius X — Source Stack
+
+All sources for the planned catechetical formation track. Every entry lists the URL, license/PD status, and what role it plays in the daily session.
+
+## Spine — Pius X 1912 (433 Qs)
+
+The text quoted verbatim in every session.
+
+### Italian original — *Catechismo della Dottrina Cristiana* (1912)
+
+| URL | Notes |
+|---|---|
+| https://www.maranatha.it/catpiox/01page.htm | Online HTML edition, browsable by section |
+| https://www.vatican.va/holy_father/pius_x/index_it.htm | Vatican holdings (text scattered) |
+| https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana | Wikisource — full text |
+
+**License:** Public domain. Issued by Pius X (d. 1914), Holy See document.
+
+### Portuguese — primary
+
+| URL | Notes |
+|---|---|
+| https://www.montfort.org.br/bra/documentos/catecismo/catecismo_s_pio_x/ | **Primary.** Montfort Cultural Association, longstanding traditional Brazilian Catholic site, browsable HTML, faithful translation of the 1912 |
+| https://img.cancaonova.com/noticias/pdf/277444_CatecismoSaoPioX.pdf | Canção Nova PDF — backup |
+| https://symposiumveritatis.blogspot.com/2022/10/catecismo-da-doutrina-crista-1912.html | Symposium Veritatis blog — explicitly the 1912 |
+
+**License:** Public domain (underlying text). Brazilian editions vary in translation; Montfort is the standard reference.
+
+### Decision
+
+**Use Montfort's PT-BR as the canonical text.** Cross-reference with the Italian (maranatha.it) and Wikisource Italian where phrasing matters.
+
+---
+
+## Primary commentary — Aquinas's Naples Lent sermons (1273)
+
+Pastoral preaching cycle. Used for ~68 of the 90 sessions.
+
+### Joseph B. Collins translation (1939) — main English source
+
+| URL | Status |
+|---|---|
+| https://www.documentacatholicaomnia.eu/03d/1225-1274,_Thomas_Aquinas,_Catechismus,_EN.pdf | **Primary download.** Full PDF |
+| https://archive.org/details/catecheticalinst0000thom | Internet Archive scan, original 1939 |
+| https://archive.org/stream/TheCatecheticalInstructionsAquinasSt.Thomas4547/The%20Catechetical%20Instructions%20-%20Aquinas%2C%20St.%20Thomas_4547_djvu.txt | Plain-text version |
+| https://www.intratext.com/IXT/ENG0029/ | IntraText with searchable concordance |
+
+**Includes:**
+- *On the Apostles' Creed* (Creed sermons, 12 articles)
+- *On the Lord's Prayer* (Pater Noster, 7 petitions)
+- *On the Angelic Salutation* (Hail Mary)
+- *On the Ten Commandments* (Decalogue sermons)
+- *Explanation of the Seven Sacraments* (the *De articulis fidei* schematic — confirmed present, but **not pastoral**; not used as base commentary)
+
+**License:** Public domain. Imprimatur 1939, Archbishop Curley of Baltimore. US copyright not renewed; widely re-hosted.
+
+### Father H.A. Rawes translation (1880) — for Two Precepts of Charity
+
+The Collins translation may not include the *Two Commandments of Charity* prologue. The Rawes 1880 translation explicitly contains both parts of Aquinas's unified work *De duobus praeceptis caritatis et decem legis praeceptis*.
+
+| URL | Status |
+|---|---|
+| https://archive.org/details/AquinasOnTheCommandments | **Primary download.** Internet Archive scan |
+
+**License:** Public domain (1880).
+
+**Use for:** ~6 sessions on Charity / Virtues (Pius X Part V). Contains Aquinas's pastoral exposition of the love of God and love of neighbor as the foundation of the law.
+
+### Latin originals (for verification / re-translation)
+
+| URL | Notes |
+|---|---|
+| https://www.corpusthomisticum.org/iopera.html | Corpus Thomisticum — Aquinas's complete works, critical Leonine text |
+| https://isidore.co/aquinas/ | Aquinas index, individual works browsable |
+
+---
+
+## Sacraments commentary — Roman Catechism (Trent, 1566)
+
+Used for ~22 sessions on the Sacraments where Aquinas's pastoral preaching has no counterpart.
+
+### McHugh & Callan translation (1923) — primary English
+
+| URL | Status |
+|---|---|
+| https://www.saintsbooks.net/books/The%20Roman%20Catechism.pdf | **Primary download.** Full PDF |
+| https://en.wikisource.org/wiki/The_Catechism_of_the_Council_of_Trent | Wikisource, full text by Part |
+| https://en.wikisource.org/wiki/The_Catechism_of_the_Council_of_Trent/Part_2 | Part 2 — The Sacraments (the section we need) |
+
+**Use:** Part 2 (The Sacraments) for the 22 Sacrament sessions.
+
+**License:** Public domain. Translation 1923, US PD.
+
+### Portuguese translation
+
+| URL | Notes |
+|---|---|
+| https://www.baixelivros.com.br/religiao/catecismo-romano | **Primary candidate.** PT-BR PDF, 728 pp |
+| https://archive.org/details/catecismo-romano-concilio-de-trento | Internet Archive PT-BR scan |
+| http://www.obrascatolicas.com/livros/Catecismo/Catecismo%20Romano%20Sao%20Pio%20V%20Ed%20Servico%20de%20Animacao%20Eucaristica%20Mariana.pdf | Direct PDF (Servico de Animação Eucarística Mariana edition, 1950 lineage) |
+| https://amzn.com.br/Catecismo-Romano-Concílio-Trento/dp/8564734133 | Print only (Editora Castela), if reference copy needed |
+
+**Status:** Need to verify translator's death date — Brazilian copyright = life + 70. If the 1950 translator died before 1956, the PT-BR translation is PD now. If later, the McHugh-Callan English is still our safe path (translate fresh to PT-BR). Underlying Latin Trent (1566) is unambiguously PD.
+
+**Action item:** identify the translator of the 1950 Servico de Animação Eucarística Mariana edition + their death date. If unverifiable within reasonable effort, default to fresh translation from McHugh-Callan English.
+
+---
+
+## Sacraments alignment — Hagan, *Compendium of Catechetical Instruction* (1910/1928)
+
+**Role:** Alignment-only. Not commentary content. We use Hagan to know "Pius X Q #X corresponds to which Trent passage." Once we have that mapping, we pull commentary text from McHugh-Callan directly.
+
+| URL | Status |
+|---|---|
+| https://archive.org/details/compendiumofcate0004revm | Volume IV — On Prayer (confirmed) |
+| https://archive.org/details/bwb_P8-BYD-166 | Vol — Commandments Part II (confirmed) |
+| https://archive.org/search.php?query=hagan+compendium+catechetical | Search for remaining volumes (Creed, Sacraments) — **GATING ITEM** |
+| https://www.basilica.ca/documents/2016/10/Msgr.%20Hagan-The%20Catechism%20of%20Saint%20Pope%20Pius%20X.pdf | Pius X portion only |
+
+**Action item:** Verify all 4 volumes are accessible online before relying on Hagan for the Sacraments mapping. If the Sacraments volume is hard to source, we map directly from McHugh-Callan to Pius X ourselves (more work, no gating).
+
+**License:** Public domain. Hagan died 1930 (life + 70 expired in EU/Brazil 2001; 1910 + 1928 editions PD in US).
+
+---
+
+## Aquinas Eucharistic hymns — closing material
+
+For the Eucharist sessions specifically, used as devotional closing fragments. Not commentary — they're poetry.
+
+### Pange Lingua (incl. Tantum Ergo as final stanzas)
+- https://en.wikipedia.org/wiki/Pange_lingua_gloriosi_corporis_mysterium
+- https://en.wikisource.org/wiki/Pange_Lingua_(Aquinas)
+
+### Adoro Te Devote
+- https://en.wikipedia.org/wiki/Adoro_te_devote
+- https://en.wikisource.org/wiki/Adoro_te_devote
+
+### Lauda Sion
+- https://en.wikipedia.org/wiki/Lauda_Sion
+
+### Verbum Supernum (incl. O Salutaris Hostia as final stanzas)
+- https://en.wikipedia.org/wiki/Verbum_supernum_prodiens
+
+### Sacris Solemniis (incl. Panis Angelicus as one stanza)
+- https://en.wikipedia.org/wiki/Sacris_solemniis
+
+**License:** All public domain. Aquinas died 1274; standard English translations from 19th century are PD (Edward Caswall 1849, John Mason Neale 1854, etc.).
+
+**Brazilian Portuguese:** Multiple PD translations available (Hinário Gregoriano, Liber Usualis Português editions). Verify per hymn.
+
+---
+
+## Image corpus — PD sacred art
+
+For the 90 daily images.
+
+| Source | Notes |
+|---|---|
+| https://commons.wikimedia.org/wiki/Category:Christian_art | Wikimedia Commons — vast PD sacred art |
+| https://www.metmuseum.org/art/the-collection | Met Open Access (CC0) — searchable |
+| https://www.rijksmuseum.nl/en/rijksstudio | Rijksmuseum — open access |
+| https://www.nga.gov/open-access-images.html | National Gallery of Art DC |
+| https://www.wga.hu/index.html | Web Gallery of Art — curated, well-organized |
+
+**Usage:** All public domain or CC0. Image selection is curatorial work, not licensing work.
+
+---
+
+## Optional deep-dive layers (later)
+
+### Spirago, *The Catechism Explained* (1899)
+
+| URL | Notes |
+|---|---|
+| https://archive.org/details/catechismexplain00spiruoft | Internet Archive — full scan |
+| https://catecismopopular.blogspot.com/ | Partial PT-BR digitization (Bivar 1944 lineage) |
+
+**Use:** One quoted excerpt per session as deep-dive (anecdote, patristic citation, example). Not as primary commentary.
+
+### Catechismo Maggiore (1905)
+
+| URL | Notes |
+|---|---|
+| https://www.maranatha.it/catpiox/01page.htm | Italian, full text |
+| https://archive.org/details/catecismo-maior-de-sc3a3o-pio-x | PT-BR scan |
+
+**Use:** Optional deep-dive — "Pius X's longer earlier exposition of the same doctrine."
+
+---
+
+## Status summary
+
+| Item | Status |
+|---|---|
+| Pius X 1912 PT-BR — canonical text | **Decided: Montfort** |
+| Aquinas Catechetical Instructions — Collins PDF | Verified URL |
+| Aquinas Two Precepts — Rawes 1880 | Verified URL |
+| Roman Catechism — McHugh-Callan PDF | Verified URL |
+| Roman Catechism PT-BR | **Candidate found** (baixelivros, 1950 lineage) — verify translator death date |
+| Hagan Compendium — Sacraments volume | **Gating item — Sacraments volume not located on Internet Archive yet** |
+| Aquinas hymns (5) | Verified URLs |
+| PD sacred art corpus | Available, no curation yet |
+
+**Next concrete actions:**
+1. Verify Hagan Sacraments vol on Internet Archive
+2. Decide PT translation strategy for Trent (find PD translation OR translate fresh)
+3. Begin Phase 1: cluster Pius X 1912 into 90 sessions

--- a/docs/features/catechism-pius-x/sources/README.md
+++ b/docs/features/catechism-pius-x/sources/README.md
@@ -54,18 +54,6 @@ Pastoral preaching cycle. Used for ~68 of the 90 sessions.
 
 **License:** Public domain. Imprimatur 1939, Archbishop Curley of Baltimore. US copyright not renewed; widely re-hosted.
 
-### Father H.A. Rawes translation (1880) — for Two Precepts of Charity
-
-The Collins translation may not include the *Two Commandments of Charity* prologue. The Rawes 1880 translation explicitly contains both parts of Aquinas's unified work *De duobus praeceptis caritatis et decem legis praeceptis*.
-
-| URL | Status |
-|---|---|
-| https://archive.org/details/AquinasOnTheCommandments | **Primary download.** Internet Archive scan |
-
-**License:** Public domain (1880).
-
-**Use for:** ~6 sessions on Charity / Virtues (Pius X Part V). Contains Aquinas's pastoral exposition of the love of God and love of neighbor as the foundation of the law.
-
 ### Latin originals (for verification / re-translation)
 
 | URL | Notes |
@@ -123,33 +111,6 @@ Used for ~22 sessions on the Sacraments where Aquinas's pastoral preaching has n
 
 ---
 
-## Aquinas Eucharistic hymns — closing material
-
-For the Eucharist sessions specifically, used as devotional closing fragments. Not commentary — they're poetry.
-
-### Pange Lingua (incl. Tantum Ergo as final stanzas)
-- https://en.wikipedia.org/wiki/Pange_lingua_gloriosi_corporis_mysterium
-- https://en.wikisource.org/wiki/Pange_Lingua_(Aquinas)
-
-### Adoro Te Devote
-- https://en.wikipedia.org/wiki/Adoro_te_devote
-- https://en.wikisource.org/wiki/Adoro_te_devote
-
-### Lauda Sion
-- https://en.wikipedia.org/wiki/Lauda_Sion
-
-### Verbum Supernum (incl. O Salutaris Hostia as final stanzas)
-- https://en.wikipedia.org/wiki/Verbum_supernum_prodiens
-
-### Sacris Solemniis (incl. Panis Angelicus as one stanza)
-- https://en.wikipedia.org/wiki/Sacris_solemniis
-
-**License:** All public domain. Aquinas died 1274; standard English translations from 19th century are PD (Edward Caswall 1849, John Mason Neale 1854, etc.).
-
-**Brazilian Portuguese:** Multiple PD translations available (Hinário Gregoriano, Liber Usualis Português editions). Verify per hymn.
-
----
-
 ## Image corpus — PD sacred art
 
 For the 90 daily images.
@@ -194,11 +155,9 @@ For the 90 daily images.
 |---|---|
 | Pius X 1912 PT-BR — canonical text | **Decided: Montfort** |
 | Aquinas Catechetical Instructions — Collins PDF | Verified URL |
-| Aquinas Two Precepts — Rawes 1880 | Verified URL |
 | Roman Catechism — McHugh-Callan PDF | Verified URL |
 | Roman Catechism PT-BR | **Candidate found** (baixelivros, 1950 lineage) — verify translator death date |
 | Hagan Compendium — Sacraments volume | **Gating item — Sacraments volume not located on Internet Archive yet** |
-| Aquinas hymns (5) | Verified URLs |
 | PD sacred art corpus | Available, no curation yet |
 
 **Next concrete actions:**


### PR DESCRIPTION
## Summary
This PR adds comprehensive source documentation for the planned Catechism of Pius X catechetical formation track. The document establishes the canonical texts, primary commentaries, and supporting materials needed for the 90-session curriculum.

## Key Changes
- **Canonical text selection:** Designates Montfort's Portuguese (PT-BR) translation of the 1912 Catechism as the primary text, with Italian sources (maranatha.it, Wikisource) as cross-references
- **Primary commentary stack:** Documents Joseph B. Collins's 1939 English translation of Aquinas's Naples Lent sermons (covering ~68 of 90 sessions) with multiple verified source URLs
- **Sacraments commentary:** Identifies McHugh & Callan's 1923 Roman Catechism translation as the secondary commentary for ~22 Sacrament-focused sessions
- **Alignment mapping:** Establishes Hagan's *Compendium of Catechetical Instruction* (1910/1928) as the reference for correlating Pius X questions to Trent passages
- **Optional layers:** Lists Spirago's *The Catechism Explained* (1899) and the *Catechismo Maggiore* (1905) as optional deep-dive sources
- **Image sourcing:** Documents public domain and CC0 sacred art repositories (Wikimedia Commons, Met, Rijksmuseum, etc.) for the 90 daily images

## Notable Implementation Details
- All primary sources verified as public domain or with confirmed licensing status
- Portuguese translation strategy documented with action item to verify copyright status of 1950 Servico de Animação Eucarística Mariana edition
- Gating item identified: Hagan's Sacraments volume availability on Internet Archive requires verification before finalizing the alignment mapping approach
- Fallback strategy documented: if Hagan Sacraments volume unavailable, direct mapping from McHugh-Callan to Pius X will be performed
- Next concrete actions listed for Phase 1 implementation (session clustering, translation decisions, curation)

https://claude.ai/code/session_017M3Hy6NVeXnb9ymfmaujXZ