### PR TITLE
Practice prose images: natural aspect ratio + tap-to-zoom

### DIFF
--- a/apps/app/src/components/prayer/ImageBlock.tsx
+++ b/apps/app/src/components/prayer/ImageBlock.tsx
@@ -1,5 +1,6 @@
 import type { BilingualText } from '@ember/content-engine'
-import { Image } from 'expo-image'
+import { Image, type ImageLoadEventData } from 'expo-image'
+import { useState } from 'react'
 import { Pressable, StyleSheet, useWindowDimensions } from 'react-native'
 import { Text, YStack } from 'tamagui'
 import { useImageViewer } from '@/components/ImageViewerContext'
@@ -18,6 +19,13 @@ export function ImageBlock({
   const imageWidth = Math.min(width - 96, 500)
   const { openViewer } = useImageViewer()
   const resolvedSrc = useResolvedImageUri(src)
+  const [aspectRatio, setAspectRatio] = useState(1)
+
+  const onLoad = (event: ImageLoadEventData) => {
+    const w = event.source?.width
+    const h = event.source?.height
+    if (w && h) setAspectRatio(w / h)
+  }
 
   return (
     <YStack alignItems="center" gap="$xs" paddingVertical="$sm">
@@ -34,8 +42,9 @@ export function ImageBlock({
       >
         <Image
           source={{ uri: resolvedSrc }}
-          style={[styles.image, { width: imageWidth, height: imageWidth * 1.2 }]}
+          style={[styles.image, { width: imageWidth, aspectRatio }]}
           contentFit="contain"
+          onLoad={onLoad}
         />
       </Pressable>
       {caption && (

--- a/apps/app/src/features/practices/components/PracticeFlow.tsx
+++ b/apps/app/src/features/practices/components/PracticeFlow.tsx
@@ -22,6 +22,7 @@ import {
   ScreenLayout,
   Threshold,
 } from '@/components'
+import { ImageViewerProvider } from '@/components/ImageViewerContext'
 import { SectionBlock } from '@/components/SectionBlock'
 import { createEngineContext } from '@/content/engineContext'
 import {
@@ -366,8 +367,7 @@ export function PracticeFlow({
             }
             if (manifest?.program) {
               const isFinalDay =
-                programProgress &&
-                programProgress.completionCount + 1 >= manifest.program.totalDays
+                programProgress && programProgress.completionCount + 1 >= manifest.program.totalDays
               if (isFinalDay) {
                 await handleProgramCompletion.mutateAsync({
                   practiceId,
@@ -392,96 +392,98 @@ export function PracticeFlow({
   }
 
   return (
-    <ScreenLayout>
-      <YStack gap="$lg" paddingVertical="$lg">
-        <YStack alignItems="center">
-          <Pressable
-            onPress={() => router.push('/')}
-            hitSlop={12}
-            accessibilityRole="link"
-            accessibilityLabel={t('a11y.home')}
-          >
-            <Home size={20} color={theme.colorSecondary.val} />
-          </Pressable>
+    <ImageViewerProvider>
+      <ScreenLayout>
+        <YStack gap="$lg" paddingVertical="$lg">
+          <YStack alignItems="center">
+            <Pressable
+              onPress={() => router.push('/')}
+              hitSlop={12}
+              accessibilityRole="link"
+              accessibilityLabel={t('a11y.home')}
+            >
+              <Home size={20} color={theme.colorSecondary.val} />
+            </Pressable>
+          </YStack>
+
+          <ManuscriptFrame>
+            <YStack
+              alignItems="center"
+              gap="$xs"
+              paddingVertical="$md"
+              paddingHorizontal={readingMargin}
+            >
+              {manifest.theme !== 'office' && (
+                <Text fontFamily="$display" fontSize="$5" color="$accent">
+                  ✠
+                </Text>
+              )}
+              <Text fontFamily="$display" fontSize="$5" color="$colorBurgundy">
+                {practiceName}
+              </Text>
+              <Text fontFamily="$heading" fontSize="$2" color="$colorSecondary" letterSpacing={1}>
+                {formattedDate}
+              </Text>
+            </YStack>
+
+            <YStack gap="$md">
+              {sections.map((section, index) => (
+                <PracticeSectionBlock
+                  key={`${section.type}-${index}`}
+                  section={section}
+                  psalmSlots={psalmResult.slots}
+                  bibleMap={bibleMap}
+                  cccMap={cccMap}
+                  bibleErrors={bibleErrors}
+                  cccErrors={cccErrors}
+                  onSelectOverride={handleSelectOverride}
+                />
+              ))}
+            </YStack>
+
+            <YStack paddingBottom="$lg" />
+          </ManuscriptFrame>
+
+          {manifest.completion !== 'manual' && (
+            <YStack paddingHorizontal={readingMargin}>
+              <AnimatedPressable
+                onPress={handleComplete}
+                disabled={logCompletionMutation.isPending}
+                accessibilityRole="button"
+                accessibilityLabel={t('office.markComplete')}
+              >
+                <YStack
+                  backgroundColor="$accent"
+                  borderRadius="$md"
+                  borderWidth={1}
+                  borderColor="$accentSubtle"
+                  paddingVertical="$md"
+                  alignItems="center"
+                  opacity={logCompletionMutation.isPending ? 0.6 : 1}
+                >
+                  <Text fontFamily="$heading" fontSize="$3" color="$background">
+                    {logCompletionMutation.isPending
+                      ? t('office.completing')
+                      : t('office.markComplete')}
+                  </Text>
+                </YStack>
+              </AnimatedPressable>
+            </YStack>
+          )}
         </YStack>
 
-        <ManuscriptFrame>
-          <YStack
-            alignItems="center"
-            gap="$xs"
-            paddingVertical="$md"
-            paddingHorizontal={readingMargin}
-          >
-            {manifest.theme !== 'office' && (
-              <Text fontFamily="$display" fontSize="$5" color="$accent">
-                ✠
-              </Text>
-            )}
-            <Text fontFamily="$display" fontSize="$5" color="$colorBurgundy">
-              {practiceName}
-            </Text>
-            <Text fontFamily="$heading" fontSize="$2" color="$colorSecondary" letterSpacing={1}>
-              {formattedDate}
-            </Text>
-          </YStack>
-
-          <YStack gap="$md">
-            {sections.map((section, index) => (
-              <PracticeSectionBlock
-                key={`${section.type}-${index}`}
-                section={section}
-                psalmSlots={psalmResult.slots}
-                bibleMap={bibleMap}
-                cccMap={cccMap}
-                bibleErrors={bibleErrors}
-                cccErrors={cccErrors}
-                onSelectOverride={handleSelectOverride}
-              />
-            ))}
-          </YStack>
-
-          <YStack paddingBottom="$lg" />
-        </ManuscriptFrame>
-
-        {manifest.completion !== 'manual' && (
-          <YStack paddingHorizontal={readingMargin}>
-            <AnimatedPressable
-              onPress={handleComplete}
-              disabled={logCompletionMutation.isPending}
-              accessibilityRole="button"
-              accessibilityLabel={t('office.markComplete')}
-            >
-              <YStack
-                backgroundColor="$accent"
-                borderRadius="$md"
-                borderWidth={1}
-                borderColor="$accentSubtle"
-                paddingVertical="$md"
-                alignItems="center"
-                opacity={logCompletionMutation.isPending ? 0.6 : 1}
-              >
-                <Text fontFamily="$heading" fontSize="$3" color="$background">
-                  {logCompletionMutation.isPending
-                    ? t('office.completing')
-                    : t('office.markComplete')}
-                </Text>
-              </YStack>
-            </AnimatedPressable>
-          </YStack>
+        {showCompleteModal && manifest?.program && (
+          <ProgramCompleteModal
+            practiceName={localizeContent(manifest.name)}
+            showRestart={manifest.program.completionBehavior === 'offer-restart'}
+            onRestart={() => {
+              restartProgramMutation.mutate({ practiceId }, { onSuccess: () => router.back() })
+            }}
+            onDone={() => router.back()}
+          />
         )}
-      </YStack>
-
-      {showCompleteModal && manifest?.program && (
-        <ProgramCompleteModal
-          practiceName={localizeContent(manifest.name)}
-          showRestart={manifest.program.completionBehavior === 'offer-restart'}
-          onRestart={() => {
-            restartProgramMutation.mutate({ practiceId }, { onSuccess: () => router.back() })
-          }}
-          onDone={() => router.back()}
-        />
-      )}
-    </ScreenLayout>
+      </ScreenLayout>
+    </ImageViewerProvider>
   )
 }
 


### PR DESCRIPTION
ImageBlock was forcing a 5:6 portrait container with contentFit="contain", which letterboxed wider images (e.g. the Renaissance artwork in the catechetical formation practice) with large empty margins above and below. Capture the loaded image's intrinsic dimensions via expo-image's onLoad and use aspectRatio so the container matches the image.

PracticeFlow wasn't wrapped in ImageViewerProvider, so tapping a prose image was a no-op. Wrap it like the chapter reader does so tap opens the existing fullscreen ImageViewer (which supports zoom).