### PR TITLE
Fix nested content prefetch and update practice routing

### DIFF
--- a/apps/app/src/features/bible/components/ThemedReadings.tsx
+++ b/apps/app/src/features/bible/components/ThemedReadings.tsx
@@ -101,8 +101,8 @@ export function ThemedReadings() {
               manifest={manifest}
               onPress={() =>
                 router.push({
-                  pathname: '/practices/[manifestId]',
-                  params: { manifestId: manifest.id },
+                  pathname: '/pray/[practiceId]',
+                  params: { practiceId: manifest.id },
                 })
               }
             />

--- a/apps/app/src/features/practices/components/PracticeFlow.tsx
+++ b/apps/app/src/features/practices/components/PracticeFlow.tsx
@@ -60,8 +60,31 @@ import type { PsalmRef } from '@/lib/liturgical'
 import { parseSlotKey } from '@/lib/slotKey'
 import { usePreferencesStore } from '@/stores/preferencesStore'
 
-function findPsalmRefs(sections: RenderedSection[]): PsalmRef[] {
+// Descends through container sections so dynamic content (readings, psalmody)
+// nested inside a select/options/collapsible/liturgical-color-scope/prayer is
+// still collected for prefetch — otherwise its query never fires and the block
+// renders blank.
+function* walkRenderedSections(sections: RenderedSection[]): Generator<RenderedSection> {
   for (const s of sections) {
+    yield s
+    switch (s.type) {
+      case 'select':
+      case 'options':
+        for (const opt of s.options) yield* walkRenderedSections(opt.sections)
+        break
+      case 'collapsible':
+      case 'liturgical-color-scope':
+        yield* walkRenderedSections(s.sections)
+        break
+      case 'prayer':
+        if (s.sections) yield* walkRenderedSections(s.sections)
+        break
+    }
+  }
+}
+
+function findPsalmRefs(sections: RenderedSection[]): PsalmRef[] {
+  for (const s of walkRenderedSections(sections)) {
     if (s.type === 'psalmody') return s.psalms
   }
   return []
@@ -79,7 +102,7 @@ function collectReadingKeys(sections: RenderedSection[]): {
 } {
   const bibleSet = new Map<string, BibleKey>()
   const cccSet = new Map<string, CccKey>()
-  for (const s of sections) {
+  for (const s of walkRenderedSections(sections)) {
     if (s.type !== 'reading') continue
     if (s.reference.type === 'bible') {
       const key = { book: s.reference.book, chapter: s.reference.chapter }
@@ -96,7 +119,7 @@ function collectReadingKeys(sections: RenderedSection[]): {
 
 function findTrackIds(sections: RenderedSection[]): string[] {
   const ids = new Set<string>()
-  for (const s of sections) {
+  for (const s of walkRenderedSections(sections)) {
     if (s.type === 'reading' && s.trackId) ids.add(s.trackId)
   }
   return Array.from(ids)


### PR DESCRIPTION
## Summary
This PR fixes content prefetching for dynamically rendered sections nested within containers, and updates the routing path for practice navigation.

## Key Changes
- **Refactored section traversal**: Introduced `walkRenderedSections()` generator function that recursively descends through container sections (select, options, collapsible, liturgical-color-scope, prayer) to ensure nested dynamic content is properly collected for prefetch
- **Updated prefetch collection**: Modified `findPsalmRefs()`, `collectReadingKeys()`, and `findTrackIds()` to use the new walker function instead of iterating only top-level sections
- **Fixed routing path**: Updated ThemedReadings component to navigate to `/pray/[practiceId]` instead of `/practices/[manifestId]`

## Implementation Details
The new `walkRenderedSections()` generator uses a depth-first traversal pattern to handle nested content that was previously being skipped during prefetch collection. This ensures that readings and psalmody nested inside container sections will have their queries properly prefetched, preventing blank renders.

https://claude.ai/code/session_015yQkqnmRPJjk39tQ8xPWyb