### PR TITLE
Add animated splash overlay with theme support

### DIFF
--- a/apps/app/app.json
+++ b/apps/app/app.json
@@ -10,7 +10,12 @@
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",
-      "backgroundColor": "#F1E6C8"
+      "backgroundColor": "#FFFFFF",
+      "dark": {
+        "image": "./assets/splash-icon.png",
+        "resizeMode": "contain",
+        "backgroundColor": "#0E0D0C"
+      }
     },
     "ios": {
       "supportsTablet": true,
@@ -46,7 +51,7 @@
     },
     "android": {
       "adaptiveIcon": {
-        "backgroundColor": "#F1E6C8",
+        "backgroundColor": "#FFFFFF",
         "foregroundImage": "./assets/android-icon-foreground.png",
         "backgroundImage": "./assets/android-icon-background.png",
         "monochromeImage": "./assets/android-icon-monochrome.png"

--- a/apps/app/src/app/_layout.tsx
+++ b/apps/app/src/app/_layout.tsx
@@ -40,6 +40,7 @@ import {
   getInstalledLibraries,
   loadInstalledLibraries,
 } from '@/features/libraries/libraryManager'
+import { SplashOverlay } from '@/features/splash'
 import { useKeepAwake } from '@/hooks/useKeepAwake'
 import { useLiturgicalTheme } from '@/hooks/useLiturgicalTheme'
 import { registerDataSources } from '@/lib/data-sources/register'
@@ -161,51 +162,56 @@ export default function RootLayout() {
   const ready =
     fontsLoaded && prefsHydrated && bibleHydrated && catechismHydrated && dbReady && seeded
 
+  // Hand off the native splash to the React overlay as soon as fonts are loaded —
+  // the typographic splash is what users perceive while the rest of startup runs.
   useEffect(() => {
-    if (ready) {
+    if (fontsLoaded) {
       SplashScreen.hideAsync()
     }
-  }, [ready])
+  }, [fontsLoaded])
 
   const resolvedTheme = themePreference === 'system' ? (systemScheme ?? 'light') : themePreference
   const { themeName } = useLiturgicalTheme()
   const rootBg = resolvedTheme === 'dark' ? darkTheme.background : lightTheme.background
 
-  if (!ready) return undefined
+  if (!fontsLoaded) return undefined
 
   return (
     <GestureHandlerRootView style={{ flex: 1, backgroundColor: rootBg }}>
-      <QueryClientProvider client={queryClient}>
-        <TamaguiProvider config={config} defaultTheme={resolvedTheme}>
-          {/* biome-ignore lint/suspicious/noExplicitAny: Tamagui sub-theme names are dynamically composed */}
-          <Theme name={themeName as any}>
-            <StatusBar hidden />
-            <Stack
-              screenOptions={{
-                headerShown: false,
-                animation: 'fade',
-                animationDuration: 200,
-                contentStyle: { backgroundColor: rootBg },
-              }}
-            >
-              <Stack.Screen name="index" options={{ title: i18n.t('a11y.home') }} />
-              <Stack.Screen name="plan" options={{ title: i18n.t('home.planOfLife') }} />
-              <Stack.Screen name="bible" options={{ title: i18n.t('home.sacredScripture') }} />
-              <Stack.Screen name="catechism" options={{ title: i18n.t('home.catechism') }} />
-              <Stack.Screen name="saints" options={{ title: i18n.t('saints.title') }} />
-              <Stack.Screen name="settings" options={{ title: i18n.t('settings.title') }} />
-              <Stack.Screen name="pray" options={{ title: i18n.t('home.pray') }} />
-              <Stack.Screen name="practices" options={{ title: i18n.t('practices.title') }} />
-              <Stack.Screen
-                name="library"
-                options={{ title: i18n.t('library.title'), gestureEnabled: false }}
-              />
-            </Stack>
-            <AppFrame />
-            <ConfirmHost />
-          </Theme>
-        </TamaguiProvider>
-      </QueryClientProvider>
+      {ready && (
+        <QueryClientProvider client={queryClient}>
+          <TamaguiProvider config={config} defaultTheme={resolvedTheme}>
+            {/* biome-ignore lint/suspicious/noExplicitAny: Tamagui sub-theme names are dynamically composed */}
+            <Theme name={themeName as any}>
+              <StatusBar hidden />
+              <Stack
+                screenOptions={{
+                  headerShown: false,
+                  animation: 'fade',
+                  animationDuration: 200,
+                  contentStyle: { backgroundColor: rootBg },
+                }}
+              >
+                <Stack.Screen name="index" options={{ title: i18n.t('a11y.home') }} />
+                <Stack.Screen name="plan" options={{ title: i18n.t('home.planOfLife') }} />
+                <Stack.Screen name="bible" options={{ title: i18n.t('home.sacredScripture') }} />
+                <Stack.Screen name="catechism" options={{ title: i18n.t('home.catechism') }} />
+                <Stack.Screen name="saints" options={{ title: i18n.t('saints.title') }} />
+                <Stack.Screen name="settings" options={{ title: i18n.t('settings.title') }} />
+                <Stack.Screen name="pray" options={{ title: i18n.t('home.pray') }} />
+                <Stack.Screen name="practices" options={{ title: i18n.t('practices.title') }} />
+                <Stack.Screen
+                  name="library"
+                  options={{ title: i18n.t('library.title'), gestureEnabled: false }}
+                />
+              </Stack>
+              <AppFrame />
+              <ConfirmHost />
+            </Theme>
+          </TamaguiProvider>
+        </QueryClientProvider>
+      )}
+      <SplashOverlay theme={resolvedTheme} ready={ready} />
     </GestureHandlerRootView>
   )
 }

--- a/apps/app/src/features/splash/SplashOverlay.tsx
+++ b/apps/app/src/features/splash/SplashOverlay.tsx
@@ -1,0 +1,141 @@
+import { useEffect } from 'react'
+import { StyleSheet, Text, View } from 'react-native'
+import Animated, {
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withTiming,
+} from 'react-native-reanimated'
+import Svg, { Path } from 'react-native-svg'
+
+import { darkTheme, lightTheme } from '@/config/themes'
+
+type Theme = 'light' | 'dark' | (string & {}) | null | undefined
+
+const palette = {
+  light: {
+    background: lightTheme.background,
+    wordmark: lightTheme.color,
+    flame: lightTheme.accent,
+    rule: lightTheme.accentSubtle,
+  },
+  dark: {
+    background: darkTheme.background,
+    wordmark: darkTheme.color,
+    flame: darkTheme.accent,
+    rule: darkTheme.accentSubtle,
+  },
+} as const
+
+export function SplashOverlay({
+  theme,
+  ready,
+  onHidden,
+}: {
+  theme: Theme
+  ready: boolean
+  onHidden?: () => void
+}) {
+  const opacity = useSharedValue(0)
+  const scale = useSharedValue(1)
+
+  useEffect(() => {
+    opacity.value = withTiming(1, { duration: 220, easing: Easing.out(Easing.quad) })
+  }, [opacity])
+
+  useEffect(() => {
+    if (!ready) return
+    opacity.value = withDelay(
+      120,
+      withTiming(0, { duration: 360, easing: Easing.in(Easing.quad) }, (finished) => {
+        if (finished && onHidden) runOnJS(onHidden)()
+      }),
+    )
+    scale.value = withDelay(
+      120,
+      withTiming(1.04, { duration: 360, easing: Easing.in(Easing.quad) }),
+    )
+  }, [ready, opacity, scale, onHidden])
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ scale: scale.value }],
+  }))
+
+  const c = theme === 'dark' ? palette.dark : palette.light
+
+  return (
+    <Animated.View
+      pointerEvents={ready ? 'none' : 'auto'}
+      style={[styles.overlay, { backgroundColor: c.background }, animatedStyle]}
+    >
+      <View style={styles.center}>
+        <FlameMark color={c.flame} />
+        <Text allowFontScaling={false} style={[styles.wordmark, { color: c.wordmark }]}>
+          Ember
+        </Text>
+        <View style={styles.ruleRow}>
+          <View style={[styles.rule, { backgroundColor: c.rule }]} />
+          <View style={[styles.dot, { backgroundColor: c.rule }]} />
+          <View style={[styles.rule, { backgroundColor: c.rule }]} />
+        </View>
+      </View>
+    </Animated.View>
+  )
+}
+
+function FlameMark({ color }: { color: string }) {
+  return (
+    <Svg width={56} height={64} viewBox="0 0 56 64" accessible={false}>
+      <Path
+        d="M28 4 C30 14, 40 20, 42 32 C44 44, 36 54, 28 56 C20 54, 12 44, 14 32 C16 22, 24 18, 24 12 C24 16, 26 18, 28 16 Z"
+        fill="none"
+        stroke={color}
+        strokeWidth={1.6}
+        strokeLinejoin="round"
+      />
+      <Path
+        d="M28 22 C29 28, 34 32, 34 40 C34 47, 30 51, 28 52 C26 51, 22 47, 22 40 C22 33, 26 30, 26 24 Z"
+        fill={color}
+        opacity={0.18}
+      />
+    </Svg>
+  )
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+  },
+  center: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  wordmark: {
+    fontFamily: 'UnifrakturMaguntia',
+    fontSize: 56,
+    lineHeight: 70,
+    marginTop: 18,
+    letterSpacing: 1,
+  },
+  ruleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 14,
+  },
+  rule: {
+    width: 36,
+    height: 1,
+  },
+  dot: {
+    width: 4,
+    height: 4,
+    borderRadius: 2,
+    marginHorizontal: 6,
+  },
+})

