### PR TITLE
Fix image rendering in catechetical formation book and practice

### DIFF
--- a/apps/app/src/components/prayer/ProseBlock.test.ts
+++ b/apps/app/src/components/prayer/ProseBlock.test.ts
@@ -284,6 +284,32 @@ describe('parseMarkdown', () => {
     ])
   })
 
+  it('parses standalone markdown image as image node', () => {
+    const result = parseMarkdown(
+      '![The Creation of the Sun, Moon, and Plants](../images/session-001.jpg)',
+    )
+    expect(result).toEqual([
+      {
+        type: 'image',
+        alt: 'The Creation of the Sun, Moon, and Plants',
+        src: '../images/session-001.jpg',
+      },
+    ])
+  })
+
+  it('parses image followed by italic attribution', () => {
+    const input =
+      '![alt](../images/session-001.jpg)\n*Michelangelo Buonarroti, The Creation (1508-1512). Public Domain.*'
+    const result = parseMarkdown(input)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual({
+      type: 'image',
+      alt: 'alt',
+      src: '../images/session-001.jpg',
+    })
+    expect(result[1].type).toBe('paragraph')
+  })
+
   it('strips footnotes from blockquotes', () => {
     const result = parseMarkdown('> A quote with ref [^2]')
     expect(result).toEqual([

--- a/apps/app/src/components/prayer/ProseBlock.tsx
+++ b/apps/app/src/components/prayer/ProseBlock.tsx
@@ -4,6 +4,7 @@ import { Fragment } from 'react'
 import { Text as RNText } from 'react-native'
 import { Text, YStack } from 'tamagui'
 import { bodyFont } from '@/config/fonts'
+import { ImageBlock } from './ImageBlock'
 import type { InlineNode } from './parseMarkdown'
 import { parseMarkdown } from './parseMarkdown'
 
@@ -121,6 +122,8 @@ export function ProseBlock({ text }: { text: BilingualText }) {
                 ))}
               </YStack>
             )
+          case 'image':
+            return <ImageBlock key={i} src={node.src} />
           default:
             return (
               <Text key={i} fontFamily="$body" fontSize="$3" color="$color">

--- a/apps/app/src/components/prayer/parseMarkdown.ts
+++ b/apps/app/src/components/prayer/parseMarkdown.ts
@@ -3,6 +3,7 @@ export type ProseNode =
   | { type: 'heading'; level: number; text: string }
   | { type: 'blockquote'; children: InlineNode[] }
   | { type: 'list'; ordered: boolean; items: InlineNode[][] }
+  | { type: 'image'; src: string; alt: string }
 
 export type InlineNode =
   | { type: 'text'; text: string }
@@ -112,6 +113,14 @@ export function parseMarkdown(markdown: string): ProseNode[] {
 
     // Non-blockquote line ends any blockquote run
     flushBlockquote()
+
+    const imageMatch = trimmed.match(/^!\[([^\]]*)\]\(([^)]+)\)$/)
+    if (imageMatch) {
+      flushParagraph()
+      flushList()
+      nodes.push({ type: 'image', alt: imageMatch[1], src: imageMatch[2] })
+      continue
+    }
 
     const headingMatch = trimmed.match(/^(#{1,3})\s+(.+)$/)
     if (headingMatch) {

--- a/apps/app/src/content/sources/filesystem.ts
+++ b/apps/app/src/content/sources/filesystem.ts
@@ -189,6 +189,13 @@ async function readTextFile(path: string): Promise<string | undefined> {
   }
 }
 
+function rewriteMarkdownImagePaths(md: string, bookDirUri: string): string {
+  return md.replace(
+    /(!\[[^\]]*\]\()(\.\.\/images\/[^)\s]+)(\))/g,
+    (_m, open, rel, close) => `${open}${bookDirUri}${rel.slice(3)}${close}`,
+  )
+}
+
 function rewriteImagePaths(sections: FlowSection[], baseUri: string): void {
   for (const section of sections) {
     if (section.type === 'image' && section.src && !section.src.startsWith('file://')) {
@@ -319,7 +326,10 @@ export async function createFileSystemSource(libraryDirUri: string): Promise<Con
     getProseText: (filePath) => proseTexts.get(filePath),
     getBookEntry: (id) => bookEntries[id],
     getAllBookEntries: () => allBookEntries,
-    loadBookChapterText: (bookId, chapterId, lang) =>
-      readTextFile(`${libraryDirUri}books/${bookId}/${lang}/${chapterId}.md`),
+    loadBookChapterText: async (bookId, chapterId, lang) => {
+      const bookDirUri = `${libraryDirUri}books/${bookId}/`
+      const md = await readTextFile(`${bookDirUri}${lang}/${chapterId}.md`)
+      return md ? rewriteMarkdownImagePaths(md, bookDirUri) : undefined
+    },
   }
 }

--- a/apps/app/src/content/sources/idb.ts
+++ b/apps/app/src/content/sources/idb.ts
@@ -109,6 +109,13 @@ function collectProseFiles(sections: FlowSection[]): string[] {
   return files
 }
 
+function rewriteMarkdownImagePaths(md: string, bookDirUri: string): string {
+  return md.replace(
+    /(!\[[^\]]*\]\()(\.\.\/images\/[^)\s]+)(\))/g,
+    (_m, open, rel, close) => `${open}${bookDirUri}${rel.slice(3)}${close}`,
+  )
+}
+
 function rewriteImagePaths(sections: FlowSection[], basePath: string): void {
   for (const section of sections) {
     if (section.type === 'image' && section.src && !section.src.startsWith('data:')) {
@@ -244,8 +251,11 @@ export async function createIdbSource(libraryId: string): Promise<ContentSource>
     getProseText: (filePath) => proseTexts.get(filePath),
     getBookEntry: (id) => bookEntries[id],
     getAllBookEntries: () => allBookEntries,
-    loadBookChapterText: (bookId, chapterId, lang) =>
-      idbReadText(`${bookDirPath}books/${bookId}/${lang}/${chapterId}.md`),
+    loadBookChapterText: async (bookId, chapterId, lang) => {
+      const bookDirUri = `idb://${bookDirPath}books/${bookId}/`
+      const md = await idbReadText(`${bookDirPath}books/${bookId}/${lang}/${chapterId}.md`)
+      return md ? rewriteMarkdownImagePaths(md, bookDirUri) : undefined
+    },
   }
 }
 

--- a/apps/app/src/features/libraries/bookReader.ts
+++ b/apps/app/src/features/libraries/bookReader.ts
@@ -358,6 +358,38 @@ function mimeForExt(filename: string): string {
   return 'image/jpeg'
 }
 
+// Scan chapter HTML for <img src="..."> values, skipping data: URIs already inlined.
+function collectImgSrcs(htmls: Iterable<string>): string[] {
+  const srcs = new Set<string>()
+  const re = /<img\b[^>]*\bsrc=["']([^"']+)["']/gi
+  for (const html of htmls) {
+    let m = re.exec(html)
+    while (m !== null) {
+      const src = m[1]
+      if (!src.startsWith('data:')) srcs.add(src)
+      m = re.exec(html)
+    }
+  }
+  return [...srcs]
+}
+
+// Resolve a chapter-relative src ("../images/foo.jpg" or "images/foo.jpg") against
+// the book directory. Returns the path under bookDirUri (no scheme).
+function resolveImgSrc(src: string, bookDirUri: string): string {
+  const rel = src.startsWith('../') ? src.slice(3) : src
+  return `${bookDirUri}${rel}`
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  const chunkSize = 0x8000
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize)
+    binary += String.fromCharCode.apply(null, chunk as unknown as number[])
+  }
+  return btoa(binary)
+}
+
 export async function loadBookContent(
   bookDirUri: string,
   lang: string,
@@ -374,7 +406,7 @@ async function loadBookContentNative(
   lang: string,
   chapterIds: string[],
 ): Promise<BookContent> {
-  const { Directory: Dir, File: NativeFile } = nativeFs
+  const { File: NativeFile } = nativeFs
   const langDir = `${bookDirUri}${lang}/`
 
   // Read stylesheet
@@ -400,21 +432,18 @@ async function loadBookContentNative(
     }),
   )
 
