### PR TITLE
Fix TS strict-mode errors and re-init ember-extra submodule for tests

### DIFF
--- a/apps/app/src/app/settings/index.tsx
+++ b/apps/app/src/app/settings/index.tsx
@@ -299,7 +299,7 @@ export default function SettingsScreen() {
               value={timeTravelDate ? parseISO(timeTravelDate) : new Date()}
               mode="date"
               display={Platform.OS === 'ios' ? 'inline' : 'default'}
-              onValueChange={(_, date) => {
+              onChange={(_, date) => {
                 setShowDatePicker(Platform.OS === 'ios')
                 if (date) setTimeTravelDate(format(date, 'yyyy-MM-dd'))
               }}

--- a/apps/workshop/src/features/flow-editor/FlowEditor.tsx
+++ b/apps/workshop/src/features/flow-editor/FlowEditor.tsx
@@ -165,7 +165,10 @@ export function FlowEditor({
 function getChildGroups(sec: FlowSection): FlowSection[][] {
   switch (sec.type) {
     case 'select':
-      return sec.options.map((opt) => (opt.sections ?? []) as FlowSection[])
+      if ('options' in sec) {
+        return sec.options.map((opt) => (opt.sections ?? []) as FlowSection[])
+      }
+      return [sec.body]
     case 'options':
       if ('options' in sec && Array.isArray((sec as Record<string, unknown>).options)) {
         return (sec as { options: { sections: FlowSection[] }[] }).options.map((o) => o.sections)

--- a/apps/workshop/src/features/flow-editor/FlowNodeForm.tsx
+++ b/apps/workshop/src/features/flow-editor/FlowNodeForm.tsx
@@ -152,7 +152,14 @@ function NodeFields({
       return <ImageFields section={section} onChange={onChange} />
 
     case 'select':
-      return <SelectFields section={section} onChange={onChange} />
+      if ('options' in section) {
+        return <SelectFields section={section} onChange={onChange} />
+      }
+      return (
+        <p className={styles.hint}>
+          Iteration select (from: {section.from} → {section.as}) — edit JSON directly.
+        </p>
+      )
 
     case 'repeat':
       return <RepeatFields section={section} onChange={onChange} />
@@ -384,7 +391,7 @@ function SelectFields({
   section,
   onChange,
 }: {
-  section: Extract<FlowSection, { type: 'select' }>
+  section: Extract<FlowSection, { type: 'select'; options: unknown[] }>
   onChange: (s: FlowSection) => void
 }) {
   function updateOption(idx: number, patch: Partial<(typeof section.options)[0]>) {

--- a/apps/workshop/src/features/flow-editor/FlowTree.tsx
+++ b/apps/workshop/src/features/flow-editor/FlowTree.tsx
@@ -16,7 +16,10 @@ function sectionSummary(sec: FlowSection): string {
     case 'meditation':
       return t((sec as { text: LocalizedText }).text)
     case 'select':
-      return `on: ${sec.on ?? 'manual'} (${sec.options.length} options)`
+      if ('options' in sec) {
+        return `on: ${sec.on ?? 'manual'} (${sec.options.length} options)`
+      }
+      return `from: ${sec.from} → ${sec.as}`
     case 'repeat':
       if ('from' in sec) return `from: ${sec.from} ×${sec.count ?? '∞'}`
       return `×${sec.count}`
@@ -86,10 +89,13 @@ const typeBadgeColor: Record<string, string> = {
 function getChildren(sec: FlowSection): { label?: string; sections: FlowSection[] }[] {
   switch (sec.type) {
     case 'select':
-      return sec.options.map((opt) => ({
-        label: `${opt.id}: ${loc(opt.label)}`,
-        sections: opt.sections ?? [],
-      }))
+      if ('options' in sec) {
+        return sec.options.map((opt) => ({
+          label: `${opt.id}: ${loc(opt.label)}`,
+          sections: opt.sections ?? [],
+        }))
+      }
+      return [{ sections: sec.body }]
     case 'options':
       if ('options' in sec && Array.isArray(sec.options)) {
         return sec.options.map((opt) => ({

--- a/packages/content-engine/src/engine.ts
+++ b/packages/content-engine/src/engine.ts
@@ -102,6 +102,7 @@ export function resolvePath(context: FlowContext, path: string): unknown {
   }
 
   const [head, ...rest] = path.split('.')
+  if (head === undefined) return undefined
   let value: unknown = context.flowData?.[head] ?? context.templateVars?.[head]
 
   for (const seg of rest) {
@@ -166,11 +167,15 @@ function getOrdinal(index: number, language: string): string {
 
 function walkVarPath(vars: Record<string, unknown>, path: string): unknown {
   const segments = path.split('.')
-  let value: unknown = vars[segments[0]]
+  const first = segments[0]
+  if (first === undefined) return undefined
+  let value: unknown = vars[first]
   for (let i = 1; i < segments.length; i++) {
     if (value === null || value === undefined) return undefined
     if (typeof value !== 'object') return undefined
-    value = (value as Record<string, unknown>)[segments[i]]
+    const seg = segments[i]
+    if (seg === undefined) return undefined
+    value = (value as Record<string, unknown>)[seg]
   }
   return value
 }
@@ -257,8 +262,9 @@ function resolvePrayerRef(ref: string, context: FlowContext, ec: EngineContext):
   }
   const resolved = asset.body.flatMap((s) => resolveSection(s, context, ec))
   // Single inline prayer: attach the asset title for collapsible rendering
-  if (resolved.length === 1 && resolved[0].type === 'prayer') {
-    return [{ ...resolved[0], title: ec.localize(asset.title) }]
+  const first = resolved[0]
+  if (resolved.length === 1 && first?.type === 'prayer') {
+    return [{ ...first, title: ec.localize(asset.title) }]
   }
   // Multi-section prayer: wrap in a prayer section with nested sections
   return [
@@ -371,14 +377,12 @@ function resolveRepeat(
   const { count, sections: templateSections } = section
 
   // Collapse repeated single-prayer refs into one section with a count
-  if (
-    templateSections.length === 1 &&
-    templateSections[0].type === 'prayer' &&
-    'ref' in templateSections[0]
-  ) {
-    const resolved = resolvePrayerRef(templateSections[0].ref, context, ec)
-    if (resolved.length === 1 && resolved[0].type === 'prayer') {
-      return [{ ...resolved[0], count }]
+  const onlyTemplate = templateSections[0]
+  if (templateSections.length === 1 && onlyTemplate?.type === 'prayer' && 'ref' in onlyTemplate) {
+    const resolved = resolvePrayerRef(onlyTemplate.ref, context, ec)
+    const firstResolved = resolved[0]
+    if (resolved.length === 1 && firstResolved?.type === 'prayer') {
+      return [{ ...firstResolved, count }]
     }
     return resolved
   }
@@ -588,6 +592,8 @@ function resolveSection(
       if (!def || !state)
         return [{ type: 'rubric', label: bilingualOf('[Reading track not loaded]') }]
       const entry = def.entries[state.current_index % def.entries.length]
+      if (entry === undefined)
+        return [{ type: 'rubric', label: bilingualOf('[Reading track not loaded]') }]
       const resolveBookName = (slug: string) => ec.t(`bookName.${slug}`, { defaultValue: slug })
       const refs = ec.parseTrackEntry(def.source, entry, resolveBookName)
       return refs.map((ref) => ({
@@ -639,7 +645,7 @@ function resolveSection(
           )
 
         if (resolved.length === 0) return []
-        if (resolved.length === 1) return resolved[0].sections
+        if (resolved.length === 1 && resolved[0]) return resolved[0].sections
         return [{ type: 'options' as const, label: ec.localize(section.label), options: resolved }]
       }
       const resolved = section.options
@@ -655,7 +661,7 @@ function resolveSection(
         })
         .filter((opt) => opt.sections.length > 0)
       if (resolved.length === 0) return []
-      if (resolved.length === 1) return resolved[0].sections
+      if (resolved.length === 1 && resolved[0]) return resolved[0].sections
       return [
         {
           type: 'options',
@@ -851,7 +857,8 @@ function resolveSection(
         typeof o.liturgicalColor === 'string' ? o.liturgicalColor.toLowerCase() : undefined
       const validColor =
         color && LITURGICAL_COLOR_LABELS[color] ? (color as RenderedLiturgicalColor) : undefined
-      const rankLabel = o.rank && RANK_LABELS[o.rank] ? ec.localize(RANK_LABELS[o.rank]) : undefined
+      const rankEntry = o.rank ? RANK_LABELS[o.rank] : undefined
+      const rankLabel = rankEntry ? ec.localize(rankEntry) : undefined
       const cycleId = section.cycleFrom
         ? (resolvePath(context, section.cycleFrom) as string | undefined)
         : undefined
@@ -1371,7 +1378,7 @@ function resolveChoiceRichText(
 
   const overrideKey = `${celebrationPath}.${section.slot}`
   const overrideId = context.selectOverrides?.[overrideKey]
-  const defaultId = section.defaultBlank ? undefined : (section.default ?? options[0].id)
+  const defaultId = section.defaultBlank ? undefined : (section.default ?? options[0]?.id)
   const selectedId = overrideId && options.some((o) => o.id === overrideId) ? overrideId : defaultId
 
   return [

--- a/packages/liturgical/src/of-position.ts
+++ b/packages/liturgical/src/of-position.ts
@@ -42,7 +42,8 @@ export function getLiturgicalYear(date: Date): number {
  * Year C = 2025, 2028, 2031 … (litYear % 3 === 1)
  */
 export function getSundayCycle(litYear: number): 'A' | 'B' | 'C' {
-  return (['C', 'A', 'B'] as const)[litYear % 3]
+  const cycles = ['C', 'A', 'B'] as const
+  return cycles[litYear % 3] ?? 'A'
 }
 
 /**

--- a/packages/liturgical/src/psalter.ts
+++ b/packages/liturgical/src/psalter.ts
@@ -7,8 +7,11 @@ export function parsePsalmRef(raw: number | string): PsalmRef {
 
   // Format: "119:33-72"
   const [psalmStr, rangeStr] = raw.split(':')
-  const psalm = Number.parseInt(psalmStr, 10)
-  const [start, end] = rangeStr.split('-').map((s) => Number.parseInt(s, 10))
+  const psalm = Number.parseInt(psalmStr ?? '', 10)
+  if (rangeStr === undefined) return { psalm }
+  const [startStr, endStr] = rangeStr.split('-')
+  const start = Number.parseInt(startStr ?? '', 10)
+  const end = Number.parseInt(endStr ?? '', 10)
   return { psalm, verseRange: [start, end] }
 }
 


### PR DESCRIPTION
- engine.ts: tighten array index narrowing under noUncheckedIndexedAccess
- of-position/psalter: handle undefined from array destructuring
- workshop flow editor: discriminate between dispatch and iteration select variants
- settings DateTimePicker: rename onValueChange to onChange (correct prop name)