--- a/apps/app/src/features/splash/index.ts
+++ b/apps/app/src/features/splash/index.ts
@@ -1,0 +1,1 @@
+export { SplashOverlay } from './SplashOverlay'


### PR DESCRIPTION
## Summary
Implements a custom animated splash overlay component that displays while the app finishes loading, replacing the native splash screen with a React-based alternative that supports theme switching and smooth animations.

## Key Changes
- **New SplashOverlay component** (`apps/app/src/features/splash/SplashOverlay.tsx`):
  - Displays a themed splash screen with the Ember wordmark and flame icon
  - Supports light and dark theme variants using the app's existing theme configuration
  - Implements smooth fade-in (220ms) and fade-out (360ms) animations using React Native Reanimated
  - Accepts `ready`, `theme`, and `onHidden` props to control visibility and lifecycle
  - Disables pointer events once the app is ready to prevent interaction with the splash

- **Updated root layout** (`apps/app/src/app/_layout.tsx`):
  - Hides the native splash screen as soon as fonts are loaded (instead of waiting for full app readiness)
  - Renders the SplashOverlay component on top of the app content
  - Defers rendering of main app content until all initialization is complete
  - Passes the resolved theme and ready state to the overlay

- **Updated app configuration** (`apps/app/app.json`):
  - Changed native splash background to white for light mode
  - Added dark mode splash configuration with dark background (#0E0D0C)
  - Updated Android adaptive icon background color to match

## Implementation Details
- The native splash is hidden early when fonts load, allowing the typographic React overlay to be the primary visual feedback during startup
- The overlay uses shared values and animated styles for performant animations
- Theme colors are derived from the app's existing light and dark theme palettes
- The flame icon is rendered as an SVG with stroke and semi-transparent fill for visual depth
- Decorative rule elements (horizontal lines with centered dot) frame the wordmark

https://claude.ai/code/session_013LkaJWEHBHHaurR8GHetjX