### PR TITLE
Enhance Extraordinary Form Mass structure and add missing fragments

### DIFF
--- a/content/libraries/base/practices/mass/flow.json
+++ b/content/libraries/base/practices/mass/flow.json
@@ -289,6 +289,9 @@
     "fragments/ef-canon-of-the-mass.json",
     "fragments/ef-communion-rite.json",
     "fragments/ef-dismissal.json",
-    "fragments/ef-last-gospel.json"
+    "fragments/ef-last-gospel.json",
+    "fragments/ef-lord-be-with-you.json",
+    "fragments/ef-asperges.json",
+    "fragments/ef-leonine-prayers.json"
   ]
 }

--- a/content/libraries/base/practices/mass/fragments/ef-asperges.json
+++ b/content/libraries/base/practices/mass/fragments/ef-asperges.json
@@ -2,181 +2,183 @@
   "fragments": {
     "ef-asperges": [
       {
-        "type": "heading",
-        "text": {
-          "en-US": "Asperges",
-          "pt-BR": "Aspersão"
-        }
-      },
-      {
-        "type": "rubric",
-        "text": {
-          "en-US": "Before the principal Mass on Sundays, the celebrant blesses water and sprinkles the altar, the clergy, and the people while the choir sings the Asperges (or Vidi Aquam in Eastertide).",
-          "pt-BR": "Antes da Missa principal aos domingos, o celebrante benze a água e asperge o altar, o clero e o povo, enquanto se canta o Asperges (ou Vidi Aquam no Tempo Pascal)."
-        }
-      },
-      {
-        "type": "select",
-        "on": "celebration.primary.season",
-        "default": "default",
-        "options": [
+        "type": "collapsible",
+        "title": {
+          "en-US": "Asperges (Sundays before principal Mass)",
+          "pt-BR": "Aspersão (domingos antes da Missa principal)"
+        },
+        "sections": [
           {
-            "id": "easter",
-            "label": {
-              "en-US": "Eastertide (Vidi Aquam)",
-              "pt-BR": "Tempo Pascal (Vidi Aquam)"
-            },
-            "sections": [
+            "type": "rubric",
+            "text": {
+              "en-US": "Before the principal Mass on Sundays, the celebrant blesses water and sprinkles the altar, the clergy, and the people while the choir sings the Asperges (or Vidi Aquam in Eastertide).",
+              "pt-BR": "Antes da Missa principal aos domingos, o celebrante benze a água e asperge o altar, o clero e o povo, enquanto se canta o Asperges (ou Vidi Aquam no Tempo Pascal)."
+            }
+          },
+          {
+            "type": "select",
+            "on": "celebration.primary.season",
+            "default": "default",
+            "options": [
               {
-                "type": "subheading",
-                "text": {
-                  "en-US": "Vidi Aquam",
-                  "pt-BR": "Vidi Aquam"
-                }
+                "id": "easter",
+                "label": {
+                  "en-US": "Eastertide (Vidi Aquam)",
+                  "pt-BR": "Tempo Pascal (Vidi Aquam)"
+                },
+                "sections": [
+                  {
+                    "type": "subheading",
+                    "text": {
+                      "en-US": "Vidi Aquam",
+                      "pt-BR": "Vidi Aquam"
+                    }
+                  },
+                  {
+                    "type": "prayer",
+                    "speaker": "priest",
+                    "inline": {
+                      "en-US": "I saw water flowing from the right side of the temple, alleluia: and all to whom that water came were saved, and they shall say: alleluia, alleluia.",
+                      "la": "Vidi aquam egrediéntem de templo, a látere dextro, allelúja: et omnes, ad quos pervénit aqua ista, salvi facti sunt, et dicent: allelúja, allelúja.",
+                      "pt-BR": "Vi a água que brotava do lado direito do templo, aleluia: e todos aqueles a quem chegou esta água foram salvos, e dirão: aleluia, aleluia."
+                    }
+                  },
+                  {
+                    "type": "prayer",
+                    "speaker": "all",
+                    "inline": {
+                      "en-US": "Praise the Lord, for He is good: for His mercy endureth for ever.\nGlory be to the Father, and to the Son, and to the Holy Spirit.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.",
+                      "la": "Confitémini Dómino, quóniam bonus: quóniam in sǽculum misericórdia ejus.\nGlória Patri, et Fílio, et Spirítui Sancto.\nSicut erat in princípio, et nunc, et semper, et in sǽcula sæculórum. Amen.",
+                      "pt-BR": "Louvai o Senhor, porque Ele é bom: porque a Sua misericórdia é eterna.\nGlória ao Pai, e ao Filho, e ao Espírito Santo.\nAssim como era no princípio, agora e sempre, por todos os séculos dos séculos. Amém."
+                    }
+                  },
+                  {
+                    "type": "rubric",
+                    "text": {
+                      "en-US": "The antiphon is then repeated:",
+                      "pt-BR": "Repete-se a antífona:"
+                    }
+                  },
+                  {
+                    "type": "prayer",
+                    "speaker": "priest",
+                    "inline": {
+                      "en-US": "I saw water flowing from the right side of the temple, alleluia: and all to whom that water came were saved, and they shall say: alleluia, alleluia.",
+                      "la": "Vidi aquam egrediéntem de templo, a látere dextro, allelúja: et omnes, ad quos pervénit aqua ista, salvi facti sunt, et dicent: allelúja, allelúja.",
+                      "pt-BR": "Vi a água que brotava do lado direito do templo, aleluia: e todos aqueles a quem chegou esta água foram salvos, e dirão: aleluia, aleluia."
+                    }
+                  }
+                ]
               },
               {
-                "type": "prayer",
-                "speaker": "priest",
-                "inline": {
-                  "en-US": "I saw water flowing from the right side of the temple, alleluia: and all to whom that water came were saved, and they shall say: alleluia, alleluia.",
-                  "la": "Vidi aquam egrediéntem de templo, a látere dextro, allelúja: et omnes, ad quos pervénit aqua ista, salvi facti sunt, et dicent: allelúja, allelúja.",
-                  "pt-BR": "Vi a água que brotava do lado direito do templo, aleluia: e todos aqueles a quem chegou esta água foram salvos, e dirão: aleluia, aleluia."
-                }
-              },
-              {
-                "type": "prayer",
-                "speaker": "all",
-                "inline": {
-                  "en-US": "Praise the Lord, for He is good: for His mercy endureth for ever.\nGlory be to the Father, and to the Son, and to the Holy Spirit.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.",
-                  "la": "Confitémini Dómino, quóniam bonus: quóniam in sǽculum misericórdia ejus.\nGlória Patri, et Fílio, et Spirítui Sancto.\nSicut erat in princípio, et nunc, et semper, et in sǽcula sæculórum. Amen.",
-                  "pt-BR": "Louvai o Senhor, porque Ele é bom: porque a Sua misericórdia é eterna.\nGlória ao Pai, e ao Filho, e ao Espírito Santo.\nAssim como era no princípio, agora e sempre, por todos os séculos dos séculos. Amém."
-                }
-              },
-              {
-                "type": "rubric",
-                "text": {
-                  "en-US": "The antiphon is then repeated:",
-                  "pt-BR": "Repete-se a antífona:"
-                }
-              },
-              {
-                "type": "prayer",
-                "speaker": "priest",
-                "inline": {
-                  "en-US": "I saw water flowing from the right side of the temple, alleluia: and all to whom that water came were saved, and they shall say: alleluia, alleluia.",
-                  "la": "Vidi aquam egrediéntem de templo, a látere dextro, allelúja: et omnes, ad quos pervénit aqua ista, salvi facti sunt, et dicent: allelúja, allelúja.",
-                  "pt-BR": "Vi a água que brotava do lado direito do templo, aleluia: e todos aqueles a quem chegou esta água foram salvos, e dirão: aleluia, aleluia."
-                }
+                "id": "default",
+                "label": {
+                  "en-US": "Asperges Me",
+                  "pt-BR": "Asperges Me"
+                },
+                "sections": [
+                  {
+                    "type": "subheading",
+                    "text": {
+                      "en-US": "Asperges Me",
+                      "pt-BR": "Asperges Me"
+                    }
+                  },
+                  {
+                    "type": "prayer",
+                    "speaker": "priest",
+                    "inline": {
+                      "en-US": "Thou shalt sprinkle me with hyssop, O Lord, and I shall be cleansed: Thou shalt wash me, and I shall be made whiter than snow.",
+                      "la": "Aspérges me, Dómine, hyssópo, et mundábor: lavábis me, et super nivem dealbábor.",
+                      "pt-BR": "Aspergir-me-eis, Senhor, com o hissopo, e ficarei puro: lavar-me-eis, e ficarei mais branco do que a neve."
+                    }
+                  },
+                  {
+                    "type": "prayer",
+                    "speaker": "all",
+                    "inline": {
+                      "en-US": "Have mercy on me, O God, according to Thy great mercy.\nGlory be to the Father, and to the Son, and to the Holy Spirit.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.",
+                      "la": "Miserére mei, Deus, secúndum magnam misericórdiam tuam.\nGlória Patri, et Fílio, et Spirítui Sancto.\nSicut erat in princípio, et nunc, et semper, et in sǽcula sæculórum. Amen.",
+                      "pt-BR": "Tende piedade de mim, ó Deus, segundo a Vossa grande misericórdia.\nGlória ao Pai, e ao Filho, e ao Espírito Santo.\nAssim como era no princípio, agora e sempre, por todos os séculos dos séculos. Amém."
+                    }
+                  },
+                  {
+                    "type": "rubric",
+                    "text": {
+                      "en-US": "The antiphon is then repeated:",
+                      "pt-BR": "Repete-se a antífona:"
+                    }
+                  },
+                  {
+                    "type": "prayer",
+                    "speaker": "priest",
+                    "inline": {
+                      "en-US": "Thou shalt sprinkle me with hyssop, O Lord, and I shall be cleansed: Thou shalt wash me, and I shall be made whiter than snow.",
+                      "la": "Aspérges me, Dómine, hyssópo, et mundábor: lavábis me, et super nivem dealbábor.",
+                      "pt-BR": "Aspergir-me-eis, Senhor, com o hissopo, e ficarei puro: lavar-me-eis, e ficarei mais branco do que a neve."
+                    }
+                  }
+                ]
               }
             ]
           },
           {
-            "id": "default",
-            "label": {
-              "en-US": "Asperges Me",
-              "pt-BR": "Asperges Me"
-            },
-            "sections": [
-              {
-                "type": "subheading",
-                "text": {
-                  "en-US": "Asperges Me",
-                  "pt-BR": "Asperges Me"
-                }
-              },
-              {
-                "type": "prayer",
-                "speaker": "priest",
-                "inline": {
-                  "en-US": "Thou shalt sprinkle me with hyssop, O Lord, and I shall be cleansed: Thou shalt wash me, and I shall be made whiter than snow.",
-                  "la": "Aspérges me, Dómine, hyssópo, et mundábor: lavábis me, et super nivem dealbábor.",
-                  "pt-BR": "Aspergir-me-eis, Senhor, com o hissopo, e ficarei puro: lavar-me-eis, e ficarei mais branco do que a neve."
-                }
-              },
-              {
-                "type": "prayer",
-                "speaker": "all",
-                "inline": {
-                  "en-US": "Have mercy on me, O God, according to Thy great mercy.\nGlory be to the Father, and to the Son, and to the Holy Spirit.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.",
-                  "la": "Miserére mei, Deus, secúndum magnam misericórdiam tuam.\nGlória Patri, et Fílio, et Spirítui Sancto.\nSicut erat in princípio, et nunc, et semper, et in sǽcula sæculórum. Amen.",
-                  "pt-BR": "Tende piedade de mim, ó Deus, segundo a Vossa grande misericórdia.\nGlória ao Pai, e ao Filho, e ao Espírito Santo.\nAssim como era no princípio, agora e sempre, por todos os séculos dos séculos. Amém."
-                }
-              },
-              {
-                "type": "rubric",
-                "text": {
-                  "en-US": "The antiphon is then repeated:",
-                  "pt-BR": "Repete-se a antífona:"
-                }
-              },
-              {
-                "type": "prayer",
-                "speaker": "priest",
-                "inline": {
-                  "en-US": "Thou shalt sprinkle me with hyssop, O Lord, and I shall be cleansed: Thou shalt wash me, and I shall be made whiter than snow.",
-                  "la": "Aspérges me, Dómine, hyssópo, et mundábor: lavábis me, et super nivem dealbábor.",
-                  "pt-BR": "Aspergir-me-eis, Senhor, com o hissopo, e ficarei puro: lavar-me-eis, e ficarei mais branco do que a neve."
-                }
-              }
-            ]
+            "type": "rubric",
+            "text": {
+              "en-US": "After the antiphon is repeated, the celebrant says (in Eastertide \"alleluia\" is added to both versicle and response):",
+              "pt-BR": "Repetida a antífona, o celebrante diz (no Tempo Pascal acrescenta-se \"aleluia\" ao versículo e à resposta):"
+            }
+          },
+          {
+            "type": "prayer",
+            "speaker": "priest",
+            "inline": {
+              "en-US": "Show us, O Lord, Thy mercy.",
+              "la": "Osténde nobis, Dómine, misericórdiam tuam.",
+              "pt-BR": "Mostrai-nos, Senhor, a Vossa misericórdia."
+            }
+          },
+          {
+            "type": "prayer",
+            "speaker": "people",
+            "inline": {
+              "en-US": "And grant us Thy salvation.",
+              "la": "Et salutáre tuum da nobis.",
+              "pt-BR": "E dai-nos a Vossa salvação."
+            }
+          },
+          {
+            "type": "prayer",
+            "speaker": "priest",
+            "inline": {
+              "en-US": "O Lord, hear my prayer.",
+              "la": "Dómine, exáudi oratiónem meam.",
+              "pt-BR": "Senhor, ouvi a minha oração."
+            }
+          },
+          {
+            "type": "prayer",
+            "speaker": "people",
+            "inline": {
+              "en-US": "And let my cry come unto Thee.",
+              "la": "Et clamor meus ad te véniat.",
+              "pt-BR": "E chegue a Vós o meu clamor."
+            }
+          },
+          {
+            "type": "call",
+            "ref": "ef-lord-be-with-you"
+          },
+          {
+            "type": "prayer",
+            "speaker": "priest",
+            "inline": {
+              "en-US": "Let us pray. Graciously hear us, O holy Lord, almighty Father, eternal God: and vouchsafe to send Thy holy Angel from heaven, to guard, cherish, protect, visit and defend all who dwell in this house. Through Christ our Lord. Amen.",
+              "la": "Orémus. Exáudi nos, Dómine sancte, Pater omnípotens, ætérne Deus: et míttere dignéris sanctum Ángelum tuum de cælis, qui custódiat, fóveat, prótegat, vísitet, atque deféndat omnes habitántes in hoc habitáculo. Per Christum Dóminum nostrum. Amen.",
+              "pt-BR": "Oremos. Ouvi-nos benignamente, ó Senhor santo, Pai todo-poderoso, Deus eterno: e dignai-Vos enviar do céu o Vosso santo Anjo, para guardar, alentar, proteger, visitar e defender todos os habitantes deste lugar. Por Cristo nosso Senhor. Amém."
+            }
           }
         ]
-      },
-      {
-        "type": "rubric",
-        "text": {
-          "en-US": "After the antiphon is repeated, the celebrant says (in Eastertide \"alleluia\" is added to both versicle and response):",
-          "pt-BR": "Repetida a antífona, o celebrante diz (no Tempo Pascal acrescenta-se \"aleluia\" ao versículo e à resposta):"
-        }
-      },
-      {
-        "type": "prayer",
-        "speaker": "priest",
-        "inline": {
-          "en-US": "Show us, O Lord, Thy mercy.",
-          "la": "Osténde nobis, Dómine, misericórdiam tuam.",
-          "pt-BR": "Mostrai-nos, Senhor, a Vossa misericórdia."
-        }
-      },
-      {
-        "type": "prayer",
-        "speaker": "people",
-        "inline": {
-          "en-US": "And grant us Thy salvation.",
-          "la": "Et salutáre tuum da nobis.",
-          "pt-BR": "E dai-nos a Vossa salvação."
-        }
-      },
-      {
-        "type": "prayer",
-        "speaker": "priest",
-        "inline": {
-          "en-US": "O Lord, hear my prayer.",
-          "la": "Dómine, exáudi oratiónem meam.",
-          "pt-BR": "Senhor, ouvi a minha oração."
-        }
-      },
-      {
-        "type": "prayer",
-        "speaker": "people",
-        "inline": {
-          "en-US": "And let my cry come unto Thee.",
-          "la": "Et clamor meus ad te véniat.",
-          "pt-BR": "E chegue a Vós o meu clamor."
-        }
-      },
-      {
-        "type": "call",
-        "ref": "ef-lord-be-with-you"
-      },
-      {
-        "type": "prayer",
-        "speaker": "priest",
-        "inline": {
-          "en-US": "Let us pray. Graciously hear us, O holy Lord, almighty Father, eternal God: and vouchsafe to send Thy holy Angel from heaven, to guard, cherish, protect, visit and defend all who dwell in this house. Through Christ our Lord. Amen.",
-          "la": "Orémus. Exáudi nos, Dómine sancte, Pater omnípotens, ætérne Deus: et míttere dignéris sanctum Ángelum tuum de cælis, qui custódiat, fóveat, prótegat, vísitet, atque deféndat omnes habitántes in hoc habitáculo. Per Christum Dóminum nostrum. Amen.",
-          "pt-BR": "Oremos. Ouvi-nos benignamente, ó Senhor santo, Pai todo-poderoso, Deus eterno: e dignai-Vos enviar do céu o Vosso santo Anjo, para guardar, alentar, proteger, visitar e defender todos os habitantes deste lugar. Por Cristo nosso Senhor. Amém."
-        }
       },
       {
         "type": "divider"

--- a/content/libraries/base/practices/mass/fragments/ef-asperges.json
+++ b/content/libraries/base/practices/mass/fragments/ef-asperges.json
@@ -1,0 +1,154 @@
+{
+  "fragments": {
+    "ef-asperges": [
+      {
+        "type": "heading",
+        "text": {
+          "en-US": "Asperges",
+          "pt-BR": "Aspersão"
+        }
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "Before the principal Mass on Sundays, the celebrant blesses water and sprinkles the altar, the clergy, and the people while the choir sings the Asperges (or Vidi Aquam in Eastertide).",
+          "pt-BR": "Antes da Missa principal aos domingos, o celebrante benze a água e asperge o altar, o clero e o povo, enquanto se canta o Asperges (ou Vidi Aquam no Tempo Pascal)."
+        }
+      },
+      {
+        "type": "select",
+        "on": "celebration.primary.season",
+        "default": "default",
+        "options": [
+          {
+            "id": "easter",
+            "label": {
+              "en-US": "Eastertide (Vidi Aquam)",
+              "pt-BR": "Tempo Pascal (Vidi Aquam)"
+            },
+            "sections": [
+              {
+                "type": "subheading",
+                "text": {
+                  "en-US": "Vidi Aquam",
+                  "pt-BR": "Vidi Aquam"
+                }
+              },
+              {
+                "type": "prayer",
+                "speaker": "priest",
+                "inline": {
+                  "en-US": "I saw water flowing from the right side of the temple, alleluia: and all to whom that water came were saved, and they shall say: alleluia, alleluia.",
+                  "la": "Vidi aquam egrediéntem de templo, a látere dextro, allelúja: et omnes, ad quos pervénit aqua ista, salvi facti sunt, et dicent: allelúja, allelúja.",
+                  "pt-BR": "Vi a água que brotava do lado direito do templo, aleluia: e todos aqueles a quem chegou esta água foram salvos, e dirão: aleluia, aleluia."
+                }
+              },
+              {
+                "type": "prayer",
+                "speaker": "all",
+                "inline": {
+                  "en-US": "Praise the Lord, for He is good: for His mercy endureth for ever.\nGlory be to the Father, and to the Son, and to the Holy Spirit.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.",
+                  "la": "Confitémini Dómino, quóniam bonus: quóniam in sǽculum misericórdia ejus.\nGlória Patri, et Fílio, et Spirítui Sancto.\nSicut erat in princípio, et nunc, et semper, et in sǽcula sæculórum. Amen.",
+                  "pt-BR": "Louvai o Senhor, porque Ele é bom: porque a Sua misericórdia é eterna.\nGlória ao Pai, e ao Filho, e ao Espírito Santo.\nAssim como era no princípio, agora e sempre, por todos os séculos dos séculos. Amém."
+                }
+              }
+            ]
+          },
+          {
+            "id": "default",
+            "label": {
+              "en-US": "Asperges Me",
+              "pt-BR": "Asperges Me"
+            },
+            "sections": [
+              {
+                "type": "subheading",
+                "text": {
+                  "en-US": "Asperges Me",
+                  "pt-BR": "Asperges Me"
+                }
+              },
+              {
+                "type": "prayer",
+                "speaker": "priest",
+                "inline": {
+                  "en-US": "Thou shalt sprinkle me with hyssop, O Lord, and I shall be cleansed: Thou shalt wash me, and I shall be made whiter than snow.",
+                  "la": "Aspérges me, Dómine, hyssópo, et mundábor: lavábis me, et super nivem dealbábor.",
+                  "pt-BR": "Aspergir-me-eis, Senhor, com o hissopo, e ficarei puro: lavar-me-eis, e ficarei mais branco do que a neve."
+                }
+              },
+              {
+                "type": "prayer",
+                "speaker": "all",
+                "inline": {
+                  "en-US": "Have mercy on me, O God, according to Thy great mercy.\nGlory be to the Father, and to the Son, and to the Holy Spirit.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.",
+                  "la": "Miserére mei, Deus, secúndum magnam misericórdiam tuam.\nGlória Patri, et Fílio, et Spirítui Sancto.\nSicut erat in princípio, et nunc, et semper, et in sǽcula sæculórum. Amen.",
+                  "pt-BR": "Tende piedade de mim, ó Deus, segundo a Vossa grande misericórdia.\nGlória ao Pai, e ao Filho, e ao Espírito Santo.\nAssim como era no princípio, agora e sempre, por todos os séculos dos séculos. Amém."
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "After the antiphon is repeated, the celebrant says:",
+          "pt-BR": "Repetida a antífona, o celebrante diz:"
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "Show us, O Lord, Thy mercy.",
+          "la": "Osténde nobis, Dómine, misericórdiam tuam.",
+          "pt-BR": "Mostrai-nos, Senhor, a Vossa misericórdia."
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "people",
+        "inline": {
+          "en-US": "And grant us Thy salvation.",
+          "la": "Et salutáre tuum da nobis.",
+          "pt-BR": "E dai-nos a Vossa salvação."
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "O Lord, hear my prayer.",
+          "la": "Dómine, exáudi oratiónem meam.",
+          "pt-BR": "Senhor, ouvi a minha oração."
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "people",
+        "inline": {
+          "en-US": "And let my cry come unto Thee.",
+          "la": "Et clamor meus ad te véniat.",
+          "pt-BR": "E chegue a Vós o meu clamor."
+        }
+      },
+      {
+        "type": "call",
+        "ref": "ef-lord-be-with-you"
+      },
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "Let us pray. Graciously hear us, O holy Lord, almighty Father, eternal God: and vouchsafe to send Thy holy Angel from heaven, to guard, cherish, protect, visit and defend all who dwell in this house. Through Christ our Lord. Amen.",
+          "la": "Orémus. Exáudi nos, Dómine sancte, Pater omnípotens, ætérne Deus: et míttere dignéris sanctum Ángelum tuum de cælis, qui custódiat, fóveat, prótegat, vísitet, atque deféndat omnes habitántes in hoc habitáculo. Per Christum Dóminum nostrum. Amen.",
+          "pt-BR": "Oremos. Ouvi-nos benignamente, ó Senhor santo, Pai todo-poderoso, Deus eterno: e dignai-Vos enviar do céu o Vosso santo Anjo, para guardar, alentar, proteger, visitar e defender todos os habitantes deste lugar. Por Cristo nosso Senhor. Amém."
+        }
+      },
+      {
+        "type": "divider"
+      }
+    ]
+  }
+}

--- a/content/libraries/base/practices/mass/fragments/ef-asperges.json
+++ b/content/libraries/base/practices/mass/fragments/ef-asperges.json
@@ -51,6 +51,22 @@
                   "la": "Confitémini Dómino, quóniam bonus: quóniam in sǽculum misericórdia ejus.\nGlória Patri, et Fílio, et Spirítui Sancto.\nSicut erat in princípio, et nunc, et semper, et in sǽcula sæculórum. Amen.",
                   "pt-BR": "Louvai o Senhor, porque Ele é bom: porque a Sua misericórdia é eterna.\nGlória ao Pai, e ao Filho, e ao Espírito Santo.\nAssim como era no princípio, agora e sempre, por todos os séculos dos séculos. Amém."
                 }
+              },
+              {
+                "type": "rubric",
+                "text": {
+                  "en-US": "The antiphon is then repeated:",
+                  "pt-BR": "Repete-se a antífona:"
+                }
+              },
+              {
+                "type": "prayer",
+                "speaker": "priest",
+                "inline": {
+                  "en-US": "I saw water flowing from the right side of the temple, alleluia: and all to whom that water came were saved, and they shall say: alleluia, alleluia.",
+                  "la": "Vidi aquam egrediéntem de templo, a látere dextro, allelúja: et omnes, ad quos pervénit aqua ista, salvi facti sunt, et dicent: allelúja, allelúja.",
+                  "pt-BR": "Vi a água que brotava do lado direito do templo, aleluia: e todos aqueles a quem chegou esta água foram salvos, e dirão: aleluia, aleluia."
+                }
               }
             ]
           },
@@ -84,6 +100,22 @@
                   "en-US": "Have mercy on me, O God, according to Thy great mercy.\nGlory be to the Father, and to the Son, and to the Holy Spirit.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.",
                   "la": "Miserére mei, Deus, secúndum magnam misericórdiam tuam.\nGlória Patri, et Fílio, et Spirítui Sancto.\nSicut erat in princípio, et nunc, et semper, et in sǽcula sæculórum. Amen.",
                   "pt-BR": "Tende piedade de mim, ó Deus, segundo a Vossa grande misericórdia.\nGlória ao Pai, e ao Filho, e ao Espírito Santo.\nAssim como era no princípio, agora e sempre, por todos os séculos dos séculos. Amém."
+                }
+              },
+              {
+                "type": "rubric",
+                "text": {
+                  "en-US": "The antiphon is then repeated:",
+                  "pt-BR": "Repete-se a antífona:"
+                }
+              },
+              {
+                "type": "prayer",
+                "speaker": "priest",
+                "inline": {
+                  "en-US": "Thou shalt sprinkle me with hyssop, O Lord, and I shall be cleansed: Thou shalt wash me, and I shall be made whiter than snow.",
+                  "la": "Aspérges me, Dómine, hyssópo, et mundábor: lavábis me, et super nivem dealbábor.",
+                  "pt-BR": "Aspergir-me-eis, Senhor, com o hissopo, e ficarei puro: lavar-me-eis, e ficarei mais branco do que a neve."
                 }
               }
             ]

--- a/content/libraries/base/practices/mass/fragments/ef-asperges.json
+++ b/content/libraries/base/practices/mass/fragments/ef-asperges.json
@@ -125,8 +125,8 @@
       {
         "type": "rubric",
         "text": {
-          "en-US": "After the antiphon is repeated, the celebrant says:",
-          "pt-BR": "Repetida a antífona, o celebrante diz:"
+          "en-US": "After the antiphon is repeated, the celebrant says (in Eastertide \"alleluia\" is added to both versicle and response):",
+          "pt-BR": "Repetida a antífona, o celebrante diz (no Tempo Pascal acrescenta-se \"aleluia\" ao versículo e à resposta):"
         }
       },
       {

--- a/content/libraries/base/practices/mass/fragments/ef-canon-of-the-mass.json
+++ b/content/libraries/base/practices/mass/fragments/ef-canon-of-the-mass.json
@@ -9,6 +9,13 @@
         }
       },
       {
+        "type": "subheading",
+        "text": {
+          "en-US": "Te Igitur",
+          "pt-BR": "Te Igitur"
+        }
+      },
+      {
         "type": "rubric",
         "text": {
           "en-US": "He kisses the altar, joins his hands and signs the oblation thrice with the Sign of the Cross.",
@@ -41,12 +48,92 @@
         }
       },
       {
-        "type": "prayer",
-        "speaker": "priest",
-        "inline": {
-          "en-US": "In union with the whole Church, we honor the memory, first of all, of the glorious ever Virgin Mary, Mother of our God and Lord Jesus Christ: and also of blessed Joseph, Spouse of the same Virgin, and of Thy blessed Apostles and Martyrs, Peter and Paul, Andrew, James, John, Thomas, James, Philip, Bartholomew, Matthew, Simon and Thaddeus, Linus, Cletus, Clement, Sixtus, Cornelius, Cyprian, Lawrence, Chrysogonus, John and Paul, Cosmas and Damian, and of all Thy Saints; by whose merits and prayers, grant that in all things we may be defended by the help of Thy protection. Through the same Christ our Lord. Amen.",
-          "la": "Communicántes, et memóriam venerántes, in primis gloriósæ semper Vírginis Maríæ, Genitrícis Dei et Dómini nostri Jesu Christi: sed et beáti Joseph, ejúsdem Vírginis Sponsi, et beatórum Apostolórum ac Mártyrum tuórum, Petri et Pauli, Andréæ, Jacóbi, Joánnis, Thomæ, Jacóbi, Philíppi, Bartholomǽi, Matthǽi, Simónis et Thaddǽi, Lini, Cleti, Cleméntis, Xysti, Cornélii, Cypriáni, Lauréntii, Chrysógoni, Joánnis et Pauli, Cosmæ et Damiáni, et ómnium Sanctórum tuórum; quorum méritis precibúsque concédas, ut in ómnibus protectiónis tuæ muniámur auxílio. Per eúndem Christum Dóminum nostrum. Amen.",
-          "pt-BR": "Em comunhão com toda a Igreja, veneramos a memória, primeiramente, da gloriosa sempre Virgem Maria, Mãe de nosso Deus e Senhor Jesus Cristo: e também do bem-aventurado São José, Esposo da mesma Virgem, e dos Vossos bem-aventurados Apóstolos e Mártires, Pedro e Paulo, André, Tiago, João, Tomé, Tiago, Filipe, Bartolomeu, Mateus, Simão e Tadeu, Lino, Cleto, Clemente, Sisto, Cornélio, Cipriano, Lourenço, Crisógono, João e Paulo, Cosme e Damião, e de todos os Vossos Santos; por cujos méritos e preces concedei que em tudo sejamos defendidos com o auxílio da Vossa proteção. Pelo mesmo Cristo nosso Senhor. Amém."
+        "type": "subheading",
+        "text": {
+          "en-US": "Communicantes",
+          "pt-BR": "Communicantes"
+        }
+      },
+      {
+        "type": "select",
+        "on": "celebration.primary.season",
+        "default": "default",
+        "options": [
+          {
+            "id": "christmas",
+            "label": {
+              "en-US": "Christmas",
+              "pt-BR": "Natal"
+            },
+            "sections": [
+              {
+                "type": "rubric",
+                "text": {
+                  "en-US": "From Christmas Eve through the Octave of the Nativity (Dec 25 – Jan 1):",
+                  "pt-BR": "Da Vigília do Natal até a Oitava da Natividade (25 dez – 1 jan):"
+                }
+              },
+              {
+                "type": "prayer",
+                "speaker": "priest",
+                "inline": {
+                  "en-US": "In union with the whole Church, celebrating the most sacred day (night) on which the spotless virginity of blessed Mary brought forth the Saviour for this world; and reverencing the memory, first of all, of the same glorious ever Virgin Mary, Mother of our God and Lord Jesus Christ: and also of blessed Joseph, Spouse of the same Virgin, and of Thy blessed Apostles and Martyrs, Peter and Paul, Andrew, James, John, Thomas, James, Philip, Bartholomew, Matthew, Simon and Thaddeus, Linus, Cletus, Clement, Sixtus, Cornelius, Cyprian, Lawrence, Chrysogonus, John and Paul, Cosmas and Damian, and of all Thy Saints; by whose merits and prayers, grant that in all things we may be defended by the help of Thy protection. Through the same Christ our Lord. Amen.",
+                  "la": "Communicántes, et diem sacratíssimum (noctem sacratíssimam) celebrántes, quo (qua) beátæ Maríæ intemeráta virgínitas huic mundo édidit Salvatórem: sed et memóriam venerántes, in primis ejúsdem gloriósæ semper Vírginis Maríæ, Genitrícis Dei et Dómini nostri Jesu Christi: sed et beáti Joseph, ejúsdem Vírginis Sponsi, et beatórum Apostolórum ac Mártyrum tuórum, Petri et Pauli, Andréæ, Jacóbi, Joánnis, Thomæ, Jacóbi, Philíppi, Bartholomǽi, Matthǽi, Simónis et Thaddǽi, Lini, Cleti, Cleméntis, Xysti, Cornélii, Cypriáni, Lauréntii, Chrysógoni, Joánnis et Pauli, Cosmæ et Damiáni, et ómnium Sanctórum tuórum; quorum méritis precibúsque concédas, ut in ómnibus protectiónis tuæ muniámur auxílio. Per eúndem Christum Dóminum nostrum. Amen.",
+                  "pt-BR": "Em comunhão com toda a Igreja, celebrando o dia sacratíssimo (a noite sacratíssima) em que a inviolada virgindade da bem-aventurada Maria deu ao mundo o Salvador: veneramos a memória, primeiramente, da mesma gloriosa sempre Virgem Maria, Mãe de nosso Deus e Senhor Jesus Cristo: e também do bem-aventurado São José, Esposo da mesma Virgem, e dos Vossos bem-aventurados Apóstolos e Mártires, Pedro e Paulo, André, Tiago, João, Tomé, Tiago, Filipe, Bartolomeu, Mateus, Simão e Tadeu, Lino, Cleto, Clemente, Sisto, Cornélio, Cipriano, Lourenço, Crisógono, João e Paulo, Cosme e Damião, e de todos os Vossos Santos; por cujos méritos e preces concedei que em tudo sejamos defendidos com o auxílio da Vossa proteção. Pelo mesmo Cristo nosso Senhor. Amém."
+                }
+              }
+            ]
+          },
+          {
+            "id": "easter",
+            "label": {
+              "en-US": "Easter",
+              "pt-BR": "Tempo Pascal"
+            },
+            "sections": [
+              {
+                "type": "rubric",
+                "text": {
+                  "en-US": "From the Easter Vigil through the Saturday in Albis (Easter Octave):",
+                  "pt-BR": "Da Vigília Pascal até o Sábado in Albis (Oitava da Páscoa):"
+                }
+              },
+              {
+                "type": "prayer",
+                "speaker": "priest",
+                "inline": {
+                  "en-US": "In union with the whole Church, celebrating the most sacred day (night) of the Resurrection of our Lord Jesus Christ in the flesh; and reverencing the memory, first of all, of the glorious ever Virgin Mary, Mother of the same our God and Lord Jesus Christ: and also of blessed Joseph, Spouse of the same Virgin, and of Thy blessed Apostles and Martyrs, Peter and Paul, Andrew, James, John, Thomas, James, Philip, Bartholomew, Matthew, Simon and Thaddeus, Linus, Cletus, Clement, Sixtus, Cornelius, Cyprian, Lawrence, Chrysogonus, John and Paul, Cosmas and Damian, and of all Thy Saints; by whose merits and prayers, grant that in all things we may be defended by the help of Thy protection. Through the same Christ our Lord. Amen.",
+                  "la": "Communicántes, et diem sacratíssimum (noctem sacratíssimam) celebrántes Resurrectiónis Dómini nostri Jesu Christi secúndum carnem: sed et memóriam venerántes, in primis gloriósæ semper Vírginis Maríæ, Genitrícis ejúsdem Dei et Dómini nostri Jesu Christi: sed et beáti Joseph, ejúsdem Vírginis Sponsi, et beatórum Apostolórum ac Mártyrum tuórum, Petri et Pauli, Andréæ, Jacóbi, Joánnis, Thomæ, Jacóbi, Philíppi, Bartholomǽi, Matthǽi, Simónis et Thaddǽi, Lini, Cleti, Cleméntis, Xysti, Cornélii, Cypriáni, Lauréntii, Chrysógoni, Joánnis et Pauli, Cosmæ et Damiáni, et ómnium Sanctórum tuórum; quorum méritis precibúsque concédas, ut in ómnibus protectiónis tuæ muniámur auxílio. Per eúndem Christum Dóminum nostrum. Amen.",
+                  "pt-BR": "Em comunhão com toda a Igreja, celebrando o dia sacratíssimo (a noite sacratíssima) da Ressurreição segundo a carne de nosso Senhor Jesus Cristo: veneramos a memória, primeiramente, da gloriosa sempre Virgem Maria, Mãe de nosso Deus e Senhor Jesus Cristo: e também do bem-aventurado São José, Esposo da mesma Virgem, e dos Vossos bem-aventurados Apóstolos e Mártires, Pedro e Paulo, André, Tiago, João, Tomé, Tiago, Filipe, Bartolomeu, Mateus, Simão e Tadeu, Lino, Cleto, Clemente, Sisto, Cornélio, Cipriano, Lourenço, Crisógono, João e Paulo, Cosme e Damião, e de todos os Vossos Santos; por cujos méritos e preces concedei que em tudo sejamos defendidos com o auxílio da Vossa proteção. Pelo mesmo Cristo nosso Senhor. Amém."
+                }
+              }
+            ]
+          },
+          {
+            "id": "default",
+            "label": {
+              "en-US": "Common",
+              "pt-BR": "Comum"
+            },
+            "sections": [
+              {
+                "type": "prayer",
+                "speaker": "priest",
+                "inline": {
+                  "en-US": "In union with the whole Church, we honor the memory, first of all, of the glorious ever Virgin Mary, Mother of our God and Lord Jesus Christ: and also of blessed Joseph, Spouse of the same Virgin, and of Thy blessed Apostles and Martyrs, Peter and Paul, Andrew, James, John, Thomas, James, Philip, Bartholomew, Matthew, Simon and Thaddeus, Linus, Cletus, Clement, Sixtus, Cornelius, Cyprian, Lawrence, Chrysogonus, John and Paul, Cosmas and Damian, and of all Thy Saints; by whose merits and prayers, grant that in all things we may be defended by the help of Thy protection. Through the same Christ our Lord. Amen.",
+                  "la": "Communicántes, et memóriam venerántes, in primis gloriósæ semper Vírginis Maríæ, Genitrícis Dei et Dómini nostri Jesu Christi: sed et beáti Joseph, ejúsdem Vírginis Sponsi, et beatórum Apostolórum ac Mártyrum tuórum, Petri et Pauli, Andréæ, Jacóbi, Joánnis, Thomæ, Jacóbi, Philíppi, Bartholomǽi, Matthǽi, Simónis et Thaddǽi, Lini, Cleti, Cleméntis, Xysti, Cornélii, Cypriáni, Lauréntii, Chrysógoni, Joánnis et Pauli, Cosmæ et Damiáni, et ómnium Sanctórum tuórum; quorum méritis precibúsque concédas, ut in ómnibus protectiónis tuæ muniámur auxílio. Per eúndem Christum Dóminum nostrum. Amen.",
+                  "pt-BR": "Em comunhão com toda a Igreja, veneramos a memória, primeiramente, da gloriosa sempre Virgem Maria, Mãe de nosso Deus e Senhor Jesus Cristo: e também do bem-aventurado São José, Esposo da mesma Virgem, e dos Vossos bem-aventurados Apóstolos e Mártires, Pedro e Paulo, André, Tiago, João, Tomé, Tiago, Filipe, Bartolomeu, Mateus, Simão e Tadeu, Lino, Cleto, Clemente, Sisto, Cornélio, Cipriano, Lourenço, Crisógono, João e Paulo, Cosme e Damião, e de todos os Vossos Santos; por cujos méritos e preces concedei que em tudo sejamos defendidos com o auxílio da Vossa proteção. Pelo mesmo Cristo nosso Senhor. Amém."
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "subheading",
+        "text": {
+          "en-US": "Hanc Igitur",
+          "pt-BR": "Hanc Igitur"
         }
       },
       {
@@ -57,12 +144,60 @@
         }
       },
       {
-        "type": "prayer",
-        "speaker": "priest",
-        "inline": {
-          "en-US": "We therefore beseech Thee, O Lord, graciously to accept this oblation of our service, and of Thy whole household: order our days in Thy peace, and command that we be delivered from eternal damnation, and numbered in the flock of Thine elect. Through Christ our Lord. Amen.",
-          "la": "Hanc ígitur oblatiónem servitútis nostræ, sed et cunctæ famíliæ tuæ, quǽsumus, Dómine, ut placátus accípias: diésque nostros in tua pace dispónas, atque ab ætérna damnatióne nos éripi, et in electórum tuórum júbeas grege numerári. Per Christum Dóminum nostrum. Amen.",
-          "pt-BR": "Nós Vos suplicamos, pois, ó Senhor, que aceiteis benigno esta oblação do nosso serviço e de toda a Vossa família: disponde os nossos dias na Vossa paz, e ordenai que sejamos livrados da eterna condenação e contados no rebanho dos Vossos eleitos. Por Cristo nosso Senhor. Amém."
+        "type": "select",
+        "on": "celebration.primary.season",
+        "default": "default",
+        "options": [
+          {
+            "id": "easter",
+            "label": {
+              "en-US": "Easter Octave",
+              "pt-BR": "Oitava da Páscoa"
+            },
+            "sections": [
+              {
+                "type": "rubric",
+                "text": {
+                  "en-US": "From the Easter Vigil through the Saturday in Albis the priest adds the proper Hanc Igitur:",
+                  "pt-BR": "Da Vigília Pascal até o Sábado in Albis o sacerdote acrescenta o Hanc Igitur próprio:"
+                }
+              },
+              {
+                "type": "prayer",
+                "speaker": "priest",
+                "inline": {
+                  "en-US": "We therefore beseech Thee, O Lord, graciously to accept this oblation of our service, and of Thy whole household, which we offer to Thee also for those whom Thou hast vouchsafed to bring forth to new life by water and the Holy Spirit, granting them remission of all their sins: order our days in Thy peace, and command that we be delivered from eternal damnation, and numbered in the flock of Thine elect. Through Christ our Lord. Amen.",
+                  "la": "Hanc ígitur oblatiónem servitútis nostræ, sed et cunctæ famíliæ tuæ, quam tibi offérimus pro his quoque, quos regeneráre dignátus es ex aqua et Spíritu Sancto, tríbuens eis remissiónem ómnium peccatórum, quǽsumus, Dómine, ut placátus accípias: diésque nostros in tua pace dispónas, atque ab ætérna damnatióne nos éripi, et in electórum tuórum júbeas grege numerári. Per Christum Dóminum nostrum. Amen.",
+                  "pt-BR": "Nós Vos suplicamos, pois, ó Senhor, que aceiteis benigno esta oblação do nosso serviço e de toda a Vossa família, que Vos oferecemos também por aqueles que Vos dignastes regenerar pela água e o Espírito Santo, concedendo-lhes a remissão de todos os pecados: disponde os nossos dias na Vossa paz, e ordenai que sejamos livrados da eterna condenação e contados no rebanho dos Vossos eleitos. Por Cristo nosso Senhor. Amém."
+                }
+              }
+            ]
+          },
+          {
+            "id": "default",
+            "label": {
+              "en-US": "Common",
+              "pt-BR": "Comum"
+            },
+            "sections": [
+              {
+                "type": "prayer",
+                "speaker": "priest",
+                "inline": {
+                  "en-US": "We therefore beseech Thee, O Lord, graciously to accept this oblation of our service, and of Thy whole household: order our days in Thy peace, and command that we be delivered from eternal damnation, and numbered in the flock of Thine elect. Through Christ our Lord. Amen.",
+                  "la": "Hanc ígitur oblatiónem servitútis nostræ, sed et cunctæ famíliæ tuæ, quǽsumus, Dómine, ut placátus accípias: diésque nostros in tua pace dispónas, atque ab ætérna damnatióne nos éripi, et in electórum tuórum júbeas grege numerári. Per Christum Dóminum nostrum. Amen.",
+                  "pt-BR": "Nós Vos suplicamos, pois, ó Senhor, que aceiteis benigno esta oblação do nosso serviço e de toda a Vossa família: disponde os nossos dias na Vossa paz, e ordenai que sejamos livrados da eterna condenação e contados no rebanho dos Vossos eleitos. Por Cristo nosso Senhor. Amém."
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "subheading",
+        "text": {
+          "en-US": "Quam Oblationem",
+          "pt-BR": "Quam Oblationem"
         }
       },
       {
@@ -151,6 +286,13 @@
         }
       },
       {
+        "type": "subheading",
+        "text": {
+          "en-US": "Unde et Memores",
+          "pt-BR": "Unde et Memores"
+        }
+      },
+      {
         "type": "rubric",
         "text": {
           "en-US": "With his hands held apart, he then proceeds:",
@@ -167,6 +309,13 @@
         }
       },
       {
+        "type": "subheading",
+        "text": {
+          "en-US": "Supra Quae",
+          "pt-BR": "Supra Quae"
+        }
+      },
+      {
         "type": "rubric",
         "text": {
           "en-US": "Extending his hands, he proceeds:",
@@ -180,6 +329,13 @@
           "en-US": "Upon which vouchsafe to look with a propitious and serene countenance: and to accept them, as Thou wert graciously pleased to accept the gifts of Thy just servant Abel, and the sacrifice of our Patriarch Abraham: and that which Thy high priest Melchisedech offered to Thee, a holy sacrifice, an unspotted victim.",
           "la": "Supra quæ propítio ac seréno vultu respícere dignéris: et accépta habére, sícuti accépta habére dignátus es múnera púeri tui justi Abel, et sacrifícium Patriárchæ nostri Ábrahæ: et quod tibi óbtulit summus sacérdos tuus Melchísedech, sanctum sacrifícium, immaculátam hóstiam.",
           "pt-BR": "Sobre os quais Vos digneis lançar um olhar propício e sereno: e aceitá-los, assim como Vos dignastes aceitar os dons do Vosso justo servo Abel, e o sacrifício do nosso Patriarca Abraão: e aquele que Vos ofereceu o Vosso sumo sacerdote Melquisedeque, sacrifício santo, hóstia imaculada."
+        }
+      },
+      {
+        "type": "subheading",
+        "text": {
+          "en-US": "Supplices te rogamus",
+          "pt-BR": "Supplices te rogamus"
         }
       },
       {
@@ -215,6 +371,13 @@
         }
       },
       {
+        "type": "subheading",
+        "text": {
+          "en-US": "Nobis quoque peccatoribus",
+          "pt-BR": "Nobis quoque peccatoribus"
+        }
+      },
+      {
         "type": "rubric",
         "text": {
           "en-US": "He strikes his breast, raising his voice slightly.",
@@ -240,6 +403,13 @@
         }
       },
       {
+        "type": "subheading",
+        "text": {
+          "en-US": "Per Ipsum",
+          "pt-BR": "Per Ipsum"
+        }
+      },
+      {
         "type": "rubric",
         "text": {
           "en-US": "He uncovers the Chalice and genuflects; then taking the Host in his right hand, and holding the Chalice in his left, he signs with the Sign of the Cross three times across the Chalice.",
@@ -258,8 +428,8 @@
       {
         "type": "rubric",
         "text": {
-          "en-US": "Replacing the Host, and covering the Chalice, he kneels down, and rising again, he says:",
-          "pt-BR": "Ajoelha-se e levantando-se, diz:"
+          "en-US": "Replacing the Host, and covering the Chalice, he kneels down, and rising again, he says aloud:",
+          "pt-BR": "Recolocando a Hóstia e cobrindo o Cálice, ajoelha-se e levantando-se, diz em voz alta:"
         }
       },
       {

--- a/content/libraries/base/practices/mass/fragments/ef-communion-rite.json
+++ b/content/libraries/base/practices/mass/fragments/ef-communion-rite.json
@@ -187,6 +187,13 @@
         }
       },
       {
+        "type": "rubric",
+        "text": {
+          "en-US": "(At a Requiem Mass: \"miserere nobis\" is replaced by \"dona eis requiem\" twice, and \"dona nobis pacem\" by \"dona eis requiem sempiternam\". The first communion prayer (Domine Jesu Christe, qui dixisti) and the Pax Domini exchange are also omitted.)",
+          "pt-BR": "(Na Missa de Réquiem: \"miserere nobis\" é substituído por \"dona eis requiem\" duas vezes, e \"dona nobis pacem\" por \"dona eis requiem sempiternam\". A primeira oração da comunhão (Domine Jesu Christe, qui dixisti) e o diálogo da Pax Domini também são omitidos.)"
+        }
+      },
+      {
         "type": "subheading",
         "text": {
           "en-US": "Communion Prayers",

--- a/content/libraries/base/practices/mass/fragments/ef-communion-rite.json
+++ b/content/libraries/base/practices/mass/fragments/ef-communion-rite.json
@@ -68,8 +68,8 @@
       {
         "type": "rubric",
         "text": {
-          "en-US": "Then the priest takes the paten between the first and second finger and says:",
-          "pt-BR": "O sacerdote descobre o Cálice, genuflecte e segura com os dedos polegar e indicador a Hóstia e diz:"
+          "en-US": "Then the priest takes the paten between the index and middle finger and says:",
+          "pt-BR": "O sacerdote toma a patena entre o indicador e o médio e diz:"
         }
       },
       {

--- a/content/libraries/base/practices/mass/fragments/ef-communion-rite.json
+++ b/content/libraries/base/practices/mass/fragments/ef-communion-rite.json
@@ -336,59 +336,61 @@
         }
       },
       {
-        "type": "subheading",
-        "text": {
-          "en-US": "Communion of the Faithful",
-          "pt-BR": "Comunhão dos Fiéis"
-        }
-      },
-      {
-        "type": "rubric",
-        "text": {
-          "en-US": "If the faithful are to receive Communion, the priest, before distributing, holds up a Sacred Host and says:",
-          "pt-BR": "Se os fiéis vão comungar, o sacerdote, antes de distribuir, ergue uma Hóstia consagrada e diz:"
-        }
-      },
-      {
-        "type": "prayer",
-        "speaker": "priest",
-        "inline": {
-          "en-US": "Behold the Lamb of God, behold Him who taketh away the sins of the world.",
-          "la": "Ecce Agnus Dei, ecce qui tollit peccáta mundi.",
-          "pt-BR": "Eis o Cordeiro de Deus, eis Aquele que tira os pecados do mundo."
-        }
-      },
-      {
-        "type": "rubric",
-        "text": {
-          "en-US": "Then he says three times, with the faithful repeating after him:",
-          "pt-BR": "Em seguida, diz três vezes, com os fiéis repetindo:"
-        }
-      },
-      {
-        "type": "prayer",
-        "speaker": "all",
-        "inline": {
-          "en-US": "Lord, I am not worthy that Thou shouldst enter under my roof: but only say the word, and my soul shall be healed.\nLord, I am not worthy that Thou shouldst enter under my roof: but only say the word, and my soul shall be healed.\nLord, I am not worthy that Thou shouldst enter under my roof: but only say the word, and my soul shall be healed.",
-          "la": "Dómine, non sum dignus, ut intres sub tectum meum: sed tantum dic verbo, et sanábitur ánima mea.\nDómine, non sum dignus, ut intres sub tectum meum: sed tantum dic verbo, et sanábitur ánima mea.\nDómine, non sum dignus, ut intres sub tectum meum: sed tantum dic verbo, et sanábitur ánima mea.",
-          "pt-BR": "Senhor, não sou digno de que entreis em minha morada: mas dizei uma só palavra, e a minha alma será salva.\nSenhor, não sou digno de que entreis em minha morada: mas dizei uma só palavra, e a minha alma será salva.\nSenhor, não sou digno de que entreis em minha morada: mas dizei uma só palavra, e a minha alma será salva."
-        }
-      },
-      {
-        "type": "rubric",
-        "text": {
-          "en-US": "To each communicant he says:",
-          "pt-BR": "A cada comungante o sacerdote diz:"
-        }
-      },
-      {
-        "type": "prayer",
-        "speaker": "priest",
-        "inline": {
-          "en-US": "May the Body of our Lord Jesus Christ preserve thy soul unto life everlasting. Amen.",
-          "la": "Corpus Dómini nostri Jesu Christi custódiat ánimam tuam in vitam ætérnam. Amen.",
-          "pt-BR": "O Corpo de nosso Senhor Jesus Cristo guarde a tua alma para a vida eterna. Amém."
-        }
+        "type": "collapsible",
+        "title": {
+          "en-US": "Communion of the Faithful (when the faithful receive)",
+          "pt-BR": "Comunhão dos Fiéis (quando os fiéis comungam)"
+        },
+        "sections": [
+          {
+            "type": "rubric",
+            "text": {
+              "en-US": "If the faithful are to receive Communion, the priest, before distributing, holds up a Sacred Host and says:",
+              "pt-BR": "Se os fiéis vão comungar, o sacerdote, antes de distribuir, ergue uma Hóstia consagrada e diz:"
+            }
+          },
+          {
+            "type": "prayer",
+            "speaker": "priest",
+            "inline": {
+              "en-US": "Behold the Lamb of God, behold Him who taketh away the sins of the world.",
+              "la": "Ecce Agnus Dei, ecce qui tollit peccáta mundi.",
+              "pt-BR": "Eis o Cordeiro de Deus, eis Aquele que tira os pecados do mundo."
+            }
+          },
+          {
+            "type": "rubric",
+            "text": {
+              "en-US": "Then he says three times, with the faithful repeating after him:",
+              "pt-BR": "Em seguida, diz três vezes, com os fiéis repetindo:"
+            }
+          },
+          {
+            "type": "prayer",
+            "speaker": "all",
+            "inline": {
+              "en-US": "Lord, I am not worthy that Thou shouldst enter under my roof: but only say the word, and my soul shall be healed.\nLord, I am not worthy that Thou shouldst enter under my roof: but only say the word, and my soul shall be healed.\nLord, I am not worthy that Thou shouldst enter under my roof: but only say the word, and my soul shall be healed.",
+              "la": "Dómine, non sum dignus, ut intres sub tectum meum: sed tantum dic verbo, et sanábitur ánima mea.\nDómine, non sum dignus, ut intres sub tectum meum: sed tantum dic verbo, et sanábitur ánima mea.\nDómine, non sum dignus, ut intres sub tectum meum: sed tantum dic verbo, et sanábitur ánima mea.",
+              "pt-BR": "Senhor, não sou digno de que entreis em minha morada: mas dizei uma só palavra, e a minha alma será salva.\nSenhor, não sou digno de que entreis em minha morada: mas dizei uma só palavra, e a minha alma será salva.\nSenhor, não sou digno de que entreis em minha morada: mas dizei uma só palavra, e a minha alma será salva."
+            }
+          },
+          {
+            "type": "rubric",
+            "text": {
+              "en-US": "To each communicant he says:",
+              "pt-BR": "A cada comungante o sacerdote diz:"
+            }
+          },
+          {
+            "type": "prayer",
+            "speaker": "priest",
+            "inline": {
+              "en-US": "May the Body of our Lord Jesus Christ preserve thy soul unto life everlasting. Amen.",
+              "la": "Corpus Dómini nostri Jesu Christi custódiat ánimam tuam in vitam ætérnam. Amen.",
+              "pt-BR": "O Corpo de nosso Senhor Jesus Cristo guarde a tua alma para a vida eterna. Amém."
+            }
+          }
+        ]
       },
       {
         "type": "subheading",

--- a/content/libraries/base/practices/mass/fragments/ef-communion-rite.json
+++ b/content/libraries/base/practices/mass/fragments/ef-communion-rite.json
@@ -16,6 +16,22 @@
         }
       },
       {
+        "type": "rubric",
+        "text": {
+          "en-US": "Then with hands joined the priest says aloud:",
+          "pt-BR": "Com as mãos juntas, o sacerdote diz em voz alta:"
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "Let us pray. Taught by our Saviour's command and formed by the word of God, we make bold to say:",
+          "la": "Orémus. Præcéptis salutáribus móniti, et divína institutióne formáti, audémus dícere:",
+          "pt-BR": "Oremos. Instruídos pelos preceitos salutares, e formados pela divina instituição, ousamos dizer:"
+        }
+      },
+      {
         "type": "prayer",
         "speaker": "priest",
         "inline": {
@@ -40,6 +56,13 @@
           "en-US": "Amen.",
           "la": "Amen.",
           "pt-BR": "Amém."
+        }
+      },
+      {
+        "type": "subheading",
+        "text": {
+          "en-US": "Libera Nos",
+          "pt-BR": "Libera Nos"
         }
       },
       {
@@ -69,9 +92,18 @@
         "type": "prayer",
         "speaker": "priest",
         "inline": {
-          "en-US": "Through the same our Lord Jesus Christ Thy Son. Who with Thee liveth and reigneth in the unity of the Holy Spirit, God, world without end.",
-          "la": "Per eúndem Dóminum nostrum Jesum Christum Fílium tuum. Qui tecum vivit et regnat in unitáte Spíritus Sancti, Deus, per ómnia sǽcula sæculórum.",
-          "pt-BR": "Pelo mesmo nosso Senhor Jesus Cristo Vosso Filho. Que convosco vive e reina na unidade do Espírito Santo, Deus, por todos os séculos dos séculos."
+          "en-US": "Through the same our Lord Jesus Christ Thy Son. Who with Thee liveth and reigneth in the unity of the Holy Spirit, God,",
+          "la": "Per eúndem Dóminum nostrum Jesum Christum Fílium tuum. Qui tecum vivit et regnat in unitáte Spíritus Sancti, Deus,",
+          "pt-BR": "Pelo mesmo nosso Senhor Jesus Cristo Vosso Filho. Que convosco vive e reina na unidade do Espírito Santo, Deus,"
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "World without end.",
+          "la": "Per ómnia sǽcula sæculórum.",
+          "pt-BR": "Por todos os séculos dos séculos."
         }
       },
       {
@@ -93,7 +125,7 @@
       {
         "type": "rubric",
         "text": {
-          "en-US": "The priest makes the Sign of the Cross with the Particle over the Chalice, saying:",
+          "en-US": "The priest makes the Sign of the Cross thrice with the Particle over the Chalice, saying:",
           "pt-BR": "O sacerdote faz três vezes o sinal da Cruz com a Divina Partícula sobre o Cálice:"
         }
       },
@@ -196,6 +228,13 @@
         }
       },
       {
+        "type": "subheading",
+        "text": {
+          "en-US": "Communion of the Priest",
+          "pt-BR": "Comunhão do Sacerdote"
+        }
+      },
+      {
         "type": "rubric",
         "text": {
           "en-US": "The priest genuflects, rises and says:",
@@ -290,10 +329,72 @@
         }
       },
       {
+        "type": "subheading",
+        "text": {
+          "en-US": "Communion of the Faithful",
+          "pt-BR": "Comunhão dos Fiéis"
+        }
+      },
+      {
         "type": "rubric",
         "text": {
-          "en-US": "The priest says silently:",
-          "pt-BR": "Entretanto, diz:"
+          "en-US": "If the faithful are to receive Communion, the priest, before distributing, holds up a Sacred Host and says:",
+          "pt-BR": "Se os fiéis vão comungar, o sacerdote, antes de distribuir, ergue uma Hóstia consagrada e diz:"
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "Behold the Lamb of God, behold Him who taketh away the sins of the world.",
+          "la": "Ecce Agnus Dei, ecce qui tollit peccáta mundi.",
+          "pt-BR": "Eis o Cordeiro de Deus, eis Aquele que tira os pecados do mundo."
+        }
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "Then he says three times, with the faithful repeating after him:",
+          "pt-BR": "Em seguida, diz três vezes, com os fiéis repetindo:"
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "all",
+        "inline": {
+          "en-US": "Lord, I am not worthy that Thou shouldst enter under my roof: but only say the word, and my soul shall be healed.\nLord, I am not worthy that Thou shouldst enter under my roof: but only say the word, and my soul shall be healed.\nLord, I am not worthy that Thou shouldst enter under my roof: but only say the word, and my soul shall be healed.",
+          "la": "Dómine, non sum dignus, ut intres sub tectum meum: sed tantum dic verbo, et sanábitur ánima mea.\nDómine, non sum dignus, ut intres sub tectum meum: sed tantum dic verbo, et sanábitur ánima mea.\nDómine, non sum dignus, ut intres sub tectum meum: sed tantum dic verbo, et sanábitur ánima mea.",
+          "pt-BR": "Senhor, não sou digno de que entreis em minha morada: mas dizei uma só palavra, e a minha alma será salva.\nSenhor, não sou digno de que entreis em minha morada: mas dizei uma só palavra, e a minha alma será salva.\nSenhor, não sou digno de que entreis em minha morada: mas dizei uma só palavra, e a minha alma será salva."
+        }
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "To each communicant he says:",
+          "pt-BR": "A cada comungante o sacerdote diz:"
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "May the Body of our Lord Jesus Christ preserve thy soul unto life everlasting. Amen.",
+          "la": "Corpus Dómini nostri Jesu Christi custódiat ánimam tuam in vitam ætérnam. Amen.",
+          "pt-BR": "O Corpo de nosso Senhor Jesus Cristo guarde a tua alma para a vida eterna. Amém."
+        }
+      },
+      {
+        "type": "subheading",
+        "text": {
+          "en-US": "Ablutions",
+          "pt-BR": "Abluções"
+        }
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "Returning to the altar, the priest holds out the Chalice to the server, who pours wine into it for the first ablution.",
+          "pt-BR": "Voltando ao altar, o sacerdote estende o cálice ao acólito, que verte vinho para a primeira ablução."
         }
       },
       {
@@ -308,8 +409,8 @@
       {
         "type": "rubric",
         "text": {
-          "en-US": "Then he holds out the Chalice to the server, who pours wine into it for the first ablution.",
-          "pt-BR": "O sacerdote purifica primeiro o cálice e depois os dedos, e toma as abluções."
+          "en-US": "Then he holds the chalice while the server pours wine and water over his fingers for the second ablution.",
+          "pt-BR": "Em seguida estende o cálice enquanto o acólito verte vinho e água sobre os seus dedos, para a segunda ablução."
         }
       },
       {
@@ -324,8 +425,15 @@
       {
         "type": "rubric",
         "text": {
-          "en-US": "The priest then washes his fingers and receives the second ablution. Then he covers the chalice and goes to the right side of the altar.",
-          "pt-BR": "Purifica o cálice e deixa-o, coberto, no meio do altar. O sacerdote passa para o lado direito do altar."
+          "en-US": "Then he covers the chalice, returns to the right side of the altar, and reads the Communion antiphon.",
+          "pt-BR": "Cobre o cálice, deixa-o no meio do altar e dirige-se ao lado direito do altar, onde lê a antífona da Comunhão."
+        }
+      },
+      {
+        "type": "subheading",
+        "text": {
+          "en-US": "Communion Antiphon",
+          "pt-BR": "Antífona de Comunhão"
         }
       },
       {
@@ -338,6 +446,9 @@
         "form": "ef"
       },
       {
+        "type": "divider"
+      },
+      {
         "type": "rubric",
         "text": {
           "en-US": "The priest kisses the altar. Then he turns to the people, and says:",
@@ -346,7 +457,23 @@
       },
       {
         "type": "call",
-        "ref": "of-lord-be-with-you"
+        "ref": "ef-lord-be-with-you"
+      },
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "Let us pray.",
+          "la": "Orémus.",
+          "pt-BR": "Oremos."
+        }
+      },
+      {
+        "type": "subheading",
+        "text": {
+          "en-US": "Postcommunion",
+          "pt-BR": "Pós-Comunhão"
+        }
       },
       {
         "type": "proper",

--- a/content/libraries/base/practices/mass/fragments/ef-credo.json
+++ b/content/libraries/base/practices/mass/fragments/ef-credo.json
@@ -9,52 +9,55 @@
         }
       },
       {
+        "type": "rubric",
+        "text": {
+          "en-US": "On Sundays and certain Feasts the priest, standing at the middle of the altar, extending and joining his hands, says the Creed:",
+          "pt-BR": "Aos domingos e em certas festas, o sacerdote, no meio do altar, estende e junta as mãos e diz o Credo:"
+        }
+      },
+      {
         "type": "prayer",
         "speaker": "all",
         "inline": {
-          "en-US": "I believe in one God, the Father almighty, maker of heaven and earth, and of all things visible and invisible.\nAnd in one Lord Jesus Christ, the only-begotten Son of God.\nBorn of the Father before all ages.\nGod of God, Light of Light, true God of true God.\nBegotten, not made, consubstantial with the Father: by whom all things were made.\nWho for us men and for our salvation came down from heaven.\nAnd was incarnate by the Holy Spirit of the Virgin Mary: and was made man.\nHe was crucified also for us: suffered under Pontius Pilate, and was buried.\nAnd the third day He rose again according to the Scriptures.\nAnd ascended into heaven: He sits at the right hand of the Father.\nAnd He shall come again with glory to judge the living and the dead: of His kingdom there shall be no end.\nAnd in the Holy Spirit, the Lord and giver of life: who proceeds from the Father and the Son.\nWho together with the Father and the Son is adored and glorified: who spoke through the Prophets.\nAnd one, holy, catholic and apostolic Church.\nI confess one baptism for the remission of sins.\nAnd I await the resurrection of the dead.\nAnd the life ✠ of the world to come. Amen.",
-          "la": "Credo in unum Deum, Patrem omnipoténtem, factórem cæli et terræ, visibílium ómnium et invisibílium.\nEt in unum Dóminum Jesum Christum, Fílium Dei unigénitum.\nEt ex Patre natum ante ómnia sǽcula.\nDeum de Deo, Lumen de Lúmine, Deum verum de Deo vero.\nGénitum, non factum, consubstantiálem Patri: per quem ómnia facta sunt.\nQui propter nos hómines et propter nostram salútem descéndit de cælis.\nEt incarnátus est de Spíritu Sancto ex María Vírgine: et homo factus est.\nCrucifíxus étiam pro nobis: sub Póntio Piláto passus, et sepúltus est.\nEt resurréxit tértia die, secúndum Scriptúras.\nEt ascéndit in cælum: sedet ad déxteram Patris.\nEt íterum ventúrus est cum glória judicáre vivos et mórtuos: cujus regni non erit finis.\nEt in Spíritum Sanctum, Dóminum et vivificántem: qui ex Patre Filióque procédit.\nQui cum Patre et Fílio simul adorátur et conglorificátur: qui locútus est per Prophétas.\nEt unam, sanctam, cathólicam et apostólicam Ecclésiam.\nConfíteor unum baptísma in remissiónem peccatórum.\nEt exspécto resurrectiónem mortuórum.\nEt vitam ✠ ventúri sǽculi. Amen.",
-          "pt-BR": "Creio em um só Deus, Pai todo-poderoso, Criador do céu e da terra, de todas as coisas visíveis e invisíveis.\nE em um só Senhor Jesus Cristo, Filho Unigénito de Deus.\nNascido do Pai antes de todos os séculos.\nDeus de Deus, Luz da Luz, Deus verdadeiro de Deus verdadeiro.\nGerado, não criado, consubstancial ao Pai: por quem todas as coisas foram feitas.\nO qual por nós homens e para nossa salvação desceu dos céus.\nE encarnou pelo Espírito Santo no seio da Virgem Maria: e Se fez homem.\nTambém por nós foi crucificado: sob Pôncio Pilatos, padeceu e foi sepultado.\nE ao terceiro dia ressuscitou segundo as Escrituras.\nE subiu ao céu: está sentado à direita do Pai.\nE de novo há de vir com glória para julgar os vivos e os mortos: e o Seu reino não terá fim.\nE no Espírito Santo, Senhor e fonte de vida: que procede do Pai e do Filho.\nE com o Pai e o Filho é conjuntamente adorado e glorificado: o qual falou pelos Profetas.\nE na Igreja una, santa, católica e apostólica.\nConfesso um só Batismo para remissão dos pecados.\nE espero a ressurreição dos mortos.\nE a vida ✠ do mundo que há de vir. Amém."
+          "en-US": "I believe in one God, the Father almighty, maker of heaven and earth, and of all things visible and invisible.\nAnd in one Lord Jesus Christ, the only-begotten Son of God.\nBorn of the Father before all ages.\nGod of God, Light of Light, true God of true God.\nBegotten, not made, consubstantial with the Father: by whom all things were made.\nWho for us men and for our salvation came down from heaven.",
+          "la": "Credo in unum Deum, Patrem omnipoténtem, factórem cæli et terræ, visibílium ómnium et invisibílium.\nEt in unum Dóminum Jesum Christum, Fílium Dei unigénitum.\nEt ex Patre natum ante ómnia sǽcula.\nDeum de Deo, Lumen de Lúmine, Deum verum de Deo vero.\nGénitum, non factum, consubstantiálem Patri: per quem ómnia facta sunt.\nQui propter nos hómines et propter nostram salútem descéndit de cælis.",
+          "pt-BR": "Creio em um só Deus, Pai todo-poderoso, Criador do céu e da terra, de todas as coisas visíveis e invisíveis.\nE em um só Senhor Jesus Cristo, Filho Unigénito de Deus.\nNascido do Pai antes de todos os séculos.\nDeus de Deus, Luz da Luz, Deus verdadeiro de Deus verdadeiro.\nGerado, não criado, consubstancial ao Pai: por quem todas as coisas foram feitas.\nO qual por nós homens e para nossa salvação desceu dos céus."
         }
       },
       {
         "type": "rubric",
         "text": {
-          "en-US": "Here kneel down.",
-          "pt-BR": "Todos se ajoelham."
+          "en-US": "All kneel at the words \"Et incarnatus est\" through \"et homo factus est.\" On the feasts of the Nativity and the Annunciation all genuflect.",
+          "pt-BR": "Todos se ajoelham nas palavras \"Et incarnatus est\" até \"et homo factus est.\" Nas festas do Natal e da Anunciação, todos genuflectem."
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "all",
+        "inline": {
+          "en-US": "And was incarnate by the Holy Spirit of the Virgin Mary: and was made man.",
+          "la": "Et incarnátus est de Spíritu Sancto ex María Vírgine: et homo factus est.",
+          "pt-BR": "E encarnou pelo Espírito Santo no seio da Virgem Maria: e Se fez homem."
+        }
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "All rise.",
+          "pt-BR": "Todos se levantam."
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "all",
+        "inline": {
+          "en-US": "He was crucified also for us: suffered under Pontius Pilate, and was buried.\nAnd the third day He rose again according to the Scriptures.\nAnd ascended into heaven: He sits at the right hand of the Father.\nAnd He shall come again with glory to judge the living and the dead: of His kingdom there shall be no end.\nAnd in the Holy Spirit, the Lord and giver of life: who proceeds from the Father and the Son.\nWho together with the Father and the Son is adored and glorified: who spoke through the Prophets.\nAnd one, holy, catholic and apostolic Church.\nI confess one baptism for the remission of sins.\nAnd I await the resurrection of the dead.\nAnd the life ✠ of the world to come. Amen.",
+          "la": "Crucifíxus étiam pro nobis: sub Póntio Piláto passus, et sepúltus est.\nEt resurréxit tértia die, secúndum Scriptúras.\nEt ascéndit in cælum: sedet ad déxteram Patris.\nEt íterum ventúrus est cum glória judicáre vivos et mórtuos: cujus regni non erit finis.\nEt in Spíritum Sanctum, Dóminum et vivificántem: qui ex Patre Filióque procédit.\nQui cum Patre et Fílio simul adorátur et conglorificátur: qui locútus est per Prophétas.\nEt unam, sanctam, cathólicam et apostólicam Ecclésiam.\nConfíteor unum baptísma in remissiónem peccatórum.\nEt exspécto resurrectiónem mortuórum.\nEt vitam ✠ ventúri sǽculi. Amen.",
+          "pt-BR": "Também por nós foi crucificado: sob Pôncio Pilatos, padeceu e foi sepultado.\nE ao terceiro dia ressuscitou segundo as Escrituras.\nE subiu ao céu: está sentado à direita do Pai.\nE de novo há de vir com glória para julgar os vivos e os mortos: e o Seu reino não terá fim.\nE no Espírito Santo, Senhor e fonte de vida: que procede do Pai e do Filho.\nE com o Pai e o Filho é conjuntamente adorado e glorificado: o qual falou pelos Profetas.\nE na Igreja una, santa, católica e apostólica.\nConfesso um só Batismo para remissão dos pecados.\nE espero a ressurreição dos mortos.\nE a vida ✠ do mundo que há de vir. Amém."
         }
       },
       {
         "type": "divider"
-      },
-      {
-        "type": "rubric",
-        "text": {
-          "en-US": "The priest kisses the altar, and turning to the people says:",
-          "pt-BR": "O padre beija o altar, e virando-se para o povo diz:"
-        }
-      },
-      {
-        "type": "call",
-        "ref": "of-lord-be-with-you"
-      },
-      {
-        "type": "prayer",
-        "speaker": "priest",
-        "inline": {
-          "en-US": "Let us pray.",
-          "la": "Orémus.",
-          "pt-BR": "Oremos."
-        }
-      },
-      {
-        "type": "proper",
-        "slot": "offertory",
-        "description": {
-          "en-US": "Offertory verse of the day",
-          "pt-BR": "Versículo do Ofertório do dia"
-        },
-        "form": "ef"
       }
     ]
   }

--- a/content/libraries/base/practices/mass/fragments/ef-credo.json
+++ b/content/libraries/base/practices/mass/fragments/ef-credo.json
@@ -1,20 +1,6 @@
 {
   "fragments": {
-    "ef-credo": [
-      {
-        "type": "heading",
-        "text": {
-          "en-US": "Credo",
-          "pt-BR": "Credo"
-        }
-      },
-      {
-        "type": "rubric",
-        "text": {
-          "en-US": "On Sundays and certain Feasts the priest, standing at the middle of the altar, extending and joining his hands, says the Creed:",
-          "pt-BR": "Aos domingos e em certas festas, o sacerdote, no meio do altar, estende e junta as mãos e diz o Credo:"
-        }
-      },
+    "ef-credo-body": [
       {
         "type": "prayer",
         "speaker": "all",
@@ -55,6 +41,35 @@
           "la": "Crucifíxus étiam pro nobis: sub Póntio Piláto passus, et sepúltus est.\nEt resurréxit tértia die, secúndum Scriptúras.\nEt ascéndit in cælum: sedet ad déxteram Patris.\nEt íterum ventúrus est cum glória judicáre vivos et mórtuos: cujus regni non erit finis.\nEt in Spíritum Sanctum, Dóminum et vivificántem: qui ex Patre Filióque procédit.\nQui cum Patre et Fílio simul adorátur et conglorificátur: qui locútus est per Prophétas.\nEt unam, sanctam, cathólicam et apostólicam Ecclésiam.\nConfíteor unum baptísma in remissiónem peccatórum.\nEt exspécto resurrectiónem mortuórum.\nEt vitam ✠ ventúri sǽculi. Amen.",
           "pt-BR": "Também por nós foi crucificado: sob Pôncio Pilatos, padeceu e foi sepultado.\nE ao terceiro dia ressuscitou segundo as Escrituras.\nE subiu ao céu: está sentado à direita do Pai.\nE de novo há de vir com glória para julgar os vivos e os mortos: e o Seu reino não terá fim.\nE no Espírito Santo, Senhor e fonte de vida: que procede do Pai e do Filho.\nE com o Pai e o Filho é conjuntamente adorado e glorificado: o qual falou pelos Profetas.\nE na Igreja una, santa, católica e apostólica.\nConfesso um só Batismo para remissão dos pecados.\nE espero a ressurreição dos mortos.\nE a vida ✠ do mundo que há de vir. Amém."
         }
+      }
+    ],
+    "ef-credo": [
+      {
+        "type": "heading",
+        "text": {
+          "en-US": "Credo",
+          "pt-BR": "Credo"
+        }
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "The Creed is said on Sundays, on feasts of I and II class, on the octave days of major feasts, and on feasts of the Apostles, Evangelists, and Doctors of the Church. It is omitted on most ferias and on memorials of saints below II class — on those days the priest passes directly from the Gospel to the Offertory.",
+          "pt-BR": "O Credo é recitado aos domingos, nas festas de I e II classe, nos dias de oitava das festas maiores, e nas festas dos Apóstolos, Evangelistas e Doutores da Igreja. Omite-se nas ferias e nas memórias de santos abaixo da II classe — nesses dias o sacerdote passa diretamente do Evangelho ao Ofertório."
+        }
+      },
+      {
+        "type": "collapsible",
+        "title": {
+          "en-US": "Credo — text",
+          "pt-BR": "Credo — texto"
+        },
+        "sections": [
+          {
+            "type": "call",
+            "ref": "ef-credo-body"
+          }
+        ]
       },
       {
         "type": "divider"

--- a/content/libraries/base/practices/mass/fragments/ef-dismissal.json
+++ b/content/libraries/base/practices/mass/fragments/ef-dismissal.json
@@ -17,31 +17,147 @@
       },
       {
         "type": "call",
-        "ref": "of-lord-be-with-you"
+        "ref": "ef-lord-be-with-you"
+      },
+      {
+        "type": "select",
+        "on": "celebration.primary.season",
+        "default": "default",
+        "options": [
+          {
+            "id": "lent",
+            "label": {
+              "en-US": "Lent",
+              "pt-BR": "Quaresma"
+            },
+            "sections": [
+              {
+                "type": "rubric",
+                "text": {
+                  "en-US": "On days when the Gloria is omitted (Lent, Septuagesima, Advent ferials, vigils, ember days):",
+                  "pt-BR": "Nos dias em que se omite o Glória (Quaresma, Septuagésima, ferias do Advento, vigílias, têmporas):"
+                }
+              },
+              {
+                "type": "prayer",
+                "speaker": "priest",
+                "inline": {
+                  "en-US": "Let us bless the Lord.",
+                  "la": "Benedicámus Dómino.",
+                  "pt-BR": "Bendigamos ao Senhor."
+                }
+              },
+              {
+                "type": "prayer",
+                "speaker": "people",
+                "inline": {
+                  "en-US": "Thanks be to God.",
+                  "la": "Deo grátias.",
+                  "pt-BR": "Graças a Deus."
+                }
+              }
+            ]
+          },
+          {
+            "id": "advent",
+            "label": {
+              "en-US": "Advent",
+              "pt-BR": "Advento"
+            },
+            "sections": [
+              {
+                "type": "rubric",
+                "text": {
+                  "en-US": "On Advent ferials when the Gloria is omitted, \"Benedicamus Domino\" replaces \"Ite Missa est\". Sundays of Advent (with Gloria) keep \"Ite Missa est\".",
+                  "pt-BR": "Nas ferias do Advento, quando se omite o Glória, \"Benedicámus Dómino\" substitui o \"Ite Missa est\". Aos domingos do Advento (com Glória) mantém-se o \"Ite Missa est\"."
+                }
+              },
+              {
+                "type": "prayer",
+                "speaker": "priest",
+                "inline": {
+                  "en-US": "Go, the Mass is ended.",
+                  "la": "Ite, Missa est.",
+                  "pt-BR": "Ide, a Missa acabou."
+                }
+              },
+              {
+                "type": "prayer",
+                "speaker": "people",
+                "inline": {
+                  "en-US": "Thanks be to God.",
+                  "la": "Deo grátias.",
+                  "pt-BR": "Graças a Deus."
+                }
+              }
+            ]
+          },
+          {
+            "id": "default",
+            "label": {
+              "en-US": "Common",
+              "pt-BR": "Comum"
+            },
+            "sections": [
+              {
+                "type": "prayer",
+                "speaker": "priest",
+                "inline": {
+                  "en-US": "Go, the Mass is ended.",
+                  "la": "Ite, Missa est.",
+                  "pt-BR": "Ide, a Missa acabou."
+                }
+              },
+              {
+                "type": "prayer",
+                "speaker": "people",
+                "inline": {
+                  "en-US": "Thanks be to God.",
+                  "la": "Deo grátias.",
+                  "pt-BR": "Graças a Deus."
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "At a Requiem Mass, in place of the above, the priest says:",
+          "pt-BR": "Na Missa de Réquiem, em lugar do acima, o sacerdote diz:"
+        }
       },
       {
         "type": "prayer",
         "speaker": "priest",
         "inline": {
-          "en-US": "Go, the Mass is ended.",
-          "la": "Ite, Missa est.",
-          "pt-BR": "Ide, a Missa acabou."
+          "en-US": "May they rest in peace.",
+          "la": "Requiéscant in pace.",
+          "pt-BR": "Descansem em paz."
         }
       },
       {
         "type": "prayer",
         "speaker": "people",
         "inline": {
-          "en-US": "Thanks be to God.",
-          "la": "Deo grátias.",
-          "pt-BR": "Graças a Deus."
+          "en-US": "Amen.",
+          "la": "Amen.",
+          "pt-BR": "Amém."
         }
       },
       {
         "type": "subheading",
         "text": {
-          "en-US": "Blessing",
-          "pt-BR": "Bênção"
+          "en-US": "Placeat tibi",
+          "pt-BR": "Placeat tibi"
+        }
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "Bowing down before the altar, the priest says:",
+          "pt-BR": "Inclinando-se diante do altar, o sacerdote diz:"
         }
       },
       {
@@ -49,8 +165,14 @@
         "speaker": "priest",
         "inline": {
           "en-US": "May the tribute of my homage be pleasing to Thee, O holy Trinity: and grant that the sacrifice which I, though unworthy, have offered in the sight of Thy majesty, may be acceptable to Thee, and through Thy mercy be a propitiation for me and for all those for whom I have offered it. Through Christ our Lord. Amen.",
-          "la": "Pláceat tibi, sancta Trínitas, obséquium servitútis meæ: et præsta; ut sacrifícium, quod óculis tuæ majestátis indígnus óbtuli, tibi sit acceptábile, mihíque, et ómnibus pro quibus illud óbtuli, sit, te miseránte, propitiábile. Per Christum Dóminum nostrum. Amen.",
-          "pt-BR": "Seja-Vos agradável, ó Santíssima Trindade, a homenagem da minha servidão: e concedei que o sacrifício que eu, embora indigno, ofereci diante da Vossa majestade, Vos seja aceito, e que, pela Vossa misericórdia, seja propiciatório para mim e para todos aqueles por quem o ofereci. Por Cristo nosso Senhor. Amém."
+          "la": "Pláceat tibi, sancta Trínitas, obséquium servitútis meæ: et præsta; ut sacrifícium, quod óculis tuæ majestátis indígnus óbtuli, tibi sit acceptábile, mihíque, et ómnibus pro quibus illud óbtuli, sit, te miseránte, propitiábile. Per Christum Dóminum nostrum. Amen."
+        }
+      },
+      {
+        "type": "subheading",
+        "text": {
+          "en-US": "Blessing",
+          "pt-BR": "Bênção"
         }
       },
       {
@@ -76,6 +198,13 @@
           "en-US": "Amen.",
           "la": "Amen.",
           "pt-BR": "Amém."
+        }
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "(At a Requiem Mass the priest does not bless the people.)",
+          "pt-BR": "(Na Missa de Réquiem o sacerdote não dá a bênção.)"
         }
       },
       {

--- a/content/libraries/base/practices/mass/fragments/ef-extraordinary-view.json
+++ b/content/libraries/base/practices/mass/fragments/ef-extraordinary-view.json
@@ -3,6 +3,10 @@
     "ef-extraordinary-view": [
       {
         "type": "call",
+        "ref": "ef-asperges"
+      },
+      {
+        "type": "call",
         "ref": "ef-prayers-at-the-foot-of-the-altar"
       },
       {
@@ -44,6 +48,10 @@
       {
         "type": "call",
         "ref": "ef-last-gospel"
+      },
+      {
+        "type": "call",
+        "ref": "ef-leonine-prayers"
       }
     ]
   }

--- a/content/libraries/base/practices/mass/fragments/ef-gloria.json
+++ b/content/libraries/base/practices/mass/fragments/ef-gloria.json
@@ -1,20 +1,6 @@
 {
   "fragments": {
-    "ef-gloria": [
-      {
-        "type": "heading",
-        "text": {
-          "en-US": "Gloria",
-          "pt-BR": "Glória"
-        }
-      },
-      {
-        "type": "rubric",
-        "text": {
-          "en-US": "The Gloria is said on Sundays outside Advent, Septuagesima and Lent, on feasts and during privileged octaves; on weekdays of Eastertide; and at votive Masses of saints. It is omitted on Lenten and Advent ferias, on Septuagesima Sundays, on vigils, ember days, and at Requiem Masses — on these days the priest passes directly from the Kyrie to \"Dominus vobiscum\" and the Collect.",
-          "pt-BR": "O Glória se diz aos domingos fora do Advento, Septuagésima e Quaresma, nas festas e oitavas privilegiadas; nos dias de semana do Tempo Pascal; e nas missas votivas dos santos. Omite-se nas ferias do Advento e da Quaresma, nos domingos da Septuagésima, nas vigílias, têmporas e missas de réquiem — nesses dias o sacerdote passa diretamente do Kýrie para o \"Dóminus vobíscum\" e a Coleta."
-        }
-      },
+    "ef-gloria-body": [
       {
         "type": "rubric",
         "text": {
@@ -39,6 +25,110 @@
           "la": "Et in terra pax homínibus bonæ voluntátis. Laudámus te. Benedícimus te. Adorámus te. Glorificámus te. Grátias ágimus tibi propter magnam glóriam tuam. Dómine Deus, Rex cæléstis, Deus Pater omnípotens. Dómine Fili unigénite, Jesu Christe. Dómine Deus, Agnus Dei, Fílius Patris. Qui tollis peccáta mundi, miserére nobis. Qui tollis peccáta mundi, súscipe deprecatiónem nostram. Qui sedes ad déxteram Patris, miserére nobis. Quóniam tu solus Sanctus. Tu solus Dóminus. Tu solus Altíssimus, Jesu Christe. Cum Sancto Spíritu, ✠ in glória Dei Patris. Amen.",
           "pt-BR": "E na terra paz aos homens de boa vontade. Nós Vos louvamos. Nós Vos bendizemos. Nós Vos adoramos. Nós Vos glorificamos. Nós Vos damos graças pela Vossa imensa glória. Senhor Deus, Rei dos céus, Deus Pai todo-poderoso. Senhor Jesus Cristo, Filho Unigénito. Senhor Deus, Cordeiro de Deus, Filho do Pai. Vós que tirais os pecados do mundo, tende piedade de nós. Vós que tirais os pecados do mundo, acolhei a nossa súplica. Vós que estais sentado à direita do Pai, tende piedade de nós. Pois só Vós sois o Santo. Só Vós sois o Senhor. Só Vós sois o Altíssimo, Jesus Cristo. Com o Espírito Santo, ✠ na glória de Deus Pai. Amém."
         }
+      }
+    ],
+    "ef-gloria": [
+      {
+        "type": "heading",
+        "text": {
+          "en-US": "Gloria",
+          "pt-BR": "Glória"
+        }
+      },
+      {
+        "type": "select",
+        "on": "celebration.primary.season",
+        "default": "default",
+        "options": [
+          {
+            "id": "lent",
+            "label": {
+              "en-US": "Lent",
+              "pt-BR": "Quaresma"
+            },
+            "sections": [
+              {
+                "type": "rubric",
+                "text": {
+                  "en-US": "The Gloria is omitted in Lent. The priest passes from the Kyrie directly to \"Dominus vobiscum\" and the Collect.",
+                  "pt-BR": "Omite-se o Glória na Quaresma. O sacerdote passa do Kýrie diretamente ao \"Dóminus vobíscum\" e à Coleta."
+                }
+              },
+              {
+                "type": "collapsible",
+                "title": {
+                  "en-US": "Gloria — text (omitted today)",
+                  "pt-BR": "Glória — texto (omitido hoje)"
+                },
+                "sections": [
+                  {
+                    "type": "call",
+                    "ref": "ef-gloria-body"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "advent",
+            "label": {
+              "en-US": "Advent",
+              "pt-BR": "Advento"
+            },
+            "sections": [
+              {
+                "type": "rubric",
+                "text": {
+                  "en-US": "The Gloria is omitted on the Sundays and ferias of Advent. It is said only at Christmas Masses, on feasts of saints during Advent, and at votive Masses with their own Gloria.",
+                  "pt-BR": "Omite-se o Glória nos domingos e ferias do Advento. Diz-se apenas nas Missas do Natal, nas festas de santos durante o Advento, e nas missas votivas com Glória próprio."
+                }
+              },
+              {
+                "type": "collapsible",
+                "title": {
+                  "en-US": "Gloria — text (usually omitted in Advent)",
+                  "pt-BR": "Glória — texto (geralmente omitido no Advento)"
+                },
+                "sections": [
+                  {
+                    "type": "call",
+                    "ref": "ef-gloria-body"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "default",
+            "label": {
+              "en-US": "Common",
+              "pt-BR": "Comum"
+            },
+            "sections": [
+              {
+                "type": "rubric",
+                "text": {
+                  "en-US": "The Gloria is omitted at Requiem Masses, on vigils, ember days, and Septuagesima Sundays. On those days the priest passes directly from the Kyrie to \"Dominus vobiscum\" and the Collect.",
+                  "pt-BR": "Omite-se o Glória nas missas de Réquiem, nas vigílias, nas têmporas, e nos domingos da Septuagésima. Nesses dias o sacerdote passa diretamente do Kýrie ao \"Dóminus vobíscum\" e à Coleta."
+                }
+              },
+              {
+                "type": "collapsible",
+                "title": {
+                  "en-US": "Gloria",
+                  "pt-BR": "Glória"
+                },
+                "defaultOpen": true,
+                "sections": [
+                  {
+                    "type": "call",
+                    "ref": "ef-gloria-body"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       {
         "type": "rubric",

--- a/content/libraries/base/practices/mass/fragments/ef-gloria.json
+++ b/content/libraries/base/practices/mass/fragments/ef-gloria.json
@@ -11,6 +11,13 @@
       {
         "type": "rubric",
         "text": {
+          "en-US": "The Gloria is said on Sundays outside Advent, Septuagesima and Lent, on feasts and during privileged octaves; on weekdays of Eastertide; and at votive Masses of saints. It is omitted on Lenten and Advent ferias, on Septuagesima Sundays, on vigils, ember days, and at Requiem Masses — on these days the priest passes directly from the Kyrie to \"Dominus vobiscum\" and the Collect.",
+          "pt-BR": "O Glória se diz aos domingos fora do Advento, Septuagésima e Quaresma, nas festas e oitavas privilegiadas; nos dias de semana do Tempo Pascal; e nas missas votivas dos santos. Omite-se nas ferias do Advento e da Quaresma, nos domingos da Septuagésima, nas vigílias, têmporas e missas de réquiem — nesses dias o sacerdote passa diretamente do Kýrie para o \"Dóminus vobíscum\" e a Coleta."
+        }
+      },
+      {
+        "type": "rubric",
+        "text": {
           "en-US": "Standing at the middle of the altar, extending and then joining his hands, the priest says the Gloria:",
           "pt-BR": "De pé, no meio do altar, estendendo e depois juntando as mãos, o sacerdote diz o Glória:"
         }

--- a/content/libraries/base/practices/mass/fragments/ef-gloria.json
+++ b/content/libraries/base/practices/mass/fragments/ef-gloria.json
@@ -36,12 +36,32 @@
       {
         "type": "rubric",
         "text": {
-          "en-US": "Then the priest kisses the altar, and turning to the people says:",
-          "pt-BR": "O sacerdote benze-se, beija o altar, volta-se para os fiéis e diz:"
+          "en-US": "Then the priest kisses the altar, and turning to the people, extending and joining his hands, says:",
+          "pt-BR": "O sacerdote beija o altar, volta-se para os fiéis, abre e junta as mãos, e diz:"
+        }
+      },
+      {
+        "type": "call",
+        "ref": "ef-lord-be-with-you"
+      },
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "Let us pray.",
+          "la": "Orémus.",
+          "pt-BR": "Oremos."
         }
       },
       {
         "type": "divider"
+      },
+      {
+        "type": "subheading",
+        "text": {
+          "en-US": "Collect",
+          "pt-BR": "Oração Coleta"
+        }
       },
       {
         "type": "proper",

--- a/content/libraries/base/practices/mass/fragments/ef-last-gospel.json
+++ b/content/libraries/base/practices/mass/fragments/ef-last-gospel.json
@@ -24,7 +24,7 @@
       },
       {
         "type": "call",
-        "ref": "of-lord-be-with-you"
+        "ref": "ef-lord-be-with-you"
       },
       {
         "type": "rubric",

--- a/content/libraries/base/practices/mass/fragments/ef-last-gospel.json
+++ b/content/libraries/base/practices/mass/fragments/ef-last-gospel.json
@@ -55,16 +55,41 @@
         "type": "prayer",
         "speaker": "priest",
         "inline": {
-          "en-US": "In the beginning was the Word, and the Word was with God, and the Word was God. The same was in the beginning with God. All things were made by Him: and without Him was made nothing that was made: in Him was life, and the life was the light of men: and the light shineth in darkness, and the darkness did not comprehend it.\nThere was a man sent from God, whose name was John. This man came for a witness, to give testimony of the light, that all men might believe through him. He was not the light, but was to give testimony of the light.\nThat was the true light, which enlighteneth every man that cometh into this world. He was in the world, and the world was made by Him, and the world knew Him not. He came unto His own, and His own received Him not. But as many as received Him, He gave them power to be made the sons of God, to them that believe in His name: who are born, not of blood, nor of the will of the flesh, nor of the will of man, but of God.\nAND THE WORD WAS MADE FLESH, and dwelt among us: and we saw His glory, the glory as it were of the only-begotten of the Father, full of grace and truth.",
-          "la": "In princípio erat Verbum, et Verbum erat apud Deum, et Deus erat Verbum. Hoc erat in princípio apud Deum. Ómnia per ipsum facta sunt: et sine ipso factum est nihil, quod factum est: in ipso vita erat, et vita erat lux hóminum: et lux in ténebris lucet, et ténebræ eam non comprehendérunt.\nFuit homo missus a Deo, cui nomen erat Joánnes. Hic venit in testimónium, ut testimónium perhibéret de lúmine, ut omnes créderent per illum. Non erat ille lux, sed ut testimónium perhibéret de lúmine.\nErat lux vera, quæ illúminat omnem hóminem veniéntem in hunc mundum. In mundo erat, et mundus per ipsum factus est, et mundus eum non cognóvit. In própria venit, et sui eum non recepérunt. Quotquot autem recepérunt eum, dedit eis potestátem fílios Dei fíeri, his qui credunt in nómine ejus: qui non ex sanguínibus, neque ex voluntáte carnis, neque ex voluntáte viri, sed ex Deo nati sunt.\nET VERBUM CARO FACTUM EST, et habitávit in nobis: et vídimus glóriam ejus, glóriam quasi Unigéniti a Patre, plenum grátiæ et veritátis.",
-          "pt-BR": "No princípio era o Verbo, e o Verbo estava junto de Deus, e o Verbo era Deus. Ele estava no princípio junto de Deus. Todas as coisas foram feitas por Ele: e sem Ele nada foi feito do que foi feito: n'Ele estava a vida, e a vida era a luz dos homens: e a luz brilha nas trevas, e as trevas não a compreenderam.\nHouve um homem enviado por Deus, cujo nome era João. Este veio como testemunha, para dar testemunho da luz, a fim de que todos cressem por meio dele. Não era ele a luz, mas veio para dar testemunho da luz.\nEra a luz verdadeira, que ilumina todo homem que vem a este mundo. Estava no mundo, e o mundo foi feito por Ele, e o mundo não O conheceu. Veio para o que era Seu, e os Seus não O receberam. Mas a todos quantos O receberam, deu-lhes o poder de se tornarem filhos de Deus, aos que creem no Seu nome: os quais não nasceram do sangue, nem da vontade da carne, nem da vontade do varão, mas de Deus.\nE O VERBO SE FEZ CARNE, e habitou entre nós: e vimos a Sua glória, glória como de Unigénito do Pai, cheio de graça e de verdade."
+          "en-US": "In the beginning was the Word, and the Word was with God, and the Word was God. The same was in the beginning with God. All things were made by Him: and without Him was made nothing that was made: in Him was life, and the life was the light of men: and the light shineth in darkness, and the darkness did not comprehend it.\nThere was a man sent from God, whose name was John. This man came for a witness, to give testimony of the light, that all men might believe through him. He was not the light, but was to give testimony of the light.\nThat was the true light, which enlighteneth every man that cometh into this world. He was in the world, and the world was made by Him, and the world knew Him not. He came unto His own, and His own received Him not. But as many as received Him, He gave them power to be made the sons of God, to them that believe in His name: who are born, not of blood, nor of the will of the flesh, nor of the will of man, but of God.",
+          "la": "In princípio erat Verbum, et Verbum erat apud Deum, et Deus erat Verbum. Hoc erat in princípio apud Deum. Ómnia per ipsum facta sunt: et sine ipso factum est nihil, quod factum est: in ipso vita erat, et vita erat lux hóminum: et lux in ténebris lucet, et ténebræ eam non comprehendérunt.\nFuit homo missus a Deo, cui nomen erat Joánnes. Hic venit in testimónium, ut testimónium perhibéret de lúmine, ut omnes créderent per illum. Non erat ille lux, sed ut testimónium perhibéret de lúmine.\nErat lux vera, quæ illúminat omnem hóminem veniéntem in hunc mundum. In mundo erat, et mundus per ipsum factus est, et mundus eum non cognóvit. In própria venit, et sui eum non recepérunt. Quotquot autem recepérunt eum, dedit eis potestátem fílios Dei fíeri, his qui credunt in nómine ejus: qui non ex sanguínibus, neque ex voluntáte carnis, neque ex voluntáte viri, sed ex Deo nati sunt.",
+          "pt-BR": "No princípio era o Verbo, e o Verbo estava junto de Deus, e o Verbo era Deus. Ele estava no princípio junto de Deus. Todas as coisas foram feitas por Ele: e sem Ele nada foi feito do que foi feito: n'Ele estava a vida, e a vida era a luz dos homens: e a luz brilha nas trevas, e as trevas não a compreenderam.\nHouve um homem enviado por Deus, cujo nome era João. Este veio como testemunha, para dar testemunho da luz, a fim de que todos cressem por meio dele. Não era ele a luz, mas veio para dar testemunho da luz.\nEra a luz verdadeira, que ilumina todo homem que vem a este mundo. Estava no mundo, e o mundo foi feito por Ele, e o mundo não O conheceu. Veio para o que era Seu, e os Seus não O receberam. Mas a todos quantos O receberam, deu-lhes o poder de se tornarem filhos de Deus, aos que creem no Seu nome: os quais não nasceram do sangue, nem da vontade da carne, nem da vontade do varão, mas de Deus."
         }
       },
       {
         "type": "rubric",
         "text": {
-          "en-US": "All genuflect at \"Et Verbum caro factum est.\"",
-          "pt-BR": "Todos genuflectem ao \"Et Verbum caro factum est.\""
+          "en-US": "Here all genuflect.",
+          "pt-BR": "Aqui todos se ajoelham."
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "AND THE WORD WAS MADE FLESH,",
+          "la": "ET VERBUM CARO FACTUM EST,",
+          "pt-BR": "E O VERBO SE FEZ CARNE,"
+        }
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "All rise.",
+          "pt-BR": "Todos se levantam."
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "and dwelt among us: and we saw His glory, the glory as it were of the only-begotten of the Father, full of grace and truth.",
+          "la": "et habitávit in nobis: et vídimus glóriam ejus, glóriam quasi Unigéniti a Patre, plenum grátiæ et veritátis.",
+          "pt-BR": "e habitou entre nós: e vimos a Sua glória, glória como de Unigénito do Pai, cheio de graça e de verdade."
         }
       },
       {

--- a/content/libraries/base/practices/mass/fragments/ef-leonine-prayers.json
+++ b/content/libraries/base/practices/mass/fragments/ef-leonine-prayers.json
@@ -2,132 +2,134 @@
   "fragments": {
     "ef-leonine-prayers": [
       {
-        "type": "heading",
-        "text": {
-          "en-US": "Leonine Prayers",
-          "pt-BR": "Orações Leoninas"
-        }
-      },
-      {
-        "type": "rubric",
-        "text": {
-          "en-US": "Prescribed by Pope Leo XIII (1884) for recitation after Low Mass. The priest kneels at the foot of the altar with the people.",
-          "pt-BR": "Prescritas pelo Papa Leão XIII (1884) para serem rezadas após a Missa rezada. O sacerdote ajoelha-se ao pé do altar com os fiéis."
-        }
-      },
-      {
-        "type": "subheading",
-        "text": {
-          "en-US": "Three Hail Marys",
-          "pt-BR": "Três Ave-Marias"
-        }
-      },
-      {
-        "type": "prayer",
-        "speaker": "all",
-        "inline": {
-          "en-US": "Hail Mary, full of grace, the Lord is with thee: blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus.\nHoly Mary, Mother of God, pray for us sinners, now and at the hour of our death. Amen.",
-          "la": "Ave María, grátia plena, Dóminus tecum: benedícta tu in muliéribus, et benedíctus fructus ventris tui, Jesus.\nSancta María, Mater Dei, ora pro nobis peccatóribus, nunc, et in hora mortis nostræ. Amen.",
-          "pt-BR": "Ave Maria, cheia de graça, o Senhor é convosco: bendita sois Vós entre as mulheres, e bendito é o fruto do Vosso ventre, Jesus.\nSanta Maria, Mãe de Deus, rogai por nós pecadores, agora e na hora da nossa morte. Amém."
-        }
-      },
-      {
-        "type": "rubric",
-        "text": {
-          "en-US": "(Repeated three times.)",
-          "pt-BR": "(Repetida três vezes.)"
-        }
-      },
-      {
-        "type": "subheading",
-        "text": {
-          "en-US": "Salve Regina",
-          "pt-BR": "Salve Rainha"
-        }
-      },
-      {
-        "type": "prayer",
-        "speaker": "all",
-        "inline": {
-          "en-US": "Hail, holy Queen, Mother of mercy, our life, our sweetness, and our hope. To thee do we cry, poor banished children of Eve. To thee do we send up our sighs, mourning and weeping in this valley of tears. Turn then, most gracious Advocate, thine eyes of mercy toward us. And after this our exile, show unto us the blessed fruit of thy womb, Jesus. O clement, O loving, O sweet Virgin Mary.",
-          "la": "Salve Regína, Mater misericórdiæ, vita, dulcédo et spes nostra, salve. Ad te clamámus, éxsules fílii Hevæ. Ad te suspirámus, geméntes et flentes in hac lacrimárum valle. Eja ergo, advocáta nostra, illos tuos misericórdes óculos ad nos convérte. Et Jesum, benedíctum fructum ventris tui, nobis post hoc exsílium osténde. O clemens, O pia, O dulcis Virgo María.",
-          "pt-BR": "Salve, Rainha, Mãe de misericórdia, vida, doçura e esperança nossa, salve. A Vós bradamos, os degredados filhos de Eva. A Vós suspiramos, gemendo e chorando neste vale de lágrimas. Eia, pois, advogada nossa, esses Vossos olhos misericordiosos a nós volvei. E, depois deste desterro, mostrai-nos Jesus, bendito fruto do Vosso ventre. Ó clemente, ó piedosa, ó doce Virgem Maria."
-        }
-      },
-      {
-        "type": "prayer",
-        "speaker": "priest",
-        "inline": {
-          "en-US": "Pray for us, O holy Mother of God.",
-          "la": "Ora pro nobis, sancta Dei Génitrix.",
-          "pt-BR": "Rogai por nós, Santa Mãe de Deus."
-        }
-      },
-      {
-        "type": "prayer",
-        "speaker": "people",
-        "inline": {
-          "en-US": "That we may be made worthy of the promises of Christ.",
-          "la": "Ut digni efficiámur promissiónibus Christi.",
-          "pt-BR": "Para que sejamos dignos das promessas de Cristo."
-        }
-      },
-      {
-        "type": "prayer",
-        "speaker": "priest",
-        "inline": {
-          "en-US": "Let us pray. O God, our refuge and our strength, look down with favor upon Thy people who cry to Thee; and by the intercession of the glorious and immaculate Virgin Mary, Mother of God, of St. Joseph her spouse, of Thy blessed Apostles Peter and Paul, and of all the Saints, mercifully and graciously hear the prayers which we pour forth for the conversion of sinners, and for the liberty and exaltation of holy Mother Church. Through the same Christ our Lord. Amen.",
-          "la": "Orémus. Deus, refúgium nostrum et virtus, pópulum ad te clamántem propítius réspice; et intercedénte gloriósa, et immaculáta Vírgine Dei Genitríce María, cum beáto Joseph, ejus Sponso, ac beátis Apóstolis tuis Petro et Paulo, et ómnibus Sanctis, quas pro conversióne peccatórum, pro libertáte et exaltatióne sanctæ Matris Ecclésiæ, preces effúndimus, miséricors et benígnus exáudi. Per eúndem Christum Dóminum nostrum. Amen.",
-          "pt-BR": "Oremos. Ó Deus, nosso refúgio e fortaleza, olhai propício para o povo que a Vós clama; e pela intercessão da gloriosa e imaculada Virgem Maria, Mãe de Deus, do bem-aventurado São José, seu Esposo, dos Vossos bem-aventurados Apóstolos Pedro e Paulo, e de todos os Santos, ouvi misericordioso e benigno as preces que Vos elevamos pela conversão dos pecadores, e pela liberdade e exaltação da santa Madre Igreja. Pelo mesmo Cristo nosso Senhor. Amém."
-        }
-      },
-      {
-        "type": "subheading",
-        "text": {
-          "en-US": "Prayer to St. Michael",
-          "pt-BR": "Oração a São Miguel"
-        }
-      },
-      {
-        "type": "prayer",
-        "speaker": "all",
-        "inline": {
-          "en-US": "Holy Michael, Archangel, defend us in the day of battle: be our safeguard against the wickedness and snares of the devil. May God rebuke him, we humbly pray; and do thou, O Prince of the heavenly host, by the power of God, thrust down to hell Satan and all the evil spirits, who wander through the world for the ruin of souls. Amen.",
-          "la": "Sancte Míchaël Archángele, defénde nos in prǽlio; contra nequítiam et insídias diáboli esto præsídium. Ímperet illi Deus, súpplices deprecámur: tuque, Princeps milítiæ cæléstis, Sátanam aliósque spíritus malígnos, qui ad perditiónem animárum pervagántur in mundo, divína virtúte in inférnum detrúde. Amen.",
-          "pt-BR": "São Miguel Arcanjo, defendei-nos no combate; sede o nosso refúgio contra a maldade e as ciladas do demônio. Repreenda-o Deus, pedimos suplicantes; e Vós, Príncipe da milícia celeste, pelo poder divino, precipitai no inferno Satanás e os outros espíritos malignos que andam pelo mundo para perdição das almas. Amém."
-        }
-      },
-      {
-        "type": "subheading",
-        "text": {
-          "en-US": "To the Sacred Heart",
-          "pt-BR": "Ao Sagrado Coração"
-        }
-      },
-      {
-        "type": "prayer",
-        "speaker": "priest",
-        "inline": {
-          "en-US": "Most Sacred Heart of Jesus,",
-          "la": "Cor Jesu sacratíssimum,",
-          "pt-BR": "Sacratíssimo Coração de Jesus,"
-        }
-      },
-      {
-        "type": "prayer",
-        "speaker": "people",
-        "inline": {
-          "en-US": "Have mercy on us.",
-          "la": "Miserére nobis.",
-          "pt-BR": "Tende piedade de nós."
-        }
-      },
-      {
-        "type": "rubric",
-        "text": {
-          "en-US": "(Repeated three times.)",
-          "pt-BR": "(Repetida três vezes.)"
-        }
+        "type": "collapsible",
+        "title": {
+          "en-US": "Leonine Prayers (after Low Mass — optional)",
+          "pt-BR": "Orações Leoninas (após a Missa rezada — opcionais)"
+        },
+        "sections": [
+          {
+            "type": "rubric",
+            "text": {
+              "en-US": "Prescribed by Pope Leo XIII (1884) for recitation after Low Mass; suspended in 1965. The priest kneels at the foot of the altar with the people.",
+              "pt-BR": "Prescritas pelo Papa Leão XIII (1884) para serem rezadas após a Missa rezada; suspensas em 1965. O sacerdote ajoelha-se ao pé do altar com os fiéis."
+            }
+          },
+          {
+            "type": "subheading",
+            "text": {
+              "en-US": "Three Hail Marys",
+              "pt-BR": "Três Ave-Marias"
+            }
+          },
+          {
+            "type": "prayer",
+            "speaker": "all",
+            "inline": {
+              "en-US": "Hail Mary, full of grace, the Lord is with thee: blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus.\nHoly Mary, Mother of God, pray for us sinners, now and at the hour of our death. Amen.",
+              "la": "Ave María, grátia plena, Dóminus tecum: benedícta tu in muliéribus, et benedíctus fructus ventris tui, Jesus.\nSancta María, Mater Dei, ora pro nobis peccatóribus, nunc, et in hora mortis nostræ. Amen.",
+              "pt-BR": "Ave Maria, cheia de graça, o Senhor é convosco: bendita sois Vós entre as mulheres, e bendito é o fruto do Vosso ventre, Jesus.\nSanta Maria, Mãe de Deus, rogai por nós pecadores, agora e na hora da nossa morte. Amém."
+            }
+          },
+          {
+            "type": "rubric",
+            "text": {
+              "en-US": "(Repeated three times.)",
+              "pt-BR": "(Repetida três vezes.)"
+            }
+          },
+          {
+            "type": "subheading",
+            "text": {
+              "en-US": "Salve Regina",
+              "pt-BR": "Salve Rainha"
+            }
+          },
+          {
+            "type": "prayer",
+            "speaker": "all",
+            "inline": {
+              "en-US": "Hail, holy Queen, Mother of mercy, our life, our sweetness, and our hope. To thee do we cry, poor banished children of Eve. To thee do we send up our sighs, mourning and weeping in this valley of tears. Turn then, most gracious Advocate, thine eyes of mercy toward us. And after this our exile, show unto us the blessed fruit of thy womb, Jesus. O clement, O loving, O sweet Virgin Mary.",
+              "la": "Salve Regína, Mater misericórdiæ, vita, dulcédo et spes nostra, salve. Ad te clamámus, éxsules fílii Hevæ. Ad te suspirámus, geméntes et flentes in hac lacrimárum valle. Eja ergo, advocáta nostra, illos tuos misericórdes óculos ad nos convérte. Et Jesum, benedíctum fructum ventris tui, nobis post hoc exsílium osténde. O clemens, O pia, O dulcis Virgo María.",
+              "pt-BR": "Salve, Rainha, Mãe de misericórdia, vida, doçura e esperança nossa, salve. A Vós bradamos, os degredados filhos de Eva. A Vós suspiramos, gemendo e chorando neste vale de lágrimas. Eia, pois, advogada nossa, esses Vossos olhos misericordiosos a nós volvei. E, depois deste desterro, mostrai-nos Jesus, bendito fruto do Vosso ventre. Ó clemente, ó piedosa, ó doce Virgem Maria."
+            }
+          },
+          {
+            "type": "prayer",
+            "speaker": "priest",
+            "inline": {
+              "en-US": "Pray for us, O holy Mother of God.",
+              "la": "Ora pro nobis, sancta Dei Génitrix.",
+              "pt-BR": "Rogai por nós, Santa Mãe de Deus."
+            }
+          },
+          {
+            "type": "prayer",
+            "speaker": "people",
+            "inline": {
+              "en-US": "That we may be made worthy of the promises of Christ.",
+              "la": "Ut digni efficiámur promissiónibus Christi.",
+              "pt-BR": "Para que sejamos dignos das promessas de Cristo."
+            }
+          },
+          {
+            "type": "prayer",
+            "speaker": "priest",
+            "inline": {
+              "en-US": "Let us pray. O God, our refuge and our strength, look down with favor upon Thy people who cry to Thee; and by the intercession of the glorious and immaculate Virgin Mary, Mother of God, of St. Joseph her spouse, of Thy blessed Apostles Peter and Paul, and of all the Saints, mercifully and graciously hear the prayers which we pour forth for the conversion of sinners, and for the liberty and exaltation of holy Mother Church. Through the same Christ our Lord. Amen.",
+              "la": "Orémus. Deus, refúgium nostrum et virtus, pópulum ad te clamántem propítius réspice; et intercedénte gloriósa, et immaculáta Vírgine Dei Genitríce María, cum beáto Joseph, ejus Sponso, ac beátis Apóstolis tuis Petro et Paulo, et ómnibus Sanctis, quas pro conversióne peccatórum, pro libertáte et exaltatióne sanctæ Matris Ecclésiæ, preces effúndimus, miséricors et benígnus exáudi. Per eúndem Christum Dóminum nostrum. Amen.",
+              "pt-BR": "Oremos. Ó Deus, nosso refúgio e fortaleza, olhai propício para o povo que a Vós clama; e pela intercessão da gloriosa e imaculada Virgem Maria, Mãe de Deus, do bem-aventurado São José, seu Esposo, dos Vossos bem-aventurados Apóstolos Pedro e Paulo, e de todos os Santos, ouvi misericordioso e benigno as preces que Vos elevamos pela conversão dos pecadores, e pela liberdade e exaltação da santa Madre Igreja. Pelo mesmo Cristo nosso Senhor. Amém."
+            }
+          },
+          {
+            "type": "subheading",
+            "text": {
+              "en-US": "Prayer to St. Michael",
+              "pt-BR": "Oração a São Miguel"
+            }
+          },
+          {
+            "type": "prayer",
+            "speaker": "all",
+            "inline": {
+              "en-US": "Holy Michael, Archangel, defend us in the day of battle: be our safeguard against the wickedness and snares of the devil. May God rebuke him, we humbly pray; and do thou, O Prince of the heavenly host, by the power of God, thrust down to hell Satan and all the evil spirits, who wander through the world for the ruin of souls. Amen.",
+              "la": "Sancte Míchaël Archángele, defénde nos in prǽlio; contra nequítiam et insídias diáboli esto præsídium. Ímperet illi Deus, súpplices deprecámur: tuque, Princeps milítiæ cæléstis, Sátanam aliósque spíritus malígnos, qui ad perditiónem animárum pervagántur in mundo, divína virtúte in inférnum detrúde. Amen.",
+              "pt-BR": "São Miguel Arcanjo, defendei-nos no combate; sede o nosso refúgio contra a maldade e as ciladas do demônio. Repreenda-o Deus, pedimos suplicantes; e Vós, Príncipe da milícia celeste, pelo poder divino, precipitai no inferno Satanás e os outros espíritos malignos que andam pelo mundo para perdição das almas. Amém."
+            }
+          },
+          {
+            "type": "subheading",
+            "text": {
+              "en-US": "To the Sacred Heart",
+              "pt-BR": "Ao Sagrado Coração"
+            }
+          },
+          {
+            "type": "prayer",
+            "speaker": "priest",
+            "inline": {
+              "en-US": "Most Sacred Heart of Jesus,",
+              "la": "Cor Jesu sacratíssimum,",
+              "pt-BR": "Sacratíssimo Coração de Jesus,"
+            }
+          },
+          {
+            "type": "prayer",
+            "speaker": "people",
+            "inline": {
+              "en-US": "Have mercy on us.",
+              "la": "Miserére nobis.",
+              "pt-BR": "Tende piedade de nós."
+            }
+          },
+          {
+            "type": "rubric",
+            "text": {
+              "en-US": "(Repeated three times.)",
+              "pt-BR": "(Repetida três vezes.)"
+            }
+          }
+        ]
       }
     ]
   }

--- a/content/libraries/base/practices/mass/fragments/ef-leonine-prayers.json
+++ b/content/libraries/base/practices/mass/fragments/ef-leonine-prayers.json
@@ -1,0 +1,134 @@
+{
+  "fragments": {
+    "ef-leonine-prayers": [
+      {
+        "type": "heading",
+        "text": {
+          "en-US": "Leonine Prayers",
+          "pt-BR": "Orações Leoninas"
+        }
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "Prescribed by Pope Leo XIII (1884) for recitation after Low Mass. The priest kneels at the foot of the altar with the people.",
+          "pt-BR": "Prescritas pelo Papa Leão XIII (1884) para serem rezadas após a Missa rezada. O sacerdote ajoelha-se ao pé do altar com os fiéis."
+        }
+      },
+      {
+        "type": "subheading",
+        "text": {
+          "en-US": "Three Hail Marys",
+          "pt-BR": "Três Ave-Marias"
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "all",
+        "inline": {
+          "en-US": "Hail Mary, full of grace, the Lord is with thee: blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus.\nHoly Mary, Mother of God, pray for us sinners, now and at the hour of our death. Amen.",
+          "la": "Ave María, grátia plena, Dóminus tecum: benedícta tu in muliéribus, et benedíctus fructus ventris tui, Jesus.\nSancta María, Mater Dei, ora pro nobis peccatóribus, nunc, et in hora mortis nostræ. Amen.",
+          "pt-BR": "Ave Maria, cheia de graça, o Senhor é convosco: bendita sois Vós entre as mulheres, e bendito é o fruto do Vosso ventre, Jesus.\nSanta Maria, Mãe de Deus, rogai por nós pecadores, agora e na hora da nossa morte. Amém."
+        }
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "(Repeated three times.)",
+          "pt-BR": "(Repetida três vezes.)"
+        }
+      },
+      {
+        "type": "subheading",
+        "text": {
+          "en-US": "Salve Regina",
+          "pt-BR": "Salve Rainha"
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "all",
+        "inline": {
+          "en-US": "Hail, holy Queen, Mother of mercy, our life, our sweetness, and our hope. To thee do we cry, poor banished children of Eve. To thee do we send up our sighs, mourning and weeping in this valley of tears. Turn then, most gracious Advocate, thine eyes of mercy toward us. And after this our exile, show unto us the blessed fruit of thy womb, Jesus. O clement, O loving, O sweet Virgin Mary.",
+          "la": "Salve Regína, Mater misericórdiæ, vita, dulcédo et spes nostra, salve. Ad te clamámus, éxsules fílii Hevæ. Ad te suspirámus, geméntes et flentes in hac lacrimárum valle. Eja ergo, advocáta nostra, illos tuos misericórdes óculos ad nos convérte. Et Jesum, benedíctum fructum ventris tui, nobis post hoc exsílium osténde. O clemens, O pia, O dulcis Virgo María.",
+          "pt-BR": "Salve, Rainha, Mãe de misericórdia, vida, doçura e esperança nossa, salve. A Vós bradamos, os degredados filhos de Eva. A Vós suspiramos, gemendo e chorando neste vale de lágrimas. Eia, pois, advogada nossa, esses Vossos olhos misericordiosos a nós volvei. E, depois deste desterro, mostrai-nos Jesus, bendito fruto do Vosso ventre. Ó clemente, ó piedosa, ó doce Virgem Maria."
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "Pray for us, O holy Mother of God.",
+          "la": "Ora pro nobis, sancta Dei Génitrix.",
+          "pt-BR": "Rogai por nós, Santa Mãe de Deus."
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "people",
+        "inline": {
+          "en-US": "That we may be made worthy of the promises of Christ.",
+          "la": "Ut digni efficiámur promissiónibus Christi.",
+          "pt-BR": "Para que sejamos dignos das promessas de Cristo."
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "Let us pray. O God, our refuge and our strength, look down with favor upon Thy people who cry to Thee; and by the intercession of the glorious and immaculate Virgin Mary, Mother of God, of St. Joseph her spouse, of Thy blessed Apostles Peter and Paul, and of all the Saints, mercifully and graciously hear the prayers which we pour forth for the conversion of sinners, and for the liberty and exaltation of holy Mother Church. Through the same Christ our Lord. Amen.",
+          "la": "Orémus. Deus, refúgium nostrum et virtus, pópulum ad te clamántem propítius réspice; et intercedénte gloriósa, et immaculáta Vírgine Dei Genitríce María, cum beáto Joseph, ejus Sponso, ac beátis Apóstolis tuis Petro et Paulo, et ómnibus Sanctis, quas pro conversióne peccatórum, pro libertáte et exaltatióne sanctæ Matris Ecclésiæ, preces effúndimus, miséricors et benígnus exáudi. Per eúndem Christum Dóminum nostrum. Amen.",
+          "pt-BR": "Oremos. Ó Deus, nosso refúgio e fortaleza, olhai propício para o povo que a Vós clama; e pela intercessão da gloriosa e imaculada Virgem Maria, Mãe de Deus, do bem-aventurado São José, seu Esposo, dos Vossos bem-aventurados Apóstolos Pedro e Paulo, e de todos os Santos, ouvi misericordioso e benigno as preces que Vos elevamos pela conversão dos pecadores, e pela liberdade e exaltação da santa Madre Igreja. Pelo mesmo Cristo nosso Senhor. Amém."
+        }
+      },
+      {
+        "type": "subheading",
+        "text": {
+          "en-US": "Prayer to St. Michael",
+          "pt-BR": "Oração a São Miguel"
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "all",
+        "inline": {
+          "en-US": "Holy Michael, Archangel, defend us in the day of battle: be our safeguard against the wickedness and snares of the devil. May God rebuke him, we humbly pray; and do thou, O Prince of the heavenly host, by the power of God, thrust down to hell Satan and all the evil spirits, who wander through the world for the ruin of souls. Amen.",
+          "la": "Sancte Míchaël Archángele, defénde nos in prǽlio; contra nequítiam et insídias diáboli esto præsídium. Ímperet illi Deus, súpplices deprecámur: tuque, Princeps milítiæ cæléstis, Sátanam aliósque spíritus malígnos, qui ad perditiónem animárum pervagántur in mundo, divína virtúte in inférnum detrúde. Amen.",
+          "pt-BR": "São Miguel Arcanjo, defendei-nos no combate; sede o nosso refúgio contra a maldade e as ciladas do demônio. Repreenda-o Deus, pedimos suplicantes; e Vós, Príncipe da milícia celeste, pelo poder divino, precipitai no inferno Satanás e os outros espíritos malignos que andam pelo mundo para perdição das almas. Amém."
+        }
+      },
+      {
+        "type": "subheading",
+        "text": {
+          "en-US": "To the Sacred Heart",
+          "pt-BR": "Ao Sagrado Coração"
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "Most Sacred Heart of Jesus,",
+          "la": "Cor Iesu sacratíssimum,",
+          "pt-BR": "Sacratíssimo Coração de Jesus,"
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "people",
+        "inline": {
+          "en-US": "Have mercy on us.",
+          "la": "Miserére nobis.",
+          "pt-BR": "Tende piedade de nós."
+        }
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "(Repeated three times.)",
+          "pt-BR": "(Repetida três vezes.)"
+        }
+      }
+    ]
+  }
+}

--- a/content/libraries/base/practices/mass/fragments/ef-leonine-prayers.json
+++ b/content/libraries/base/practices/mass/fragments/ef-leonine-prayers.json
@@ -109,7 +109,7 @@
         "speaker": "priest",
         "inline": {
           "en-US": "Most Sacred Heart of Jesus,",
-          "la": "Cor Iesu sacratíssimum,",
+          "la": "Cor Jesu sacratíssimum,",
           "pt-BR": "Sacratíssimo Coração de Jesus,"
         }
       },

--- a/content/libraries/base/practices/mass/fragments/ef-liturgy-of-the-word.json
+++ b/content/libraries/base/practices/mass/fragments/ef-liturgy-of-the-word.json
@@ -145,13 +145,6 @@
       },
       {
         "type": "divider"
-      },
-      {
-        "type": "rubric",
-        "text": {
-          "en-US": "On Sundays and certain Feasts the priest recites the Creed:",
-          "pt-BR": "Aos domingos e certos dias de festa, o celebrante vai ao meio do altar e diz o Credo:"
-        }
       }
     ]
   }

--- a/content/libraries/base/practices/mass/fragments/ef-liturgy-of-the-word.json
+++ b/content/libraries/base/practices/mass/fragments/ef-liturgy-of-the-word.json
@@ -10,6 +10,20 @@
         "colorFrom": "celebration.primary.liturgicalColor"
       },
       {
+        "type": "subheading",
+        "text": {
+          "en-US": "Epistle",
+          "pt-BR": "Epístola"
+        }
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "The priest reads the Epistle at the Epistle side of the altar. At the end the server answers:",
+          "pt-BR": "O sacerdote lê a Epístola no lado da Epístola do altar. Ao final, o acólito responde:"
+        }
+      },
+      {
         "type": "proper",
         "slot": "epistle",
         "description": {
@@ -52,7 +66,7 @@
       },
       {
         "type": "call",
-        "ref": "of-lord-be-with-you"
+        "ref": "ef-lord-be-with-you"
       },
       {
         "type": "rubric",

--- a/content/libraries/base/practices/mass/fragments/ef-liturgy-of-the-word.json
+++ b/content/libraries/base/practices/mass/fragments/ef-liturgy-of-the-word.json
@@ -33,6 +33,22 @@
         "form": "ef"
       },
       {
+        "type": "prayer",
+        "speaker": "people",
+        "inline": {
+          "en-US": "Thanks be to God.",
+          "la": "Deo grátias.",
+          "pt-BR": "Graças a Deus."
+        }
+      },
+      {
+        "type": "subheading",
+        "text": {
+          "en-US": "Gradual / Alleluia / Tract",
+          "pt-BR": "Gradual / Aleluia / Trato"
+        }
+      },
+      {
         "type": "proper",
         "slot": "gradual",
         "description": {
@@ -109,6 +125,22 @@
           "en-US": "Praise be to Thee, O Christ.",
           "la": "Laus tibi, Christe.",
           "pt-BR": "Louvor a Vós, ó Cristo."
+        }
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "The priest kisses the book and says quietly:",
+          "pt-BR": "O sacerdote beija o livro e diz em voz baixa:"
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "By the words of the Gospel may our sins be blotted out.",
+          "la": "Per evangélica dicta deleántur nostra delícta.",
+          "pt-BR": "Pelas palavras do Evangelho sejam apagados os nossos pecados."
         }
       },
       {

--- a/content/libraries/base/practices/mass/fragments/ef-lord-be-with-you.json
+++ b/content/libraries/base/practices/mass/fragments/ef-lord-be-with-you.json
@@ -1,0 +1,24 @@
+{
+  "fragments": {
+    "ef-lord-be-with-you": [
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "The Lord be with you.",
+          "la": "Dóminus vobíscum.",
+          "pt-BR": "O Senhor esteja convosco."
+        }
+      },
+      {
+        "type": "prayer",
+        "speaker": "people",
+        "inline": {
+          "en-US": "And with thy spirit.",
+          "la": "Et cum spíritu tuo.",
+          "pt-BR": "E com o vosso espírito."
+        }
+      }
+    ]
+  }
+}

--- a/content/libraries/base/practices/mass/fragments/ef-offertory.json
+++ b/content/libraries/base/practices/mass/fragments/ef-offertory.json
@@ -222,6 +222,20 @@
         }
       },
       {
+        "type": "subheading",
+        "text": {
+          "en-US": "Secret",
+          "pt-BR": "Secreta"
+        }
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "The priest reads the Secret silently, with hands extended; he concludes aloud only the final phrase \"Per omnia saecula saeculorum\" leading into the Preface dialogue.",
+          "pt-BR": "O sacerdote lê a Secreta em silêncio, com as mãos estendidas; profere em voz alta apenas a conclusão \"Per omnia saecula saeculorum\", que conduz ao diálogo do Prefácio."
+        }
+      },
+      {
         "type": "proper",
         "slot": "secret",
         "description": {

--- a/content/libraries/base/practices/mass/fragments/ef-offertory.json
+++ b/content/libraries/base/practices/mass/fragments/ef-offertory.json
@@ -11,6 +11,45 @@
       {
         "type": "rubric",
         "text": {
+          "en-US": "The priest kisses the altar, turns to the people and says \"Dóminus vobíscum\"; turning back to the altar he says \"Orémus\" and reads the Offertory antiphon.",
+          "pt-BR": "O sacerdote beija o altar, volta-se aos fiéis e diz \"Dóminus vobíscum\"; voltando-se ao altar, diz \"Orémus\" e lê a antífona do Ofertório."
+        }
+      },
+      {
+        "type": "call",
+        "ref": "ef-lord-be-with-you"
+      },
+      {
+        "type": "prayer",
+        "speaker": "priest",
+        "inline": {
+          "en-US": "Let us pray.",
+          "la": "Orémus.",
+          "pt-BR": "Oremos."
+        }
+      },
+      {
+        "type": "subheading",
+        "text": {
+          "en-US": "Offertory Antiphon",
+          "pt-BR": "Antífona do Ofertório"
+        }
+      },
+      {
+        "type": "proper",
+        "slot": "offertory",
+        "description": {
+          "en-US": "Offertory verse of the day",
+          "pt-BR": "Versículo do Ofertório do dia"
+        },
+        "form": "ef"
+      },
+      {
+        "type": "divider"
+      },
+      {
+        "type": "rubric",
+        "text": {
           "en-US": "The priest takes the paten with the host and offers it up, saying:",
           "pt-BR": "O sacerdote descobre o cálice e toma nas mãos a patena com o pão, oferecendo-o a Deus, dizendo:"
         }

--- a/content/libraries/base/practices/mass/fragments/ef-prayers-at-the-foot-of-the-altar.json
+++ b/content/libraries/base/practices/mass/fragments/ef-prayers-at-the-foot-of-the-altar.json
@@ -205,9 +205,9 @@
         "type": "prayer",
         "speaker": "people",
         "inline": {
-          "en-US": "May almighty God have mercy on you, forgive you your sins, and bring you to everlasting life.",
+          "en-US": "May almighty God have mercy on thee, forgive thee thy sins, and bring thee to life everlasting.",
           "la": "Misereátur tui omnípotens Deus, et dimíssis peccátis tuis, perdúcat te ad vitam ætérnam.",
-          "pt-BR": "Deus todo-poderoso tenha misericórdia de vós, perdoe os vossos pecados e vos conduza à vida eterna."
+          "pt-BR": "Deus todo-poderoso tenha misericórdia de ti, e, perdoados os teus pecados, te conduza à vida eterna."
         }
       },
       {

--- a/content/libraries/base/practices/mass/fragments/ef-prayers-at-the-foot-of-the-altar.json
+++ b/content/libraries/base/practices/mass/fragments/ef-prayers-at-the-foot-of-the-altar.json
@@ -268,6 +268,13 @@
         }
       },
       {
+        "type": "subheading",
+        "text": {
+          "en-US": "Indulgentiam",
+          "pt-BR": "Indulgentiam"
+        }
+      },
+      {
         "type": "rubric",
         "text": {
           "en-US": "Signing himself with the Sign of the Cross, the priest says:",
@@ -362,7 +369,7 @@
       },
       {
         "type": "call",
-        "ref": "of-lord-be-with-you"
+        "ref": "ef-lord-be-with-you"
       },
       {
         "type": "rubric",
@@ -405,6 +412,20 @@
       },
       {
         "type": "divider"
+      },
+      {
+        "type": "rubric",
+        "text": {
+          "en-US": "The priest goes to the Epistle side of the altar and reads the Introit, signing himself with the Sign of the Cross.",
+          "pt-BR": "O sacerdote dirige-se ao lado da Epístola e lê o Intróito, benzendo-se com o Sinal da Cruz."
+        }
+      },
+      {
+        "type": "subheading",
+        "text": {
+          "en-US": "Introit",
+          "pt-BR": "Intróito"
+        }
       },
       {
         "type": "proper",

--- a/content/libraries/base/practices/mass/fragments/ef-preface.json
+++ b/content/libraries/base/practices/mass/fragments/ef-preface.json
@@ -28,7 +28,7 @@
       },
       {
         "type": "call",
-        "ref": "of-lord-be-with-you"
+        "ref": "ef-lord-be-with-you"
       },
       {
         "type": "prayer",

--- a/packages/mass-propers/src/do-file-id.ts
+++ b/packages/mass-propers/src/do-file-id.ts
@@ -134,3 +134,15 @@ export function getDoSanctiId(date: Date): string {
   const d = normalizeDate(date)
   return `${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`
 }
+
+// Same week's Sunday id — used as the EF ferial fallback. In the 1962 Missal,
+// a free ferial weekday (no feast, no proper Mass) repeats the previous Sunday's
+// Mass. DO encodes this as sparse weekday files: each weekday tempora file ships
+// only what differs from the Sunday (often just the Preface), so callers must
+// gap-fill from the Sunday file. This helper builds the Sunday id by swapping
+// the trailing day-of-week digit to 0.
+export function getDoTemporaSundayId(weekdayId: string): string | undefined {
+  const m = weekdayId.match(/^(.+)-([0-6])$/)
+  if (!m || m[2] === '0') return undefined
+  return `${m[1]}-0`
+}

--- a/packages/mass-propers/src/index.ts
+++ b/packages/mass-propers/src/index.ts
@@ -1,4 +1,4 @@
-export { getDoSanctiId, getDoTemporaId } from './do-file-id'
+export { getDoSanctiId, getDoTemporaId, getDoTemporaSundayId } from './do-file-id'
 export {
   chooseProperSource,
   getProperDay,

--- a/packages/mass-propers/src/resolve.test.ts
+++ b/packages/mass-propers/src/resolve.test.ts
@@ -8,7 +8,12 @@ import {
 } from '@ember/liturgical'
 import { describe, expect, it } from 'vitest'
 
-import { chooseProperSource } from './resolve'
+import {
+  chooseProperSource,
+  getRawProperForSlot,
+  type PropersDataSource,
+  type RawProperFile,
+} from './resolve'
 
 const entries: LiturgicalEntry[] = JSON.parse(
   readFileSync(resolve(__dirname, '../../../content/liturgical/entries.json'), 'utf8'),
@@ -67,5 +72,47 @@ describe('chooseProperSource', () => {
 
   it('defaults to Tempora when no calendar is provided', () => {
     expect(chooseProperSource(new Date(2026, 3, 2), undefined)).toBe('tempora')
+  })
+})
+
+function makeSource(files: Record<string, RawProperFile>): PropersDataSource {
+  return {
+    loadTempora: async (id) => files[`tempora/${id}`],
+    loadSancti: async (id) => files[`sancti/${id}`],
+  }
+}
+
+describe('ferial Sunday fallback', () => {
+  // 2026-06-08 is Monday after Pent II (Pent02-1) — week 2 Monday post-Trinity.
+  const pentFerial = new Date(2026, 5, 8)
+
+  it('Pentecost ferial Monday gap-fills from same week Sunday', async () => {
+    const source = makeSource({
+      'tempora/Pent02-0': {
+        Introitus: { 'en-US': 'Sunday introit', la: 'Introitus Dominicae' },
+        Lectio: { 'en-US': 'Sunday epistle', la: 'Lectio Dominicae' },
+        Evangelium: { 'en-US': 'Sunday gospel', la: 'Evangelium Dominicae' },
+      },
+      'tempora/Pent02-1': {
+        Prefatio: { la: 'Praefatio communis' },
+      },
+    })
+    const epistle = await getRawProperForSlot(pentFerial, 'epistle', undefined, source)
+    expect(epistle?.['en-US']).toBe('Sunday epistle')
+    const intr = await getRawProperForSlot(pentFerial, 'introit', undefined, source)
+    expect(intr?.['en-US']).toBe('Sunday introit')
+  })
+
+  it("ferial's own slot wins over Sunday fallback", async () => {
+    const source = makeSource({
+      'tempora/Pent02-0': {
+        Lectio: { 'en-US': 'Sunday epistle' },
+      },
+      'tempora/Pent02-1': {
+        Lectio: { 'en-US': 'Monday own epistle' },
+      },
+    })
+    const epistle = await getRawProperForSlot(pentFerial, 'epistle', undefined, source)
+    expect(epistle?.['en-US']).toBe('Monday own epistle')
   })
 })

--- a/packages/mass-propers/src/resolve.ts
+++ b/packages/mass-propers/src/resolve.ts
@@ -1,5 +1,5 @@
 import type { DayCalendar, LiturgicalCategory } from '@ember/liturgical'
-import { getDoSanctiId, getDoTemporaId } from './do-file-id'
+import { getDoSanctiId, getDoTemporaId, getDoTemporaSundayId } from './do-file-id'
 import { getSectionIdsForSlot } from './slot-map'
 import type { ProperDay, ProperSection } from './types'
 
@@ -122,8 +122,20 @@ async function loadRawProperDay(
   const temporaId = getDoTemporaId(date)
   const sanctiId = getDoSanctiId(date)
 
-  const tempora = temporaId ? await dataSource.loadTempora(temporaId) : undefined
+  const dayTempora = temporaId ? await dataSource.loadTempora(temporaId) : undefined
   const sancti = await dataSource.loadSancti(sanctiId)
+
+  // EF free-ferial rule: weekday tempora files (-1..-6) ship only the slots that
+  // differ from the previous Sunday. Gap-fill from that Sunday so missing
+  // Introit/Collect/Epistle/Gradual/Gospel/Offertory/Secret/Communion/Postcommunion
+  // resolve to last Sunday's text. Days with own propers (Lent, Advent ferials,
+  // ember days, vigils) win slot-by-slot via the overlay.
+  const sundayId = temporaId ? getDoTemporaSundayId(temporaId) : undefined
+  const sundayTempora = sundayId ? await dataSource.loadTempora(sundayId) : undefined
+  const tempora =
+    sundayTempora && dayTempora
+      ? { ...sundayTempora, ...dayTempora }
+      : (dayTempora ?? sundayTempora)
 
   // Use the calendar-determined source, fall back to the other if unavailable.
   // This handles cases like Christmas (calendar says Tempora, DO stores in Sancti).


### PR DESCRIPTION
## Summary
This PR significantly expands and restructures the Extraordinary Form (EF) Latin Mass implementation by adding missing liturgical fragments, improving seasonal variations, and refactoring shared components for better reusability.

## Key Changes

### New Fragments Added
- **ef-asperges.json**: Implements the Asperges/Vidi Aquam rite with seasonal variations (Eastertide vs. standard)
- **ef-leonine-prayers.json**: Adds optional Leonine Prayers (Three Hail Marys, Salve Regina) recited after Low Mass
- **ef-lord-be-with-you.json**: Extracted reusable "Dominus vobiscum" / "Et cum spiritu tuo" exchange fragment

### Canon of the Mass Restructuring
- Added "Te Igitur" and "Communicantes" subheadings for better organization
- Implemented seasonal variations for Communicantes prayer with conditional rendering:
  - Christmas (Dec 25 - Jan 1): Special Christmas text
  - Easter (Easter Vigil through Saturday in Albis): Special Easter text
  - Default: Standard Communicantes text
- Converted single prayer into a select-based structure for liturgical season awareness

### Communion Rite Enhancements
- Added "Libera Nos" subheading
- Improved rubric clarity for paten handling
- Split final doxology ("Per omnia saecula saeculorum") into separate prayer element for proper rendering
- Added "Communion of the Priest" subheading
- Implemented collapsible "Communion of the Faithful" section with conditional display
- Added Requiem Mass note explaining variations (dona eis requiem, dona eis requiem sempiternam)

### Dismissal Rite Restructuring
- Implemented seasonal variations via select structure:
  - **Lent**: "Benedicamus Domino" instead of "Ite Missa est"
  - **Advent**: Conditional logic (Benedicamus on ferials, Ite Missa est on Sundays)
  - **Common**: Standard "Ite Missa est"
- Added Requiem Mass variant ("Requiescant in pace")
- Reorganized "Placeat tibi" as dedicated subheading with improved rubric

### Gloria Fragment Refactoring
- Extracted Gloria body text into separate "ef-gloria-body" fragment for reusability
- Implemented seasonal omission logic:
  - **Lent**: Gloria omitted with collapsible reference to text
  - **Advent**: Gloria usually omitted with collapsible reference
  - **Common**: Gloria included by default with collapsible option
- Added detailed rubrics explaining when Gloria is omitted

### Credo Refactoring
- Extracted Credo body text into "ef-credo-body" fragment for reusability
- Implemented seasonal variations with select structure

### Offertory Enhancements
- Added rubric explaining priest's actions (kiss altar, Dominus vobiscum, Oremus)
- Added "Dominus vobiscum" exchange via fragment reference
- Added "Offertory Antiphon" subheading with proper slot reference
- Added "Secret" subheading with rubric explaining silent recitation

### Liturgy of the Word Improvements
- Added "Epistle" subheading and rubric
- Added "Deo gratias" response after Epistle
- Added "Gradual / Alleluia / Tract" subheading
- Fixed "Dominus vobiscum" references to use new ef-lord-be-with-you fragment
- Improved Gospel section with clearer rubric

### Last Gospel Updates
- Fixed "Dominus vobiscum" reference to use new fragment
- Expanded Gospel text with complete John 1:1-14 passage

### Prayers at the Foot of the Altar
- Corrected pronouns in absolution (you → thee, thy) for proper liturgical language
- Added "Indulgentiam" subheading

### Propers Resolution Enhancement
- Added `getRawProperForSlot` export for better testability
- Implemented ferial Sunday fallback logic:

https://claude.ai/code/session_01F8i74SpeNUXomoVZFGudJG