### PR TITLE
Improve notification system: multi-reminder, lead-time, localized copy

### DIFF
--- a/apps/app/src/content/manifestTypes.ts
+++ b/apps/app/src/content/manifestTypes.ts
@@ -69,6 +69,16 @@ export type SlotDefault = {
   enabled?: boolean
 }
 
+export type LocalizedMessagePool = {
+  'en-US'?: string | string[]
+  'pt-BR'?: string | string[]
+}
+
+export type NotificationsManifest = {
+  defaultReminders?: { offset: number }[]
+  messages?: LocalizedMessagePool
+}
+
 export type ProgramConfig = {
   totalDays: number
   perDayFlows?: string
@@ -104,6 +114,7 @@ export type PracticeManifest = {
   pack?: string
   tags?: string[]
   defaults?: { sortOrder?: number; slots?: SlotDefault[] }
+  notifications?: NotificationsManifest
   flowHash?: BlobRef
   fragments?: { id: string; hash: string; size: number }[]
   dataHashes?: { name: string; hash: string; size: number }[]

--- a/apps/app/src/db/schema.ts
+++ b/apps/app/src/db/schema.ts
@@ -10,9 +10,13 @@ export type UserPractice = {
   archived: number
 }
 
+export type NotifyReminder = {
+  offset: number // minutes before slot.time; 0 = on time
+}
+
 export type NotifyConfig = {
   enabled: boolean
-  before?: number // minutes before, future use
+  reminders?: NotifyReminder[] // when omitted on enabled config, fall back to manifest defaults
 }
 
 export type Completion = {

--- a/apps/app/src/features/plan-of-life/components/SlotConfigurator.tsx
+++ b/apps/app/src/features/plan-of-life/components/SlotConfigurator.tsx
@@ -1,5 +1,5 @@
 import DateTimePicker from '@react-native-community/datetimepicker'
-import { Bell, ChevronRight, Clock, Plus, Trash2 } from 'lucide-react-native'
+import { Bell, ChevronRight, Clock, Plus, Trash2, X } from 'lucide-react-native'
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Platform, Switch } from 'react-native'
@@ -17,15 +17,142 @@ import { AnimatedPressable, confirm } from '@/components'
 import { calmSpring } from '@/config/animation'
 import { tierConfig } from '@/config/constants'
 import type { SlotState } from '@/db/events'
-import type { Tier } from '@/db/schema'
+import type { NotifyConfig, NotifyReminder, Tier } from '@/db/schema'
 import { lightTap, mediumTap } from '@/lib/haptics'
 import { enrichSlot } from '../getPracticeName'
+import { describeLeadTime, parseNotifyConfig, REMINDER_PRESETS } from '../notify'
 import { parseSchedule } from '../schedule'
 import { deriveTimeBlock } from '../timeBlocks'
 import { SchedulePicker } from './SchedulePicker'
 import { TierBadge } from './TierBadge'
 
 const tierEntries = Object.entries(tierConfig) as [Tier, { color: string }][]
+
+function useReminderLabel() {
+  const { t } = useTranslation()
+  return (offset: number): string => {
+    const lead = describeLeadTime(offset)
+    if (lead.kind === 'at') return t('editor.reminderOnTime')
+    if (lead.kind === 'hours') return t('editor.reminderHoursBefore', { count: lead.count })
+    return t('editor.reminderMinutesBefore', { count: lead.count })
+  }
+}
+
+function NotificationsSection({
+  notify,
+  onChange,
+}: {
+  notify: NotifyConfig
+  onChange: (next: NotifyConfig) => void
+}) {
+  const { t } = useTranslation()
+  const theme = useTheme()
+  const reminderLabel = useReminderLabel()
+  const reminders: NotifyReminder[] = notify.reminders ?? [{ offset: 0 }]
+  const usedOffsets = new Set(reminders.map((r) => r.offset))
+  const availablePresets = REMINDER_PRESETS.filter((p) => !usedOffsets.has(p))
+
+  function setEnabled(enabled: boolean) {
+    lightTap()
+    onChange({ enabled, reminders: enabled ? reminders : undefined })
+  }
+
+  function addReminder(offset: number) {
+    lightTap()
+    const next = [...reminders, { offset }].sort((a, b) => b.offset - a.offset)
+    onChange({ enabled: true, reminders: next })
+  }
+
+  function removeReminder(offset: number) {
+    lightTap()
+    const remaining = reminders.filter((r) => r.offset !== offset)
+    if (remaining.length === 0) {
+      onChange({ enabled: false, reminders: undefined })
+      return
+    }
+    onChange({ enabled: true, reminders: remaining })
+  }
+
+  return (
+    <YStack gap="$sm">
+      <XStack alignItems="center" minHeight={44}>
+        <Bell size={18} color={theme.colorSecondary.val} />
+        <Text fontFamily="$body" fontSize="$3" color="$color" flex={1} marginLeft="$sm">
+          {t('editor.notifications')}
+        </Text>
+        <Switch
+          value={notify.enabled}
+          trackColor={{ false: theme.borderColor.val, true: theme.accent.val }}
+          thumbColor="white"
+          onValueChange={setEnabled}
+        />
+      </XStack>
+
+      {notify.enabled && (
+        <Animated.View entering={FadeIn.duration(200)} exiting={FadeOut.duration(150)}>
+          <YStack gap="$xs">
+            {reminders.map((r) => (
+              <XStack
+                key={r.offset}
+                alignItems="center"
+                paddingVertical="$xs"
+                paddingHorizontal="$sm"
+                borderRadius="$md"
+                backgroundColor="$background"
+                borderWidth={0.5}
+                borderColor="$borderColor"
+                minHeight={40}
+              >
+                <Text fontFamily="$body" fontSize="$3" color="$color" flex={1}>
+                  {reminderLabel(r.offset)}
+                </Text>
+                {reminders.length > 1 && (
+                  <AnimatedPressable
+                    onPress={() => removeReminder(r.offset)}
+                    hitSlop={12}
+                    accessibilityRole="button"
+                    accessibilityLabel={t('common.remove')}
+                  >
+                    <X size={16} color={theme.colorSecondary.val} />
+                  </AnimatedPressable>
+                )}
+              </XStack>
+            ))}
+
+            {availablePresets.length > 0 && (
+              <XStack gap="$xs" flexWrap="wrap" paddingTop="$xs">
+                {availablePresets.map((offset) => (
+                  <AnimatedPressable
+                    key={offset}
+                    onPress={() => addReminder(offset)}
+                    accessibilityRole="button"
+                    accessibilityLabel={`${t('editor.addReminder')}: ${reminderLabel(offset)}`}
+                  >
+                    <XStack
+                      alignItems="center"
+                      gap="$xs"
+                      paddingVertical="$xs"
+                      paddingHorizontal="$sm"
+                      borderRadius="$md"
+                      borderWidth={1}
+                      borderColor="$accent"
+                      borderStyle="dashed"
+                    >
+                      <Plus size={14} color={theme.accent.val} />
+                      <Text fontFamily="$body" fontSize="$2" color="$accent">
+                        {reminderLabel(offset)}
+                      </Text>
+                    </XStack>
+                  </AnimatedPressable>
+                ))}
+              </XStack>
+            )}
+          </YStack>
+        </Animated.View>
+      )}
+    </YStack>
+  )
+}
 
 function TierSelector({ value, onChange }: { value: Tier; onChange: (tier: Tier) => void }) {
   const { t } = useTranslation()
@@ -210,8 +337,8 @@ function SlotRow({
 
   const [localEnabled, setLocalEnabled] = useState(slot.enabled === 1)
   const [localTier, setLocalTier] = useState<Tier>(slot.tier)
-  const [localNotify, setLocalNotify] = useState(
-    slot.notify ? JSON.parse(slot.notify).enabled : false,
+  const [localNotify, setLocalNotify] = useState<NotifyConfig>(
+    () => parseNotifyConfig(slot.notify) ?? { enabled: false },
   )
 
   const chevronRotation = useSharedValue(0)
@@ -301,22 +428,13 @@ function SlotRow({
 
               <YStack borderBottomWidth={0.5} borderColor="$borderColor" />
 
-              <XStack alignItems="center" minHeight={44}>
-                <Bell size={18} color={theme.colorSecondary.val} />
-                <Text fontFamily="$body" fontSize="$3" color="$color" flex={1} marginLeft="$sm">
-                  {t('editor.notifications')}
-                </Text>
-                <Switch
-                  value={localNotify}
-                  trackColor={{ false: theme.borderColor.val, true: theme.accent.val }}
-                  thumbColor="white"
-                  onValueChange={(v) => {
-                    setLocalNotify(v)
-                    lightTap()
-                    onUpdate({ notify: JSON.stringify({ enabled: v }) })
-                  }}
-                />
-              </XStack>
+              <NotificationsSection
+                notify={localNotify}
+                onChange={(next) => {
+                  setLocalNotify(next)
+                  onUpdate({ notify: JSON.stringify(next) })
+                }}
+              />
 
               {onDelete && (
                 <AnimatedPressable

--- a/apps/app/src/features/plan-of-life/notify.test.ts
+++ b/apps/app/src/features/plan-of-life/notify.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest'
+
+import type { NotificationsManifest } from '@/content/manifestTypes'
+import type { NotifyConfig } from '@/db/schema'
+
+import {
+  computeTriggerTime,
+  describeLeadTime,
+  hashSeed,
+  localizeMessages,
+  parseNotifyConfig,
+  pickMessage,
+  resolveReminders,
+  shiftWeekday,
+} from './notify'
+
+describe('parseNotifyConfig', () => {
+  it('returns undefined for null/empty input', () => {
+    expect(parseNotifyConfig(null)).toBeUndefined()
+    expect(parseNotifyConfig('')).toBeUndefined()
+    expect(parseNotifyConfig(undefined)).toBeUndefined()
+  })
+
+  it('returns undefined for malformed JSON', () => {
+    expect(parseNotifyConfig('{not json')).toBeUndefined()
+    expect(parseNotifyConfig('"just a string"')).toBeUndefined()
+  })
+
+  it('parses legacy { enabled: true } shape', () => {
+    expect(parseNotifyConfig('{"enabled":true}')).toEqual({ enabled: true })
+  })
+
+  it('parses new shape with reminders', () => {
+    const json = '{"enabled":true,"reminders":[{"offset":30},{"offset":0}]}'
+    expect(parseNotifyConfig(json)).toEqual({
+      enabled: true,
+      reminders: [{ offset: 30 }, { offset: 0 }],
+    })
+  })
+})
+
+describe('resolveReminders', () => {
+  it('returns no reminders when notify is disabled', () => {
+    expect(resolveReminders({ enabled: false }, undefined)).toEqual([])
+    expect(resolveReminders(undefined, undefined)).toEqual([])
+  })
+
+  it('uses explicit reminders when provided', () => {
+    const notify: NotifyConfig = {
+      enabled: true,
+      reminders: [{ offset: 0 }, { offset: 60 }],
+    }
+    expect(resolveReminders(notify, undefined)).toEqual([{ offset: 60 }, { offset: 0 }])
+  })
+
+  it('falls back to manifest defaults when reminders missing', () => {
+    const manifest: NotificationsManifest = {
+      defaultReminders: [{ offset: 60 }, { offset: 0 }],
+    }
+    expect(resolveReminders({ enabled: true }, manifest)).toEqual([{ offset: 60 }, { offset: 0 }])
+  })
+
+  it('falls back to [{offset:0}] when no manifest defaults', () => {
+    expect(resolveReminders({ enabled: true }, undefined)).toEqual([{ offset: 0 }])
+    expect(resolveReminders({ enabled: true }, {})).toEqual([{ offset: 0 }])
+  })
+
+  it('dedupes and rejects negative offsets', () => {
+    const notify: NotifyConfig = {
+      enabled: true,
+      reminders: [{ offset: 30 }, { offset: 30 }, { offset: -5 }, { offset: 0 }],
+    }
+    expect(resolveReminders(notify, undefined)).toEqual([{ offset: 30 }, { offset: 0 }])
+  })
+
+  it('falls back to manifest when reminders array is empty', () => {
+    const manifest: NotificationsManifest = { defaultReminders: [{ offset: 15 }] }
+    expect(resolveReminders({ enabled: true, reminders: [] }, manifest)).toEqual([{ offset: 15 }])
+  })
+})
+
+describe('computeTriggerTime', () => {
+  it('returns slot time when offset is 0', () => {
+    expect(computeTriggerTime('08:00', 0)).toEqual({ hour: 8, minute: 0, weekdayShift: 0 })
+  })
+
+  it('subtracts the offset within the same day', () => {
+    expect(computeTriggerTime('08:00', 30)).toEqual({ hour: 7, minute: 30, weekdayShift: 0 })
+    expect(computeTriggerTime('08:00', 60)).toEqual({ hour: 7, minute: 0, weekdayShift: 0 })
+    expect(computeTriggerTime('14:15', 90)).toEqual({ hour: 12, minute: 45, weekdayShift: 0 })
+  })
+
+  it('wraps to previous day when offset crosses midnight', () => {
+    expect(computeTriggerTime('00:15', 30)).toEqual({ hour: 23, minute: 45, weekdayShift: -1 })
+    expect(computeTriggerTime('00:00', 60)).toEqual({ hour: 23, minute: 0, weekdayShift: -1 })
+  })
+
+  it('returns undefined for malformed slot time', () => {
+    expect(computeTriggerTime('25:00', 0)).toBeUndefined()
+    expect(computeTriggerTime('abc', 0)).toBeUndefined()
+    expect(computeTriggerTime('08', 0)).toBeUndefined()
+  })
+
+  it('clamps negative reminder offset to 0', () => {
+    expect(computeTriggerTime('08:00', -10)).toEqual({ hour: 8, minute: 0, weekdayShift: 0 })
+  })
+})
+
+describe('shiftWeekday', () => {
+  it('handles same-day (no shift)', () => {
+    expect(shiftWeekday(0, 0)).toBe(0)
+    expect(shiftWeekday(3, 0)).toBe(3)
+  })
+
+  it('shifts back one day correctly', () => {
+    expect(shiftWeekday(1, -1)).toBe(0) // Mon → Sun
+    expect(shiftWeekday(0, -1)).toBe(6) // Sun → Sat
+  })
+
+  it('shifts forward and wraps', () => {
+    expect(shiftWeekday(6, 1)).toBe(0) // Sat → Sun
+  })
+})
+
+describe('localizeMessages', () => {
+  it('returns en-US strings for default locale', () => {
+    const pool = { 'en-US': ['hello', 'hi'], 'pt-BR': ['olá'] }
+    expect(localizeMessages(pool, 'en-US')).toEqual(['hello', 'hi'])
+  })
+
+  it('returns pt-BR for portuguese locale', () => {
+    const pool = { 'en-US': ['hello'], 'pt-BR': ['olá', 'oi'] }
+    expect(localizeMessages(pool, 'pt-BR')).toEqual(['olá', 'oi'])
+  })
+
+  it('falls back to en-US when locale missing', () => {
+    const pool = { 'en-US': ['hello'] }
+    expect(localizeMessages(pool, 'pt-BR')).toEqual(['hello'])
+  })
+
+  it('wraps a single string into an array', () => {
+    expect(localizeMessages({ 'en-US': 'hello' }, 'en-US')).toEqual(['hello'])
+  })
+
+  it('returns empty array when pool undefined or empty', () => {
+    expect(localizeMessages(undefined, 'en-US')).toEqual([])
+    expect(localizeMessages({}, 'en-US')).toEqual([])
+  })
+})
+
+describe('pickMessage', () => {
+  it('returns undefined for empty pool', () => {
+    expect(pickMessage([], 0)).toBeUndefined()
+  })
+
+  it('selects deterministically by seed', () => {
+    const pool = ['a', 'b', 'c']
+    expect(pickMessage(pool, 0)).toBe('a')
+    expect(pickMessage(pool, 1)).toBe('b')
+    expect(pickMessage(pool, 4)).toBe('b')
+  })
+
+  it('handles negative seeds', () => {
+    const pool = ['a', 'b']
+    expect(pickMessage(pool, -1)).toBe('b')
+  })
+})
+
+describe('hashSeed', () => {
+  it('is deterministic', () => {
+    expect(hashSeed(['rosary::default', 30])).toBe(hashSeed(['rosary::default', 30]))
+  })
+
+  it('varies by inputs', () => {
+    expect(hashSeed(['a', 0])).not.toBe(hashSeed(['a', 30]))
+    expect(hashSeed(['a', 0])).not.toBe(hashSeed(['b', 0]))
+  })
+})
+
+describe('describeLeadTime', () => {
+  it('returns "at" for offset 0 or negative', () => {
+    expect(describeLeadTime(0)).toEqual({ kind: 'at' })
+    expect(describeLeadTime(-5)).toEqual({ kind: 'at' })
+  })
+
+  it('returns minutes for sub-hour offsets', () => {
+    expect(describeLeadTime(15)).toEqual({ kind: 'minutes', count: 15 })
+    expect(describeLeadTime(45)).toEqual({ kind: 'minutes', count: 45 })
+  })
+
+  it('returns hours for whole-hour offsets ≥ 60', () => {
+    expect(describeLeadTime(60)).toEqual({ kind: 'hours', count: 1 })
+    expect(describeLeadTime(120)).toEqual({ kind: 'hours', count: 2 })
+  })
+
+  it('returns minutes for non-whole-hour offsets ≥ 60', () => {
+    expect(describeLeadTime(90)).toEqual({ kind: 'minutes', count: 90 })
+  })
+})

--- a/apps/app/src/features/plan-of-life/notify.ts
+++ b/apps/app/src/features/plan-of-life/notify.ts
@@ -1,0 +1,119 @@
+import type { LocalizedMessagePool, NotificationsManifest } from '@/content/manifestTypes'
+import type { NotifyConfig, NotifyReminder } from '@/db/schema'
+
+export const DEFAULT_REMINDER: NotifyReminder = { offset: 0 }
+
+export const REMINDER_PRESETS: number[] = [0, 5, 15, 30, 60, 120]
+
+export function parseNotifyConfig(json: string | null | undefined): NotifyConfig | undefined {
+  if (!json) return undefined
+  try {
+    const parsed = JSON.parse(json) as NotifyConfig
+    if (typeof parsed?.enabled !== 'boolean') return undefined
+    return parsed
+  } catch {
+    return undefined
+  }
+}
+
+export function resolveReminders(
+  notify: NotifyConfig | undefined,
+  manifestNotifications: NotificationsManifest | undefined,
+): NotifyReminder[] {
+  if (!notify?.enabled) return []
+  if (notify.reminders && notify.reminders.length > 0) {
+    return dedupeReminders(notify.reminders)
+  }
+  const fromManifest = manifestNotifications?.defaultReminders
+  if (fromManifest && fromManifest.length > 0) {
+    return dedupeReminders(fromManifest.map((r) => ({ offset: r.offset })))
+  }
+  return [DEFAULT_REMINDER]
+}
+
+function dedupeReminders(reminders: NotifyReminder[]): NotifyReminder[] {
+  const seen = new Set<number>()
+  const out: NotifyReminder[] = []
+  for (const r of reminders) {
+    if (!Number.isFinite(r.offset) || r.offset < 0) continue
+    const offset = Math.round(r.offset)
+    if (seen.has(offset)) continue
+    seen.add(offset)
+    out.push({ offset })
+  }
+  return out.sort((a, b) => b.offset - a.offset) // earliest reminder first
+}
+
+export type TriggerTime = {
+  hour: number
+  minute: number
+  weekdayShift: number // 0 = same day; -1 = previous day (when offset wraps past midnight)
+}
+
+export function computeTriggerTime(
+  slotTime: string,
+  offsetMinutes: number,
+): TriggerTime | undefined {
+  const [hStr, mStr] = slotTime.split(':')
+  const hours = Number(hStr)
+  const minutes = Number(mStr)
+  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) return undefined
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return undefined
+
+  const totalAtSlot = hours * 60 + minutes
+  let total = totalAtSlot - Math.max(0, Math.round(offsetMinutes))
+  let weekdayShift = 0
+  while (total < 0) {
+    total += 24 * 60
+    weekdayShift -= 1
+  }
+  return { hour: Math.floor(total / 60), minute: total % 60, weekdayShift }
+}
+
+export function shiftWeekday(weekday: number, shift: number): number {
+  const wrapped = (((weekday + shift) % 7) + 7) % 7
+  return wrapped
+}
+
+export function localizeMessages(
+  pool: LocalizedMessagePool | undefined,
+  language: string,
+): string[] {
+  if (!pool) return []
+  const primary = language === 'pt-BR' ? pool['pt-BR'] : pool['en-US']
+  const fallback = pool['en-US']
+  const chosen = primary ?? fallback
+  if (!chosen) return []
+  return Array.isArray(chosen) ? chosen.filter(Boolean) : [chosen]
+}
+
+export function pickMessage(messages: string[], seed: number): string | undefined {
+  if (messages.length === 0) return undefined
+  const idx = Math.abs(seed) % messages.length
+  return messages[idx]
+}
+
+// Stable small hash for picking deterministic body per (slotId, offset, day).
+// Avoids reshuffling on every reschedule pass.
+export function hashSeed(parts: (string | number)[]): number {
+  const s = parts.join('|')
+  let h = 2166136261
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  return h >>> 0
+}
+
+export type LeadTime =
+  | { kind: 'at' }
+  | { kind: 'minutes'; count: number }
+  | { kind: 'hours'; count: number }
+
+export function describeLeadTime(offsetMinutes: number): LeadTime {
+  if (offsetMinutes <= 0) return { kind: 'at' }
+  if (offsetMinutes >= 60 && offsetMinutes % 60 === 0) {
+    return { kind: 'hours', count: offsetMinutes / 60 }
+  }
+  return { kind: 'minutes', count: offsetMinutes }
+}

--- a/apps/app/src/features/plan-of-life/notify.ts
+++ b/apps/app/src/features/plan-of-life/notify.ts
@@ -41,7 +41,7 @@ function dedupeReminders(reminders: NotifyReminder[]): NotifyReminder[] {
     seen.add(offset)
     out.push({ offset })
   }
-  return out.sort((a, b) => b.offset - a.offset) // earliest reminder first
+  return out.sort((a, b) => b.offset - a.offset)
 }
 
 export type TriggerTime = {

--- a/apps/app/src/lib/i18n/locales/en-US.ts
+++ b/apps/app/src/lib/i18n/locales/en-US.ts
@@ -1063,7 +1063,6 @@ export default {
     titleInMinutes: '{{name}} in {{count}} min',
     titleInHours_one: '{{name}} in {{count}} hr',
     titleInHours_other: '{{name}} in {{count}} hrs',
-    bodyDefault: 'Time for prayer.',
     bodyPool: [
       'Time for prayer.',
       'A few minutes with the Lord.',

--- a/apps/app/src/lib/i18n/locales/en-US.ts
+++ b/apps/app/src/lib/i18n/locales/en-US.ts
@@ -529,6 +529,13 @@ export default {
     description: 'Description',
     descriptionPlaceholder: 'Optional description',
     notifications: 'Notifications',
+    reminders: 'Reminders',
+    addReminder: 'Add reminder',
+    reminderOnTime: 'On time',
+    reminderMinutesBefore_one: '{{count}} min before',
+    reminderMinutesBefore_other: '{{count}} min before',
+    reminderHoursBefore_one: '{{count}} hr before',
+    reminderHoursBefore_other: '{{count}} hrs before',
     reminderTime: 'Reminder time',
     enabled: 'Enabled',
     createPractice: 'Create Practice',
@@ -1050,6 +1057,20 @@ export default {
     scheduleFailed: 'Reminders couldn\u2019t be scheduled',
     scheduleFailedDesc:
       'Your change was saved, but reminder notifications couldn\u2019t be set up. Check your notification permissions and try again.',
+  },
+
+  notifications: {
+    titleInMinutes: '{{name}} in {{count}} min',
+    titleInHours_one: '{{name}} in {{count}} hr',
+    titleInHours_other: '{{name}} in {{count}} hrs',
+    bodyDefault: 'Time for prayer.',
+    bodyPool: [
+      'Time for prayer.',
+      'A few minutes with the Lord.',
+      'Pause the world. Come and pray.',
+      'A moment to lift your heart to God.',
+      'Be still, and know that He is here.',
+    ],
   },
 
   bookName: {

--- a/apps/app/src/lib/i18n/locales/pt-BR.ts
+++ b/apps/app/src/lib/i18n/locales/pt-BR.ts
@@ -533,6 +533,13 @@ export default {
     description: 'Descri\u00e7\u00e3o',
     descriptionPlaceholder: 'Descri\u00e7\u00e3o opcional',
     notifications: 'Notifica\u00e7\u00f5es',
+    reminders: 'Lembretes',
+    addReminder: 'Adicionar lembrete',
+    reminderOnTime: 'No hor\u00e1rio',
+    reminderMinutesBefore_one: '{{count}} min antes',
+    reminderMinutesBefore_other: '{{count}} min antes',
+    reminderHoursBefore_one: '{{count}} h antes',
+    reminderHoursBefore_other: '{{count}} h antes',
     reminderTime: 'Hora do lembrete',
     enabled: 'Ativada',
     createPractice: 'Criar Pr\u00e1tica',
@@ -1053,6 +1060,20 @@ export default {
     scheduleFailed: 'Não foi possível agendar os lembretes',
     scheduleFailedDesc:
       'Sua alteração foi salva, mas as notificações de lembrete não puderam ser configuradas. Verifique as permissões de notificação e tente novamente.',
+  },
+
+  notifications: {
+    titleInMinutes: '{{name}} em {{count}} min',
+    titleInHours_one: '{{name}} em {{count}} h',
+    titleInHours_other: '{{name}} em {{count}} h',
+    bodyDefault: 'Hora de rezar.',
+    bodyPool: [
+      'Hora de rezar.',
+      'Alguns minutos com o Senhor.',
+      'Pause o mundo. Venha rezar.',
+      'Um momento para elevar o coração a Deus.',
+      'Aquietai-vos e sabei que Ele está aqui.',
+    ],
   },
 
   bookName: {

--- a/apps/app/src/lib/i18n/locales/pt-BR.ts
+++ b/apps/app/src/lib/i18n/locales/pt-BR.ts
@@ -1066,7 +1066,6 @@ export default {
     titleInMinutes: '{{name}} em {{count}} min',
     titleInHours_one: '{{name}} em {{count}} h',
     titleInHours_other: '{{name}} em {{count}} h',
-    bodyDefault: 'Hora de rezar.',
     bodyPool: [
       'Hora de rezar.',
       'Alguns minutos com o Senhor.',

--- a/apps/app/src/lib/notifications.ts
+++ b/apps/app/src/lib/notifications.ts
@@ -2,7 +2,7 @@ import { Platform } from 'react-native'
 import { getManifest } from '@/content/resolver'
 import type { SlotState } from '@/db/events'
 import { getEnabledSlots, getPractice } from '@/db/repositories'
-import type { NotifyReminder, UserPractice } from '@/db/schema'
+import type { UserPractice } from '@/db/schema'
 import {
   computeTriggerTime,
   describeLeadTime,
@@ -57,38 +57,11 @@ function getScheduledDays(schedule: Schedule): number[] | undefined {
   return undefined
 }
 
-function buildContent(
-  practiceName: string,
-  reminder: NotifyReminder,
-  slot: SlotState,
-  bodyPool: string[],
-): { title: string; body: string; data: Record<string, unknown> } {
-  const lead = describeLeadTime(reminder.offset)
-  const t = i18n.t.bind(i18n)
-  const title =
-    lead.kind === 'at'
-      ? practiceName
-      : lead.kind === 'hours'
-        ? t('notifications.titleInHours', { name: practiceName, count: lead.count })
-        : t('notifications.titleInMinutes', { name: practiceName, count: lead.count })
-
-  const seed = hashSeed([slot.id, reminder.offset])
-  const fallbackPool = t('notifications.bodyPool', { returnObjects: true }) as unknown as
-    | string[]
-    | string
-  const fallback = Array.isArray(fallbackPool) ? fallbackPool : [String(fallbackPool)]
-  const pool = bodyPool.length > 0 ? bodyPool : fallback
-  const body = pickMessage(pool, seed) ?? t('notifications.bodyDefault')
-
-  return {
-    title,
-    body,
-    data: {
-      practiceId: slot.practice_id,
-      slotId: parseSlotKey(slot.id).slotId,
-      offset: reminder.offset,
-    },
-  }
+function formatTitle(practiceName: string, offset: number): string {
+  const lead = describeLeadTime(offset)
+  if (lead.kind === 'at') return practiceName
+  const key = lead.kind === 'hours' ? 'notifications.titleInHours' : 'notifications.titleInMinutes'
+  return i18n.t(key, { name: practiceName, count: lead.count })
 }
 
 function scheduleRemindersForSlot(
@@ -108,14 +81,22 @@ function scheduleRemindersForSlot(
   const scheduledDays = getScheduledDays(schedule)
   const practiceName =
     practice?.custom_name ?? (manifest ? localizeContent(manifest.name) : slot.practice_id)
-  const bodyPool = localizeMessages(manifest?.notifications?.messages, i18n.language)
+  const manifestPool = localizeMessages(manifest?.notifications?.messages, i18n.language)
+  const fallbackPool = i18n.t('notifications.bodyPool', { returnObjects: true }) as string[]
+  const bodyPool = manifestPool.length > 0 ? manifestPool : fallbackPool
   const androidChannel = Platform.OS === 'android' ? { channelId: 'practice-reminders' } : {}
+  const dataBase = { practiceId: slot.practice_id, slotId: parseSlotKey(slot.id).slotId }
 
   const tasks: Promise<string>[] = []
   for (const reminder of reminders) {
     const trigger = computeTriggerTime(slot.time, reminder.offset)
     if (!trigger) continue
-    const content = buildContent(practiceName, reminder, slot, bodyPool)
+    const body = pickMessage(bodyPool, hashSeed([slot.id, reminder.offset])) ?? bodyPool[0]
+    const content = {
+      title: formatTitle(practiceName, reminder.offset),
+      body,
+      data: { ...dataBase, offset: reminder.offset },
+    }
 
     if (scheduledDays) {
       for (const day of scheduledDays) {

--- a/apps/app/src/lib/notifications.ts
+++ b/apps/app/src/lib/notifications.ts
@@ -2,9 +2,19 @@ import { Platform } from 'react-native'
 import { getManifest } from '@/content/resolver'
 import type { SlotState } from '@/db/events'
 import { getEnabledSlots, getPractice } from '@/db/repositories'
-import type { NotifyConfig, UserPractice } from '@/db/schema'
+import type { NotifyReminder, UserPractice } from '@/db/schema'
+import {
+  computeTriggerTime,
+  describeLeadTime,
+  hashSeed,
+  localizeMessages,
+  parseNotifyConfig,
+  pickMessage,
+  resolveReminders,
+  shiftWeekday,
+} from '@/features/plan-of-life/notify'
 import { parseSchedule, type Schedule } from '@/features/plan-of-life/schedule'
-import { localizeContent } from '@/lib/i18n'
+import i18n, { localizeContent } from '@/lib/i18n'
 import { parseSlotKey } from '@/lib/slotKey'
 
 // expo-notifications is native-only
@@ -42,20 +52,43 @@ export async function setupNotifications() {
   }
 }
 
-function parseNotifyConfig(json: string | null): NotifyConfig | undefined {
-  if (!json) return undefined
-  try {
-    return JSON.parse(json) as NotifyConfig
-  } catch {
-    return undefined
-  }
+function getScheduledDays(schedule: Schedule): number[] | undefined {
+  if (schedule.type === 'days-of-week') return schedule.days
+  return undefined
 }
 
-function getScheduledDays(schedule: Schedule): number[] | undefined {
-  if (schedule.type === 'daily') return undefined
-  if (schedule.type === 'days-of-week') return schedule.days
-  if (schedule.type === 'times-per') return undefined
-  return undefined
+function buildContent(
+  practiceName: string,
+  reminder: NotifyReminder,
+  slot: SlotState,
+  bodyPool: string[],
+): { title: string; body: string; data: Record<string, unknown> } {
+  const lead = describeLeadTime(reminder.offset)
+  const t = i18n.t.bind(i18n)
+  const title =
+    lead.kind === 'at'
+      ? practiceName
+      : lead.kind === 'hours'
+        ? t('notifications.titleInHours', { name: practiceName, count: lead.count })
+        : t('notifications.titleInMinutes', { name: practiceName, count: lead.count })
+
+  const seed = hashSeed([slot.id, reminder.offset])
+  const fallbackPool = t('notifications.bodyPool', { returnObjects: true }) as unknown as
+    | string[]
+    | string
+  const fallback = Array.isArray(fallbackPool) ? fallbackPool : [String(fallbackPool)]
+  const pool = bodyPool.length > 0 ? bodyPool : fallback
+  const body = pickMessage(pool, seed) ?? t('notifications.bodyDefault')
+
+  return {
+    title,
+    body,
+    data: {
+      practiceId: slot.practice_id,
+      slotId: parseSlotKey(slot.id).slotId,
+      offset: reminder.offset,
+    },
+  }
 }
 
 function scheduleRemindersForSlot(
@@ -64,48 +97,57 @@ function scheduleRemindersForSlot(
 ): Promise<string[]> {
   if (!slot.time) return Promise.resolve([])
 
-  const [hours, minutes] = slot.time.split(':').map(Number)
-  if (Number.isNaN(hours) || Number.isNaN(minutes)) return Promise.resolve([])
+  const notify = parseNotifyConfig(slot.notify)
+  if (!notify?.enabled) return Promise.resolve([])
+
+  const manifest = getManifest(slot.practice_id)
+  const reminders = resolveReminders(notify, manifest?.notifications)
+  if (reminders.length === 0) return Promise.resolve([])
 
   const schedule = parseSchedule(slot.schedule)
   const scheduledDays = getScheduledDays(schedule)
-  const manifest = getManifest(slot.practice_id)
   const practiceName =
     practice?.custom_name ?? (manifest ? localizeContent(manifest.name) : slot.practice_id)
-
-  const content = {
-    title: practiceName,
-    body: 'Time for prayer',
-    data: { practiceId: slot.practice_id, slotId: parseSlotKey(slot.id).slotId },
-  }
+  const bodyPool = localizeMessages(manifest?.notifications?.messages, i18n.language)
   const androidChannel = Platform.OS === 'android' ? { channelId: 'practice-reminders' } : {}
 
-  if (scheduledDays) {
-    return Promise.all(
-      scheduledDays.map((day) =>
+  const tasks: Promise<string>[] = []
+  for (const reminder of reminders) {
+    const trigger = computeTriggerTime(slot.time, reminder.offset)
+    if (!trigger) continue
+    const content = buildContent(practiceName, reminder, slot, bodyPool)
+
+    if (scheduledDays) {
+      for (const day of scheduledDays) {
+        const shifted = shiftWeekday(day, trigger.weekdayShift)
+        tasks.push(
+          Notifications.scheduleNotificationAsync({
+            content,
+            trigger: {
+              type: Notifications.SchedulableTriggerInputTypes.WEEKLY,
+              weekday: shifted === 0 ? 1 : shifted + 1,
+              hour: trigger.hour,
+              minute: trigger.minute,
+              ...androidChannel,
+            },
+          }),
+        )
+      }
+    } else {
+      tasks.push(
         Notifications.scheduleNotificationAsync({
           content,
           trigger: {
-            type: Notifications.SchedulableTriggerInputTypes.WEEKLY,
-            weekday: day === 0 ? 1 : day + 1,
-            hour: hours,
-            minute: minutes,
+            type: Notifications.SchedulableTriggerInputTypes.DAILY,
+            hour: trigger.hour,
+            minute: trigger.minute,
             ...androidChannel,
           },
         }),
-      ),
-    )
+      )
+    }
   }
-
-  return Notifications.scheduleNotificationAsync({
-    content,
-    trigger: {
-      type: Notifications.SchedulableTriggerInputTypes.DAILY,
-      hour: hours,
-      minute: minutes,
-      ...androidChannel,
-    },
-  }).then((id: string) => [id])
+  return Promise.all(tasks)
 }
 
 export async function cancelPracticeReminder(practiceId: string): Promise<void> {
@@ -123,7 +165,10 @@ export async function rescheduleAllReminders(): Promise<void> {
   const slots = await getEnabledSlots()
   const notifiable = slots.filter((s) => parseNotifyConfig(s.notify)?.enabled && s.time)
 
-  if (notifiable.length === 0) return
+  if (notifiable.length === 0) {
+    await Notifications.cancelAllScheduledNotificationsAsync()
+    return
+  }
 
   const hasPermission = await requestNotificationPermission()
   if (!hasPermission) return

--- a/content/practices/angelus/manifest.json
+++ b/content/practices/angelus/manifest.json
@@ -42,5 +42,22 @@
 				"tier": "ideal"
 			}
 		]
+	},
+	"notifications": {
+		"defaultReminders": [
+			{ "offset": 0 }
+		],
+		"messages": {
+			"en-US": [
+				"The Angel of the Lord declared unto Mary…",
+				"A short pause to greet Our Lady.",
+				"Three Hail Marys at the sound of the bell."
+			],
+			"pt-BR": [
+				"O Anjo do Senhor anunciou a Maria…",
+				"Uma breve pausa para saudar Nossa Senhora.",
+				"Três Ave Marias ao toque do sino."
+			]
+		}
 	}
 }

--- a/content/practices/examination-of-conscience/manifest.json
+++ b/content/practices/examination-of-conscience/manifest.json
@@ -54,5 +54,22 @@
 				"tier": "essential"
 			}
 		]
+	},
+	"notifications": {
+		"defaultReminders": [
+			{ "offset": 0 }
+		],
+		"messages": {
+			"en-US": [
+				"Bring your day to the Lord.",
+				"A few minutes of quiet before sleep.",
+				"Look back with the Lord at the day He gave."
+			],
+			"pt-BR": [
+				"Apresente o seu dia ao Senhor.",
+				"Alguns minutos de silêncio antes de dormir.",
+				"Reveja com o Senhor o dia que Ele lhe deu."
+			]
+		}
 	}
 }

--- a/content/practices/mass/manifest.json
+++ b/content/practices/mass/manifest.json
@@ -43,5 +43,25 @@
         "tier": "essential"
       }
     ]
+  },
+  "notifications": {
+    "defaultReminders": [
+      { "offset": 60 },
+      { "offset": 0 }
+    ],
+    "messages": {
+      "en-US": [
+        "Time for the Holy Mass.",
+        "The Lord's Day — meet Him at the altar.",
+        "Sursum corda — lift up your hearts.",
+        "Come and receive the Bread of Life."
+      ],
+      "pt-BR": [
+        "Hora da Santa Missa.",
+        "O Dia do Senhor — encontre-O no altar.",
+        "Sursum corda — corações ao alto.",
+        "Venha receber o Pão da Vida."
+      ]
+    }
   }
 }

--- a/content/practices/rosary/manifest.json
+++ b/content/practices/rosary/manifest.json
@@ -52,5 +52,26 @@
 				"tier": "essential"
 			}
 		]
+	},
+	"notifications": {
+		"defaultReminders": [
+			{ "offset": 0 }
+		],
+		"messages": {
+			"en-US": [
+				"A few minutes with Our Lady.",
+				"Pause the world for the Rosary.",
+				"Hail Mary, full of grace…",
+				"Take up your beads. Mary is waiting.",
+				"Walk the mysteries with the Mother of God."
+			],
+			"pt-BR": [
+				"Alguns minutos com Nossa Senhora.",
+				"Pause o mundo pelo Rosário.",
+				"Ave Maria, cheia de graça…",
+				"Pegue o terço. Maria espera por você.",
+				"Caminhe pelos mistérios com a Mãe de Deus."
+			]
+		}
 	}
 }


### PR DESCRIPTION
- Add multiple reminders per slot via offset list (`{ offset: minutes }`),
  backwards-compatible with the legacy `{ enabled }` shape (no migration).
- Manifest-driven defaults and rotating message pools per practice
  (Rosary, Angelus, Mass, Examination of Conscience seeded).
- Localize notification body (en + pt-BR) with deterministic per-slot/offset
  picks so messages don't reshuffle on every reschedule.
- Lead-time-aware title: "Holy Mass in 1 hr" vs at-time bare name.
- Compute trigger times by subtracting offset and shifting weekday when
  the reminder crosses midnight (e.g. 30 min before 00:15).
- New SlotConfigurator UI: enable toggle + reminder chips + preset adders
  (on time / 5/15/30 min / 1 hr / 2 hrs).