### PR TITLE
Pass ordinalFem when formatting OT-II weekday names

### DIFF
--- a/packages/liturgical/src/dayName.ts
+++ b/packages/liturgical/src/dayName.ts
@@ -178,7 +178,13 @@ export function getLiturgicalDayName(
   const { week: rawWeek, dayOfWeek } = weekAndDay(otIIStart, d)
   const week = rawWeek + otIWeeks
   const ordinal = t(`ordinal.${week}`)
+  const ordinalFem = t(`ordinalFem.${week}`, { defaultValue: ordinal })
   const season = t('home.liturgicalDay.seasons.ordinaryTime')
   if (dayOfWeek === 0) return t('home.liturgicalDay.sundayOf', { ordinal, season })
-  return t('home.liturgicalDay.weekdayOf', { day: dayName(t, `${dayOfWeek}`), ordinal, season })
+  return t('home.liturgicalDay.weekdayOf', {
+    day: dayName(t, `${dayOfWeek}`),
+    ordinal,
+    ordinalFem,
+    season,
+  })
 }


### PR DESCRIPTION
The OT-II branch (after Pentecost, before Advent) built the
home.liturgicalDay.weekdayOf t() call inline and forgot ordinalFem.
The pt-BR template needs the feminine ordinal because Semana is
feminine, so titles rendered as 'Terça-Feira da {{ordinalFem}} Semana
do Tempo Comum'. Mirrors the formatWeekday helper used by the other
seasons, with defaultValue: ordinal so locales without ordinalFem
(e.g. en-US) keep working unchanged.