-  // Read images (filter by extension to avoid non-image files like manifest.json)
+  // Inline only images actually referenced by chapter HTML; avoids relying on
+  // Directory.list(), which has been unreliable on iOS.
   const images = new Map<string, string>()
-  try {
-    const imagesDir = new Dir(`${bookDirUri}images`)
-    const entries = imagesDir.list()
-    await Promise.all(
-      entries
-        .filter((entry: any) => /\.(jpg|jpeg|png|gif|webp|svg)$/i.test(entry.name ?? ''))
-        .map(async (file: any) => {
-          const b64 = await file.base64()
-          const dataUri = `data:${mimeForExt(file.name)};base64,${b64}`
-          images.set(`images/${file.name}`, dataUri)
-        }),
-    )
-  } catch {}
+  await Promise.all(
+    collectImgSrcs(chapters.values()).map(async (src) => {
+      try {
+        const absPath = resolveImgSrc(src, bookDirUri)
+        const b64 = await new NativeFile(absPath).base64()
+        images.set(src, `data:${mimeForExt(absPath)};base64,${b64}`)
+      } catch {}
+    }),
+  )
 
   return { css, chapters, images }
 }
@@ -424,7 +453,7 @@ async function loadBookContentWeb(
   lang: string,
   chapterIds: string[],
 ): Promise<BookContent> {
-  const { idbReadText } = await import('@/lib/idb-fs')
+  const { idbReadText, idbReadBinary } = await import('@/lib/idb-fs')
 
   // bookDirUri is like "idb://books/libraryId/" — strip the idb:// prefix
   const basePath = bookDirUri.replace(/^idb:\/\//, '')
@@ -451,10 +480,19 @@ async function loadBookContentWeb(
     }),
   )
 
-  // Images: read from IDB as binary, convert to data URIs
-  // We don't have a directory listing in IDB, so we skip image preloading on web
-  // Images referenced in HTML will need to be resolved differently
+  // IDB has no directory listing, so resolve only the images the chapters reference.
   const images = new Map<string, string>()
+  await Promise.all(
+    collectImgSrcs(chapters.values()).map(async (src) => {
+      try {
+        const absPath = resolveImgSrc(src, basePath)
+        const bytes = await idbReadBinary(absPath)
+        if (!bytes) return
+        const b64 = bytesToBase64(bytes)
+        images.set(src, `data:${mimeForExt(absPath)};base64,${b64}`)
+      } catch {}
+    }),
+  )
 
   return { css, chapters, images }
 }


### PR DESCRIPTION
Two paths were broken on iOS:

1. Book reader (WebView) showed alt text only because Directory.list()
   on the images/ folder has been unreliable, leaving the data-URI
   replacement map empty. Switch to scanning each chapter's HTML for
   <img src> values and reading those files directly via NativeFile.
   Same approach also fixes images on web (no IDB directory listing
   needed) so loadBookContentWeb now inlines images too.

2. Practice ('prose' with book/chapter ref) rendered raw markdown
   ![alt](path) text because parseMarkdown and ProseBlock had no
   image node type. Add an image node and render it via the existing
   ImageBlock component. Rewrite ../images/* refs to absolute
   file:// (native) or idb:// (web) URIs in loadBookChapterText so
   useResolvedImageUri can resolve them.