### PR TITLE
Custody PRD: app/website blocking feature spec

### DIFF
--- a/docs/features/custody.md
+++ b/docs/features/custody.md
@@ -105,10 +105,10 @@ App Group `group.me.dpgu.ember.custody` shares state between the main app and ex
 
 Android has no first-party Family Controls equivalent. Three approaches; one was just killed.
 
-| Path | Viable | Effort | Shields |
+| Path | Viable | Complexity | Shields |
 |---|---|---|---|
-| VPN service + DNS filter | ✓ | ~2–3 weeks | Web domains |
-| UsageStatsManager + foreground service + Activity overlay | ✓ | ~3–4 weeks | Apps |
+| VPN service + DNS filter | ✓ | Moderate (Kotlin VPN service, DNS resolver, single-VPN-slot UX) | Web domains |
+| UsageStatsManager + foreground service + Activity overlay | ✓ | High (long-running foreground service; OEM-variable battery behavior; full-screen Activity overlay UX) | Apps |
 | AccessibilityService | ✗ killed | — | — |
 
 The **October 30, 2025 Google Play policy update** restricted the AccessibilityService API to genuine disability features; non-accessibility automation is prohibited and apps in the focus-blocker category have been removed. Ember's Android approach avoids `AccessibilityService` entirely.
@@ -251,9 +251,13 @@ Web hidden in v1.
 
 Track-as-milestone convention. Two milestones: **Custody** (v1) and **Custody — v2** (Android bound mode).
 
-### Custody — v1 (~6–9 weeks)
+### Custody — v1
 
-#### Phase A — Foundation (cross-platform, no native) — ~1.5 weeks
+Phases A and B are JS-only and reversible. Phase C is the platform-locked native step and the dominant complexity gate. Phases D and E close the loop.
+
+#### Phase A — Foundation (cross-platform, no native)
+
+Complexity: **Moderate.** Pure JS work; the only non-trivial bit is extending the migration runner to support multi-file migrations.
 
 1. Spec promotion (this document).
 2. Migration mechanic: extend `apps/app/src/db/client.ts` for multi-file migrations.
@@ -263,7 +267,9 @@ Track-as-milestone convention. Two milestones: **Custody** (v1) and **Custody �
 6. i18n keys: en-US + pt-BR.
 7. Expo Router scaffold under `apps/app/src/app/custody/`.
 
-#### Phase B — Spiritual surface (cross-platform, JS-only) — ~1.5 weeks
+#### Phase B — Spiritual surface (cross-platform, JS-only)
+
+Complexity: **Moderate.** UI breadth is the cost (Custody screens, Examen integration, Confessio falls-log, home-today block). All reversible.
 
 8. `CommitmentList` + `CommitmentEditor` + `SeverityPicker` + `FrictionPicker` (light/firm only at this stage).
 9. Custody session runner + bells + anchor picker.
@@ -274,7 +280,11 @@ Track-as-milestone convention. Two milestones: **Custody** (v1) and **Custody �
 
 Phase B is independently shippable: Ember v(N+1) without bound mode but with the spiritual frame. Validates the data model before the native dive.
 
-#### Phase C — iOS bound mode — ~3–4 weeks
+#### Phase C — iOS bound mode
+
+Complexity: **High — and gated.** This is the project's first custom Expo native module, the first config plugin, the first time we leave managed Expo for a custom dev client, and it ships *three* iOS extension targets (`DeviceActivityMonitor`, `ShieldConfiguration`, `ShieldAction`) wired through an App Group. Apple's Family Controls entitlement is an external dependency that gates App Store distribution (lead time: days–weeks; dev builds work without it). Family Controls does not run in the simulator — every meaningful test requires a physical iPhone.
+
+Risks: entitlement denial or delay; `react-native-device-activity` proving insufficient for the prayer-shield UI (fallback: fork or wrap); App Review pushback on the Custody framing (fallback: refine justification, resubmit).
 
 14. **File the Family Controls Individual entitlement request for `me.dpgu.ember`** — before any code. Lead time: days–weeks.
 15. Add `react-native-device-activity` to `apps/app/package.json`; switch to a custom dev client.
@@ -289,22 +299,30 @@ Phase B is independently shippable: Ember v(N+1) without bound mode but with the
 24. Manual QA on a physical iPhone (simulator does not support Family Controls).
 25. TestFlight build + Apple App Review prep with Family Controls justification.
 
-#### Phase D — Android handoff + DNS walkthrough — ~3–5 days
+#### Phase D — Android handoff + DNS walkthrough
+
+Complexity: **Low.** Mostly copy, screenshots, and a deep-link helper.
 
 26. Digital Wellbeing deep-link helper.
 27. NextDNS / AdGuard DNS setup walkthrough.
 28. Render bound severity as "coming to Android in v2" with the DNS walkthrough as today's recommendation.
 
-#### Phase E — Polish, locales, docs — ~3–5 days
+#### Phase E — Polish, locales, docs
+
+Complexity: **Low**, but the pt-BR catechetical-vocabulary review needs a careful pass — *propósito*, *firme propósito de emenda*, *custódia dos sentidos* are theological terms that must land precisely.
 
 29. pt-BR catechetical-vocabulary review (*propósito*, *firme propósito de emenda*, *custódia dos sentidos*).
 30. Saint-quote pool for shield-empty defaults.
 31. `docs/journal.md` entries for Family Controls quirks.
 32. Screenshots and store-listing copy.
 
-### Custody — v2 (Android bound mode, ~4–6 weeks)
+### Custody — v2 (Android bound mode)
 
-#### Phase F — Android VPN + DNS (web targets) — ~2 weeks
+The platform's first Kotlin native module. Two enforcement halves (web via VPN/DNS, apps via UsageStats), then OEM polish. No off-the-shelf Expo Android equivalent of `react-native-device-activity` — this is hand-written.
+
+#### Phase F — Android VPN + DNS (web targets)
+
+Complexity: **Moderate–High.** First Kotlin Expo module; VPN service must be implemented carefully (single-VPN-slot conflict, DNS-over-HTTPS bypass on some browsers, graceful denial path). Reference implementation: [DNSNet](https://github.com/t895/DNSNet).
 
 33. `apps/app/modules/ember-custody-android/` — Kotlin Expo module skeleton.
 34. `EmberVpnService extends VpnService` — DNS interception, per-commitment domain blocklist.
@@ -312,7 +330,9 @@ Phase B is independently shippable: Ember v(N+1) without bound mode but with the
 36. First-run consent: explain VPN slot conflict; system VPN dialog; handle denial.
 37. Web-target commitments now show "Active on Android".
 
-#### Phase G — Android UsageStats + shield Activity (app targets) — ~3 weeks
+#### Phase G — Android UsageStats + shield Activity (app targets)
+
+Complexity: **High.** A long-running foreground service that polls and launches Activities is exactly the surface OEMs aggressively kill. The 1–3s detection delay is a UX limit we cannot engineer around. The `PACKAGE_USAGE_STATS` deep-link flow is unfamiliar to most users; onboarding copy carries the load.
 
 38. `EmberMonitorService` foreground service.
 39. UsageStats poll loop + foreground-app detection.
@@ -321,7 +341,9 @@ Phase B is independently shippable: Ember v(N+1) without bound mode but with the
 42. Permission flows: `PACKAGE_USAGE_STATS` deep-link, battery-optimization opt-out.
 43. Friction modes implemented in `PrayerShieldActivity`.
 
-#### Phase H — Android polish — ~3–5 days
+#### Phase H — Android polish
+
+Complexity: **Low per task, but the OEM matrix is irreducible.** Samsung One UI, Xiaomi MIUI, OnePlus OxygenOS each kill background services differently. Real devices required for verification — emulators do not reproduce these behaviors.
 
 44. Battery / wake-lock tuning; verify foreground service survives Doze and App Standby.
 45. OEM-specific testing (Samsung One UI, Xiaomi MIUI, OnePlus OxygenOS).

--- a/docs/features/custody.md
+++ b/docs/features/custody.md
@@ -1,0 +1,420 @@
+# Custody
+
+> Status: spec (v1, draft). No code yet. The first `Custody` GitHub milestone gates implementation.
+
+A discipline / focus surface for Ember that limits or blocks selected apps and websites at the OS level — and turns each blocked moment into a moment of prayer. Catholic framing: custody of the senses, mortification, *firm purpose of amendment* after confession. Fits the **Fidelity** pillar as the negative half of the rule of life — what the user *refuses*, alongside what they *do*.
+
+The differentiator: Opal's blocked screen shows a score. **Ember's blocked screen shows a prayer.** A verse, an aspiration, a Sacred Heart image — and one button: *Pray and continue blocking*.
+
+---
+
+## Concepts
+
+### Commitment
+
+A user-authored ascetical resolution. The rule itself.
+
+```typescript
+type Commitment = {
+  id: string
+  name: string
+  description?: string
+  confessorNote?: string
+  kind: 'abstain' | 'time-limit' | 'time-fence'
+  targets: Target[]                  // opaque tokens, DNS keys, or domains
+  schedule: ScheduleRule             // reuses plan-of-life schedule rules
+  severity: 'light' | 'firm' | 'bound'
+  friction: 'none' | 'wait' | 'prayer' | 'confession-only'
+  shieldAnchorRef: string            // e.g., 'prayer/anima-christi'
+  fallPolicy: 'log' | 'examen' | 'confession-prep'
+  archived: boolean
+  createdAt: number
+}
+```
+
+Examples:
+
+- "Abstain from pornographic websites — always." (`abstain`, `bound`, `confession-only`)
+- "No Instagram between 21:00 and 07:00." (`time-fence`, `bound`, `wait` 5m)
+- "No news sites during Lent." (`abstain`, season-gated, `firm`)
+- "No more than 30 min/day of YouTube on weekdays." (`time-limit`, `bound`, `prayer`)
+
+**Severity** decides enforcement: spiritual (logs and prompts) vs. technical (OS shields the app/site). **Friction** decides how easy escape is — implemented as policy in our shield action, not Apple/Google APIs.
+
+### Custody session
+
+A timed focus block *inside Ember*. Not a blocker of other apps. The user picks a duration (5/10/20/40/60 min) and an **anchor**:
+
+- a `prayer/...` ref (e.g., `prayer/anima-christi`)
+- a lectio passage
+- an examen prompt
+- silence + sacred art
+
+For the window: Ember's notifications silence, screen stays awake (`expo-keep-awake`), anchor renders full-screen, gentle bell at 1/3, 2/3, end. Counts as an *Ideal* practice on the fidelity wall (configurable per user). Optionally deep-links to iOS Focus / Android DND on entry.
+
+A commitment is a long-running rule. A custody session is a single sit-down prayer block. They compose: a Lenten user might have an active "no social media" commitment all season, and start a 20-minute Custody session for lectio each morning.
+
+### Prayer shield (iOS, v1)
+
+When a `bound` commitment fires and the user opens a shielded app, iOS overlays Ember's branded screen via `ShieldConfigurationDataSource`. The shield shows the commitment's anchor, a "Pray and continue blocking" button, and (if friction allows) a "Disable temporarily" path with the configured wait/prayer/confession friction. **This is the product.**
+
+---
+
+## Self-restraint, not parental control
+
+Apple's framework name (*Family Controls*) implies parental control. It is not. Family Controls is the umbrella for the entire iOS Screen Time API stack (`FamilyControls` + `ManagedSettings` + `DeviceActivity`), which is the only iOS API capable of shielding apps or websites.
+
+| Mode | Meaning | Ember? |
+|---|---|---|
+| `.individual` | The user authorizes restrictions on their own device, for themselves. Picker selections are opaque tokens; nothing leaves the device. | **Yes** |
+| `.child` | Controlling another device via Apple Family Sharing. | No |
+
+Ember Custody is single-user, single-device, self-restraint. No guardian, no remote, no shared account. The `com.apple.developer.family-controls` entitlement is still required (Apple's standard gate; days–weeks lead time before App Store distribution; dev builds work without it). The phrase "Family Controls" appears only in technical docs — never in user-facing UI.
+
+---
+
+## iOS — bound mode
+
+### Library
+
+`kingstinct/react-native-device-activity`. Configured as an Expo config plugin (`appleTeamId`, `appGroup`); covers `DeviceActivityMonitor`, `ShieldConfiguration`, `ShieldAction`, `FamilyControls`. Requires a custom dev client and iOS 15+. The library hosts the plumbing; Ember owns the prayer-shield UI by providing its own `ShieldConfiguration` content.
+
+### Architecture
+
+1. `FamilyActivityPicker` — user selects apps and categories. Selections are opaque tokens.
+2. `ManagedSettingsStore` — applies app and web-domain shields.
+3. `DeviceActivityMonitor` extension — OS-scheduled activation/deactivation; runs in the background even when the app is cold.
+4. `ShieldConfigurationDataSource` extension — renders Ember's prayer-shield.
+5. `ShieldActionExtension` — handles the friction modes on early disable.
+
+App Group `group.me.dpgu.ember.custody` shares state between the main app and extensions.
+
+### What can and can't be blocked
+
+- ✓ Native apps (selected via picker), shown as shielded
+- ✓ Web domains in Safari and any WebKit-based iOS browser (Chrome, Firefox, Edge — all WebKit on iOS)
+- ✗ Content *inside* apps that fetch their own (Reddit, X, TikTok). Either the whole app is shielded or web access to the same content is blocked, or nothing.
+
+### Apple entitlement
+
+`com.apple.developer.family-controls` (Individual). File the request before any iOS code. App Store distribution blocked until approval; local dev builds work without it.
+
+---
+
+## Android — bound mode (v2)
+
+Android has no first-party Family Controls equivalent. Three approaches; one was just killed.
+
+| Path | Viable | Effort | Shields |
+|---|---|---|---|
+| VPN service + DNS filter | ✓ | ~2–3 weeks | Web domains |
+| UsageStatsManager + foreground service + Activity overlay | ✓ | ~3–4 weeks | Apps |
+| AccessibilityService | ✗ killed | — | — |
+
+The **October 30, 2025 Google Play policy update** restricted the AccessibilityService API to genuine disability features; non-accessibility automation is prohibited and apps in the focus-blocker category have been removed. Ember's Android approach avoids `AccessibilityService` entirely.
+
+### Architecture
+
+1. **`EmberVpnService extends VpnService`** — DNS interception against the commitment's `targets` domain list. Used by NextDNS, Blokada, AdGuard. Only one VPN slot at a time on Android — detect existing VPNs at setup, warn, let the user choose.
+2. **`EmberMonitorService` foreground service** — sticky notification (`FOREGROUND_SERVICE_SPECIAL_USE`); polls `UsageStatsManager` every ~500ms. When a shielded app comes foreground, starts the shield Activity.
+3. **`PrayerShieldActivity`** — full-screen Compose UI; same `shieldAnchorRef` resolution as iOS; same friction modes.
+
+### Permissions
+
+- `BIND_VPN_SERVICE`
+- `PACKAGE_USAGE_STATS` (special access; deep-link to system Settings)
+- `FOREGROUND_SERVICE` + `FOREGROUND_SERVICE_SPECIAL_USE` (Android 14+)
+- `POST_NOTIFICATIONS` (Android 13+)
+- `REQUEST_IGNORE_BATTERY_OPTIMIZATIONS` (deep-link only — never auto-grant)
+
+### Limits vs iOS
+
+| Constraint | Impact |
+|---|---|
+| One VPN slot only | Conflicts with corporate VPN, NextDNS, AdGuard |
+| 1–3s detection delay | Shielded app briefly visible before shield Activity launches |
+| Continuous foreground service | Sticky notification, battery cost |
+| More bypassable | User can disable Usage Access in system settings; Custody is ascetical aid, not jail |
+| Per-browser engines | DNS filter at VPN level catches all browsers — better than iOS in this one regard |
+
+### Privacy posture differs from iOS
+
+iOS opaque tokens hide app identities from the developer. Android's package-name model exposes them. Document this difference in onboarding copy.
+
+---
+
+## Integration with existing features
+
+### Reuse
+
+- **Schedule evaluation.** Commitments use the existing `ScheduleRule` discriminated union from `apps/app/src/features/plan-of-life/schedule.ts:18-26`. `isApplicableOn(rule, date, ctx)` at `schedule.ts:41` is the evaluator. `ScheduleContext` (season + dayCalendar) at `schedule.ts:28-31` is reused unchanged. Season-gating for Lent/Advent commitments works without new schedule types.
+- **Notifications.** `apps/app/src/lib/notifications.ts:26-80` — reuse `requestNotificationPermission()` and the channel-setup pattern; add a `'custody'` channel for nudges.
+- **Examen.** `apps/app/src/app/examen.tsx:13-47` already exists (six-phase Ignatian). The `peccatum` and `propositum` phases hook in: "Did I keep my resolutions today?"
+- **Confessio.** `apps/app/src/app/confessio/index.tsx` already tracks confession dates. Custody adds a "falls since last confession" surface that joins `commitment_events` of type `fell` against the last confession's `recorded_at`.
+- **Fidelity wall.** `apps/app/src/features/plan-of-life/utils.ts:102-113` — completed Custody sessions emit standard `Completion` rows so they roll into `buildTieredWallData()` without special-casing.
+- **DB / repositories.** Match the event-sourced pattern from `apps/app/src/db/repositories/practices.ts` (`emit` / `emitBatch`).
+
+### New code
+
+```
+apps/app/src/features/custody/                  — types, hooks, components, screens
+apps/app/src/app/custody/                       — Expo Router routes (mirror /plan/, /examen.tsx)
+apps/app/modules/ember-custody-ios/             — Swift module + 3 extension targets
+apps/app/modules/ember-custody-android/         — Kotlin module + VPN + foreground services (v2)
+apps/app/plugins/withCustodyIOS.ts              — Expo config plugin
+apps/app/src/db/repositories/custody.ts         — CRUD with event-sourced mutations
+apps/app/src/db/migrations/0002_custody.sql     — new tables (subject to confirmation)
+```
+
+### `app.json` additions
+
+```json
+{
+  "expo": {
+    "plugins": [
+      ["react-native-device-activity", {
+        "appleTeamId": "<TEAM_ID>",
+        "appGroup": "group.me.dpgu.ember.custody"
+      }],
+      "./plugins/withCustodyIOS"
+    ],
+    "ios": {
+      "entitlements": { "com.apple.developer.family-controls": true }
+    }
+  }
+}
+```
+
+---
+
+## Data model
+
+```sql
+commitments (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  confessor_note TEXT,
+  kind TEXT NOT NULL,
+  targets TEXT NOT NULL,              -- JSON
+  schedule TEXT NOT NULL,             -- JSON ScheduleRule
+  severity TEXT NOT NULL,
+  friction TEXT NOT NULL,
+  shield_anchor_ref TEXT,
+  fall_policy TEXT NOT NULL,
+  archived INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL
+)
+
+commitment_events (
+  id TEXT PRIMARY KEY,
+  commitment_id TEXT NOT NULL,
+  type TEXT NOT NULL,                 -- 'kept' | 'fell' | 'paused' | 'overrode' | 'confessed'
+  occurred_at INTEGER NOT NULL,
+  note TEXT
+)
+
+custody_sessions (
+  id TEXT PRIMARY KEY,
+  anchor_ref TEXT NOT NULL,
+  planned_seconds INTEGER NOT NULL,
+  started_at INTEGER NOT NULL,
+  completed_at INTEGER,
+  ended_reason TEXT                   -- 'completed' | 'aborted' | 'app-killed'
+)
+```
+
+The existing schema runs `0001_initial.sql` once at boot via `apps/app/src/db/client.ts:26-51`. The migration runner is naive and needs a tiny extension to support multi-file migrations before `0002_custody.sql` can land.
+
+---
+
+## v1 — what ships
+
+| Layer | iOS | Android |
+|---|---|---|
+| Commitments (data + schedule + UI) | ✓ | ✓ |
+| Custody sessions | ✓ | ✓ |
+| Severity: light / firm | ✓ | ✓ |
+| Severity: bound | ✓ Family Controls | "coming v2" (disabled) |
+| Prayer shield | ✓ | — |
+| OS handoff (Screen Time / Digital Wellbeing) | ✓ | ✓ |
+| DNS setup walkthrough (NextDNS / AdGuard) | ✓ | ✓ |
+| Examen integration | ✓ | ✓ |
+| Confessio "falls log" surface | ✓ | ✓ |
+| en-US + pt-BR locales | ✓ | ✓ |
+
+Web hidden in v1.
+
+---
+
+## Milestones
+
+Track-as-milestone convention. Two milestones: **Custody** (v1) and **Custody — v2** (Android bound mode).
+
+### Custody — v1 (~6–9 weeks)
+
+#### Phase A — Foundation (cross-platform, no native) — ~1.5 weeks
+
+1. Spec promotion (this document).
+2. Migration mechanic: extend `apps/app/src/db/client.ts` for multi-file migrations.
+3. `0002_custody.sql` — `commitments`, `commitment_events`, `custody_sessions`.
+4. `apps/app/src/db/repositories/custody.ts`.
+5. `apps/app/src/features/custody/` — types, hooks, schedule wrappers.
+6. i18n keys: en-US + pt-BR.
+7. Expo Router scaffold under `apps/app/src/app/custody/`.
+
+#### Phase B — Spiritual surface (cross-platform, JS-only) — ~1.5 weeks
+
+8. `CommitmentList` + `CommitmentEditor` + `SeverityPicker` + `FrictionPicker` (light/firm only at this stage).
+9. Custody session runner + bells + anchor picker.
+10. Home today: active-commitment block.
+11. Examen `peccatum` and `propositum` extensions: pull broken commitments since last examen.
+12. Confessio: "falls since last confession" surface.
+13. Notifications: nudges for upcoming `firm` commitments.
+
+Phase B is independently shippable: Ember v(N+1) without bound mode but with the spiritual frame. Validates the data model before the native dive.
+
+#### Phase C — iOS bound mode — ~3–4 weeks
+
+14. **File the Family Controls Individual entitlement request for `me.dpgu.ember`** — before any code. Lead time: days–weeks.
+15. Add `react-native-device-activity` to `apps/app/package.json`; switch to a custom dev client.
+16. App Group `group.me.dpgu.ember.custody`.
+17. `apps/app/plugins/withCustodyIOS.ts` — entitlement, extension targets, App Group, Info.plist.
+18. `apps/app/modules/ember-custody-ios/` — Swift module exposing `authorize`, `presentPicker`, `applyShield`, `removeShield`, `getStatus`.
+19. `ShieldConfiguration` extension — render the prayer-shield (anchor text/image, "Pray and continue blocking" CTA, friction-aware "Disable" path).
+20. `ShieldAction` extension — friction modes (`none`, `wait`, `prayer`, `confession-only`).
+21. `DeviceActivityMonitor` extension — schedule activation/deactivation per commitment.
+22. `AppPicker` JS wrapper around `FamilyActivityPicker`.
+23. Onboarding flow: explain, request authorization, present picker, choose anchor.
+24. Manual QA on a physical iPhone (simulator does not support Family Controls).
+25. TestFlight build + Apple App Review prep with Family Controls justification.
+
+#### Phase D — Android handoff + DNS walkthrough — ~3–5 days
+
+26. Digital Wellbeing deep-link helper.
+27. NextDNS / AdGuard DNS setup walkthrough.
+28. Render bound severity as "coming to Android in v2" with the DNS walkthrough as today's recommendation.
+
+#### Phase E — Polish, locales, docs — ~3–5 days
+
+29. pt-BR catechetical-vocabulary review (*propósito*, *firme propósito de emenda*, *custódia dos sentidos*).
+30. Saint-quote pool for shield-empty defaults.
+31. `docs/journal.md` entries for Family Controls quirks.
+32. Screenshots and store-listing copy.
+
+### Custody — v2 (Android bound mode, ~4–6 weeks)
+
+#### Phase F — Android VPN + DNS (web targets) — ~2 weeks
+
+33. `apps/app/modules/ember-custody-android/` — Kotlin Expo module skeleton.
+34. `EmberVpnService extends VpnService` — DNS interception, per-commitment domain blocklist.
+35. JS bridge: `startVpn`, `stopVpn`, `getVpnStatus`.
+36. First-run consent: explain VPN slot conflict; system VPN dialog; handle denial.
+37. Web-target commitments now show "Active on Android".
+
+#### Phase G — Android UsageStats + shield Activity (app targets) — ~3 weeks
+
+38. `EmberMonitorService` foreground service.
+39. UsageStats poll loop + foreground-app detection.
+40. `PrayerShieldActivity` (Compose) — same `shieldAnchorRef` and friction modes as iOS.
+41. App-picker UX: list installed packages with launcher intents.
+42. Permission flows: `PACKAGE_USAGE_STATS` deep-link, battery-optimization opt-out.
+43. Friction modes implemented in `PrayerShieldActivity`.
+
+#### Phase H — Android polish — ~3–5 days
+
+44. Battery / wake-lock tuning; verify foreground service survives Doze and App Standby.
+45. OEM-specific testing (Samsung One UI, Xiaomi MIUI, OnePlus OxygenOS).
+46. Play Console submission with VPN justification and explicit "no AccessibilityService" disclosure.
+47. Update copy: bound severity is now active on Android.
+
+### Beyond v2 — backlog
+
+- Browser extensions (Chrome / Firefox / Safari).
+- Accountability partner sharing.
+- Override penances ("give X to charity to lift session").
+- `practice/custody-of-eyes` and `practice/digital-fast-friday` catalog content.
+- Parental / family management mode.
+- Cloud sync of commitments.
+
+---
+
+## What we copy from Opal, and what we change
+
+| Opal mechanic | Copy? | Notes |
+|---|---|---|
+| `FamilyActivityPicker` | Yes | Apple-mandated; only path |
+| Token-only privacy | Yes | Embrace it in onboarding copy |
+| `DeviceActivityMonitor` background scheduling | Yes | OS wakes the extension; main app can be cold |
+| Custom shield UI | **Yes — and reframe** | Score → prayer |
+| Friction on early disable | Yes | Implement as policy in our shield action |
+| Streaks / scores / leaderboards | **No** | Fidelity, not achievement; falls go to examen |
+| Paid unlock button | **No** | Unconscionable on Custody |
+| Saint quotes everywhere | **Add** | Catechesis as UX |
+
+---
+
+## Privacy
+
+- Commitments and `commitment_events` are stored locally only. No sync, no transmission, no analytics, in v1.
+- iOS picker selections are opaque tokens — Ember literally cannot enumerate which apps the user picked. Surface this in onboarding copy.
+- DNS filtering uses external resolvers; document the choice in plain language during the setup walkthrough.
+- Shield content is local — never fetched at shield-trigger time. The network can't be relied on at the moment of temptation, and the moment of temptation must not leak to a server.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Apple entitlement delays Phase C | File request as story 14, before code. Phases A+B ship independently. |
+| `react-native-device-activity` proves limiting | Fork or write thin wrapper. Time-box discovery to first 3 days of Phase C. |
+| Migration runner change breaks existing data | Test on a staging DB with realistic Plan of Life data before merge. |
+| Android v1 dignity gap for pt-BR users | Honest "coming v2" copy + working DNS walkthrough today; commit publicly to v2 timeline. |
+| Schema additions violate "no migrations unless asked" | Confirm explicitly before story 3. |
+| Confessio surface insufficient for falls-log | Scope a minimal addition into Phase B if needed. |
+| Shield content authoring underspecified | Default anchor pool + per-commitment override in Phase B. |
+| Google Play policy further restricts UsageStats or VPN | Avoid Accessibility entirely; document VPN+UsageStats justification in Play Console. |
+| One-VPN-slot conflict on Android v2 | Detect existing VPN at setup; explain trade-off; user choice. |
+| Android OEM kills the foreground service | Phase H allocates real budget for OEM testing. |
+
+---
+
+## Verification
+
+- Manual on a physical iPhone (simulator does not support Family Controls):
+  - Authorization prompt; deny path works.
+  - `FamilyActivityPicker` opens; selections persist as opaque tokens.
+  - Activate a `bound` commitment; opening a shielded app shows the Ember prayer-shield, not Apple's default.
+  - Each `friction` mode behaves correctly on disable.
+  - `DeviceActivityMonitor` fires at scheduled times with the app cold-killed.
+  - Web-domain shield works in Safari and Chrome on iOS.
+- Manual on Android: commitments + Custody sessions + Digital Wellbeing handoff + DNS walkthrough work end-to-end. Bound severity is correctly disabled with v2 copy.
+- Unit tests: `ScheduleRule` evaluation under season-gated commitments; fall/kept event logging; falls-since-last-confession join.
+- Component tests: `CommitmentEditor`, `CustodySession` runner, `FallsLog`.
+- Stores: TestFlight build well before public release. Document Family Controls justification for App Review.
+
+---
+
+## Not in scope (v1)
+
+- Accountability partner / shared logs.
+- Android native shielding (deferred to v2).
+- Browser extensions for desktop.
+- Parental / family management mode.
+- Cloud sync of commitment data.
+- Paywall on the unlock button.
+
+---
+
+## References
+
+- [kingstinct/react-native-device-activity](https://github.com/kingstinct/react-native-device-activity)
+- [Apple — Configuring Family Controls](https://developer.apple.com/documentation/xcode/configuring-family-controls)
+- [Apple — Screen Time API](https://developer.apple.com/documentation/screentimeapidocumentation)
+- [Apple — Meet the Screen Time API (WWDC21)](https://developer.apple.com/videos/play/wwdc2021/10123/)
+- [Google Play — Use of the AccessibilityService API](https://support.google.com/googleplay/android-developer/answer/10964491?hl=en)
+- [Google Play — Policy announcement, October 30, 2025](https://support.google.com/googleplay/android-developer/answer/16550159?hl=en)
+- [Android — UsageStatsManager](https://developer.android.com/reference/android/app/usage/UsageStatsManager)
+- [Android — VpnService](https://developer.android.com/reference/android/net/VpnService)
+- [DNSNet — open-source Android DNS filter](https://github.com/t895/DNSNet)

--- a/docs/features/custody/README.md
+++ b/docs/features/custody/README.md
@@ -6,6 +6,22 @@ A discipline / focus surface for Ember that limits or blocks selected apps and w
 
 The differentiator: Opal's blocked screen shows a score. **Ember's blocked screen shows a prayer.** A verse, an aspiration, a Sacred Heart image — and one button: *Pray and continue blocking*.
 
+## Documents
+
+This README is the overview. Each phase has its own technical design doc with the major decisions, architecture, and tasks for that phase.
+
+**v1 — Custody**
+- [Phase A — Foundation](./phase-a-foundation.md) — schema, migration runner, types, repositories, hooks, routing scaffold
+- [Phase B — Spiritual surface](./phase-b-spiritual-surface.md) — UI, custody session runner, examen + confessio integration, notifications
+- [Phase C — iOS bound mode](./phase-c-ios-bound.md) — config plugin, Swift module, three extension targets, prayer-shield, App Group, Apple submission
+- [Phase D — Android handoff + DNS walkthrough](./phase-d-android-handoff.md) — Digital Wellbeing deep-link, NextDNS / AdGuard setup
+- [Phase E — Polish, locales, docs](./phase-e-polish.md) — pt-BR catechetical vocabulary, anchor pool, store assets
+
+**v2 — Custody (Android bound mode)**
+- [Phase F — Android VPN + DNS](./phase-f-android-vpn.md) — VpnService, DNS interception, single-VPN-slot UX
+- [Phase G — Android UsageStats + shield Activity](./phase-g-android-usagestats.md) — foreground service, polling, full-screen overlay
+- [Phase H — Android OEM polish](./phase-h-android-oem.md) — Doze, manufacturer-specific kill behaviors, Play Console
+
 ---
 
 ## Concepts
@@ -251,104 +267,31 @@ Web hidden in v1.
 
 Track-as-milestone convention. Two milestones: **Custody** (v1) and **Custody — v2** (Android bound mode).
 
+Each phase has a dedicated technical design doc with major decisions, architecture, and concrete tasks. The list below is a one-line summary; click through for the detail.
+
 ### Custody — v1
 
 Phases A and B are JS-only and reversible. Phase C is the platform-locked native step and the dominant complexity gate. Phases D and E close the loop.
 
-#### Phase A — Foundation (cross-platform, no native)
+| Phase | Complexity | Doc |
+|---|---|---|
+| A — Foundation | Moderate | [phase-a-foundation.md](./phase-a-foundation.md) |
+| B — Spiritual surface | Moderate | [phase-b-spiritual-surface.md](./phase-b-spiritual-surface.md) |
+| C — iOS bound mode | High and gated | [phase-c-ios-bound.md](./phase-c-ios-bound.md) |
+| D — Android handoff + DNS walkthrough | Low | [phase-d-android-handoff.md](./phase-d-android-handoff.md) |
+| E — Polish, locales, docs | Low | [phase-e-polish.md](./phase-e-polish.md) |
 
-Complexity: **Moderate.** Pure JS work; the only non-trivial bit is extending the migration runner to support multi-file migrations.
-
-1. Spec promotion (this document).
-2. Migration mechanic: extend `apps/app/src/db/client.ts` for multi-file migrations.
-3. `0002_custody.sql` — `commitments`, `commitment_events`, `custody_sessions`.
-4. `apps/app/src/db/repositories/custody.ts`.
-5. `apps/app/src/features/custody/` — types, hooks, schedule wrappers.
-6. i18n keys: en-US + pt-BR.
-7. Expo Router scaffold under `apps/app/src/app/custody/`.
-
-#### Phase B — Spiritual surface (cross-platform, JS-only)
-
-Complexity: **Moderate.** UI breadth is the cost (Custody screens, Examen integration, Confessio falls-log, home-today block). All reversible.
-
-8. `CommitmentList` + `CommitmentEditor` + `SeverityPicker` + `FrictionPicker` (light/firm only at this stage).
-9. Custody session runner + bells + anchor picker.
-10. Home today: active-commitment block.
-11. Examen `peccatum` and `propositum` extensions: pull broken commitments since last examen.
-12. Confessio: "falls since last confession" surface.
-13. Notifications: nudges for upcoming `firm` commitments.
-
-Phase B is independently shippable: Ember v(N+1) without bound mode but with the spiritual frame. Validates the data model before the native dive.
-
-#### Phase C — iOS bound mode
-
-Complexity: **High — and gated.** This is the project's first custom Expo native module, the first config plugin, the first time we leave managed Expo for a custom dev client, and it ships *three* iOS extension targets (`DeviceActivityMonitor`, `ShieldConfiguration`, `ShieldAction`) wired through an App Group. Apple's Family Controls entitlement is an external dependency that gates App Store distribution (lead time: days–weeks; dev builds work without it). Family Controls does not run in the simulator — every meaningful test requires a physical iPhone.
-
-Risks: entitlement denial or delay; `react-native-device-activity` proving insufficient for the prayer-shield UI (fallback: fork or wrap); App Review pushback on the Custody framing (fallback: refine justification, resubmit).
-
-14. **File the Family Controls Individual entitlement request for `me.dpgu.ember`** — before any code. Lead time: days–weeks.
-15. Add `react-native-device-activity` to `apps/app/package.json`; switch to a custom dev client.
-16. App Group `group.me.dpgu.ember.custody`.
-17. `apps/app/plugins/withCustodyIOS.ts` — entitlement, extension targets, App Group, Info.plist.
-18. `apps/app/modules/ember-custody-ios/` — Swift module exposing `authorize`, `presentPicker`, `applyShield`, `removeShield`, `getStatus`.
-19. `ShieldConfiguration` extension — render the prayer-shield (anchor text/image, "Pray and continue blocking" CTA, friction-aware "Disable" path).
-20. `ShieldAction` extension — friction modes (`none`, `wait`, `prayer`, `confession-only`).
-21. `DeviceActivityMonitor` extension — schedule activation/deactivation per commitment.
-22. `AppPicker` JS wrapper around `FamilyActivityPicker`.
-23. Onboarding flow: explain, request authorization, present picker, choose anchor.
-24. Manual QA on a physical iPhone (simulator does not support Family Controls).
-25. TestFlight build + Apple App Review prep with Family Controls justification.
-
-#### Phase D — Android handoff + DNS walkthrough
-
-Complexity: **Low.** Mostly copy, screenshots, and a deep-link helper.
-
-26. Digital Wellbeing deep-link helper.
-27. NextDNS / AdGuard DNS setup walkthrough.
-28. Render bound severity as "coming to Android in v2" with the DNS walkthrough as today's recommendation.
-
-#### Phase E — Polish, locales, docs
-
-Complexity: **Low**, but the pt-BR catechetical-vocabulary review needs a careful pass — *propósito*, *firme propósito de emenda*, *custódia dos sentidos* are theological terms that must land precisely.
-
-29. pt-BR catechetical-vocabulary review (*propósito*, *firme propósito de emenda*, *custódia dos sentidos*).
-30. Saint-quote pool for shield-empty defaults.
-31. `docs/journal.md` entries for Family Controls quirks.
-32. Screenshots and store-listing copy.
+Phase B is independently shippable: it delivers the spiritual frame without bound mode, and validates the data model before Phase C's native dive.
 
 ### Custody — v2 (Android bound mode)
 
-The platform's first Kotlin native module. Two enforcement halves (web via VPN/DNS, apps via UsageStats), then OEM polish. No off-the-shelf Expo Android equivalent of `react-native-device-activity` — this is hand-written.
+The project's first Kotlin native module. Two enforcement halves (web via VPN/DNS, apps via UsageStats) then OEM polish. No off-the-shelf Expo Android equivalent of `react-native-device-activity` — this is hand-written.
 
-#### Phase F — Android VPN + DNS (web targets)
-
-Complexity: **Moderate–High.** First Kotlin Expo module; VPN service must be implemented carefully (single-VPN-slot conflict, DNS-over-HTTPS bypass on some browsers, graceful denial path). Reference implementation: [DNSNet](https://github.com/t895/DNSNet).
-
-33. `apps/app/modules/ember-custody-android/` — Kotlin Expo module skeleton.
-34. `EmberVpnService extends VpnService` — DNS interception, per-commitment domain blocklist.
-35. JS bridge: `startVpn`, `stopVpn`, `getVpnStatus`.
-36. First-run consent: explain VPN slot conflict; system VPN dialog; handle denial.
-37. Web-target commitments now show "Active on Android".
-
-#### Phase G — Android UsageStats + shield Activity (app targets)
-
-Complexity: **High.** A long-running foreground service that polls and launches Activities is exactly the surface OEMs aggressively kill. The 1–3s detection delay is a UX limit we cannot engineer around. The `PACKAGE_USAGE_STATS` deep-link flow is unfamiliar to most users; onboarding copy carries the load.
-
-38. `EmberMonitorService` foreground service.
-39. UsageStats poll loop + foreground-app detection.
-40. `PrayerShieldActivity` (Compose) — same `shieldAnchorRef` and friction modes as iOS.
-41. App-picker UX: list installed packages with launcher intents.
-42. Permission flows: `PACKAGE_USAGE_STATS` deep-link, battery-optimization opt-out.
-43. Friction modes implemented in `PrayerShieldActivity`.
-
-#### Phase H — Android polish
-
-Complexity: **Low per task, but the OEM matrix is irreducible.** Samsung One UI, Xiaomi MIUI, OnePlus OxygenOS each kill background services differently. Real devices required for verification — emulators do not reproduce these behaviors.
-
-44. Battery / wake-lock tuning; verify foreground service survives Doze and App Standby.
-45. OEM-specific testing (Samsung One UI, Xiaomi MIUI, OnePlus OxygenOS).
-46. Play Console submission with VPN justification and explicit "no AccessibilityService" disclosure.
-47. Update copy: bound severity is now active on Android.
+| Phase | Complexity | Doc |
+|---|---|---|
+| F — Android VPN + DNS | Moderate–High | [phase-f-android-vpn.md](./phase-f-android-vpn.md) |
+| G — Android UsageStats + shield Activity | High | [phase-g-android-usagestats.md](./phase-g-android-usagestats.md) |
+| H — Android OEM polish | Low per task; irreducible OEM matrix | [phase-h-android-oem.md](./phase-h-android-oem.md) |
 
 ### Beyond v2 — backlog
 

--- a/docs/features/custody/phase-a-foundation.md
+++ b/docs/features/custody/phase-a-foundation.md
@@ -1,0 +1,392 @@
+# Phase A — Foundation
+
+> Scope: data layer + types + routing scaffold. No UI work, no native code.
+> Complexity: **Moderate.** Pure JS / SQLite. The migration runner extension is the only non-trivial bit; everything else is the existing repository pattern applied to new tables.
+> Depends on: nothing. This phase opens the milestone.
+
+## Goal
+
+Stand up the data and routing primitives Custody needs so Phases B and C have somewhere to land. Three new tables, an extended migration runner, the type system that flows through the rest of the feature, the repository, the React Query hooks, and an empty Expo Router scaffold. After Phase A, the app builds and boots; the Custody tab opens but is empty.
+
+## Major decisions
+
+### A1. Migration runner: track applied migrations in a dedicated `_migrations` table
+
+Today, `apps/app/src/db/client.ts:33` runs `0001_initial.sql` unconditionally on every boot via `_db.execAsync(initialMigration)`. That works for one migration; it doesn't compose for two.
+
+Three options for adding a second:
+
+- **(a) Probe `sqlite_master` for each table before each migration.** Works but couples the runner to migration internals — every new migration would have to advertise the tables it creates so the runner knows what to probe. Brittle.
+- **(b) Store applied migration filenames in the existing `preferences` table.** Works with no schema change, but pollutes a key/value store that's intended for user preferences. Mixing platform metadata with user data invites bugs.
+- **(c) Add a dedicated `_migrations` table that records `(name TEXT PRIMARY KEY, applied_at INTEGER)`.** Standard, explicit, low-cost.
+
+**Decision: (c).** Cost is one extra table. Benefit is a clean substrate for every future migration in the project.
+
+The runner change itself is small — under 30 lines. The migration table is created with `CREATE TABLE IF NOT EXISTS` so it's safe on first boot. Existing installs that already ran `0001_initial.sql` need a backfill: if `user_practices` exists but `_migrations` is empty, insert `('0001_initial.sql', now)` before scanning new migrations. Without that backfill, the runner would re-run `0001_initial.sql` on existing installs and the table-creation `CREATE TABLE` statements would fail unless they're all `IF NOT EXISTS` — which they are not currently.
+
+### A2. Targets type: discriminated union with a `tokenRef` indirection for iOS
+
+Commitments target *something*. That something is platform-specific:
+
+- iOS apps and categories: opaque `ActivityToken` blobs returned from `FamilyActivityPicker`. Cannot be enumerated; cannot be inspected. Large.
+- Android apps: stable `packageName` strings.
+- Domains: free-text, e.g., `instagram.com`.
+- Curated lists: a key into a shipped block-list (e.g., `porn`, `gambling`, `social`).
+
+```typescript
+type Target =
+  | { kind: 'ios-app'; tokenRef: string }
+  | { kind: 'ios-category'; tokenRef: string }
+  | { kind: 'android-app'; packageName: string }
+  | { kind: 'domain'; domain: string }
+  | { kind: 'domain-list'; listKey: 'porn' | 'gambling' | 'social' | 'news' }
+```
+
+The `tokenRef` is an indirection: SQLite stores the ref string (e.g., a UUID); the actual `ActivityToken` bytes live in App Group `UserDefaults` under that ref. Reasoning:
+
+1. **The iOS `ShieldConfiguration` extension cannot read SQLite directly.** Apple does not give app extensions a sane way to share an SQLite file with the main app — the App Group filesystem is shared but locking and migration coordination across processes is fragile. `UserDefaults` is the documented mechanism.
+2. **Tokens are large.** Storing them in SQLite once is fine; storing them again in `UserDefaults` for the extension is fine; storing them in two places that drift is not. One source of truth (UserDefaults), with SQLite holding the ref, is the cleanest split.
+3. **The ref is a stable handle.** The token bytes can rotate (e.g., the user re-picks an app); the ref does not. Commitment events that point at "I fell on this token" need a stable target identity.
+
+For Android and domains, no indirection — those values are stable and small enough to inline. The discriminated union accommodates both shapes.
+
+### A3. `commitments` schema with explicit CHECK constraints
+
+```sql
+CREATE TABLE commitments (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  confessor_note TEXT,
+  kind TEXT NOT NULL CHECK (kind IN ('abstain', 'time-limit', 'time-fence')),
+  targets TEXT NOT NULL,                                       -- JSON Target[]
+  schedule TEXT NOT NULL,                                      -- JSON ScheduleRule
+  severity TEXT NOT NULL CHECK (severity IN ('light', 'firm', 'bound')),
+  friction TEXT NOT NULL CHECK (friction IN ('none', 'wait', 'prayer', 'confession-only')),
+  friction_config TEXT,                                        -- JSON, e.g., { waitSeconds: 300 }
+  shield_anchor TEXT,                                          -- JSON Anchor
+  fall_policy TEXT NOT NULL CHECK (fall_policy IN ('log', 'examen', 'confession-prep')),
+  archived INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX commitments_active ON commitments(archived) WHERE archived = 0;
+```
+
+CHECK constraints on enums catch typos at write time and are essentially free. The partial index on `archived = 0` makes the home-today query fast even with hundreds of archived commitments.
+
+`friction_config` is a separate JSON column rather than nested into `friction` because the friction modes have different config shapes (`wait` has seconds; `prayer` has a prayer ref; `confession-only` has nothing). A flat enum in `friction` plus a sidecar config JSON keeps queries simple.
+
+### A4. `commitment_events`: append-only, JOIN-friendly
+
+```sql
+CREATE TABLE commitment_events (
+  id TEXT PRIMARY KEY,
+  commitment_id TEXT NOT NULL REFERENCES commitments(id) ON DELETE CASCADE,
+  type TEXT NOT NULL CHECK (type IN ('kept', 'fell', 'paused', 'overrode', 'confessed')),
+  occurred_at INTEGER NOT NULL,
+  note TEXT,
+  metadata TEXT                                                -- JSON
+);
+
+CREATE INDEX commitment_events_by_commitment ON commitment_events(commitment_id, occurred_at DESC);
+CREATE INDEX commitment_events_by_type ON commitment_events(type, occurred_at DESC);
+```
+
+Append-only by convention — the repository never updates rows, only inserts. Two indexes: by commitment for streak/list queries, by type for the confession-prep "falls log" query (which is `WHERE type = 'fell' AND occurred_at > ?`).
+
+`ON DELETE CASCADE` because users will be allowed to fully delete archived commitments; the events go with them. (Archive is the soft delete; full delete is the hard one.)
+
+### A5. `custody_sessions`: separate from `commitment_events`
+
+A custody session is *not* a commitment event. They are different objects:
+
+- A commitment event records what the user did or didn't do relative to a rule.
+- A custody session records a finite prayer block: when, how long, with what anchor, completed or aborted.
+
+Folding them into one table would require nullable foreign keys (sessions don't belong to a commitment) and a wider `type` enum. Two tables is clearer.
+
+```sql
+CREATE TABLE custody_sessions (
+  id TEXT PRIMARY KEY,
+  anchor_ref TEXT NOT NULL,
+  anchor_type TEXT NOT NULL CHECK (anchor_type IN ('text', 'image', 'prayer', 'lectio', 'silence')),
+  planned_seconds INTEGER NOT NULL,
+  started_at INTEGER NOT NULL,
+  completed_at INTEGER,
+  ended_reason TEXT CHECK (ended_reason IN ('completed', 'aborted', 'app-killed'))
+);
+```
+
+### A6. Schedule reuse, not extension
+
+`apps/app/src/features/plan-of-life/schedule.ts:18-26` defines `ScheduleRule` as a discriminated union of temporal patterns (daily, days-of-week, day-of-month, nth-weekday, times-per, fixed-program, periodic-series, holy-days-of-obligation). `isApplicableOn(rule, date, ctx)` at `schedule.ts:41` evaluates it.
+
+The temptation is to wrap `ScheduleRule` in a `CommitmentSchedule` type, "in case commitments need their own schedule semantics." They don't. A commitment is active on the same days a practice is. Season-gating works the same way (Lent-only commitments use `seasons?: LiturgicalSeason[]` exactly as practices do).
+
+**Decision: reuse `ScheduleRule` directly.** Custody imports it and `isApplicableOn` from plan-of-life. No wrapper. If commitments ever need a temporal pattern practices don't (e.g., per-hour micro-schedules for time-limit), extend the existing union — that's how `holy-days-of-obligation` was added.
+
+The one new helper Custody adds is `nextActivation(commitment, ctx)` and `nextDeactivation(commitment, ctx)` to render time-fence countdowns in the UI. Those live in Custody's own `schedule.ts`, not in plan-of-life.
+
+### A7. Anchor type: discriminated union with platform-renderable variants
+
+The `shield_anchor` column carries the content the iOS extension or the Android Activity will render. The extension cannot fetch at trigger time (network, content-resolver); it must be self-contained.
+
+```typescript
+type Anchor =
+  | { kind: 'text'; text: string; attribution?: string }
+  | { kind: 'image'; imageRef: string; caption?: string }       // bundled asset key
+  | { kind: 'prayer'; prayerRef: string; rendered: string }     // rendered text inline
+  | { kind: 'lectio'; reference: string; rendered: string }
+  | { kind: 'silence' }
+```
+
+For `prayer` and `lectio`, the *rendered* text is denormalized into the anchor at edit time. The reason is simple: at shield-trigger time on iOS, our extension cannot call the content resolver. Storing the resolved text inline is the only way the extension can render the prayer.
+
+Cost: prayer text changes upstream (e.g., a translation fix in the corpus) won't propagate to active commitments until the user re-saves them. Acceptable: anchors are personal choices, and users will edit them rarely. Phase E adds a "refresh anchor" affordance that re-renders against the current corpus.
+
+### A8. TanStack Query keys: namespaced under `['custody']`
+
+Existing pattern in `practices.ts` uses keys like `['practices', 'all']`. Custody mirrors it:
+
+- `['custody', 'commitments', 'all']` — full list (active + archived)
+- `['custody', 'commitments', commitmentId]` — single
+- `['custody', 'commitments', 'active-today']` — filtered through `isApplicableOn`
+- `['custody', 'events', commitmentId]` — events for a commitment
+- `['custody', 'falls', 'since-confession']` — joined falls log
+- `['custody', 'falls', 'since-examen']` — joined falls log for examen
+- `['custody', 'sessions', 'recent']` — recent custody sessions
+
+Mutations invalidate `['custody']` at the root for simplicity. The query count is small enough that fine-grained invalidation is premature.
+
+### A9. Routing scaffold: mirror `/plan/`, surface from Plan tab
+
+Expo Router tree:
+
+```
+apps/app/src/app/custody/
+  _layout.tsx                    Stack header, matches /plan/'s nav style
+  index.tsx                      Custody overview (list + active-today + sessions)
+  new.tsx                        Create commitment
+  [commitmentId].tsx             View / edit
+  session.tsx                    Custody session runner
+```
+
+Entry point: a tile under the Plan tab that links to `/custody`, mirroring how `examen` and `confessio` are surfaced from the home screen. Not a top-level sidebar tab — Custody is part of Fidelity, not a peer of it.
+
+### A10. `_migrations` table living in `0001_initial.sql` vs. created by the runner
+
+If we put `CREATE TABLE _migrations` inside `0001_initial.sql`, it's tracked alongside everything else. But existing installs already ran `0001_initial.sql` without it.
+
+If the runner creates `_migrations` itself before applying any migration, it's outside the migration history but always present. Cleaner.
+
+**Decision: runner creates the table.** The runner is the only piece that reads or writes it; it owns the table.
+
+## Architecture
+
+### File layout added in Phase A
+
+```
+apps/app/src/db/
+  client.ts                           [edited: extended migration runner]
+  migrations/
+    0001_initial.sql                  [unchanged]
+    0002_custody.sql                  [new]
+  repositories/
+    custody.ts                        [new]
+
+apps/app/src/features/custody/
+  index.ts                            [new: barrel]
+  types.ts                            [new]
+  schedule.ts                         [new: thin wrapper utils]
+  hooks.ts                            [new: TanStack Query hooks]
+
+apps/app/src/app/custody/
+  _layout.tsx                         [new: stub]
+  index.tsx                           [new: stub]
+  new.tsx                             [new: stub]
+  [commitmentId].tsx                  [new: stub]
+  session.tsx                         [new: stub]
+
+apps/app/src/lib/i18n/locales/
+  en-US.ts                            [edited: + custody.* keys]
+  pt-BR.ts                            [edited: + custody.* keys]
+
+apps/app/src/app/plan/
+  index.tsx                           [edited: + Custody tile]
+```
+
+### Migration runner sketch
+
+```typescript
+// apps/app/src/db/client.ts (after init)
+
+await _db.execAsync(`
+  CREATE TABLE IF NOT EXISTS _migrations (
+    name TEXT PRIMARY KEY,
+    applied_at INTEGER NOT NULL
+  )
+`)
+
+// Backfill: if user_practices exists but _migrations is empty, mark 0001 as applied.
+const hasUserPractices = await _db.getFirstAsync<{ count: number }>(
+  `SELECT COUNT(*) AS count FROM sqlite_master WHERE type='table' AND name='user_practices'`
+)
+const hasMigrations = await _db.getFirstAsync<{ count: number }>(
+  `SELECT COUNT(*) AS count FROM _migrations`
+)
+if (hasUserPractices?.count && !hasMigrations?.count) {
+  await _db.runAsync(
+    `INSERT INTO _migrations(name, applied_at) VALUES (?, ?)`,
+    ['0001_initial.sql', Date.now()]
+  )
+}
+
+// Apply pending migrations in order.
+const migrations: { name: string; sql: string }[] = [
+  { name: '0001_initial.sql', sql: initialMigration },
+  { name: '0002_custody.sql', sql: custodyMigration },
+]
+for (const m of migrations) {
+  const applied = await _db.getFirstAsync<{ name: string }>(
+    `SELECT name FROM _migrations WHERE name = ?`, [m.name]
+  )
+  if (applied) continue
+  await _db.withExclusiveTransactionAsync(async (tx) => {
+    await tx.execAsync(m.sql)
+    await tx.runAsync(`INSERT INTO _migrations(name, applied_at) VALUES (?, ?)`, [m.name, Date.now()])
+  })
+}
+```
+
+### Repository sketch
+
+`apps/app/src/db/repositories/custody.ts` follows the event-sourced mutation pattern from `practices.ts`. Public API:
+
+```typescript
+listCommitments(opts?: { includeArchived?: boolean }): Promise<Commitment[]>
+getCommitment(id: string): Promise<Commitment | undefined>
+createCommitment(input: CommitmentInput): Promise<Commitment>
+updateCommitment(id: string, patch: Partial<CommitmentInput>): Promise<Commitment>
+archiveCommitment(id: string): Promise<void>
+deleteCommitment(id: string): Promise<void>           // hard delete; cascades
+
+recordEvent(input: { commitmentId: string; type: EventType; note?: string; metadata?: object }): Promise<CommitmentEvent>
+listEventsForCommitment(commitmentId: string, opts?: { limit?: number }): Promise<CommitmentEvent[]>
+listFallsSince(timestamp: number): Promise<(CommitmentEvent & { commitment: Commitment })[]>
+
+createSession(input: { anchor: Anchor; plannedSeconds: number }): Promise<CustodySession>
+endSession(id: string, reason: CustodySession['endedReason']): Promise<CustodySession>
+listRecentSessions(limit: number): Promise<CustodySession[]>
+```
+
+JSON-serialize `targets`, `schedule`, `friction_config`, `shield_anchor`, and `metadata` on the way in; parse on the way out. Repository is the only place that touches JSON columns.
+
+## Tasks
+
+### T-A1. Extend the SQLite migration runner
+
+In `apps/app/src/db/client.ts`, add the `_migrations` table creation, the existing-install backfill, and the migration-loop logic shown in the sketch above. The migrations array is in-source for now (no filesystem scanning — Expo bundles SQL files via `require`/`import` or inline strings). Wrap each migration application in `withExclusiveTransactionAsync` so a failure rolls back both the schema change and the `_migrations` insert. Add a unit test in `apps/app/src/db/__tests__/migrations.test.ts` that runs against an in-memory `expo-sqlite` instance and verifies: (a) fresh boot applies both migrations, (b) second boot is a no-op, (c) backfill path inserts `0001` when `user_practices` already exists.
+
+### T-A2. Author `0002_custody.sql`
+
+Three `CREATE TABLE` statements (`commitments`, `commitment_events`, `custody_sessions`), three `CREATE INDEX` statements, all `CHECK` constraints on enum columns, foreign-key cascade from events and sessions to `commitments`. File goes in `apps/app/src/db/migrations/0002_custody.sql`. Reference the schema in this doc verbatim.
+
+### T-A3. Define types in `apps/app/src/features/custody/types.ts`
+
+Top-level types:
+
+- `Commitment` (matches the SQL schema; `targets`, `schedule`, `friction_config`, `shield_anchor` are typed shapes, not JSON strings)
+- `CommitmentInput` (the same minus generated fields: `id`, `created_at`, `updated_at`)
+- `CommitmentKind`, `Severity`, `Friction`, `FallPolicy` (string-literal unions matching the CHECK enums)
+- `Target` (discriminated union, five variants — see A2)
+- `Anchor` (discriminated union, five variants — see A7)
+- `CommitmentEvent`, `EventType`, `CustodySession`
+
+Re-export `ScheduleRule` and `ScheduleContext` from plan-of-life for the convenience of downstream code.
+
+### T-A4. Implement `apps/app/src/db/repositories/custody.ts`
+
+CRUD with the API surface above. Use the same `emit`/`emitBatch` event-sourced pattern as `practices.ts`. Repository is responsible for JSON (de)serialization on every column that holds structured data. `listFallsSince` does a `JOIN` of `commitment_events` against `commitments`. `listCommitments({ includeArchived: false })` uses the partial index.
+
+### T-A5. TanStack Query hooks in `apps/app/src/features/custody/hooks.ts`
+
+The keys listed in A8. One hook per key. Mutations go through repository functions and invalidate `['custody']` root. Add `useActiveCommitmentsToday(date?: Date, ctx?: ScheduleContext)` that calls `listCommitments({ includeArchived: false })` then filters in JS via `isApplicableOn`. SSR-safe: every hook is `useQuery`/`useMutation` against the repo.
+
+### T-A6. Schedule wrappers in `apps/app/src/features/custody/schedule.ts`
+
+Re-export `isApplicableOn` from plan-of-life as `isCommitmentActiveOn` for naming clarity. Add `nextActivation(commitment, ctx)` and `nextDeactivation(commitment, ctx)` that compute the next time-fence boundaries from the schedule + the commitment's `kind`. For `time-fence`, this is the next start/end of the fence window today or tomorrow.
+
+### T-A7. i18n keys
+
+Add the `custody.*` namespace to both `en-US.ts` and `pt-BR.ts`. Match the existing dot-namespaced style. Keys to start with:
+
+```
+custody.title
+custody.tagline
+custody.empty.heading
+custody.empty.cta
+custody.commitments.create
+custody.commitments.edit
+custody.kinds.abstain.label
+custody.kinds.abstain.help
+custody.kinds.time-limit.label
+custody.kinds.time-limit.help
+custody.kinds.time-fence.label
+custody.kinds.time-fence.help
+custody.severity.light.label
+custody.severity.light.help
+custody.severity.firm.label
+custody.severity.firm.help
+custody.severity.bound.label
+custody.severity.bound.help
+custody.severity.bound.coming-android
+custody.friction.none.label
+custody.friction.wait.label
+custody.friction.prayer.label
+custody.friction.confession-only.label
+custody.shield.cta.pray
+custody.shield.cta.disable
+custody.session.start
+custody.session.duration.5
+custody.session.duration.10
+custody.session.duration.20
+custody.session.duration.40
+custody.session.duration.60
+custody.anchor.kinds.text
+custody.anchor.kinds.prayer
+custody.anchor.kinds.lectio
+custody.anchor.kinds.image
+custody.anchor.kinds.silence
+```
+
+### T-A8. Expo Router scaffold
+
+Five files under `apps/app/src/app/custody/`. Stubs only — each renders a Tamagui `YStack` with the route name centered. `_layout.tsx` matches `apps/app/src/app/plan/_layout.tsx`'s nav configuration.
+
+### T-A9. Plan-tab entry point
+
+Edit `apps/app/src/app/plan/index.tsx` to add a Custody tile that links to `/custody`. Match the visual treatment of the existing tiles (e.g., the Examen tile if present). Hide the tile behind a feature flag check (`flags.custody`) so Phase A can land without exposing the empty surface to users — Phase B turns the flag on.
+
+### T-A10. Feature flag plumbing
+
+Add `flags.custody` to whatever flag mechanism the project uses (or create a minimal one in `apps/app/src/config/flags.ts` if none exists). Default off; can be flipped on per-build for development.
+
+## Verification
+
+- Unit tests for the migration runner cover fresh-boot, second-boot, and existing-install backfill paths.
+- Repository tests cover round-trip JSON serialization for `targets`, `schedule`, `friction_config`, `shield_anchor`.
+- App boots cleanly on a device that has been running an older build (existing-install path).
+- `_migrations` table contains rows for `0001_initial.sql` and `0002_custody.sql` after first boot.
+- `/custody` route opens; tabs/nav render; placeholder copy in en-US and pt-BR.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Migration runner change breaks existing installs | Backfill path tested explicitly; staging snapshot of a real user's DB used in tests. |
+| Anchor inline-rendering drifts from corpus over time | Phase E adds "refresh anchor" affordance; document the trade-off. |
+| Schedule reuse blocks future commitment-only patterns | Extend the existing union when needed; precedent from `holy-days-of-obligation`. |
+| Feature flag exposes incomplete surface accidentally | Default off; flag check guards both the tile and the route entry. |
+| JSON column shape drift (no schema check beyond `CHECK`) | Repository is the single read/write boundary; type-check inputs there. |

--- a/docs/features/custody/phase-b-spiritual-surface.md
+++ b/docs/features/custody/phase-b-spiritual-surface.md
@@ -1,0 +1,351 @@
+# Phase B — Spiritual surface
+
+> Scope: all cross-platform UI, the custody session runner, examen + confessio integration, notifications.
+> Complexity: **Moderate.** No native code. The cost is breadth — multiple touch points across Custody, Examen, Confessio, Home, and Notifications.
+> Depends on: Phase A (data layer + types + routing scaffold).
+> Independently shippable: yes. Ember v(N+1) without bound mode but with the spiritual frame intact.
+
+## Goal
+
+Give the user the full Custody experience minus OS-level enforcement. Commitments at `light` and `firm` severity work end-to-end. Custody sessions run with bells and an anchor. Falls surface in examen and confessio. Bound severity shows up in the UI but is gated as "Coming on iOS" / "Coming on Android in v2." After Phase B, an honest user gets real spiritual value with no native dependency; Phase C just adds the prevention layer for the borderline case.
+
+## Major decisions
+
+### B1. Custody session state machine
+
+States: `idle`, `running`, `paused`, `completed`, `aborted`, `app-killed`.
+
+Transitions:
+
+```
+idle ─start→ running ─pause→ paused ─resume→ running
+                ├─timer→ completed
+                ├─stop→ aborted
+                └─background→ (see B2)
+```
+
+State lives in a Zustand store (`apps/app/src/features/custody/sessionStore.ts`) with immer middleware. Transition events get persisted as DB writes via `endSession(id, reason)`. The store is in-memory only — on cold launch we never resume an in-flight session, we treat it as `app-killed` (see B2).
+
+### B2. Backgrounding policy: timer authoritative, bells foreground-only
+
+Three plausible policies for what happens when the user backgrounds the app mid-session:
+
+- **(a) Pause and resume.** Pause on `AppState.change → background`; resume on `foreground`. Kind UX. Rewards cheating (background, scroll TikTok, return claiming credit).
+- **(b) Wall-clock authoritative; bells foreground-only.** `started_at + plannedSeconds` is the truth. On foreground, recompute elapsed. No system notifications during the session — bells only fire when the app is foreground.
+- **(c) Treat background as kill.** Harsh; punishes legitimate interruptions (a phone call).
+
+**Decision: (b).** A custody session is a sit-down prayer block; if the user leaves Ember mid-session, they are not praying with the app. The wall clock keeps running so a brief interruption doesn't reset progress, but we don't push notification "bells" while the user is in another app — a chime that interrupts whatever they're doing is the opposite of formative.
+
+Edge cases:
+- User backgrounds for the entire planned duration. On return, elapsed ≥ planned. End the session with `ended_reason: 'completed'` and `completed_at = started_at + plannedSeconds` (not `now`). Show a gentle "you spent the time elsewhere; the session is closed."
+- User force-quits the app. On next launch the in-memory store is empty; we never auto-resume. The DB has the `started_at` row with `completed_at = NULL`. A reconciliation step on app boot writes `ended_reason: 'app-killed'` to any session older than the planned duration with no `completed_at`.
+
+### B3. CommitmentEditor: a single form, not a wizard
+
+Wizards add ceremony for what is essentially six fields. A scroll-form with collapsible sections is more direct and matches the project's existing `SchedulePicker` UX from plan-of-life.
+
+Sections (top to bottom):
+
+1. Name + description (text inputs)
+2. Kind (segmented control: Abstain / Daily limit / Time fence)
+3. Targets (kind-aware sub-component; see B6)
+4. Schedule (reuse `SchedulePicker` from plan-of-life)
+5. Severity (radio + help text; see B4)
+6. Friction (radio + help text; only visible when severity = `bound`; see B5)
+7. Shield anchor (button that opens a sub-screen; see B11)
+8. Confessor note (optional text)
+
+Single Save button at the bottom. No partial save, no drafts. Validation: name required, at least one target, schedule must be set.
+
+### B4. SeverityPicker honest about what each tier does
+
+Severity is the most consequential choice in the editor. The labels must reflect actual behavior, not aspiration:
+
+- **Light** — *Logged at examen and confession prep. Not enforced.*
+- **Firm** — *Logged + reminders. Not enforced.*
+- **Bound** — *Enforced by your phone.*
+  - On iOS during Phase B (before Phase C ships): selectable but with a "Coming on iOS — for now this acts as Firm" inline note.
+  - On Android: selectable but with a "Coming on Android in v2" note.
+  - On web: hidden (Custody isn't shown on web in v1).
+
+The platform-aware copy is computed at render time from `Platform.OS` and the feature flag `flags.custodyBoundIOS` / `flags.custodyBoundAndroid`. No code that reads severity ever needs to branch on platform — the data stays clean; only the UI explains the asymmetry.
+
+### B5. FrictionPicker is conditional on `bound`
+
+Friction is meaningless for `light` and `firm` — there is nothing to make harder; the OS isn't preventing anything. Only render the FrictionPicker section when severity = `bound`. The user can still configure friction on Android pre-v2 ("we'll honor this when bound mode lands"), so we save the choice; we just don't pretend it's active.
+
+### B6. TargetPicker: split by `Target.kind`, not unified
+
+A single picker that handles "iOS apps OR Android apps OR domains OR curated lists" is fragile. Split by kind, with the user picking *target type* first:
+
+- `domain` → text input with `[+ Add another]`. Validates basic shape (`example.com`, `*.example.com`).
+- `domain-list` → multi-select chips of curated lists shipped with the app (`porn`, `gambling`, `social`, `news`). Each list ships ~50 domains in a JSON file under `apps/app/src/features/custody/blocklists/`.
+- `ios-app` / `ios-category` → button "Pick apps" that opens `FamilyActivityPicker`. Phase B renders the button as a placeholder ("Coming on iOS"). Phase C wires it.
+- `android-app` → button "Pick apps" that opens our installed-apps list. Phase B placeholder; Phase G wires it.
+
+In Phase B, only `domain` and `domain-list` are functional. That's enough to ship a real porn-blocking commitment for users willing to set up DNS (Phase D walks them through it).
+
+### B7. Examen integration: extend, don't replace
+
+`apps/app/src/app/examen.tsx:13-47` runs a six-phase Ignatian examen (`praesentia`, `gratia`, `affectus`, `peccatum`, `propositum`, closing). Decision: don't modify the flow. Extend the data each phase reads.
+
+- **`peccatum`** — surface a list of falls since the last completed examen via a new hook `useFallsSinceLastExamen()`. Render below the existing prose. The user can tap a fall to add a note (writes to `commitment_events.note`).
+- **`propositum`** — surface active commitments. For each: "Will you keep this tomorrow?" with a yes/no toggle. The toggles don't change the commitment — they're a journaling artifact persisted to a new `examen_resolutions` collection in `preferences` (no schema change needed; `preferences` is the project's existing key-value store for this kind of small free-form data).
+
+Last-examen timestamp lives in `preferences` already (existing pattern). Custody reads it and joins against `commitment_events`.
+
+### B8. Confessio integration: a `FallsLog` component
+
+`apps/app/src/app/confessio/index.tsx` tracks confession dates. Add a `FallsLog` component below the existing "last confession" surface. Renders:
+
+- Falls grouped by commitment, ordered by `occurred_at DESC`
+- Per-commitment: name, severity dot, fall count, kept count
+- Per-fall: timestamp, optional note, "include in confession prep" toggle (writes a separate `commitment_events.confession_marked` flag stored as a metadata key)
+
+Implementation: a new component `apps/app/src/features/custody/components/FallsLog.tsx` calling `useFallsSinceLastConfession()`. The hook reads the last confession's `recorded_at` from the existing `confessio` schema and joins `commitment_events WHERE type = 'fell' AND occurred_at > ?`.
+
+A dedicated "Confession prep" screen is out of scope for v1; the falls log is the substitute.
+
+### B9. Notifications for firm commitments
+
+Severity = `light` triggers no notifications — log only. Severity = `firm` triggers nudges. Three nudge points per commitment:
+
+1. **At fence start** (`time-fence` only): "Your Instagram fence starts now. Pray for the grace to keep it."
+2. **Halfway through fence**: "You've kept your fence for {N} hours. Halfway."
+3. **Daily examen reminder** (per user, not per commitment): at 21:00 default, "Time for examen. {N} falls today."
+
+Channel: a new `'custody'` channel (Android) with `LOW` importance — these are gentle nudges, not alarms. Reuse `requestNotificationPermission()` and the channel-setup pattern from `apps/app/src/lib/notifications.ts:26-80`. Add a `setupCustodyNotifications()` function alongside the existing `setupNotifications()`.
+
+Scheduling: recompute and re-schedule on every commitment edit. The strategy is identical to the existing `scheduleRemindersForSlot()` in `notifications.ts:80` — clear all existing notifications for the commitment, then schedule fresh based on its current schedule. Keep notification IDs in a per-commitment array so cancellation is precise.
+
+If notification permission is denied, degrade to in-app-only nudges (a banner on the home screen) and surface a one-time prompt explaining how to enable.
+
+### B10. Home-today active-commitment block
+
+Add a new block to `apps/app/src/app/index.tsx:33-51` between the greeting and the time-block sections. The block renders the active commitments for today and their state.
+
+Visual:
+
+```
+TODAY'S COMMITMENTS
+╭─────────────────────────────────────────╮
+│ 🔒 No pornographic sites — kept         │
+│    Bound · always                       │
+├─────────────────────────────────────────┤
+│ ⏰ Instagram 21:00–07:00 — active 2h    │
+│    Bound · time fence                   │
+├─────────────────────────────────────────┤
+│ 📰 No news during Lent — fell 14:23 ⚠   │
+│    Firm · season                        │
+╰─────────────────────────────────────────╯
+```
+
+A fall today shows a discreet red marker. Tapping a row opens the commitment. The block is hidden entirely when there are no active commitments — Custody is opt-in.
+
+### B11. ShieldAnchorPicker: a sub-screen with five sources
+
+Anchor selection is rich enough to warrant its own screen, reached from CommitmentEditor's "Shield anchor" row.
+
+Five sources:
+
+1. **Curated text** — a list of saint quotes and Scripture aspirations shipped with the app. Phase E populates ~30; Phase B ships ~6 as a starter.
+2. **Prayer** — pick a `prayer/...` ref via the existing content resolver. The selected prayer's text is denormalized into the anchor at save time (the iOS extension can't fetch at trigger time).
+3. **Lectio** — a Bible reference + version. Resolved + inlined at save time.
+4. **Image** — a bundled sacred-art asset. Phase E ships ~6; Phase B ships 1 (Sacred Heart) as a starter.
+5. **Silence** — no content; the shield is monochrome with the commitment name only.
+
+The picker writes a fully-resolved `Anchor` (see Phase A's `Anchor` type). Trade-off: text changes upstream don't propagate — Phase E adds a "Refresh anchor" affordance.
+
+### B12. Phase B ships independently
+
+After Phase B, with `flags.custody = true` but `flags.custodyBoundIOS = false`:
+
+- Custody is visible from the Plan tab.
+- Users can declare commitments at `light` and `firm` severity.
+- Domain and curated-list targets work end-to-end (paired with Phase D's DNS walkthrough for actual web blocking — the OS does the work, Ember just records the rule).
+- Custody sessions run with anchor + bells.
+- Examen surfaces falls; Confessio shows the falls log.
+- Notifications nudge firm commitments.
+
+This is a real shippable surface. It validates the data model and UX flow before Phase C commits to native code.
+
+## Architecture
+
+### File layout added in Phase B
+
+```
+apps/app/src/features/custody/
+  sessionStore.ts                       Zustand store for session state
+  components/
+    CommitmentList.tsx
+    CommitmentEditor.tsx
+    SeverityPicker.tsx
+    FrictionPicker.tsx
+    TargetPicker.tsx                    Dispatcher
+    DomainTargetPicker.tsx
+    DomainListTargetPicker.tsx
+    AppTargetPickerPlaceholder.tsx      Phase B placeholder; Phase C/G wire real pickers
+    ShieldAnchorPicker.tsx              Sub-screen
+    AnchorPreview.tsx                   Renders an Anchor (used in editor + session)
+    CustodySessionRunner.tsx
+    SessionDurationPicker.tsx
+    ActiveCommitmentsBlock.tsx          Home-today block
+    FallsLog.tsx                        Confessio integration
+    CommitmentRow.tsx                   Reused in lists
+  blocklists/
+    porn.json
+    gambling.json
+    social.json
+    news.json
+  anchors/
+    starter-text.ts                     ~6 starter text anchors (Phase E expands)
+    starter-images/
+      sacred-heart.png
+  notifications.ts                      Custody-specific scheduling
+
+apps/app/src/app/custody/
+  index.tsx                             [filled in: list + active-today + sessions]
+  new.tsx                               [filled in: CommitmentEditor]
+  [commitmentId].tsx                    [filled in: CommitmentEditor]
+  session.tsx                           [filled in: CustodySessionRunner]
+  anchor.tsx                            [new: ShieldAnchorPicker sub-screen]
+
+apps/app/src/app/index.tsx              [edited: ActiveCommitmentsBlock]
+apps/app/src/app/examen.tsx             [edited: peccatum + propositum extensions]
+apps/app/src/app/confessio/index.tsx    [edited: FallsLog mount]
+
+apps/app/src/lib/notifications.ts       [edited: setupCustodyNotifications]
+
+apps/app/src/lib/i18n/locales/{en-US,pt-BR}.ts   [edited: custody.* expanded]
+```
+
+### Custody session runner sketch
+
+```typescript
+// apps/app/src/features/custody/sessionStore.ts
+type SessionState =
+  | { kind: 'idle' }
+  | { kind: 'running'; sessionId: string; startedAt: number; plannedSeconds: number; anchor: Anchor }
+  | { kind: 'paused'; sessionId: string; startedAt: number; pausedAt: number; plannedSeconds: number; elapsedAtPause: number; anchor: Anchor }
+
+const useSessionStore = create<{
+  state: SessionState
+  start: (input: { plannedSeconds: number; anchor: Anchor }) => Promise<void>
+  pause: () => void
+  resume: () => void
+  abort: () => Promise<void>
+  tick: () => void   // called by an interval; transitions to 'idle' on completion
+}>(...)
+
+// Bell scheduling: an effect inside CustodySessionRunner watches elapsed and plays
+// a chime via expo-av at floor(elapsed / planned * 3) crossings. Only when foreground.
+```
+
+### Examen integration sketch
+
+```typescript
+// apps/app/src/features/custody/hooks.ts
+function useFallsSinceLastExamen() {
+  const lastExamen = usePreference<number>('examen.lastCompletedAt')
+  return useQuery({
+    queryKey: ['custody', 'falls', 'since-examen', lastExamen],
+    queryFn: () => listFallsSince(lastExamen ?? 0),
+  })
+}
+
+// In examen.tsx peccatum phase render:
+const { data: falls } = useFallsSinceLastExamen()
+return (
+  <YStack>
+    {/* existing prose */}
+    {falls?.length ? <FallsRecap falls={falls} editable /> : null}
+  </YStack>
+)
+```
+
+## Tasks
+
+### T-B1. CommitmentList component
+
+`apps/app/src/features/custody/components/CommitmentList.tsx`. Renders rows from `useCommitments({ includeArchived: false })`. Each row: name, kind icon, severity dot, last-event indicator (kept today / fell at HH:MM / paused). Tap → `/custody/[commitmentId]`. Empty state: "Add your first commitment" CTA → `/custody/new`.
+
+### T-B2. CommitmentEditor
+
+`apps/app/src/features/custody/components/CommitmentEditor.tsx`. Single scroll-form with the eight sections from B3. On Save: validate, call `createCommitment` or `updateCommitment` from the repo, navigate back. Used by both `new.tsx` and `[commitmentId].tsx`.
+
+### T-B3. SeverityPicker
+
+`apps/app/src/features/custody/components/SeverityPicker.tsx`. Vertical radio with help text per option. Platform-aware copy for `bound` (B4). Reads `flags.custodyBoundIOS` / `flags.custodyBoundAndroid` to render the inline platform note.
+
+### T-B4. FrictionPicker
+
+`apps/app/src/features/custody/components/FrictionPicker.tsx`. Vertical radio; conditional rendering tied to severity prop. For `wait`, renders a duration sub-input. For `prayer`, renders a prayer-ref picker (reuse the prayer picker from ShieldAnchorPicker).
+
+### T-B5. TargetPicker dispatcher
+
+`apps/app/src/features/custody/components/TargetPicker.tsx`. The user picks a target *type* first; then the matching sub-picker mounts. Supports add-multiple. State is a `Target[]` list shown above the type picker.
+
+### T-B6. DomainTargetPicker + DomainListTargetPicker
+
+`DomainTargetPicker.tsx` is a text input with `[+ Add]`. `DomainListTargetPicker.tsx` is a multi-select chip list reading from `apps/app/src/features/custody/blocklists/`. Ship the four starter blocklists (`porn`, `gambling`, `social`, `news`) — domain lists curated from known sources, ~50 domains each, hand-reviewed (deferred to Phase E for the full curation pass; Phase B ships minimal seed content).
+
+### T-B7. ShieldAnchorPicker sub-screen
+
+`apps/app/src/app/custody/anchor.tsx` + `ShieldAnchorPicker.tsx`. Five tabs: Text, Prayer, Lectio, Image, Silence. Text tab reads from `apps/app/src/features/custody/anchors/starter-text.ts`. Prayer tab uses the existing content resolver to pick a `prayer/...` ref; on selection, calls the resolver to get rendered text and inlines it into the anchor. Lectio tab is a Bible reference picker (reuse existing component if present; otherwise a simple book/chapter/verse triple). Image tab is a grid of `apps/app/src/features/custody/anchors/starter-images/`. Save returns to the editor with the chosen Anchor.
+
+### T-B8. CustodySessionRunner
+
+`apps/app/src/features/custody/components/CustodySessionRunner.tsx`. Full-screen view bound to the route `/custody/session`. Reads `sessionStore` for state. Renders the anchor (via `AnchorPreview`), the elapsed/remaining timer, and a Pause/Resume/Stop control. Plays a chime via `expo-av` at 1/3, 2/3, end (foreground only — see B2). Calls `useKeepAwake()` for the duration. On `AppState` background → does not pause; just stops bell scheduling. On foreground → recomputes elapsed.
+
+### T-B9. SessionDurationPicker + start flow
+
+`SessionDurationPicker.tsx` — five chips (5/10/20/40/60). On selection, opens AnchorPicker (or "use last anchor"); on confirm, starts the session. Entry point lives on `/custody/index.tsx` ("Begin custody" button) and on individual commitment screens ("Pray over this commitment").
+
+### T-B10. ActiveCommitmentsBlock
+
+`apps/app/src/features/custody/components/ActiveCommitmentsBlock.tsx`. Reads `useActiveCommitmentsToday()`. Renders rows per B10. Mount in `apps/app/src/app/index.tsx` between the greeting and the time-block sections; conditional on the hook returning a non-empty array.
+
+### T-B11. FallsLog component for Confessio
+
+`apps/app/src/features/custody/components/FallsLog.tsx`. Reads `useFallsSinceLastConfession()`. Mount in `apps/app/src/app/confessio/index.tsx` below the last-confession surface. Per-row toggle marks/unmarks for confession prep (writes a metadata key on the event).
+
+### T-B12. Examen integration
+
+Edit `apps/app/src/app/examen.tsx`: in the `peccatum` phase render, mount a `FallsRecap` component below the existing prose; in the `propositum` phase, mount a `ResolutionCheck` component listing active commitments with yes/no toggles. Implement `useFallsSinceLastExamen()` and a `markExamenCompleted()` mutation that bumps `examen.lastCompletedAt` in `preferences` on examen completion. The existing examen completion hook fires this mutation.
+
+### T-B13. Notification scheduling
+
+`apps/app/src/features/custody/notifications.ts`:
+
+- `setupCustodyNotifications()` — creates the `'custody'` channel with `LOW` importance. Called from existing app-init alongside `setupNotifications()`.
+- `scheduleNudgesForCommitment(commitment)` — clears any existing notifications for this commitment, then schedules fence-start + fence-half notifications for `firm` time-fence commitments.
+- `scheduleDailyExamenReminder()` — single global daily nudge at 21:00 that fetches the current fall count and renders the body.
+
+Hook into `useUpdateCommitment` and `useCreateCommitment` mutations to re-schedule on every save. Hook into `useArchiveCommitment` and `useDeleteCommitment` to clear.
+
+### T-B14. Default text-anchor pool
+
+`apps/app/src/features/custody/anchors/starter-text.ts` — ~6 starter text anchors. Sample seeds: "Custodi linguam tuam a malo, et labia tua ne loquantur dolum" (Ps 33:14); "Quis ascendet in montem Domini?" (Ps 23:3); "Vigilate et orate" (Mt 26:41); "He must increase, but I must decrease" (Jn 3:30); a de Sales line on custody of the eyes; a Bosco line on the dignity of the body. Text + attribution. Phase E expands to ~30.
+
+### T-B15. Feature flag flip + smoke test
+
+Set `flags.custody = true` for development builds. Walk the full flow on iOS Simulator and an Android emulator: create commitment → run session → trigger a fall (manual log) → complete examen → verify falls in confessio → verify nudges fire. Confirm bound mode shows the platform note, not error states.
+
+## Verification
+
+- **Unit tests**: `useActiveCommitmentsToday`, `useFallsSinceLastExamen`, `useFallsSinceLastConfession` for correct date filtering. Session store transitions for all state changes including background recovery.
+- **Component tests**: `CommitmentEditor` validation, `SeverityPicker` platform copy, `FrictionPicker` conditional rendering, `CustodySessionRunner` bell scheduling.
+- **Manual**: full flow on a physical device (iOS + Android) with notifications enabled, then with notifications denied (degrade path).
+- **Manual**: backgrounding mid-session for varied durations (10s, half the session, longer than the session) — verify the policy from B2 holds in each case.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| iOS audio session conflict with Mass / liturgy practices that play audio | Configure session bell category as `ambient` so it ducks but doesn't preempt; test alongside an active liturgy practice. |
+| Notification permission denied → silent commitments | In-app banner on home for upcoming nudges; one-time educational prompt. |
+| Falls-log query performance with thousands of events | Index `commitment_events_by_type` from Phase A handles this; verify with seeded data. |
+| Examen flow disturbance from new components | Feature-flag the integration; A/B against the existing flow before turning on by default. |
+| Anchor inlining stale prayer text | Phase E "Refresh anchor" affordance documented and visible in the editor. |
+| Bell chime startles user during prayer | Bells are quiet (`-12 dB`); volume override via user setting; default off for the closing bell. |
+| Background-policy edge cases (B2) feel arbitrary | Surface the policy in a help-text tooltip on the session start screen so the user knows what counts. |

--- a/docs/features/custody/phase-c-ios-bound.md
+++ b/docs/features/custody/phase-c-ios-bound.md
@@ -1,0 +1,511 @@
+# Phase C — iOS bound mode
+
+> Scope: real OS-level shielding on iOS via Apple's Screen Time API stack, with the prayer-shield as the centerpiece.
+> Complexity: **High and gated.** First custom Expo native module in the repo, first config plugin, first time leaving the managed workflow, three iOS extension targets, and an external dependency on Apple's Family Controls entitlement.
+> Depends on: Phase A (data layer), Phase B (UI surface). Phase B's `bound` severity placeholder is what this phase fills in.
+> Independently shippable: no. Phase C only delivers value once it lands; pre-Phase-C, `bound` reads as `firm` per the platform note.
+
+## Goal
+
+When a user activates a `bound` commitment and opens a shielded app, iOS overlays Ember's prayer-shield: a sacred-art card with a short verse or aspiration and one button — *Pray and continue blocking*. A second button offers a friction-aware path to disable temporarily (`wait`, `prayer`, `confession-only`). All of this works against opaque tokens — Ember literally cannot enumerate which apps the user picked. The implementation lives in an Expo Module + Config Plugin + three iOS extension targets, sharing state with the main app via an App Group.
+
+This phase is the platform-locked native step. Phases A and B are reversible JS work; Phase C commits the project to native code, a custom dev client, an Apple entitlement, and a TestFlight pipeline.
+
+---
+
+## Background: what Apple gives us, and what they don't
+
+Three frameworks, each with a corresponding extension target:
+
+| Framework | Extension target | Role |
+|---|---|---|
+| `FamilyControls` | (none — runs in main app) | Authorization, the picker that returns opaque selections |
+| `ManagedSettings` | (none) | Apply/remove restrictions on the active selection |
+| `DeviceActivity` | **`DeviceActivityMonitor`** | OS-scheduled wake-ups; switches restrictions on/off; observes thresholds |
+| (`ManagedSettings.shield`) | **`ShieldConfiguration`** | Renders the shield UI when a shielded app is opened |
+| (`ManagedSettings.shield`) | **`ShieldAction`** | Handles button taps on the shield |
+
+The shield UI is **not** a full SwiftUI view we own. Apple gives us a fixed shape: an icon (UIImage), a title (attributed string), a subtitle (attributed string), a primary button label, a secondary button label, and a few colors. Long-form prayer rendering inside the shield is not possible — we work within the shape.
+
+Authorization mode: `.individual` (self-restraint). Selection is opaque: `applicationTokens`, `categoryTokens`, `webDomainTokens` — the developer never sees bundle IDs.
+
+---
+
+## Major decisions
+
+### C1. Library: `kingstinct/react-native-device-activity` covers ~80% of the plumbing
+
+Reviewed in the README. Decision: use it as the FamilyControls + Picker + ManagedSettings + extension-target boilerplate layer. The library ships:
+
+- A Swift bridge for `requestAuthorization(.individual)`, `displayFamilyActivityPicker(...)`, `blockSelection(...)`, `unblockSelection(...)`
+- Templates for the three extension targets, configurable via the Expo config plugin
+- App Group + entitlement wiring through the plugin
+- Status polling (`getAuthorizationStatus`)
+
+We customize the extensions where needed — particularly `ShieldConfiguration` and `ShieldAction`, which are where the prayer-shield and friction logic live. `DeviceActivityMonitor` we customize for our schedule-mapping logic.
+
+**Fallback:** if the library proves insufficient (some Apple API not yet bridged, or the extension hooks are too coarse), fork it. Time-box the discovery to the first 3 days of Phase C — if a fork is needed, do it early and stop pretending otherwise.
+
+### C2. App Group: `group.me.dpgu.ember` (single group, namespaced keys)
+
+The App Group is the only practical channel between the main app and the extensions. Two options:
+
+- **(a) Per-feature group** (`group.me.dpgu.ember.custody`). Cleaner isolation. Locks Custody's storage from any other future extension.
+- **(b) Single group** (`group.me.dpgu.ember`). Forward-compatible with future extensions (a Liturgical Hours Live Activity, a Saints widget). Requires keys to be namespaced.
+
+**Decision: (b).** Custody namespaces its keys with `custody.*`. The bundle ID `me.dpgu.ember` already establishes the convention.
+
+### C3. UserDefaults schema in the App Group
+
+Extensions read this on every shield trigger. Schema:
+
+| Key | Type | Written by | Read by |
+|---|---|---|---|
+| `custody.commitments` | JSON `CommitmentSnapshot[]` | main app | all extensions |
+| `custody.tokens.<commitmentId>` | `Data` (encoded `FamilyActivitySelection`) | main app | DeviceActivityMonitor |
+| `custody.lockedUntil.<commitmentId>` | Number (epoch ms) | ShieldAction | ShieldConfiguration |
+| `custody.dailyLimits.<commitmentId>` | JSON `{ limitSeconds, accumulatedSeconds, resetAt }` | DeviceActivityMonitor | ShieldConfiguration |
+| `custody.shieldEvents.queue` | JSON `ShieldEvent[]` | extensions | main app (drains on launch) |
+
+`CommitmentSnapshot` is the extension-friendly subset of `Commitment`:
+
+```swift
+struct CommitmentSnapshot: Codable {
+  let id: String
+  let name: String
+  let friction: String              // "none" | "wait" | "prayer" | "confession-only"
+  let frictionConfig: [String: Any]?
+  let anchor: AnchorSnapshot
+}
+
+struct AnchorSnapshot: Codable {
+  let kind: String                  // "text" | "image" | "prayer" | "lectio" | "silence"
+  let title: String                 // short — fits the shield title
+  let subtitle: String              // short — fits the shield subtitle
+  let imageData: Data?              // pre-rendered card image
+}
+```
+
+The main app keeps this in sync on every commitment create / update / archive via the Swift module's `syncSnapshots` JS-callable. The extensions read on demand.
+
+### C4. The shield's UI shape forces anchor pre-rendering
+
+Apple's `ShieldConfiguration` API:
+
+```swift
+ShieldConfiguration(
+  backgroundBlurStyle: UIBlurEffect.Style,
+  backgroundColor: UIColor?,
+  icon: UIImage?,
+  title: ShieldConfiguration.Label,           // attributed string + color
+  subtitle: ShieldConfiguration.Label,
+  primaryButtonLabel: ShieldConfiguration.Label,
+  primaryButtonBackgroundColor: UIColor,
+  secondaryButtonLabel: ShieldConfiguration.Label?
+)
+```
+
+We can't render a 200-word Anima Christi inside the shield. We can render:
+
+- An icon (sacred art card, ~120×120 displayed area on the shield)
+- A title (~30–40 chars before truncation)
+- A subtitle (~80–120 chars before truncation; varies by device)
+
+**Decision:** at commitment-edit time in the main app, the anchor picker produces three artifacts per anchor:
+1. A short `title` (≤30 chars; e.g., "Custódia")
+2. A short `subtitle` (≤120 chars; the verse / aspiration)
+3. A pre-rendered card `imageData` (PNG; the sacred-art card if `kind=image`, or a typeset card if `kind=text|prayer|lectio` — in v1, only `image` and bundled cards; typeset card rendering is deferred to v1.5)
+
+For longer prayers (`kind=prayer`), the shield shows the prayer's *title* and a one-line *opening* as the subtitle. The full prayer text is shown when the user taps "Pray and continue blocking" — we deep-link into the main app's prayer renderer.
+
+### C5. `Pray and continue blocking` deep-links into the main app
+
+When the user taps the primary shield button:
+
+- ShieldAction logs a `kept` event into the App Group's `custody.shieldEvents.queue`.
+- ShieldAction returns `.defer` and opens `ember://custody/shield-pray/<commitmentId>` via `extensionContext.open(url:)`.
+- The main app launches (or wakes), routes to a full-screen prayer view that renders the anchor's full prayer/text, and ticks a checkpoint after the user dismisses.
+- The shield's restriction stays applied; the user has prayed; iOS's normal app-switching is preserved.
+
+This is the heart of the product loop: every time the temptation hits, the user is brought through one decision moment and one prayer moment before they can return to Ember or continue blocking.
+
+### C6. Friction modes implemented in ShieldAction
+
+Secondary button: "Disable temporarily." Per friction:
+
+| Friction | Behavior |
+|---|---|
+| `none` | Log `overrode`. Remove shield for this app for the rest of the day. Return `.defer`. |
+| `wait` | Write `custody.lockedUntil.<commitmentId> = now + frictionConfig.waitSeconds`. Return `.none`. ShieldConfiguration on next trigger reads the lock and renders a countdown subtitle ("disable in 4:32") with the secondary button disabled. After expiry, secondary becomes "Confirm disable" → log `overrode` and remove shield. |
+| `prayer` | Open `ember://custody/pray-to-disable/<commitmentId>` via `extensionContext.open(url:)`. Main app shows the prayer; on user mark-as-prayed, calls back into the Swift module to remove the shield. Log `overrode` with `metadata.via='prayer'`. |
+| `confession-only` | Open `ember://confessio` via deep link. Secondary button on the shield reads "After confession". The user can only override by recording a confession in the Confessio surface. The Confessio screen, on save, calls into the Swift module to lift the override. Log `overrode` with `metadata.via='confession'`. |
+
+The lock timestamps (`custody.lockedUntil.*`) and the friction policy are in UserDefaults — the extensions read them; they don't call into JS.
+
+### C7. Schedule mapping: `ScheduleRule` → `DeviceActivitySchedule[]`
+
+`DeviceActivitySchedule` is rigid: an `intervalStart: DateComponents`, `intervalEnd: DateComponents`, `repeats: Bool`, optional `warningTime`. It does not understand days-of-week, seasons, holy days, or fixed programs.
+
+**Decision:** the Swift module flattens `ScheduleRule` into a list of concrete schedules; the main app re-flattens on commitment edit and on liturgical-season transitions.
+
+Mapping table:
+
+| `ScheduleRule` | Flattened to |
+|---|---|
+| `daily` (always-on `abstain`) | One schedule, `00:00–23:59`, `repeats: true` |
+| `time-fence` (e.g., 21:00–07:00 daily) | One schedule, the fence times, `repeats: true` |
+| `days-of-week: [Mon, Wed]` | Two schedules, one per active day, `repeats: true` (Apple's `DateComponents.weekday`) |
+| `season-gated: lent` | Same as above, but registered/unregistered at season boundaries by the main app |
+| `holy-days-of-obligation` | Per-occurrence; main app schedules each one as `fixed-program` of one day |
+| `fixed-program: 9 days` | Nine concrete schedules, one per day |
+| `times-per: 3 / week` | **Not bound-supported.** Falls back to `firm` with a UI note. (No way to express "first three times you open Instagram this week" in DeviceActivitySchedule.) |
+
+The flattening produces a `DeviceActivity`-named registration per schedule. Activity names are `commitmentId + "_" + scheduleIndex`. When a commitment is edited, all activities matching the prefix are stopped and re-registered.
+
+For `time-limit` (e.g., "no more than 30 min/day of YouTube"), we use `DeviceActivityEvent` with a usage threshold instead of a schedule. The DeviceActivityMonitor extension's `eventDidReachThreshold` callback fires; we then apply the shield. Reset happens via a daily `intervalEnd` callback.
+
+### C8. Web domain shielding: explicit + Apple's curated categories
+
+Two dimensions of web blocking:
+
+- `ManagedSettings.shield.webDomains` — explicit list of domains
+- `ManagedSettings.shield.webDomainCategories` — Apple's curated categories (`adult`, etc.)
+
+For Ember:
+
+- A commitment with `Target.kind = 'domain'` writes to `webDomains`.
+- A commitment with `Target.kind = 'domain-list'` writes:
+  - `webDomains` for our explicit list (defense in depth, captures known sites Apple may not have categorized)
+  - `webDomainCategories` for the matching Apple category where one exists (`porn` → `.adult`)
+
+The shield UI for web vs app: same `ShieldConfiguration`, our extension overrides `configuration(shielding webDomain: WebDomain)` in addition to `configuration(shielding application: Application)`.
+
+### C9. Authorization flow with explicit recovery
+
+Three states from `AuthorizationCenter.shared.authorizationStatus`: `notDetermined`, `denied`, `approved`.
+
+Flow when the user toggles severity to `bound` for the first time:
+
+1. App reads status.
+2. If `approved`: proceed to picker.
+3. If `notDetermined`:
+   - Show explainer screen ("To enforce this commitment, Ember needs Screen Time access. We never see which apps you pick.")
+   - On "Continue", call `requestAuthorization(.individual)`.
+   - On approval, proceed to picker. On denial, jump to recovery.
+4. If `denied`:
+   - Show recovery screen ("Custody enforcement is currently disabled. To re-enable, open Settings → Screen Time and allow Ember.")
+   - "Open Settings" deep-link to `App-Prefs:SCREEN_TIME` (or the closest available URL — Apple's Settings deep-link surface is unstable; fall back to `UIApplication.openSettingsURLString`).
+   - Until the user re-grants, the commitment is saved at `bound` but acts as `firm`. UI on the commitment row shows "Awaiting Screen Time access."
+
+### C10. Onboarding flow
+
+A multi-step screen sequence the first time the user activates a bound commitment:
+
+```
+1. "Custody is your phone helping you keep your word."     [Continue]
+2. "Custody is single-user. No one else controls your apps." [Continue]
+3. "We never see which apps you pick — Apple keeps that private." [Continue]
+4. (System sheet) "Allow Ember to manage Screen Time?"     [system]
+5. (System sheet) "Pick the apps and websites this commitment covers." [system]
+6. "Pick a prayer or image to show when this app opens."   [Anchor picker]
+7. "Custody is active. You can pause or remove it any time." [Done]
+```
+
+Steps 4 and 5 are Apple's system sheets — we don't style them. The pre/post copy is ours.
+
+### C11. EAS / dev-client transition
+
+Adding `react-native-device-activity` and the Family Controls entitlement leaves the managed workflow. Concrete changes:
+
+- `apps/app/eas.json`: add a new `development` profile `withCustody: true`. Existing profiles unchanged for now (so non-Custody dev work keeps the lighter loop). The `production` profile flips to the Custody-enabled config when Phase C ships.
+- `apps/app/app.config.ts` (we may need to migrate from `app.json` to `app.config.ts` here for conditional plugin loading): includes the plugin chain only when the Custody flag is on.
+- A custom dev client built once via `eas build --profile development-custody`. Engineers run against this client.
+- `pnpm` scripts: `start:custody` runs against the custom client.
+
+This is the moment the project crosses from "managed Expo" to "managed Expo + custom dev client." Document the transition in `docs/journal.md` so future devs understand the asymmetry.
+
+### C12. Apple entitlement: file before any code
+
+Family Controls entitlement (`com.apple.developer.family-controls`) approval is the long pole and cannot be parallelized into the build. File the request *first*, before any Phase C engineering:
+
+- Submit via Apple Developer Portal → Capabilities → Family Controls → Request entitlement.
+- Justification draft: "Ember is a Catholic prayer companion that helps users keep ascetical commitments through prayer and self-imposed restrictions on their own device. Custody uses Family Controls in Individual mode (`.individual`); the user picks which apps to shield, configures friction modes, and may revoke at any time. No second party is involved. Selections are opaque tokens; Ember never enumerates which apps the user picked."
+- Provide a 60–90 second demo video of the Phase B flow + a mockup of the prayer-shield (record on a dev build with locally-enabled Family Controls).
+- Review timeline: historically days–weeks; sometimes months. The request can sit in parallel with Phases A and B.
+
+If denied, the typical revisions are sharper "self-restraint" copy and removal of any framing that implies surveillance. Build in time for one revision cycle.
+
+### C13. Failure modes
+
+| Failure | Behavior |
+|---|---|
+| Picker dismissed without selection | Commitment saves with empty `targets`; UI shows "No targets — pick apps to enforce" badge; bound is inactive until targets are set. |
+| Authorization revoked from Settings while a bound commitment is active | App detects revocation on next foreground; shows a banner; commitment auto-degrades to `firm` until re-authorized. |
+| User uninstalls Ember | iOS removes the entitlement; restrictions lift automatically. (This is a feature, not a bug — Custody is ascetical aid, not jail.) |
+| Apple's `webDomainCategories.adult` mis-categorizes a site we want allowed | Our explicit `webDomains` list takes precedence for the *blocked* side; Apple's allow-list does not override our blocks. The reverse — Apple blocks something we'd rather allow — requires the user to remove the corresponding domain-list target. |
+| User opens shielded app with no network | Shield still appears (it's local). "Pray and continue blocking" still deep-links to Ember (also local). All-offline path works. |
+| App Group fails to write (iCloud sync conflict, disk full) | Detect on next sync attempt; surface a "Custody data is out of sync" banner; offer manual re-sync. |
+
+---
+
+## Architecture
+
+### File layout added in Phase C
+
+```
+apps/app/modules/ember-custody-ios/
+  expo-module.config.json
+  index.ts                                  JS bridge type declarations
+  ios/
+    EmberCustodyModule.swift                Main module: authorize, picker, sync, status
+    Snapshots/
+      CommitmentSnapshot.swift              Codable shapes shared with extensions
+      AnchorSnapshot.swift
+      AppGroupKeys.swift                    Centralised key constants
+    Shield/
+      EmberShieldConfiguration.swift        ShieldConfigurationDataSource subclass
+      EmberShieldAction.swift               ShieldActionExtension subclass
+      FrictionState.swift                   Read/write lockedUntil
+    Monitor/
+      EmberDeviceActivityMonitor.swift      DeviceActivityMonitor subclass
+      ScheduleFlattener.swift               ScheduleRule → DeviceActivitySchedule[]
+    Targets/
+      ActivityMonitor/Info.plist
+      ShieldConfiguration/Info.plist
+      ShieldAction/Info.plist
+
+apps/app/plugins/
+  withCustodyIOS.ts                         Expo config plugin
+
+apps/app/src/features/custody/
+  native/
+    ios.ts                                  TS facade over the module (typed)
+    fallback.ts                             No-op for non-iOS / sim
+  components/
+    AppTargetPickerIOS.tsx                  Wraps FamilyActivityPicker
+    BoundOnboarding.tsx                     Multi-step explainer
+    AuthorizationGuard.tsx                  notDetermined / denied / approved branching
+    SyncStatusBanner.tsx                    Authorization revoked / out-of-sync
+  shieldEvents.ts                           Drains the extension event queue on launch
+
+apps/app/src/app/custody/
+  shield-pray/[commitmentId].tsx            Deep-link target for "Pray and continue"
+  pray-to-disable/[commitmentId].tsx        Deep-link target for prayer friction
+
+apps/app/app.config.ts                       [new — replaces app.json for conditional plugins]
+apps/app/eas.json                            [edited]
+```
+
+### JS-callable surface of the Swift module
+
+```typescript
+// apps/app/modules/ember-custody-ios/index.ts
+export type AuthStatus = 'notDetermined' | 'denied' | 'approved' | 'unsupported'
+
+export const EmberCustodyIOS: {
+  isSupported(): boolean                       // false on iOS < 15 or simulator
+  getAuthorizationStatus(): Promise<AuthStatus>
+  requestAuthorization(): Promise<AuthStatus>
+  presentPicker(commitmentId: string, includeWebDomains: boolean): Promise<{ tokenRef: string } | null>
+  syncSnapshots(snapshots: CommitmentSnapshot[]): Promise<void>
+  applyShield(commitmentId: string): Promise<void>
+  removeShield(commitmentId: string): Promise<void>
+  removeAllShields(): Promise<void>
+  getStatus(): Promise<{ activeCommitmentIds: string[]; lockedUntil: Record<string, number> }>
+  drainShieldEvents(): Promise<ShieldEvent[]>
+  liftFrictionLock(commitmentId: string, reason: 'prayer' | 'confession'): Promise<void>
+  openSettings(): Promise<void>                // best-effort Screen Time deep-link
+}
+
+type ShieldEvent = {
+  type: 'kept' | 'overrode'
+  commitmentId: string
+  occurredAt: number
+  via?: 'prayer' | 'confession' | 'wait'
+}
+```
+
+The TS facade in `apps/app/src/features/custody/native/ios.ts` falls back to no-ops on Android / simulator / unsupported iOS. Every Custody hook calls through the facade so the rest of the codebase doesn't branch on platform.
+
+### Config plugin sketch
+
+```typescript
+// apps/app/plugins/withCustodyIOS.ts
+const withCustodyIOS: ConfigPlugin<{ teamId: string; appGroup: string }> = (config, props) => {
+  config = withEntitlementsPlist(config, (c) => {
+    c.modResults['com.apple.developer.family-controls'] = true
+    c.modResults['com.apple.security.application-groups'] = [props.appGroup]
+    return c
+  })
+  config = withInfoPlist(config, (c) => {
+    c.modResults.NSFamilyControlsUsageDescription = 'Custody helps you keep your ascetical commitments by shielding selected apps and websites.'
+    return c
+  })
+  // Three extension targets via withXcodeProject; uses templates from the
+  // bundled native module folder.
+  config = withCustodyExtensionTargets(config, props)
+  return config
+}
+```
+
+### Anchor card image generation
+
+For Phase C v1, anchor card images are bundled assets (`apps/app/src/features/custody/anchors/cards/*.png`), one per starter (Sacred Heart, Christ Crucified, Our Lady, etc.). The user picks a card; the picker writes the corresponding bundled asset path into the snapshot's `imageData` (read at sync-time, encoded into UserDefaults).
+
+Typeset cards (text rendered onto a designed background) are deferred to v1.5. They require a Skia or `react-native-skia` renderer in the main app — significant addition, not in scope here.
+
+---
+
+## Tasks
+
+### T-C1. File the Family Controls entitlement request
+
+**Procedural — first task of Phase C, before any code.** Submit the request via Apple Developer Portal with the justification draft from C12, the demo video, and screenshots. Track the ticket ID in `docs/journal.md`. While waiting, proceed with T-C2 through T-C5; the entitlement isn't needed for local dev builds, only for App Store distribution.
+
+### T-C2. Create the custom dev client
+
+- Migrate `apps/app/app.json` → `apps/app/app.config.ts` to enable conditional plugin loading on a `CUSTODY=1` env flag.
+- Add a `development-custody` profile to `apps/app/eas.json`.
+- `pnpm add react-native-device-activity` in `apps/app/package.json`.
+- Build the dev client: `eas build --profile development-custody --platform ios`.
+- Document the new dev workflow in `docs/journal.md`: when to use the standard dev client vs the custody one.
+
+### T-C3. Write the Expo config plugin
+
+`apps/app/plugins/withCustodyIOS.ts`. Uses `withEntitlementsPlist`, `withInfoPlist`, and (via the library or a custom `withXcodeProject` mod) creates the three extension targets, sets their bundle IDs (`me.dpgu.ember.activity-monitor` / `.shield-config` / `.shield-action`), entitles each with `com.apple.developer.family-controls` + the App Group, and points each at the corresponding source folder.
+
+### T-C4. Initialize the Swift module skeleton
+
+`apps/app/modules/ember-custody-ios/`. Create `expo-module.config.json` and `EmberCustodyModule.swift` per Expo Modules API. Wire `isSupported`, `getAuthorizationStatus`, `requestAuthorization` first — these don't need extensions and let us validate the JS bridge end-to-end before tackling the heavier surface.
+
+### T-C5. App Group keys + snapshot codables
+
+`apps/app/modules/ember-custody-ios/ios/Snapshots/`. Define `CommitmentSnapshot`, `AnchorSnapshot`, `AppGroupKeys` (centralized key constants — avoids string drift across the four targets). Implement `syncSnapshots(snapshots:)` that writes to UserDefaults atomically (encode to JSON, single write under `custody.commitments`).
+
+### T-C6. ShieldConfiguration extension
+
+`apps/app/modules/ember-custody-ios/ios/Shield/EmberShieldConfiguration.swift`. Subclass `ShieldConfigurationDataSource`. Override:
+
+- `configuration(shielding application: Application) -> ShieldConfiguration`
+- `configuration(shielding application: Application, in category: ActivityCategory)`
+- `configuration(shielding webDomain: WebDomain)`
+- `configuration(shielding webDomain: WebDomain, in category: WebDomainCategory)`
+
+Each reads `custody.commitments` + `custody.lockedUntil.*` from UserDefaults, finds the active commitment(s) for this token, and returns a `ShieldConfiguration` with:
+
+- `icon` = decoded `imageData` from the anchor snapshot
+- `title` = anchor `title` as `ShieldConfiguration.Label`
+- `subtitle` = anchor `subtitle`, OR a countdown if `lockedUntil > now`
+- `primaryButtonLabel` = "Pray and continue blocking"
+- `secondaryButtonLabel` = friction-aware ("Disable" / "Disable in 4:32" / "After confession" / "Pray to disable")
+
+Test on a physical device (extension cannot be exercised in the simulator).
+
+### T-C7. ShieldAction extension
+
+`apps/app/modules/ember-custody-ios/ios/Shield/EmberShieldAction.swift`. Subclass `ShieldActionExtension`. Override `handle(action:for:completionHandler:)` and `handle(action:forWebDomain:completionHandler:)`. Implement the four friction modes per C6. For `prayer` and `confession-only`, use `extensionContext.open(url:completionHandler:)` to launch the deep-link. Append events to `custody.shieldEvents.queue`.
+
+### T-C8. DeviceActivityMonitor extension + schedule flattener
+
+`apps/app/modules/ember-custody-ios/ios/Monitor/EmberDeviceActivityMonitor.swift`. Subclass `DeviceActivityMonitor`. Override `intervalDidStart`, `intervalDidEnd`, `eventDidReachThreshold`. On `intervalDidStart`, apply `ManagedSettings.shield` against the relevant commitment's tokens. On `intervalDidEnd`, remove. On `eventDidReachThreshold` (used by `time-limit`), apply.
+
+`ScheduleFlattener.swift` translates a `ScheduleRule` payload (passed from JS) into one or more `DeviceActivitySchedule` registrations. Names use the convention `<commitmentId>_<index>`.
+
+### T-C9. AppPicker iOS component
+
+`apps/app/src/features/custody/components/AppTargetPickerIOS.tsx`. On press, calls `EmberCustodyIOS.presentPicker(commitmentId, includeWebDomains)`. The library renders Apple's system sheet. On selection, the Swift side encodes the `FamilyActivitySelection`, writes it to `custody.tokens.<commitmentId>`, returns a `tokenRef`. The TS side stores `Target { kind: 'ios-app', tokenRef }` in the commitment.
+
+### T-C10. Authorization guard + onboarding
+
+`apps/app/src/features/custody/components/AuthorizationGuard.tsx` — branches on `getAuthorizationStatus()` (notDetermined / denied / approved) and renders the explainer / recovery / continue UI per C9.
+
+`apps/app/src/features/custody/components/BoundOnboarding.tsx` — the multi-step sequence from C10. Triggered the first time the user picks `bound` severity in CommitmentEditor.
+
+### T-C11. Sync orchestration
+
+A `useSyncCommitmentSnapshots()` hook listens to commitment mutations and calls `EmberCustodyIOS.syncSnapshots(...)` after each write. Also runs on app foreground (recovers from any drift). Drains `custody.shieldEvents.queue` on the same trigger, logging events into `commitment_events` via the repo.
+
+### T-C12. Web-domain shielding path
+
+In the schedule flattener and the Swift apply logic, branch on `Target.kind`:
+
+- `domain` / `domain-list` → write to `webDomains` and (where mapped) `webDomainCategories`
+- `ios-app` / `ios-category` → write to `applicationTokens` / `categoryTokens`
+
+The `ShieldConfiguration` overrides for web domains return the same anchor-driven UI.
+
+### T-C13. Time-limit support via `DeviceActivityEvent`
+
+For commitments with `kind: 'time-limit'`, register a `DeviceActivityEvent` with `threshold = limitSeconds` instead of a daily schedule. The monitor's `eventDidReachThreshold` applies the shield. A daily reset schedule (`intervalEnd` at midnight) clears `accumulatedSeconds` in UserDefaults.
+
+### T-C14. Disable-shield deep-link handlers
+
+`apps/app/src/app/custody/shield-pray/[commitmentId].tsx` — full-screen renderer of the anchor's full text/prayer. On dismiss, no shield change (the user prayed; the shield stays).
+
+`apps/app/src/app/custody/pray-to-disable/[commitmentId].tsx` — same renderer, but the dismiss CTA is "I have prayed — lift the shield." On dismiss, calls `EmberCustodyIOS.liftFrictionLock(commitmentId, 'prayer')`. The Swift side removes the shield for the commitment for the rest of the day, logs `overrode` with `via: 'prayer'`.
+
+### T-C15. Confessio override path
+
+Edit `apps/app/src/app/confessio/index.tsx` — on a new confession record, call `EmberCustodyIOS.liftFrictionLock(commitmentId, 'confession')` for any commitment with `friction: 'confession-only'` whose user is currently in lock. Single confession lifts all such locks (no per-commitment confession state — that would be exhausting in confession prep).
+
+### T-C16. Manual QA matrix
+
+Test on a physical device (iOS 17+, then iOS 16):
+
+| Scenario | Expected |
+|---|---|
+| First-time `bound` activation | Onboarding → auth → picker → anchor → done |
+| Auth denied → recovery → re-grant | Banner clears; commitment activates |
+| Open shielded app while bound active | Prayer shield appears; both buttons render |
+| `Pray and continue blocking` | Deep-links to Ember prayer view; shield stays |
+| `wait` friction tap → countdown → confirm | Shield re-renders with countdown; after expiry, override works |
+| `prayer` friction tap | Deep-link to pray-to-disable; on prayed, shield lifts |
+| `confession-only` friction | Tap deep-links to Confessio; recording confession lifts shield |
+| App-cold-killed during bound period | DeviceActivityMonitor still wakes; shield still applies |
+| Auth revoked from Settings | App detects on foreground; banner; degrade to firm |
+| Web domain shielding (Safari) | Same shield UI |
+| Web domain shielding (Chrome iOS) | Same shield UI (Chrome iOS uses WebKit) |
+| Lent-only commitment outside Lent | No shield applied |
+| Lent-only commitment first day of Lent | Shield applies starting at season transition |
+
+### T-C17. TestFlight + App Review prep
+
+- Build production-flavor with Custody plugin enabled.
+- Upload to TestFlight; internal-test for a week.
+- App Review submission package:
+  - Privacy disclosures: Family Controls used, no data leaves device, opaque tokens
+  - Demo build credentials (none — Custody is local-only)
+  - Demo video: full Phase C flow on a real device
+  - Justification text from C12
+  - Screenshots of the prayer-shield in three states (active, countdown, confession-required)
+- Plan for at least one revision cycle.
+
+### T-C18. Journal entries
+
+Document in `docs/journal.md` everything Apple-quirky we learn during Phase C: shield title/subtitle character limits, `extensionContext.open(url:)` quirks, App Group write-coalescing behavior, simulator vs device divergences. This phase will produce more journal-worthy material than any other.
+
+---
+
+## Verification
+
+- All scenarios in T-C16 pass on a physical iPhone running the most recent two iOS major versions.
+- `drainShieldEvents` reliably round-trips events from the extension to `commitment_events`.
+- Authorization revocation and re-grant cycles cleanly without orphaned shields.
+- TestFlight build accepted; App Review approves on first or second submission.
+- DeviceActivityMonitor wakes correctly with the app cold-killed (verify via Console.app device logs).
+- `webDomainCategories.adult` actually blocks known sites in Safari and Chrome (smoke test against a known-safe sample).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Apple entitlement denied or delayed | File first (T-C1); build the rest of Phase C in parallel against a locally-entitled dev build. |
+| `react-native-device-activity` insufficient for our shield UX | Time-box discovery to the first 3 days; fork or fall back to direct Swift if needed. |
+| Shield title/subtitle character limits more restrictive than expected | The anchor pre-rendering pipeline already accommodates short forms; truncate at known-safe lengths (30 / 120 chars). |
+| App Review pushback on framing | Sharper "self-restraint" copy ready in advance; one revision cycle budgeted. |
+| Extension binary bloat (App Group + image cards) | Cards are bundled in main app and copied at build time; extensions reference paths, not duplicate assets. Verify per-target binary size stays under Apple's extension limits. |
+| Swift module signature drift between dev clients | Use the typed TS facade (`native/ios.ts`) as the single source of truth; runtime checks at module boot. |
+| User confusion about why an app is blocked when commitment is paused | The shield UI stays applied until DeviceActivityMonitor processes the change; document the lag (minutes) in onboarding copy. |
+| Deep-link to Settings → Screen Time fragile across iOS versions | Fall back to `UIApplication.openSettingsURLString` (always works); show in-app instructions as backup. |
+| Anchor cards visually mediocre at v1 | Phase E ships ~6 designed cards; v1.5 adds typeset card rendering for prayer/lectio anchors. |
+| Time-limit reset timing off by hours due to time-zone edge cases | Daily reset uses `Calendar.current.startOfDay` — covers DST and travel; document and test. |

--- a/docs/features/custody/phase-d-android-handoff.md
+++ b/docs/features/custody/phase-d-android-handoff.md
@@ -1,0 +1,230 @@
+# Phase D — Android handoff + DNS walkthrough
+
+> Scope: Android v1 closes the dignity gap with two tools — a Digital Wellbeing deep-link and a DNS-filtering setup walkthrough. No native code; no Android module.
+> Complexity: **Low.** Mostly copy, screenshots, and a couple of system-deep-link helpers.
+> Depends on: Phase A (data layer — for the bound-Android UI copy that reads commitment severity), Phase B (the surfaces we're augmenting).
+
+## Goal
+
+Until Phase F+G ship native Android shielding, Android users still need a path to actually block apps and websites today. Phase D delivers two of them, both based on the OS or a third-party service rather than Ember code:
+
+1. **Digital Wellbeing handoff** — Android's built-in app-limit and Focus Mode UI. Ember points the user at it.
+2. **DNS-based filtering setup walkthrough** — guide the user through configuring Private DNS to a Catholic-friendly resolver (Cloudflare for Families, NextDNS, OpenDNS FamilyShield).
+
+Combined, these cover ~80% of what a porn-blocking commitment needs (web targets are the bulk) and a softer fraction of app-blocking. Phase G is what closes the last gap.
+
+The Android `bound` severity stays disabled in v1 with explicit "coming v2" copy that points at these handoffs as today's tool.
+
+---
+
+## Major decisions
+
+### D1. Lead with Cloudflare for Families (1.1.1.3); offer NextDNS as the advanced option
+
+Four DNS resolvers in scope, each with trade-offs:
+
+| Resolver | Pros | Cons | When to recommend |
+|---|---|---|---|
+| **Cloudflare for Families (1.1.1.3 / family.cloudflare-dns.com)** | Free, fast, no account, strong privacy, blocks malware + adult content by default | Fixed blocklist — no user customization | **Default.** Set-it-and-forget-it for most users. |
+| **NextDNS** | Free tier 300k queries/month, custom Catholic-friendly blocklists, native filter rules, query log | Requires account, monthly cap on free tier | "Advanced" option for users who want category control beyond adult/malware. |
+| **AdGuard DNS Family** | Free, no account, blocks ads + adult | Privacy posture less battle-tested than Cloudflare | Alternative if Cloudflare is blocked in the user's network. |
+| **OpenDNS FamilyShield (208.67.222.123)** | Free, no account, well-known | IPv4 only on the public free tier; no DoT/DoH on the free tier easily | Legacy / fallback only. |
+
+**Decision: Cloudflare default, NextDNS as "advanced," AdGuard as fallback, OpenDNS not surfaced.** Three options is enough; four becomes choice paralysis. Order them in the UI by recommendation strength.
+
+### D2. Setup walkthrough format: in-app screen sequence with screenshots
+
+Three options for the walkthrough delivery:
+
+- **(a) External web link** to a guide on `dpgu.me`. Easiest to maintain; worst UX (user leaves the app, may not return).
+- **(b) Inline in-app prose** with text-only steps. Easy; relies on the user understanding Android settings paths.
+- **(c) In-app screen sequence with annotated screenshots.** More effort up front; much higher completion rate.
+
+**Decision: (c).** Each provider gets a dedicated multi-step screen. Each step has an annotated screenshot of the relevant Android screen. pt-BR localization is text-overlay only — screenshots can be shared across locales (Android setting names are already localized by the OS in the screenshot context, but our annotations are in our copy).
+
+### D3. Deep-link directly to Private DNS settings on Android 9+
+
+Android added `Settings.ACTION_PRIVATE_DNS_SETTINGS` in API 28 (Android 9). On API 28+, we can deep-link directly. On older versions, we fall back to `Settings.ACTION_WIFI_SETTINGS` and tell the user to navigate manually.
+
+**Decision: deep-link where supported; provide manual instructions otherwise.** The deep-link is best-effort — if the intent fails (unusual OEMs may not support it), fall back automatically.
+
+### D4. Detect existing VPN; warn before setup
+
+If the user already has a VPN active (NextDNS native app, Mullvad, corporate VPN), DNS-level blocking *is* in their hands — but it's also in conflict with Phase F's future bound mode. Detect on entry to the DNS walkthrough; show a one-line note:
+
+> You currently have a VPN active ({name}). DNS settings on this phone may be controlled by that app. If you're using NextDNS or AdGuard, your blocking is already set up — you can skip this walkthrough.
+
+VPN detection on Android: `ConnectivityManager.NetworkCapabilities.NET_CAPABILITY_NOT_VPN` is the canonical check. We don't get the VPN's name without `BIND_VPN_SERVICE`, which we don't request in v1. The note can say "a VPN" without naming it.
+
+### D5. Digital Wellbeing handoff: a sequence of best-effort intents
+
+Android's Digital Wellbeing app has different package names and entry points by manufacturer:
+
+| OEM | Package | Notes |
+|---|---|---|
+| Pixel / stock Android | `com.google.android.apps.wellbeing` | Standard intents work |
+| Samsung | `com.samsung.android.forest` | "Modes and Routines" / "Digital Wellbeing" |
+| Xiaomi | varies; often disabled by default | May require user to enable Digital Wellbeing first |
+| Other OEMs | varies | Fall back to Settings root |
+
+Strategy: try a sequence of intents in priority order; fall back to general Settings if all fail.
+
+```kotlin
+val intents = listOf(
+  Intent("com.google.android.apps.wellbeing.action.DASHBOARD"),
+  Intent().setComponent(ComponentName("com.google.android.apps.wellbeing", "com.google.android.apps.wellbeing.home.HomeActivity")),
+  Intent(Settings.ACTION_SETTINGS)
+)
+```
+
+The opening intent is wrapped with `try`/`catch` for `ActivityNotFoundException`. The final fallback always works.
+
+This is a small Kotlin function exposed via `expo-linking` / a tiny wrapper. We'll add a thin module-level helper rather than a full Expo Module — `expo-linking` already exposes `openURL` for `intent://` URIs, which is enough.
+
+### D6. Android-bound copy in CommitmentEditor
+
+When the user picks `bound` severity on Android in v1, the SeverityPicker shows:
+
+> **Coming on Android in v2**
+> For now this commitment will act as Firm — logged at examen and confession prep, with reminders. To enforce blocking on Android today:
+> [Set up DNS filtering →]   [Open Digital Wellbeing →]
+
+The two CTAs deep-link into the Phase D surfaces. Phase B's SeverityPicker placeholder is upgraded here with these CTAs.
+
+### D7. Per-target recommendation shape
+
+Different commitment target kinds are well or poorly served by Phase D's tools:
+
+| Target | Phase D coverage | UI message |
+|---|---|---|
+| `domain` (specific site) | Excellent via DNS | "DNS will block this exactly." |
+| `domain-list: porn` | Excellent via DNS | "Cloudflare 1.1.1.3 already blocks adult sites; NextDNS adds custom lists." |
+| `domain-list: gambling` / `social` / `news` | Good via NextDNS only | "Use NextDNS for category lists beyond adult." |
+| `android-app` (specific Android app) | Partial via Digital Wellbeing | "Digital Wellbeing can set a daily timer or pause." |
+
+CommitmentEditor's "Bound on Android" copy is target-aware — surface the relevant tool per target.
+
+---
+
+## Architecture
+
+### File layout added in Phase D
+
+```
+apps/app/src/features/custody/
+  android/
+    digitalWellbeing.ts                Best-effort intent helper
+    privateDns.ts                      Deep-link to Private DNS settings
+    vpnDetection.ts                    NetworkCapabilities check
+  components/
+    AndroidBoundCallouts.tsx           CTAs in CommitmentEditor for bound + Android
+    DnsWalkthrough.tsx                 Provider-agnostic shell
+    DnsProviderCard.tsx                Per-provider tile
+    DnsCloudflareSteps.tsx             Annotated screenshots
+    DnsNextDnsSteps.tsx
+    DnsAdGuardSteps.tsx
+    DigitalWellbeingHandoff.tsx        Explainer + handoff CTA
+  copy/
+    dns-providers.ts                   Provider metadata + copy keys
+
+apps/app/src/app/custody/
+  setup-dns.tsx                        New route: provider chooser → walkthrough
+  setup-app-limit.tsx                  New route: Digital Wellbeing handoff
+
+apps/app/assets/custody/
+  android-private-dns/                 Annotated screenshots: stock, Samsung, Xiaomi
+  digital-wellbeing/                   Screenshots for the handoff explainer
+
+apps/app/src/lib/i18n/locales/{en-US,pt-BR}.ts   [edited: custody.dns.* + custody.android.*]
+```
+
+### Walkthrough screen shape (per provider)
+
+Each provider walkthrough is 3–5 screens, each with one screenshot + ≤2 sentences of copy. Example for Cloudflare:
+
+1. **Why** — "Cloudflare for Families is free, fast, and blocks malware and adult sites by default."
+2. **Open settings** — "Open Settings → Network & Internet → Private DNS." [Open Settings →]
+3. **Choose Private DNS provider** — Annotated screenshot: tap "Private DNS provider hostname".
+4. **Enter hostname** — Annotated screenshot: type `family.cloudflare-dns.com`.
+5. **Verify** — "When you tap Save, your phone will route DNS through Cloudflare. Test it: try opening a known adult site — it should fail to load."
+
+The "Open Settings" CTA on screen 2 deep-links to `Settings.ACTION_PRIVATE_DNS_SETTINGS` per D3.
+
+---
+
+## Tasks
+
+### T-D1. DNS provider metadata + copy
+
+`apps/app/src/features/custody/copy/dns-providers.ts` — typed list of three providers with: id, name, hostname, requires-account flag, blocklist description, recommendation tier, screenshot keys.
+
+### T-D2. Deep-link helpers
+
+`apps/app/src/features/custody/android/privateDns.ts` — exports `openPrivateDnsSettings()`. Tries `Settings.ACTION_PRIVATE_DNS_SETTINGS` (`android.settings.PRIVATE_DNS_SETTINGS`), falls back to `android.settings.WIFI_SETTINGS`, then `android.settings.SETTINGS`. Returns `'opened-private-dns' | 'opened-wifi' | 'opened-root' | 'failed'` so the UI can adjust copy.
+
+`apps/app/src/features/custody/android/digitalWellbeing.ts` — exports `openDigitalWellbeing()`. Tries the intent sequence from D5; returns whether the dashboard opened or only Settings.
+
+### T-D3. VPN detection
+
+`apps/app/src/features/custody/android/vpnDetection.ts` — exports `isVpnActive(): Promise<boolean>` using `expo-network` if its NetworkType API exposes the VPN capability, otherwise a tiny native bridge that calls `ConnectivityManager.getActiveNetwork()` + `getNetworkCapabilities(...)`. Read-only; no permissions needed beyond `ACCESS_NETWORK_STATE`.
+
+### T-D4. DnsWalkthrough shell
+
+`apps/app/src/features/custody/components/DnsWalkthrough.tsx` — multi-step component with prev/next, dot indicator, and a "Open Settings" CTA on the relevant step. Provider-specific step lists are passed as a prop so the shell stays generic.
+
+### T-D5. Provider-specific step components
+
+Three components (`DnsCloudflareSteps.tsx`, `DnsNextDnsSteps.tsx`, `DnsAdGuardSteps.tsx`), each rendering 3–5 step entries. Each entry is `{ heading, body, screenshotKey, cta? }`. Screenshots are bundled in `apps/app/assets/custody/android-private-dns/`.
+
+### T-D6. DnsProviderCard + chooser screen
+
+`apps/app/src/app/custody/setup-dns.tsx` — landing screen with three `DnsProviderCard`s. Selecting one opens `DnsWalkthrough` with that provider's steps.
+
+### T-D7. Digital Wellbeing handoff screen
+
+`apps/app/src/app/custody/setup-app-limit.tsx` + `DigitalWellbeingHandoff.tsx` — explainer ("Android's Digital Wellbeing can set per-app daily limits or pause apps. Ember will sync your commitments here once Custody v2 ships on Android. Until then, set limits manually."), then a "Open Digital Wellbeing" CTA via `openDigitalWellbeing()`. If the OEM-specific deep-link fails, fall back copy explains the path manually.
+
+### T-D8. AndroidBoundCallouts in CommitmentEditor
+
+`apps/app/src/features/custody/components/AndroidBoundCallouts.tsx` — rendered inside SeverityPicker when severity = `bound` and `Platform.OS === 'android'`. Contains the two CTAs from D6 and the v2 timeline note. Target-aware (D7) — picks which CTA is primary based on the commitment's targets.
+
+### T-D9. Screenshot capture pass
+
+Capture annotated screenshots for the three priority OEMs (stock Android, Samsung One UI, Xiaomi MIUI) of the Private DNS settings flow. Save under `apps/app/assets/custody/android-private-dns/{stock,samsung,xiaomi}/{step1.png, step2.png, ...}`. Detect OEM at runtime to pick the matching screenshot set.
+
+OEM detection: `Build.MANUFACTURER` via `expo-device` is enough; not all OEMs need their own pack — Pixel/OnePlus/Nothing all share the stock screens. We ship two packs in v1 (stock, Samsung) and add Xiaomi as a v1.5 polish item if data shows the audience needs it.
+
+### T-D10. Bound-Android v2-timeline copy
+
+A single copy block reused across surfaces ("Coming to Android with Custody v2"). Single source of truth in i18n; reused by SeverityPicker, CommitmentEditor's bound section, and the home-today block when an Android user has a bound commitment that's currently inactive.
+
+### T-D11. Smoke test on three Android variants
+
+On a physical Pixel, a Samsung One UI device, and a Xiaomi MIUI device:
+
+- Setup-DNS walkthrough completes for each provider.
+- Private DNS deep-link opens the right Settings screen.
+- Digital Wellbeing handoff lands somewhere usable.
+- VPN detection correctly identifies an active NextDNS app vs no VPN.
+- Bound-Android copy renders in en-US and pt-BR.
+
+---
+
+## Verification
+
+- All three providers have working walkthroughs with annotated screenshots in en-US and pt-BR.
+- Private DNS deep-link succeeds on Pixel and Samsung; falls back gracefully on Xiaomi if Settings.ACTION_PRIVATE_DNS_SETTINGS is unavailable.
+- Digital Wellbeing handoff opens to a usable surface on each tested OEM (or the cleanest fallback).
+- VPN detection correctly reflects test states (no VPN / NextDNS active / Mullvad active).
+- A user can complete the Cloudflare setup in under 90 seconds following the walkthrough.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Provider hostnames change | Single source of truth in `dns-providers.ts`; document the update process in `docs/journal.md`. |
+| Annotated screenshots become outdated as Android evolves | Capture-pass is a deliberate v1.x maintenance task; flag obvious staleness with a "screenshots last verified Android 14" note in the doc copy. |
+| OEMs (especially Xiaomi) don't expose Digital Wellbeing | Final fallback to general Settings is always available; copy explains. |
+| Cloudflare for Families blocks something legitimate | Document that the user can switch providers from the walkthrough; provide an "Undo: switch back to default DNS" companion screen. |
+| User mistakes the walkthrough for actual blocking by Ember | Onboarding copy must be explicit: "Once you set this, your phone will block — not Ember. Removing it requires going back into Settings." |
+| Walkthrough completion drops at the manual-typing step | Offer a copy-to-clipboard tap on the hostname; consider a long-press shortcut. |

--- a/docs/features/custody/phase-e-polish.md
+++ b/docs/features/custody/phase-e-polish.md
@@ -1,0 +1,284 @@
+# Phase E — Polish, locales, docs
+
+> Scope: pt-BR catechetical vocabulary review, anchor pool curation, store listing assets, journal entries.
+> Complexity: **Low per task; the pt-BR theological review needs care** — these are the words a confessor would use, and they carry weight.
+> Depends on: Phases A–D landed. Phase E is the closing pass before v1 ships.
+
+## Goal
+
+The bones of v1 are in place after Phases A–D. Phase E is the difference between "shippable" and "delightful, accurate, and Catholic." Three pillars:
+
+1. **Voice** — pt-BR theological vocabulary correct in every surface; en-US copy reviewed for tone (custody, mortification, *firm purpose of amendment* are all theological terms; mishandling them is worse than not having them).
+2. **Anchor content** — a curated pool of saint quotes, Scripture aspirations, and sacred-art cards that make the prayer-shield genuinely formative on first launch.
+3. **Store and docs** — App Store / Play Store listings, screenshots, privacy disclosures, and the journal entries documenting what we learned.
+
+After Phase E, Custody v1 is ready to ship.
+
+---
+
+## Major decisions
+
+### E1. pt-BR review without a Brazilian reviewer
+
+This is a solo project. There's no pt-BR catechetical reviewer on the team. Three options:
+
+- **(a) Self-translate using authoritative sources.** Cross-reference the *Catecismo da Igreja Católica* (CNBB edition), the CNBB's published prayer translations, and the *Liturgia das Horas* official translations. Slow but correct.
+- **(b) Hire a one-time freelance reviewer.** A canonist or seminarian via a Catholic freelance network. Fastest path to confidence; modest cost.
+- **(c) Open a public review thread.** Post the glossary on the project's GitHub and ask Brazilian Catholic users to review.
+
+**Decision: (a) for v1, (b) before public release.** Build the glossary against authoritative sources; ship to TestFlight and a small pt-BR alpha group with the glossary visible; commission a one-time review before public release. (c) introduces variance and timing dependency that doesn't fit a launch.
+
+The glossary is checked into `docs/features/custody/i18n-glossary.md` and referenced from every PR that touches `custody.*` keys.
+
+### E2. Saint-quote pool: ~30 starters, theological breadth
+
+Six is the v1.x starter count. Expand to ~30 in Phase E to give variety and avoid first-launch déjà vu. Sources:
+
+- **Scripture aspirations** (Psalms 23, 33, 50; Phil 4:8; Jn 3:30; Mt 5:8) — short, memorizable
+- **Augustine** (Confessions, on disordered loves)
+- **Francis de Sales** (*Introduction to the Devout Life*, custody of the eyes, custody of the heart)
+- **Imitation of Christ** (book 1, on contempt of the world)
+- **John Bosco** (on sensuality and innocence)
+- **Josemaría Escrivá** (*The Way*, on mortification)
+- **Catechism of the Catholic Church** §§2517–2520 (purity of heart)
+- **Liturgical antiphons** (Ash Wednesday, Septuagesima)
+
+Each entry: `{ id, en, pt, attribution, sourceRef }`. Bilingual at authoring time — no machine translation. Stored in `apps/app/src/features/custody/anchors/quotes.ts`.
+
+The quote pool seeds two surfaces: ShieldAnchorPicker's "Curated text" tab, and a daily auto-rotating default for users who don't pick a custom anchor.
+
+### E3. Sacred-art cards: ~6 starters, public domain or licensed
+
+Anchor cards are images that fit the iOS shield's icon slot (~120×120 displayed, render at 360×360 PNG for retina). Six starters:
+
+| Card | Source | License |
+|---|---|---|
+| Sacred Heart of Jesus | Pompeo Batoni, 1740 (Public domain) | PD |
+| Christ Crucified | Velázquez, *Christ Crucified* 1632 (Public domain) | PD |
+| Our Lady of Sorrows | Carlo Dolci, *Mater Dolorosa* (Public domain) | PD |
+| Christ in Gethsemane | Heinrich Hofmann, *Christ in Gethsemane* (Public domain status varies; verify) | PD or licensed |
+| St. Michael the Archangel | Guido Reni, *Archangel Michael* 1635 (Public domain) | PD |
+| The Annunciation | Fra Angelico, *Annunciation* (Public domain) | PD |
+
+All cropped to a square aspect ratio, color-graded for visibility against the shield's background blur, stored in `apps/app/src/features/custody/anchors/cards/`. Licensing verification is a real task — Hofmann in particular has murky US/EU PD status; either confirm PD or substitute a clearly-PD piece.
+
+### E4. Default anchor for fresh commitments
+
+When a user creates a commitment without explicitly picking an anchor, what shows on the shield?
+
+Three options:
+
+- **(a) Empty / generic** — Apple's default shield, or a plain "Custody" card. Boring; loses the product.
+- **(b) Tier-default** — `bound` commitments get the Sacred Heart card + a default verse; `firm` shows a plain card. Predictable.
+- **(c) Daily-rotating** — pick a different starter quote each day from the pool, weighted toward the liturgical season. Always fresh.
+
+**Decision: (c).** The cost is one extra rotation table; the benefit is that a user who never picks a custom anchor still gets ~30 different shields over a month. Liturgical-season weighting comes from the existing `LiturgicalSeason` resolver: in Lent, weight Augustine and Imitation; in Advent, weight Annunciation and de Sales; in Ordinary Time, weight Scripture aspirations.
+
+The rotation is computed in the main app on snapshot sync — the iOS extension doesn't pick at trigger time (no network, deterministic-only). On each daily sync (or on app foreground if more than 24h since last sync), recompute the day's default anchor for any commitment without a custom anchor.
+
+### E5. Anchor refresh affordance
+
+When a prayer or lectio anchor's underlying corpus text changes (e.g., translation fix), the inlined text in the commitment goes stale. Phase A documented the trade-off; Phase E adds the affordance.
+
+UI: in CommitmentEditor's anchor row, when the inlined text differs from the current resolver output, show a one-line note "Prayer text updated upstream — [Refresh]." Tap re-renders against the current corpus and saves.
+
+Detection: store the prayer's `revisionId` (a hash of the resolver output at save time) alongside the rendered text. On open, compare to current. If different, surface the affordance. Cheap.
+
+### E6. Store listings: explicit Catholic framing
+
+App Store and Play Store listings for Ember already exist. Phase E adds Custody to the feature list with explicit Catholic framing:
+
+> **Custody** — Build and keep a rule of life. Declare resolutions to abstain from pornographic websites, social-media doomscrolling, or any specific app. On iOS, the OS shields blocked apps with a prayer of your choice — turning each moment of temptation into a moment of grace. Single-user only: no parents, no remote control.
+
+This copy is *deliberately* explicit about porn-blocking — the audience this serves should find it without ambiguity. App Review may push back on the specificity; if so, soften "pornographic websites" to "adult content" but keep the rest.
+
+### E7. Privacy disclosure: foreground
+
+Both stores require privacy disclosures. Custody adds:
+
+- **Data not collected** (the truthful answer). Custody data — commitments, falls, sessions, opaque tokens, lock states — is local-only. No cloud sync, no analytics on Custody usage.
+- **Permissions** (iOS): Family Controls, App Group, deep-linking to Settings.
+- **Permissions** (Android, v1): None beyond what Phase D needs — a deep-link to Private DNS Settings does not require any new manifest permission.
+
+The privacy listing is more important than usual because Custody is sensitive — porn-blocking implies the user has admitted that need, and that admission must never become product surface for a second party.
+
+### E8. Journal entries: capture institutional knowledge
+
+Custody is the project's first native module + first Apple entitlement + first non-trivial cross-platform asymmetry. Future devs (including future-you) will retread this ground if it isn't documented.
+
+Required `docs/journal.md` entries by end of Phase E:
+
+- **2026-XX — Family Controls entitlement, Individual mode**: what we filed, the demo video URL, Apple's response, screenshots of the approval email.
+- **2026-XX — kingstinct/react-native-device-activity in Expo**: how we wired it, what we forked or extended, gotchas.
+- **2026-XX — Shield title/subtitle character limits**: actual measured limits per device, not Apple's documented limits.
+- **2026-XX — App Group write coalescing**: the hard-won knowledge of when UserDefaults changes propagate to extensions.
+- **2026-XX — Schedule flattening**: when `ScheduleRule` ↔ `DeviceActivitySchedule` translation hit edge cases.
+- **2026-XX — pt-BR catechetical glossary**: the chosen translations and why.
+- **2026-XX — DNS provider landscape, May 2026**: state of free DNS providers; reasoning for Cloudflare default.
+- **2026-XX — Custody and the Plan of Life integration**: how falls roll into the fidelity wall, what a fall counts as.
+
+Each entry is short (≤200 words) but specific. The journal is what saves the next person from the failure paths we already mapped.
+
+### E9. Empty-state copy as catechesis
+
+The Custody empty state is a teaching moment. v1 first-launch state shows:
+
+> **A rule of life is not only what you do.**
+> It is also what you refuse.
+> Custody helps you keep that "no" — by reminding you, by logging your falls for examen, and (on iOS) by your phone itself.
+>
+> *"Custodi linguam tuam a malo, et labia tua ne loquantur dolum." — Salmo 33:14*
+>
+> [ Begin your first commitment ]
+
+This is in the design system already (Tamagui empty-state component); Phase E writes the copy. pt-BR uses the Vulgate Latin verbatim (Latin retains for both locales) plus a translated paraphrase below.
+
+---
+
+## Architecture
+
+### File layout added in Phase E
+
+```
+apps/app/src/features/custody/
+  anchors/
+    quotes.ts                                30 bilingual entries
+    cards/                                   6 PNGs + manifest
+    rotation.ts                              Daily-default picker
+    refresh.ts                               Detect stale rendered text
+  empty-state/
+    EmptyState.tsx                           Catechesis empty state
+
+apps/app/src/lib/i18n/locales/{en-US,pt-BR}.ts   [final pass: every custody.* key reviewed]
+
+docs/features/custody/
+  i18n-glossary.md                           pt-BR theological vocabulary glossary
+
+docs/journal.md                              [edited: ~8 new entries]
+
+apps/app/store-listings/
+  app-store/
+    ember-en.txt                             Custody section added
+    ember-pt-BR.txt
+    screenshots/custody-*.png
+  play-store/
+    ember-en.txt
+    ember-pt-BR.txt
+    screenshots/custody-*.png
+```
+
+### pt-BR glossary entries (excerpt)
+
+```
+custody (of the eyes/senses)        custódia dos olhos / dos sentidos
+firm purpose of amendment           firme propósito de emenda
+mortification                       mortificação
+ascetical resolution                propósito ascético / propósito firme
+chastity                            castidade
+penitence                           penitência
+self-restraint                      domínio próprio / autodomínio
+contrition                          contrição
+fall (moral)                        queda
+spiritual combat                    combate espiritual
+abstinence                          abstinência
+custody session (focus block)       sessão de recolhimento
+recollection                        recolhimento
+devout life                         vida devota
+purity of heart                     pureza do coração
+```
+
+The glossary is mandatory reference for any PR touching pt-BR copy. Source citations point at the CNBB Catechism, *Imitação de Cristo*, and the official *Liturgia das Horas*.
+
+---
+
+## Tasks
+
+### T-E1. Author the pt-BR theological glossary
+
+`docs/features/custody/i18n-glossary.md`. Source-cited entries for all theological terms used in `custody.*` i18n keys. Cross-reference CNBB Catechism, the *Liturgia das Horas*, and the official Catholic Bible Brazilian-Portuguese translations. Mark each entry with the source in a footnote.
+
+### T-E2. pt-BR copy review pass
+
+Read every `custody.*` key in `pt-BR.ts` against the glossary. Where a term diverges, fix. Where a term has no glossary entry, add one. Where copy uses a phrase the glossary doesn't cover (e.g., a tooltip), check the surrounding theological context for accuracy. This pass is the bulk of Phase E's effort.
+
+### T-E3. Curate the saint-quote pool
+
+`apps/app/src/features/custody/anchors/quotes.ts`. Thirty bilingual entries with source attribution. Each entry: `{ id, en, pt, attribution, sourceRef, season?: LiturgicalSeason }`. The optional `season` field weights the daily-default rotation (E4).
+
+### T-E4. License-verify and bundle the six sacred-art cards
+
+For each card from E3:
+
+1. Verify public-domain status (or obtain license).
+2. Crop to square aspect ratio.
+3. Render at 360×360 PNG (retina-ready) and 120×120 (smaller variant for memory).
+4. Add to `apps/app/src/features/custody/anchors/cards/` with a manifest `cards.ts` (id, displayName, attribution, paths).
+
+If a card's PD status is uncertain (Hofmann's *Christ in Gethsemane*), substitute a verified-PD alternative.
+
+### T-E5. Daily-default anchor rotation
+
+`apps/app/src/features/custody/anchors/rotation.ts`. Function `pickDailyDefaultAnchor(seed: { date: Date; season?: LiturgicalSeason; commitmentId: string }): Anchor`. Deterministic given the seed (so the iOS extension and main app converge). Weighted by season; salted by commitmentId so two commitments don't both show the same daily default.
+
+Hook into the snapshot sync (Phase C) — recompute on each sync for any commitment without a user-set anchor.
+
+### T-E6. Anchor refresh affordance
+
+`apps/app/src/features/custody/anchors/refresh.ts`. Compare a saved anchor's `revisionId` to the current resolver output. If stale, surface a `<RefreshAnchorButton commitmentId>` in CommitmentEditor's anchor row. On tap: re-render and save.
+
+### T-E7. Empty-state component
+
+`apps/app/src/features/custody/empty-state/EmptyState.tsx`. Catechesis copy from E9, Tamagui-styled, en-US and pt-BR. Mounted in `apps/app/src/app/custody/index.tsx` when commitment list is empty. Include the Latin verse + translated paraphrase.
+
+### T-E8. App Store / Play Store listings update
+
+Add the Custody copy block (E6) to both store listings, both locales. Capture seven screenshots:
+
+1. Commitments list with three example commitments
+2. CommitmentEditor with the severity picker visible
+3. The prayer-shield (real shield captured on a physical device)
+4. Custody session running with an anchor
+5. Examen with falls surfaced
+6. Confessio with the falls log
+7. Empty state (catechesis)
+
+Save under `apps/app/store-listings/{app-store,play-store}/screenshots/custody-*.png`.
+
+### T-E9. Privacy listing pass
+
+For both stores, update the privacy disclosures per E7. The Apple App Store privacy nutrition label needs the Family Controls usage explicitly marked; the Play Store needs the matching declaration. Cross-reference the actual data handling against what we've written — the disclosures must be true, not just plausible.
+
+### T-E10. Journal entries
+
+Write the eight entries from E8 in `docs/journal.md`. Reference the relevant phase docs. Each entry is concrete (file paths, decision rationale, what surprised us); none are abstract reflections.
+
+### T-E11. Smoke test the polished experience
+
+End-to-end on a physical iPhone and a physical Android device:
+
+- First launch shows the catechesis empty state in the active locale.
+- Creating a commitment without picking an anchor shows a daily-rotating default that matches season weighting.
+- Updating a prayer in the corpus surfaces the refresh affordance in the editor.
+- pt-BR mode renders every key with a glossary-correct translation.
+- Empty quote/card pools render fallback copy gracefully.
+
+---
+
+## Verification
+
+- pt-BR glossary covers every theological term in the i18n keys.
+- All six anchor cards verified PD or licensed.
+- Daily-default rotation produces the same output on iOS extension and main app for the same seed.
+- Anchor refresh surfaces correctly when a corpus prayer is edited and re-pulled.
+- Store listings approved (App Store + Play Store) on first or second submission.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Self-authored pt-BR review misses a theological subtlety | Mark v1 release as "translation review pending"; commission the freelance review before stable v1.0 announcement; fix in a fast-follow patch. |
+| Sacred-art card licensing incorrectly verified | Substitute conservative PD pieces if any source is uncertain; document the verification process in `docs/journal.md`. |
+| App Store rejection on Custody copy specificity ("pornographic websites") | Soften to "adult content" if pushed; the underlying functionality is unchanged. |
+| Apple privacy nutrition label flagged for Family Controls usage | The pre-prepared justification (Phase C) covers this; resubmit with refined disclosure. |
+| Daily-rotation drift between extension and main app | Deterministic seed function; unit-test parity between the JS implementation and a Swift port. |
+| Glossary terms drift from canonical CNBB usage over time | Glossary linked from PR template; periodic review documented in `docs/journal.md`. |

--- a/docs/features/custody/phase-f-android-vpn.md
+++ b/docs/features/custody/phase-f-android-vpn.md
@@ -1,0 +1,432 @@
+# Phase F — Android VPN + DNS
+
+> Scope: Android-side enforcement of *web* targets via a local `VpnService` that intercepts DNS. App-target enforcement is Phase G; this phase only handles domains and domain-lists.
+> Complexity: **Moderate–High.** First Kotlin native module in the project. The VPN-service shape is well-understood (DNSNet, AdGuard, NextDNS all do it) but doing it cleanly inside an Expo Module — with the Custody-specific snapshot sync, friction states, and the Phase G coexistence story — is the hard part.
+> Depends on: Phases A–E shipped (v1). Custody v2 milestone opens with this phase.
+
+## Goal
+
+After Phase F, an Android user with a `bound` commitment that targets domains or a curated domain-list (porn/gambling/social/news) actually has those domains blocked at the OS level. Browsers — Chrome, Firefox, Samsung Internet, anything — fail to resolve the blocked hosts and show a network error. Web targets are now first-class on Android.
+
+App-target enforcement (Instagram by package name) waits for Phase G; this phase explicitly does not shield apps. The two halves combine in v2.0; v1.x ships F+G together.
+
+---
+
+## Background: how Android local-VPN filters work
+
+Android's `VpnService` lets a single app become the system's VPN. Once active:
+
+- The OS routes all device IP traffic through a `tun` interface owned by our service.
+- We read raw IP packets from the `tun` file descriptor.
+- We choose what to do with each: forward to the real network (transparent), drop, or rewrite.
+- Outbound DNS is UDP/53 (and TCP/53). We inspect those packets, parse the DNS question, and either drop / NXDOMAIN-respond (block) or forward to an upstream resolver (allow).
+- Non-DNS traffic is forwarded transparently — we are not a content firewall, only a DNS filter.
+
+Reference implementations: [DNSNet](https://github.com/t895/DNSNet), [AdGuard's Android client](https://github.com/AdguardTeam/AdguardForAndroid), Blokada. Our shape is closest to DNSNet's "DNS-only mode."
+
+What this gives us:
+
+- Web domain blocking that works in every browser, including Chrome's DoH-disabled mode.
+- Coverage across the entire device (system apps, embedded WebViews, server pings).
+
+What it does **not** give us:
+
+- App shielding (Phase G).
+- Robustness against browsers using DNS-over-HTTPS (Chrome, Firefox, Brave by default). We address this in F8.
+- Coverage when the user's own NextDNS or Mullvad app is active (single-VPN-slot conflict; F9).
+
+---
+
+## Major decisions
+
+### F1. DNS-only architecture, not packet inspection
+
+Two architectural extremes:
+
+- **(a) DNS-only**: parse only UDP/TCP DNS traffic; transparently forward everything else. What DNSNet does. Lightweight, low battery, easy to reason about.
+- **(b) Full packet inspection**: read every packet, do SNI sniffing on TLS, block by hostname even for IPs. What AdGuard's pro tier does. Heavy, complex, high battery cost, brittle against ECH (Encrypted Client Hello).
+
+**Decision: (a).** Custody is an ascetical aid, not enterprise content filtering. DNS-only catches ~95% of the web traffic we care about (a porn site that the user can navigate to by IP is not realistic in practice). The simplicity buys us reliability and battery.
+
+Future-proofing: the interface boundary leaves room for (b) later — `EmberVpnPipeline` is the abstraction; v1 has only `DnsFilter` plugged in.
+
+### F2. Upstream resolver: configurable, default to current Private DNS or 1.1.1.1
+
+When a query is allowed, we forward it. To where?
+
+Three options:
+
+- **(a) System resolver** — read the OS's current DNS via `LinkProperties.dnsServers`. Uses whatever the user already configured (e.g., Cloudflare for Families from Phase D, or their carrier).
+- **(b) Hardcoded 1.1.1.1** — predictable; ignores user setup.
+- **(c) User-configurable** — Custody settings expose an upstream resolver picker.
+
+**Decision: (a) with (c) as a settings escape hatch.** Default behavior respects the user's existing setup — if they followed Phase D's walkthrough and enabled Cloudflare for Families, queries we *allow* still go through Cloudflare's adult-blocking, providing two layers of defense. If the system resolver is unavailable (e.g., empty `LinkProperties`), fall back to `1.1.1.1`.
+
+Settings exposes "Upstream DNS" (advanced) for users who want to override.
+
+### F3. DoH/DoT bypass: best-effort, document the limit
+
+Modern browsers ship DNS-over-HTTPS (DoH) on by default — Chrome, Firefox, Brave. When DoH is in use, our DNS interception sees nothing (the queries go over HTTPS to a public DoH endpoint, which our VPN forwards as opaque TCP/443 traffic).
+
+Three approaches:
+
+- **(a) Block known DoH endpoints by IP.** Maintain a list of public DoH provider IPs (`1.1.1.1:443`, `8.8.8.8:443`, `8.8.4.4:443`, etc.) and reject TCP/443 SYNs to them. Forces browsers to fall back to system DNS (which we control).
+- **(b) Detect via SNI**. Read TLS ClientHello SNI; reject `cloudflare-dns.com`, `dns.google`, `mozilla.cloudflare-dns.com`, etc. Stops working when ECH lands broadly.
+- **(c) Document the limit; tell the user how to disable DoH in their browser.**
+
+**Decision: (a) for known providers + (c) for the limit.** Maintain a DoH-IP blocklist as a separate JSON file shipped with the app; reject SYNs to those IP+port combinations during the VPN's packet inspection (one lookup per outbound TCP SYN — manageable). This stops the vast majority of DoH browser users without false-flagging legitimate traffic. Document the residual gap (newer or self-hosted DoH endpoints) in onboarding copy and offer per-browser instructions to disable DoH.
+
+ECH (Encrypted Client Hello) when widely deployed will eventually break (b); (a) survives because it operates on IPs, not hostnames.
+
+The DoH-blocking is a setting the user can toggle; defaults to **on** for `bound` commitments with web targets.
+
+### F4. Blocklist data structure: domain trie
+
+Per-commitment target lists join into a single global "blocked domains" set the VPN service consults on every DNS query. Naive `HashSet<String>` works for ~10k entries; goes south at 100k+ once we add curated lists.
+
+**Decision: a domain trie keyed by reversed labels.** `instagram.com` is stored as `com → instagram → ★`. A query for `cdn.instagram.com` reverses to `com.instagram.cdn`, walks the trie, and matches at `com → instagram → ★`. Wildcards (`*.instagram.com`) are first-class; subdomain matches are the common case for porn-list curation.
+
+Implementation: `DomainTrie.kt` — single class, ~60 lines, no external dependency. Rebuilt on every snapshot sync from JS (Phase A's repository).
+
+### F5. Single-VPN-slot UX: detect, explain, never silently take
+
+Android allows exactly one active VPN at a time. If the user already has NextDNS, Mullvad, or a corporate VPN active, activating Custody's VPN displaces theirs.
+
+**Decision: detect on every activation attempt; require explicit user choice.**
+
+```
+User toggles bound on a web-target commitment for the first time:
+1. VpnService.prepare(ctx) returns null if we already have permission, else an Intent.
+2. We additionally check ConnectivityManager for an active VPN.
+3. If active VPN belongs to another app:
+   - Block activation
+   - Show: "Custody can't run alongside another VPN. {OtherApp} is currently active.
+     To use Custody, disable it first. Or keep {OtherApp} and configure your blocking there."
+   - Two CTAs: "Open Settings → VPN" and "Cancel"
+4. If no other VPN: present the OS VPN-permission dialog.
+```
+
+We never silently take the slot. Even if the user allows the system dialog, our service refuses to start until the conflict is explicitly resolved.
+
+### F6. Snapshot sync: mirror Phase C, store under `SharedPreferences`
+
+Phase C established the pattern: main app keeps a snapshot of all commitments in shared storage, native side reads it on demand, drains an event queue back. Phase F reuses the pattern with Android's `SharedPreferences` and a JSON serialization:
+
+| Key | Type | Written by | Read by |
+|---|---|---|---|
+| `custody.commitments.json` | JSON `CommitmentSnapshot[]` | main app (JS) | VPN service |
+| `custody.blockedDomains.json` | JSON `string[]` (flattened from snapshots) | main app | VPN service |
+| `custody.upstreamDns` | string | main app (settings) | VPN service |
+| `custody.dohBlock` | boolean | main app (settings) | VPN service |
+| `custody.eventQueue.json` | JSON `BlockEvent[]` | VPN service | main app (drains on foreground) |
+
+The VPN service reads on every commitment-snapshot change (broadcast intent from the JS side) and rebuilds the trie. The flattened `blockedDomains` is computed in JS so the native side doesn't have to know about Target shapes — it gets a flat list and a trie to build.
+
+### F7. Bound severity per-target: web targets active in Phase F, app targets still pending
+
+Multi-target commitments (e.g., "no Instagram + no instagram.com") are normal. After Phase F, only the *web* targets of those commitments are enforced; the *app* targets remain "coming v2" (Phase G).
+
+The CommitmentEditor surfaces this clearly: per-target status row showing "Active" for web targets and "Coming when Phase G ships" for app targets, both visible. The user always knows what's on and what's off.
+
+### F8. Logging: minimal, never the queries themselves
+
+A web blocker is in a unique privacy position: the queries it sees would be a complete browsing history if logged. The VPN service:
+
+- Logs **counts** per blocked domain per day (for the falls log)
+- Logs **timestamps and commitment IDs** for blocked queries
+- Never logs **the queries themselves** beyond hashed identifiers
+- Never logs **allowed queries**
+- Has no analytics, no telemetry, no remote logging
+
+The `BlockEvent` posted to the queue contains: `{ commitmentId, occurredAt, targetKind: 'domain'|'domain-list', targetId: string }`. The actual blocked hostname is *not* in the event — only the matching target. That's enough to mark a fall in commitment_events without recording browsing.
+
+### F9. Performance budget
+
+A device-wide VPN sits in the hot path of every network operation. Acceptable overhead:
+
+- DNS: <2ms per query (trie lookup is O(labels) — negligible). UDP forwarding socket.
+- Non-DNS forwarding: <1ms per packet (the OS still does most of the work; we just relay the buffer).
+- Battery: <1% additional drain over 24h with normal usage. Measured against a baseline of no VPN.
+
+Budget is enforced via a smoke-test pass before merge: a benchmark script runs network operations and measures both metrics. Any regression > 10% is a blocker.
+
+### F10. Restart resilience
+
+The VPN service must:
+
+- Survive the OS killing it (use `START_STICKY`).
+- Restart automatically when the user reboots, if `bound` web commitments exist (boot receiver, conditioned on a snapshot saying so).
+- Reconnect when the network changes (Wi-Fi to mobile, etc.).
+- Stop cleanly when the last bound web commitment is paused or archived.
+
+A foreground service notification (LOW importance) advertises that Custody is active; tapping it opens the Custody overview. This is required by Android 14+ and useful UX.
+
+---
+
+## Architecture
+
+### File layout added in Phase F
+
+```
+apps/app/modules/ember-custody-android/
+  expo-module.config.json
+  index.ts                                   JS bridge type declarations
+  android/
+    src/main/
+      java/me/dpgu/ember/custody/
+        EmberCustodyModule.kt                Main module: snapshot sync, start/stop VPN
+        vpn/
+          EmberVpnService.kt                 VpnService implementation
+          DnsFilter.kt                       DNS packet inspection + decision
+          DnsResolver.kt                     UDP forwarding to upstream
+          DomainTrie.kt                      Reversed-label trie
+          DohBlocker.kt                      Known-DoH-IP rejection
+          PipelineRouter.kt                  Routes packets between filters
+        snapshots/
+          CommitmentSnapshot.kt              Codable matching iOS shape
+          AppGroupKeys.kt                    SharedPreferences key constants
+          SnapshotStore.kt                   Read/write SharedPreferences
+        events/
+          BlockEvent.kt
+          EventQueue.kt
+        boot/
+          BootReceiver.kt                    Re-arm on device boot
+        settings/
+          UpstreamDnsResolver.kt             Read system DNS or configured upstream
+      AndroidManifest.xml                    Service declaration, BIND_VPN_SERVICE perm
+      res/values/strings.xml                 Foreground notification copy
+  android/build.gradle                       Kotlin, Compose, no third-party deps for VPN
+
+apps/app/src/features/custody/
+  android/
+    vpnControl.ts                            JS facade for the module
+    blocklists/
+      doh-providers.json                     Known DoH IPs to block
+  components/
+    AppTargetPickerAndroid.tsx               Phase G placeholder; AppPicker wired in G
+    BoundActivationGuardAndroid.tsx          VPN-conflict / permission flow
+    BoundCommitmentTargetStatus.tsx          Per-target Active / Coming v2 row
+
+apps/app/app.config.ts                       [edited: ember-custody-android plugin]
+apps/app/eas.json                            [edited: Android variant uses custody plugin]
+```
+
+### JS bridge surface
+
+```typescript
+// apps/app/modules/ember-custody-android/index.ts
+export const EmberCustodyAndroid: {
+  isSupported(): boolean
+  hasVpnPermission(): Promise<boolean>
+  hasVpnConflict(): Promise<{ hasConflict: boolean; conflictingApp?: string }>
+  requestVpnPermission(): Promise<'granted' | 'denied' | 'cancelled'>
+  syncSnapshots(snapshots: CommitmentSnapshot[]): Promise<void>
+  startVpn(): Promise<void>
+  stopVpn(): Promise<void>
+  getVpnStatus(): Promise<'inactive' | 'active' | 'starting' | 'error'>
+  drainEvents(): Promise<BlockEvent[]>
+  setUpstreamDns(value: 'system' | string): Promise<void>
+  setDohBlock(enabled: boolean): Promise<void>
+}
+```
+
+### Packet flow inside `EmberVpnService`
+
+```
+[tun read]
+   ↓
+[parse IP packet]
+   ↓
+   ├── UDP/53 or TCP/53 → DnsFilter
+   │      ├── parse DNS query; extract hostname
+   │      ├── DomainTrie.contains(hostname) → block: synthesize NXDOMAIN, write back to tun
+   │      └── allow: forward to UpstreamDnsResolver, write response back to tun
+   ↓
+   ├── TCP SYN to known DoH IP+port → drop (if dohBlock enabled)
+   ↓
+   └── any other → forward transparently
+```
+
+### Snapshot sync flow
+
+```
+JS: useUpdateCommitment mutation
+   → repo.updateCommitment(...)
+   → buildSnapshots(allActiveBoundCommitmentsWithWebTargets)
+   → EmberCustodyAndroid.syncSnapshots(snapshots)
+       → SnapshotStore.write(snapshots)
+       → broadcast intent ACTION_CUSTODY_SNAPSHOT_UPDATED
+           → EmberVpnService catches intent
+           → rebuild DomainTrie from snapshots
+           → no VPN restart required
+```
+
+---
+
+## Tasks
+
+### T-F1. Kotlin Expo module skeleton
+
+`apps/app/modules/ember-custody-android/`. Create `expo-module.config.json` and the Gradle setup. The module exports `EmberCustodyModule.kt` with `isSupported`, `hasVpnPermission`, `requestVpnPermission`, `getVpnStatus` first — these are the simplest entry points that don't require the VPN service running. Validate the JS bridge end-to-end before going deeper.
+
+### T-F2. AndroidManifest declarations
+
+Declare `EmberVpnService`:
+
+```xml
+<service
+    android:name=".vpn.EmberVpnService"
+    android:permission="android.permission.BIND_VPN_SERVICE"
+    android:exported="false"
+    android:foregroundServiceType="systemExempted">  <!-- Phase G upgrades to special-use -->
+  <intent-filter>
+    <action android:name="android.net.VpnService" />
+  </intent-filter>
+</service>
+```
+
+Plus permissions: `BIND_VPN_SERVICE`, `FOREGROUND_SERVICE`, `POST_NOTIFICATIONS`, `RECEIVE_BOOT_COMPLETED`, `ACCESS_NETWORK_STATE`. The `foregroundServiceType` will switch to `specialUse` in Phase G when we add the monitor service alongside.
+
+### T-F3. `DomainTrie` implementation
+
+`vpn/DomainTrie.kt`. Reversed-label trie with `★` terminal marker for "any subdomain matches." API: `add(domain: String, wildcard: Boolean)`, `contains(host: String): Boolean`, `clear()`, `rebuildFrom(domains: Iterable<String>)`. Unit tests covering exact match, wildcard subdomains, mixed-case, IDN, and edge cases (empty hostname, trailing dot, root).
+
+### T-F4. `DnsFilter`
+
+`vpn/DnsFilter.kt`. Parses DNS queries from raw UDP packets per RFC 1035 (read header, name decompression, query type). Calls `DomainTrie.contains`. On block: synthesize an NXDOMAIN response, write back to the tun. On allow: hand off to `DnsResolver`. Supports A and AAAA; ignores TXT/MX/SRV blocking (forwards transparently — those don't carry web traffic).
+
+TCP/53 (used by some clients for large responses) is handled too: same parser, different framing.
+
+### T-F5. `DnsResolver` (upstream forwarder)
+
+`vpn/DnsResolver.kt`. Holds a UDP socket pool to the upstream resolver (default: system DNS via `LinkProperties.dnsServers[0]`, fallback `1.1.1.1`). Forwards parsed queries; receives responses; writes back to tun with the appropriate framing. Times out at 2s and synthesizes SERVFAIL.
+
+`UpstreamDnsResolver.kt` provides the upstream IP — reads `LinkProperties` if `setting=='system'`, else parses the configured upstream string.
+
+### T-F6. `EmberVpnService` skeleton
+
+`vpn/EmberVpnService.kt`. `extends VpnService`. On `onStartCommand`:
+
+- Build the tun interface: `Builder().addAddress("10.99.99.1", 30).addRoute("0.0.0.0", 0).addRoute("::", 0).addDnsServer("10.99.99.2").establish()`
+- Start a foreground notification ("Custody is active").
+- Spawn a thread that reads the tun fd in a loop, classifies packets, dispatches to `DnsFilter` / `DohBlocker` / transparent-forward.
+- Return `START_STICKY`.
+
+On `onDestroy`: close tun, stop foreground.
+
+### T-F7. `DohBlocker` (Phase F8)
+
+`vpn/DohBlocker.kt`. On every outbound TCP SYN: parse destination IP+port; check against the bundled `doh-providers.json` list; drop if matched. Reads `custody.dohBlock` setting from SharedPreferences on init and on broadcast.
+
+### T-F8. Snapshot store + broadcast intent
+
+`snapshots/SnapshotStore.kt`. Reads/writes JSON to SharedPreferences. `EmberCustodyModule.kt` exposes `syncSnapshots(...)` to JS, which serializes and writes; on success, sends an `Intent(ACTION_CUSTODY_SNAPSHOT_UPDATED)` ordered broadcast caught by the VPN service (when running) to rebuild its trie.
+
+The flattening from `CommitmentSnapshot[]` to `domains[]` happens in JS:
+
+```typescript
+function flattenWebTargets(snapshots: CommitmentSnapshot[]): string[] {
+  return snapshots.flatMap(s =>
+    s.targets.flatMap(t => {
+      if (t.kind === 'domain') return [t.domain]
+      if (t.kind === 'domain-list') return BLOCKLISTS[t.listKey] // imported from bundled JSON
+      return [] // ios-* and android-app skipped here; android-app handled in Phase G
+    })
+  )
+}
+```
+
+### T-F9. Block event recording
+
+`events/EventQueue.kt`. Append-only file in app private storage. `DnsFilter` calls `EventQueue.append(BlockEvent(...))` on each block. `EmberCustodyModule.drainEvents()` reads the file, returns the events to JS, truncates the file. JS writes the events into `commitment_events` via the repo.
+
+Events do **not** include the blocked hostname (F8). They include: `commitmentId`, `targetKind`, `targetId`, `occurredAt`. That's enough to log a `fell` event with metadata sufficient for examen.
+
+### T-F10. VPN-conflict guard UI
+
+`apps/app/src/features/custody/components/BoundActivationGuardAndroid.tsx`. On entry to bound activation flow on Android:
+
+1. Calls `hasVpnConflict()`.
+2. If conflict: shows the explainer + two CTAs from F5.
+3. If no conflict: calls `requestVpnPermission()` which presents the OS VPN dialog.
+4. On permission granted + no conflict: calls `startVpn()`.
+
+### T-F11. Per-target status row in CommitmentEditor
+
+`BoundCommitmentTargetStatus.tsx`. Renders one row per target: target description, status indicator. After Phase F: web targets show "Active on Android" with a green dot; app targets show "Coming with Phase G" with a gray dot. After Phase G ships, this component reads both and renders both.
+
+### T-F12. Boot receiver
+
+`boot/BootReceiver.kt`. On `BOOT_COMPLETED`, reads SnapshotStore. If any active bound commitment with web targets exists, starts the VPN service. Avoids cold-start flicker if the user reboots their phone with active commitments.
+
+### T-F13. Settings UI for upstream DNS and DoH blocking
+
+A new `Settings → Custody → Advanced` surface in the JS app exposes:
+
+- Upstream DNS (default "Use system DNS"; advanced text field for custom)
+- Block known DoH endpoints (default on)
+
+Saves call `setUpstreamDns` / `setDohBlock`. The VPN service picks up changes via SharedPreferences without a restart.
+
+### T-F14. Performance benchmarking
+
+`apps/app/modules/ember-custody-android/android/src/androidTest/...`: benchmark suite that:
+
+- Runs 1000 DNS queries with a 10k-entry blocklist; asserts p99 < 5ms.
+- Streams 100 MB of HTTP traffic; asserts < 5% throughput overhead.
+- Measures battery delta over a 4h benchmark run.
+
+Run on a real device before merge; record results in `docs/journal.md`.
+
+### T-F15. DoH-providers blocklist curation
+
+`apps/app/src/features/custody/android/blocklists/doh-providers.json`: bundled list of known public DoH endpoints with their resolved IPs. Phase F seed: Cloudflare 1.1.1.1, Google 8.8.8.8 / 8.8.4.4, Mozilla, OpenDNS, Quad9. Document refresh cadence (~every 6 months) in `docs/journal.md`.
+
+### T-F16. Manual QA matrix
+
+On a physical Pixel and a Samsung One UI device:
+
+| Scenario | Expected |
+|---|---|
+| First-time bound activation, no prior VPN | OS dialog → service starts → notification appears |
+| Existing VPN active (NextDNS app) | Conflict guard blocks activation; CTAs work |
+| Single domain commitment activated | Site fails to load in Chrome (DoH off) |
+| Domain-list `porn` activated | Sample known sites fail in Chrome and Firefox |
+| DoH on in Chrome | Domain still blocked when DoH-block setting is on |
+| DoH on, DoH-block off | Documented limit visible: domain *not* blocked |
+| Pause commitment | VPN still runs (other commitments active); affected domain unblocks |
+| Pause last bound web commitment | VPN stops; notification clears |
+| Reboot phone with active bound commitment | Service auto-starts via boot receiver |
+| Network switch (Wi-Fi → cellular) | Filtering continues |
+| App force-quit | Service survives (START_STICKY) |
+| Force-stop the service via Settings | Custody surfaces a banner; commitment marked inactive until re-arm |
+
+### T-F17. Journal entries
+
+In `docs/journal.md`: VPN-permission UX patterns, OEM-specific quirks (Samsung's "Battery Optimization" interaction with our service), DoH endpoint list maintenance, performance numbers, single-VPN-slot framing.
+
+---
+
+## Verification
+
+- All scenarios in T-F16 pass on Pixel and Samsung devices.
+- Performance budget (F9) holds.
+- DNS interception works for both UDP and TCP queries.
+- IPv6 (AAAA) queries are filtered, not just IPv4.
+- The trie correctly handles wildcard subdomains in real-world domain lists.
+- The block-event log accumulates without ever recording the blocked hostname.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Single-VPN-slot conflict surprises users | Detect-and-explain flow (F5); never silent. |
+| DoH adoption broader than the bundled list | Setting toggle + documented limit in onboarding; refresh DoH list on a 6-month cadence. |
+| ECH (Encrypted Client Hello) eventually breaks SNI-based DoH detection | We use IP+port detection (F3), which survives ECH; document the timeline. |
+| Performance regression from packet inspection | Benchmark gate before merge; trie complexity O(labels). |
+| Boot receiver restarts service on devices where the user expected Custody to be off | Boot receiver checks `custody.startOnBoot` flag (default on); user can disable in Settings → Custody → Advanced. |
+| OEM kills the foreground service (Samsung, Xiaomi) | Phase H allocates dedicated time for OEM testing; battery-optimization opt-out flow at activation. |
+| User expects app shielding from this phase | UI is explicit (F7): web targets active, app targets "Coming with Phase G". CommitmentEditor shows status per target. |
+| TCP DNS forwarding edge cases | Treat TCP/53 as a slow path; tests cover both transports. |
+| Trie memory bloat from large blocklists | Cap total domains at 250k; warn in JS when approaching the cap. |
+| Block events leak browsing history through `targetId` | `targetId` is a stable list key (e.g., `porn`), not the hostname; verify in unit tests. |

--- a/docs/features/custody/phase-g-android-usagestats.md
+++ b/docs/features/custody/phase-g-android-usagestats.md
@@ -1,0 +1,464 @@
+# Phase G — Android UsageStats + shield Activity
+
+> Scope: Android-side enforcement of *app* targets. A foreground monitor service polls `UsageStatsManager` and launches a full-screen `PrayerShieldActivity` over shielded apps. App-picker, friction modes, and coexistence with Phase F's VPN service.
+> Complexity: **High.** A continuously-running foreground service that polls and launches Activities is the exact surface OEMs aggressively kill. The 1–3s detection delay is an irreducible UX limit. The `PACKAGE_USAGE_STATS` flow is unfamiliar; copy carries the load.
+> Depends on: Phase F (VPN service + module skeleton + snapshot sync). Phase G adds a sibling service inside the same Kotlin module.
+
+## Goal
+
+After Phase G, an Android user with a `bound` commitment that targets specific apps (Instagram by package name, TikTok, Reddit) sees Ember's full-screen prayer-shield within ~1s of opening the shielded app. The shield mirrors iOS Phase C — same anchor, same friction modes, same deep-link to "Pray and continue blocking" / "Disable temporarily." The two halves of v2 (Phase F web + Phase G app) ship together; there is no v2.0-without-Phase-G.
+
+This phase explicitly does **not** use `AccessibilityService` (closed by Google's October 2025 policy update). The mechanism is `PACKAGE_USAGE_STATS` + a foreground polling service, the same legitimate combination used by current focus apps that survived the policy change.
+
+---
+
+## Background: how Android app shielding works without Accessibility
+
+The legitimate-2026 stack:
+
+1. **`PACKAGE_USAGE_STATS`** — special permission (granted in Settings → Special access → Usage access). Lets us query foreground events from `UsageStatsManager`.
+2. **Foreground service** — runs continuously, polls usage events, decides when a shielded app comes foreground.
+3. **Full-screen Activity** — launched over the shielded app, presents the prayer-shield UI.
+
+Observed industry pattern (post-October-2025): poll at ~500ms with screen-on gating, launch a `singleTop` Activity from the service when a target package is detected, accept the ~600–1300ms detection delay as the cost of avoiding `AccessibilityService`.
+
+---
+
+## Major decisions
+
+### G1. Two services, not one combined service
+
+Phase F introduced `EmberVpnService`. Phase G adds `EmberMonitorService`. Two questions:
+
+- **(a) One unified service.** Single notification, simpler lifecycle.
+- **(b) Two services with independent lifecycles.** Each starts only when relevant; each can be stopped independently.
+
+**Decision: (b).** Web-only commitments don't need the monitor; app-only commitments don't need the VPN. Combining them couples concerns and doubles battery cost for users whose commitments only need one half. Two services with grouped notifications (G9) is the cleaner shape.
+
+Both services run inside the same `ember-custody-android` Expo Module.
+
+### G2. Polling cadence: 500ms screen-on, paused screen-off
+
+`UsageStatsManager.queryEvents(start, end)` returns events in `(start, end]`. We tail the stream by passing `lastSeen` as `start` and `now` as `end`, polling at intervals.
+
+Cadence trade-offs:
+
+| Interval | Detection latency | Battery |
+|---|---|---|
+| 200 ms | ~300–400 ms (best UX) | High; 4 reads/s sustained |
+| 500 ms | ~600–800 ms (matches industry) | Acceptable |
+| 1 s | ~1100–1300 ms | Cheap |
+| 2 s | ~2100–2300 ms (user notices) | Negligible |
+
+**Decision: 500 ms when screen on; paused when screen off.** A foreground app can't be opened while the screen is off, so polling adds no value. Use `DisplayManager.DisplayListener` to react to `STATE_ON` / `STATE_OFF`. On screen-off, the service stays alive (foreground) but the polling thread sleeps on a condition variable.
+
+### G3. Honest detection-delay copy
+
+The 600–1300 ms window is unavoidable. During it, the shielded app is visible and may render content. This matters most for a porn-blocking commitment — the blocked content can flash before the shield takes over.
+
+**Decision: be explicit in onboarding copy.** Specifically:
+
+> Custody on Android catches up to ~1 second after you open a blocked app. Apple's iOS lets us shield instantly; Android does not have an equivalent API. For sensitive blocking (adult content), pair Custody with the DNS walkthrough — DNS blocks the website *before* it loads.
+
+This sets expectations and routes users to DNS for adult content (which is web-delivered anyway).
+
+### G4. Activity launch from service: standard `startActivity` with `singleTop`
+
+Three approaches considered:
+
+- **(a) `SYSTEM_ALERT_WINDOW` overlay.** Non-Activity overlay drawn on top. Hostile permission post-Android 12; risk of Play Store flags.
+- **(b) `USE_FULL_SCREEN_INTENT` notification.** A notification configured with `setFullScreenIntent` that launches the Activity. Designed for incoming-call-style alerts. Android 14+ requires user-granted permission and only allows it for "high-priority alerts that require immediate attention."
+- **(c) Direct `startActivity` from the foreground service.** Standard. Allowed for foreground services with visible notifications. The shield Activity is `singleTop` so duplicate launches collapse.
+
+**Decision: (c).** It's the documented happy path for foreground services; doesn't require `SYSTEM_ALERT_WINDOW` or `USE_FULL_SCREEN_INTENT`; survives Play Store policy. The Activity is declared `singleTop` + `excludeFromRecents` + `noHistory`. Launch flags: `FLAG_ACTIVITY_NEW_TASK | FLAG_ACTIVITY_CLEAR_TOP | FLAG_ACTIVITY_REORDER_TO_FRONT`.
+
+We add `setShowWhenLocked(true)` + `setTurnScreenOn(true)` so the shield works on the lock screen too.
+
+### G5. `PrayerShieldActivity`: Compose UI mirroring iOS
+
+A full-screen Compose Activity. The same `Anchor` JSON shape as iOS Phase C; the UI logic is shared in spirit (typography, spacing, copy) though re-implemented in Compose. Four states:
+
+| State | UI |
+|---|---|
+| Normal | Anchor card + title + subtitle + "Pray and continue blocking" / "Disable temporarily" |
+| Wait friction (locked) | Same + countdown subtitle + secondary disabled |
+| Prayer friction | "Disable" launches `PrayToDisableActivity` with the prayer rendered full-screen |
+| Confession-only | "After confession" launches Confessio surface in the main app |
+
+Anchor decoding: the snapshot's `imageData` (PNG bytes) is decoded once per shield launch; `title` and `subtitle` are attributed strings. The `kind: 'prayer'` and `kind: 'lectio'` anchors render their full prerendered text in the prayer-to-disable surface, not in the shield itself (which is constrained vertically).
+
+### G6. App-picker: filter to launchable, expose package names with explicit privacy note
+
+`PackageManager.getInstalledApplications` returns thousands including system services. Filter to apps with launcher activities:
+
+```kotlin
+val launcherIntent = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER)
+val resolved = packageManager.queryIntentActivities(launcherIntent, 0)
+val launchablePackages = resolved.map { it.activityInfo.packageName }.distinct()
+```
+
+Cache in service memory. Refresh on `Intent.ACTION_PACKAGE_ADDED` / `ACTION_PACKAGE_REMOVED` broadcasts.
+
+UX in CommitmentEditor's TargetPicker:
+
+- Search-as-you-type
+- Sort alphabetically by app label
+- Visual: app icon + label + package name (small)
+- Multi-select via checkboxes
+
+**Privacy asymmetry**: unlike iOS's opaque tokens, Android exposes package names. Custody on Android *can* enumerate which apps the user picked. This is a real privacy-posture difference and we surface it in the picker copy:
+
+> On Android, Custody knows which apps you pick. Apple's iOS does not allow apps to see this; Android does. Your selections never leave your phone, but Ember's database does record them.
+
+This is the truth, plainly. Users who care can use the DNS walkthrough alone (Phase D) and avoid app targets.
+
+### G7. Permission flow: unfamiliar surface, deep-link with explainer
+
+`PACKAGE_USAGE_STATS` is granted in Settings → Apps → Special access → Usage access — three taps deep, unfamiliar to most users.
+
+Flow:
+
+1. User toggles severity to `bound` with at least one app target.
+2. Check `AppOpsManager.checkOpNoThrow(OPSTR_GET_USAGE_STATS, ...)`.
+3. If `MODE_ALLOWED`: proceed.
+4. If not allowed:
+   - Show explainer screen: "Custody needs Usage access to know when a blocked app opens. We don't read content; we only see which app is foreground."
+   - Animated screenshot of the Settings flow.
+   - "Open Usage access" CTA → `Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS)`.
+   - On return, recheck. Loop until granted or user cancels.
+
+This is the heaviest permission UX in the whole feature on Android. Phase E's polish pass tunes the copy and animation.
+
+### G8. Battery-optimization opt-out: required, deep-linked, never auto-requested
+
+Without battery-optimization opt-out, Samsung / Xiaomi / Huawei kill the monitor service within hours.
+
+Standard request:
+
+```kotlin
+val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
+  .setData(Uri.parse("package:$packageName"))
+startActivity(intent)
+```
+
+The user sees a system dialog with "Allow" / "Deny." We never auto-request — Play Store rejects apps that surprise-prompt this.
+
+Triggered on bound activation, after `PACKAGE_USAGE_STATS` is granted. If the user denies battery opt-out, the commitment still saves and the service starts; we surface a banner explaining that enforcement may degrade after a few hours.
+
+OEM-specific extras (Samsung's "Deep sleep" auto-list, Xiaomi's "Autostart") cannot be deep-linked reliably — those go in Phase H's polish pass.
+
+### G9. Coexistence with VPN service: grouped notifications, independent lifecycles
+
+When the user has bound commitments with both web and app targets, both services run. Two notifications would be ugly; we group them.
+
+Channels:
+
+- `custody-vpn` (Phase F): "Custody is active for web filtering."
+- `custody-monitor` (Phase G): "Custody is active for app monitoring."
+
+Both `IMPORTANCE_LOW` (no sound, no peek). Both set `setGroup("custody")`. Android collapses them into a single visual entry in the shade. A summary notification at group level: "Custody is active."
+
+Lifecycle: each service starts only when its required commitments exist; each stops independently. Adding/removing/archiving commitments triggers a re-evaluation in JS that calls `startVpn`/`stopVpn`/`startMonitor`/`stopMonitor` accordingly.
+
+### G10. Friction modes: identical semantics to iOS
+
+The friction logic is platform-agnostic; only the implementation differs.
+
+| Friction | Android implementation |
+|---|---|
+| `none` | Tap secondary → log `overrode` event → set commitment `suspendedUntil` to start of next day → finish() the shield Activity. |
+| `wait` | Read `lockedUntil` from SharedPreferences. If `now < lockedUntil`: render countdown subtitle, secondary disabled. If `now ≥ lockedUntil`: secondary becomes "Confirm disable"; tap → log `overrode` → suspend. On user-initiated wait start: `lockedUntil = now + waitSeconds`; persist. |
+| `prayer` | Tap secondary → start `PrayToDisableActivity` with the commitment's prayer/lectio anchor rendered full-screen + "I have prayed — lift the shield" CTA. On confirm: log `overrode` with `via='prayer'` → suspend. |
+| `confession-only` | Tap secondary → launch the main app with deep link `ember://confessio?return=custody`. On confession recorded, the main app's confession-save mutation calls `EmberCustodyAndroid.liftFrictionLock(commitmentId, 'confession')`. |
+
+Suspension semantics: a commitment with `suspendedUntil > now` is treated as inactive — monitor service skips it; the user can re-open the app freely until the suspension expires.
+
+### G11. Resilience: re-arm on app uninstall, package change, network change
+
+The monitor cares about app-list changes:
+
+- `Intent.ACTION_PACKAGE_REMOVED`: if a shielded package is uninstalled, mark the corresponding target as orphaned in the snapshot; surface a UI banner; don't crash.
+- `Intent.ACTION_PACKAGE_ADDED`: refresh the launchable-app cache.
+
+The service registers a `BroadcastReceiver` for these. Service lifecycle is independent of the broadcasts; receivers just notify the polling thread to refresh state.
+
+### G12. Suspension after override: per-commitment, until next reset
+
+When the user successfully overrides a commitment, the commitment is suspended until the next "reset" — which is one of:
+
+- Start of next day (default).
+- Start of next week (for weekly commitments — config knob).
+- Until next confession (for `confession-only` friction).
+- Indefinitely (configurable per friction).
+
+Decision: default to start-of-next-day. Configurable per commitment via a new `suspensionReset` field added to the schema. Phase G adds the schema column (small migration, `0003_custody_suspension.sql`) and the UI control. Pre-existing commitments default to `start-of-next-day`.
+
+This is a real schema change; confirm willingness per CLAUDE.md before writing the migration.
+
+---
+
+## Architecture
+
+### File layout added in Phase G
+
+```
+apps/app/modules/ember-custody-android/android/src/main/java/me/dpgu/ember/custody/
+  monitor/
+    EmberMonitorService.kt                Foreground service; polling thread
+    UsageEventsTail.kt                    UsageStatsManager.queryEvents tail loop
+    ScreenStateGate.kt                    Pause polling on screen off
+    AppListCache.kt                       Launchable apps cache + refresh
+    PackageChangeReceiver.kt              ACTION_PACKAGE_ADDED/REMOVED
+    ShieldDispatcher.kt                   Decides when to launch the shield
+  shield/
+    PrayerShieldActivity.kt               Full-screen Compose Activity
+    PrayToDisableActivity.kt              Prayer friction surface
+    AnchorRenderer.kt                     Compose composables for each Anchor.kind
+    FrictionState.kt                      lockedUntil read/write
+    SuspensionStore.kt                    suspendedUntil per commitment
+  permission/
+    UsageStatsPermission.kt               Check + deep-link
+    BatteryOptimizationOptOut.kt          Opt-out request flow
+  notifications/
+    NotificationGroup.kt                  Group both Custody services into one shade entry
+  AndroidManifest.xml                     [edited: monitor service, shield activity, broadcast receiver, USE_EXACT_ALARM if needed]
+
+apps/app/src/features/custody/
+  android/
+    monitorControl.ts                     JS facade: startMonitor / stopMonitor / status
+    usagePermission.ts                    JS facade for the permission flow
+  components/
+    AppTargetPickerAndroid.tsx             [filled in: real picker]
+    UsagePermissionGuard.tsx               Explainer + deep-link
+    BatteryOptOutPrompt.tsx                Post-permission battery opt-out
+    AndroidPrivacyNote.tsx                 The "Custody knows your picks on Android" disclosure
+
+apps/app/src/db/migrations/
+  0003_custody_suspension.sql             [pending confirmation: suspensionReset column]
+```
+
+### JS bridge surface added in Phase G
+
+```typescript
+// extension to apps/app/modules/ember-custody-android/index.ts
+export const EmberCustodyAndroid: {
+  // ...existing Phase F surface...
+  hasUsageStatsPermission(): Promise<boolean>
+  openUsageStatsSettings(): Promise<void>
+  hasBatteryOptOut(): Promise<boolean>
+  requestBatteryOptOut(): Promise<'granted' | 'denied' | 'unavailable'>
+  startMonitor(): Promise<void>
+  stopMonitor(): Promise<void>
+  getMonitorStatus(): Promise<'inactive' | 'active' | 'starting' | 'killed'>
+  liftFrictionLock(commitmentId: string, reason: 'prayer' | 'confession'): Promise<void>
+  listLaunchableApps(): Promise<Array<{ packageName: string; label: string; iconUri: string }>>
+}
+```
+
+### Polling-loop pseudocode
+
+```kotlin
+class UsageEventsTail(
+  private val usm: UsageStatsManager,
+  private val screenGate: ScreenStateGate,
+  private val onForeground: (packageName: String) -> Unit,
+) {
+  private var lastSeen: Long = System.currentTimeMillis()
+  private val pollInterval = 500L
+
+  fun loop() {
+    while (running) {
+      screenGate.awaitScreenOn()
+      val now = System.currentTimeMillis()
+      val events = usm.queryEvents(lastSeen, now)
+      val ev = UsageEvents.Event()
+      while (events.hasNextEvent()) {
+        events.getNextEvent(ev)
+        if (ev.eventType == UsageEvents.Event.MOVE_TO_FOREGROUND) {
+          onForeground(ev.packageName)
+        }
+      }
+      lastSeen = now
+      Thread.sleep(pollInterval)
+    }
+  }
+}
+
+class ShieldDispatcher(
+  private val snapshots: SnapshotStore,
+  private val launcher: ShieldLauncher,
+) {
+  fun onForeground(pkg: String) {
+    val activeSnapshots = snapshots.activeBoundAppCommitments()
+    val matching = activeSnapshots.firstOrNull { it.targets.any { t -> t is AppTarget && t.packageName == pkg } }
+    if (matching != null && !matching.isSuspended()) {
+      launcher.launchShield(matching)
+    }
+  }
+}
+```
+
+---
+
+## Tasks
+
+### T-G1. `EmberMonitorService` skeleton
+
+`monitor/EmberMonitorService.kt`. Foreground service with `IMPORTANCE_LOW` notification, type `specialUse` (Android 14+) with reason `appBlocking`. `onStartCommand` returns `START_STICKY`. Spawns a polling thread on first start; stops it on `onDestroy`.
+
+### T-G2. `UsageEventsTail` polling loop
+
+`monitor/UsageEventsTail.kt`. Tails `UsageStatsManager.queryEvents`, dispatches `MOVE_TO_FOREGROUND` events to `ShieldDispatcher`. 500ms interval, gated by `ScreenStateGate`.
+
+### T-G3. `ScreenStateGate`
+
+`monitor/ScreenStateGate.kt`. Listens for `Intent.ACTION_SCREEN_ON` / `ACTION_SCREEN_OFF`. Provides `awaitScreenOn()` that blocks the polling thread when the screen is off and releases on screen-on.
+
+### T-G4. `ShieldDispatcher`
+
+`monitor/ShieldDispatcher.kt`. Reads snapshots, matches incoming foreground packages against active app targets, launches the shield via `ShieldLauncher` (which builds the Intent with the right flags and calls `startActivity`). De-dupes: don't relaunch the shield if it's already on top for the same commitment.
+
+### T-G5. `PrayerShieldActivity` Compose UI
+
+`shield/PrayerShieldActivity.kt`. Full-screen, `singleTop`, `excludeFromRecents`, `noHistory`. Compose UI with:
+
+- Background blur (decode the anchor's `imageData`, scale, apply a 30 px blur)
+- Anchor card centered (decoded `imageData`, ~120×120 dp display)
+- Title (`Anchor.title`) and subtitle (`Anchor.subtitle`) below the card
+- Two buttons: primary ("Pray and continue blocking"), secondary (friction-aware label)
+- `setShowWhenLocked(true)`, `setTurnScreenOn(true)`
+
+`AnchorRenderer.kt` factors out the anchor-specific composables so the same logic applies to `PrayToDisableActivity`.
+
+### T-G6. Friction logic
+
+`shield/FrictionState.kt`. Read/write `lockedUntil` per commitment in SharedPreferences. The shield's secondary button reads this on display and updates its label and enabled state.
+
+`shield/SuspensionStore.kt`. Read/write `suspendedUntil` per commitment. `ShieldDispatcher` consults this before launching.
+
+The four friction modes' transition logic lives in `PrayerShieldActivity`'s ViewModel:
+
+```kotlin
+fun onSecondaryTapped() {
+  when (commitment.friction) {
+    None -> { recordOverride(); suspend(); finish() }
+    Wait -> if (now < lockedUntil) { /* no-op; UI shows countdown */ }
+            else if (lockedUntil == 0L) { setLockedUntil(now + waitSeconds) }
+            else { recordOverride(via = "wait"); suspend(); finish() }
+    Prayer -> startActivity(PrayToDisableActivity intent)
+    ConfessionOnly -> startActivity(/* deep link to ember://confessio */)
+  }
+}
+```
+
+### T-G7. App-picker UX + AppListCache
+
+`monitor/AppListCache.kt`. Builds and caches the launchable-apps list from `PackageManager`. `PackageChangeReceiver` invalidates on package adds/removes.
+
+`AppTargetPickerAndroid.tsx`. Calls `listLaunchableApps()` from the JS facade. Search-as-you-type. Multi-select. Selected packages persist as `Target { kind: 'android-app', packageName }` in the commitment.
+
+### T-G8. Usage-stats permission flow
+
+`UsageStatsPermission.kt` exposes `isGranted()` (via `AppOpsManager.checkOpNoThrow`) and `openSettings()` (deep-link). JS facade exposes both as `hasUsageStatsPermission` and `openUsageStatsSettings`.
+
+`UsagePermissionGuard.tsx` is the explainer + deep-link UI. Mounted before the picker on first bound-app activation.
+
+### T-G9. Battery opt-out flow
+
+`BatteryOptimizationOptOut.kt` exposes `isAlreadyOptedOut()` and `requestOptOut()`. JS facade exposes both. `BatteryOptOutPrompt.tsx` shows the explainer screen and deep-links the user, then re-checks on return.
+
+### T-G10. Notification grouping
+
+`NotificationGroup.kt` provides a shared `IMPORTANCE_LOW` channel and a group-summary builder. Both Phase F's VPN service and Phase G's monitor service post into the group. The summary notification reads "Custody is active" and tapping it opens the Custody overview.
+
+### T-G11. Snapshot sync extension for app targets
+
+Extend Phase F's `SnapshotStore` to include `appTargets: string[]` per commitment in the snapshot JSON. The flattening function in JS adds another branch:
+
+```typescript
+function flattenAppTargets(snapshots: CommitmentSnapshot[]): Map<string, string[]> {
+  const m = new Map<string, string[]>()
+  for (const s of snapshots) {
+    const apps = s.targets.filter(t => t.kind === 'android-app').map(t => t.packageName)
+    if (apps.length) m.set(s.id, apps)
+  }
+  return m
+}
+```
+
+`ShieldDispatcher` reads this map on every snapshot update.
+
+### T-G12. Lift-friction-lock from main app
+
+`PrayToDisableActivity` on confirm calls a new module method `liftFrictionLock(commitmentId, 'prayer')`. The Confessio mutation in the main app, on confession recorded, calls the same with `'confession'`. Internally: clears `lockedUntil`, sets `suspendedUntil` per the suspension reset rule, logs the override event.
+
+### T-G13. Schema migration `0003_custody_suspension.sql`
+
+(Pending CLAUDE.md confirmation.) Adds two columns to `commitments`:
+
+```sql
+ALTER TABLE commitments ADD COLUMN suspension_reset TEXT NOT NULL DEFAULT 'start-of-next-day'
+  CHECK (suspension_reset IN ('start-of-next-day', 'start-of-next-week', 'until-confession', 'indefinite'));
+ALTER TABLE commitments ADD COLUMN suspended_until INTEGER;  -- nullable; epoch ms
+```
+
+If the user prefers no migration, fall back to representing this in `friction_config` JSON. Decision pending; document either way.
+
+### T-G14. Manual QA matrix
+
+On Pixel, Samsung One UI, and Xiaomi MIUI:
+
+| Scenario | Expected |
+|---|---|
+| First-time bound activation with app target | Permission flow → battery opt-out → picker → done |
+| Open shielded app | Shield within ~1s |
+| Shield on lock screen (open shielded app from lock) | Shield shows; user can interact |
+| Pray and continue blocking | Logs event; shield closes; if user re-opens app, shield re-launches |
+| Disable temporarily (none friction) | Suspends commitment for the day; re-opening the app is unblocked |
+| Wait friction tap → countdown → confirm | Countdown displays; secondary becomes "Confirm disable" after expiry |
+| Prayer friction → prayer surface → confirm | Lifts the shield; logs override with via=prayer |
+| Confession-only friction → record confession in app → return | Shield lifted on next foreground trigger |
+| Phase F VPN + Phase G monitor both active | Single grouped notification; both services stable |
+| Restart phone | Both services auto-start; commitments resume |
+| Battery opt-out denied | Banner warns; service still starts; degrade after long idle |
+| Service force-stopped via Settings | Banner detects on next foreground |
+| Uninstall a shielded app | Target marked orphaned; commitment edited |
+| Install an app while picker is open | Picker auto-refreshes |
+| Polling during a 4h benchmark with screen on | Battery delta < 2% over baseline |
+
+### T-G15. Journal entries
+
+In `docs/journal.md`:
+
+- Foreground service patterns post-Android-14 special-use type
+- UsageStats event-tail rate-limit reality
+- Activity-launch-from-service constraints in 2026
+- OEM kill behaviors observed
+- Privacy-asymmetry framing decisions (the iOS/Android disclosure)
+
+---
+
+## Verification
+
+- All scenarios in T-G14 pass on at least Pixel and Samsung; Xiaomi covered by Phase H.
+- Battery overhead < 2% over a 4h screen-on benchmark.
+- Detection latency p99 < 1.3s on cold-launch of a shielded app.
+- Shield Activity correctly handles back button, recents button, and home button.
+- Friction modes match iOS Phase C semantics 1:1 (parity test).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| OEMs (especially Samsung, Xiaomi) kill the monitor service | Phase H allocates dedicated time; battery opt-out + OEM-specific deep-links + stickier service. |
+| `startActivity` from a foreground service blocked by some OEMs | Test matrix covers the major three; fallback to full-screen-intent notification path documented but not preferred. |
+| Detection delay frustrates users | Honest copy in onboarding (G3); recommend DNS for adult content. |
+| Privacy asymmetry between iOS and Android perceived as inconsistent | Disclosed in app on Android; documented in privacy listing. |
+| Polling at 500ms drains battery on lower-end devices | Screen-on gate caps the worst case; benchmark gate before merge. |
+| Shield stuck-on-top after pray-and-continue | `singleTop` + `noHistory` + de-dupe in `ShieldDispatcher`. |
+| `PACKAGE_USAGE_STATS` permission denied | Re-check loop with explainer; commitment saves but stays inactive until granted. |
+| App uninstall mid-shield | `PackageChangeReceiver` invalidates the target; shield Activity gracefully closes. |
+| Suspension semantics disagree across timezones / DST | Use `Calendar.getInstance().apply { ... start-of-day }`; unit tests cover DST transitions. |
+| Schema migration `0003` violates "no migrations unless asked" | Confirm before authoring; have JSON-in-friction_config fallback ready. |
+| Shield Activity drawn over fingerprint / biometric prompt | `setShowWhenLocked` interaction with secure inputs is fragile; defer to system on KeyguardManager events. |
+| Confessio deep-link returns to wrong tab | Deep-link includes `?return=custody`; the main app routes back on confession save. |

--- a/docs/features/custody/phase-h-android-oem.md
+++ b/docs/features/custody/phase-h-android-oem.md
@@ -1,0 +1,335 @@
+# Phase H — Android OEM polish
+
+> Scope: harden the Phase F + G services against manufacturer-specific battery killers; ship the Play Console submission with a clean justification; pass the OEM matrix.
+> Complexity: **Low per task; the OEM matrix is irreducible.** Real devices required for verification — emulators do not reproduce the kill behaviors that matter.
+> Depends on: Phases F and G shipped and stable in dev. Phase H is the closing pass for v2.
+
+## Goal
+
+Custody on Android needs to *stay running*. Phases F and G build the right architecture; Phase H makes it survive Samsung's "Deep sleep," Xiaomi's "Battery saver," OnePlus's "Advanced optimization," and Huawei's "PowerGenie." After Phase H, a user who set up bound mode and rebooted their phone three times still has an active shield two weeks later.
+
+A secondary goal: pass Play Console review with a clean disclosure of what we use (`BIND_VPN_SERVICE`, `PACKAGE_USAGE_STATS`, `FOREGROUND_SERVICE_SPECIAL_USE`) and a clean disclosure of what we don't (no `AccessibilityService`, no `SYSTEM_ALERT_WINDOW`, no `USE_FULL_SCREEN_INTENT`).
+
+---
+
+## Major decisions
+
+### H1. Officially-supported OEM matrix: stock + Samsung + Xiaomi
+
+Android's OEM landscape is wide. Officially testing every brand is impractical for a solo project. Three priority tiers:
+
+- **Tier 1 (officially supported)**: stock Android (Pixel, OnePlus on OxygenOS 13+, Nothing) — predictable behavior, the OS as Google ships it. Samsung One UI — the dominant non-Pixel OEM and the one with the most aggressive battery rules. Xiaomi MIUI / HyperOS — the dominant Brazilian-market OEM, important for pt-BR.
+- **Tier 2 (best-effort)**: Huawei EMUI, Honor MagicOS, OPPO ColorOS. We don't certify these but the architecture should work; document deviations in `docs/journal.md`.
+- **Tier 3 (unsupported)**: anything older than Android 12.
+
+Tier 1 gets explicit OEM-aware code paths and tested QA. Tier 2 inherits Tier 1's mitigations and is left alone unless a specific issue is reported.
+
+### H2. The standard mitigation pyramid
+
+OEM kill behaviors share a common surface:
+
+1. **Battery optimization** (universal Android API) → opt-out via `Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS`. Already in Phase G.
+2. **Auto-start permission** (Xiaomi, OPPO, Vivo) → app starts on boot. Specific Settings deep-links per OEM.
+3. **Deep-sleep / "auto-sleeping apps" allowlist** (Samsung) → app exempted from sleep when idle. Settings deep-link.
+4. **Lock-app-in-recents** (some OEMs) → user pins our app in the recents UI to prevent OEM-killing. We can only instruct, not enforce.
+5. **Foreground service "stickiness"** → `START_STICKY`, low-importance notification, and the `FOREGROUND_SERVICE_SPECIAL_USE` type. Already in F+G.
+
+Phase H stitches these together into a single onboarding sub-flow: "Help Custody stay running." The user runs through the relevant prompts in order; we check each grant before moving on.
+
+### H3. Per-OEM deep-links: best-effort fallback chain
+
+Most OEM-specific Settings screens are accessible via known activity components:
+
+```kotlin
+val samsungAutoSleep = ComponentName(
+  "com.samsung.android.lool",
+  "com.samsung.android.sm.battery.ui.BatteryActivity"
+)
+
+val xiaomiAutostart = ComponentName(
+  "com.miui.securitycenter",
+  "com.miui.permcenter.autostart.AutoStartManagementActivity"
+)
+
+val oppoAutostart = ComponentName(
+  "com.coloros.safecenter",
+  "com.coloros.safecenter.permission.startup.StartupAppListActivity"
+)
+```
+
+These component names drift between OS versions. Fallback chain per OEM:
+
+1. Try the canonical component.
+2. Try the package's launcher activity.
+3. Fall back to `Settings.ACTION_APPLICATION_DETAILS_SETTINGS` (the app's settings page).
+4. Final fallback: general Settings.
+
+Each step is wrapped in `try`/`catch`; the user always lands somewhere.
+
+### H4. Detection of OEM and version
+
+`Build.MANUFACTURER` is the entry point but it's not enough — Samsung's One UI has different behavior across versions. We use a lookup table:
+
+```kotlin
+data class OemProfile(
+  val oem: String,
+  val needsAutoStart: Boolean,
+  val needsDeepSleepExemption: Boolean,
+  val deepLinks: Map<String, ComponentName>,
+)
+
+val profiles = mapOf(
+  "samsung" to OemProfile(...),
+  "xiaomi" to OemProfile(...),
+  "oppo" to OemProfile(...),
+  "vivo" to OemProfile(...),
+  "huawei" to OemProfile(...),
+)
+```
+
+`Build.MANUFACTURER.lowercase()` indexes; default is the stock profile (no extra mitigations needed).
+
+### H5. "Help Custody stay running" onboarding flow
+
+A new sub-flow runs once after the user completes the regular bound-mode onboarding. It's gated to OEMs that need it (skipped on stock Android).
+
+Steps for Samsung:
+
+1. Explainer screen ("Samsung phones may sleep Custody after a few days. Two settings keep it running.")
+2. Battery optimization → already done in Phase G
+3. Deep sleep exemption → deep-link to "Apps that won't be put to sleep" Settings, "Add Ember"
+4. Done
+
+Steps for Xiaomi:
+
+1. Explainer
+2. Battery optimization
+3. Auto-start permission → deep-link to "Manage app's auto-startup" Settings
+4. "Lock in recents" tip with screenshot
+5. Done
+
+Each step verifies before continuing where possible (e.g., re-check battery-opt status). Some OEM grants can't be programmatically verified; for those, we ask the user "Did you do that?" with a screenshot reminder.
+
+### H6. Play Console submission
+
+The Play Console submission for v2 is the moment Custody publicly declares the Android architecture. The data-safety form needs:
+
+- **Personal info**: none collected
+- **App info**: none collected
+- **Device or other IDs**: none collected
+- **App activity**: none transmitted (in-app records of falls / events stay local)
+- **Sensitive permissions**:
+  - `BIND_VPN_SERVICE` — declared with justification: "Custody runs a local VPN to filter DNS for user-selected blocked domains. No traffic leaves the device beyond standard DNS resolution."
+  - `PACKAGE_USAGE_STATS` — declared with justification: "Custody detects when a user-blocked app comes foreground in order to display the user's chosen prayer."
+  - `FOREGROUND_SERVICE_SPECIAL_USE` reasons: VPN ("dnsFiltering"), Monitor ("appBlocking"). Both new in Android 14; both require explicit reason documentation.
+- **Explicit non-use disclosures**:
+  - "We do not use `AccessibilityService`."
+  - "We do not use `SYSTEM_ALERT_WINDOW`."
+  - "We do not use `USE_FULL_SCREEN_INTENT`."
+
+The October 2025 policy update is recent enough that Play Console reviewers will check the Accessibility-non-use claim; making it explicit in the submission notes saves a back-and-forth.
+
+### H7. Demo video for Play review
+
+Like Apple, Google sometimes asks for a demo. Pre-record a 90-second screen capture showing:
+
+- Empty Custody surface
+- Creating a bound commitment with both web and app targets
+- Permission grants (VPN dialog, Usage access, battery opt-out, OEM-specific)
+- Opening a blocked website in Chrome → shield
+- Opening a blocked app → prayer-shield
+- Each friction mode (skim)
+- Pause and resume
+
+Captured on a Pixel + a Samsung side-by-side if budget allows.
+
+### H8. Doze + App Standby coexistence
+
+Beyond OEM customizations, the stock Android battery model has Doze (deep sleep when device idle) and App Standby (apps not used recently get throttled). Both interact with foreground services:
+
+- **Foreground services are exempt from Doze restrictions** for as long as they're in the foreground state.
+- `START_STICKY` ensures the OS restarts a killed service.
+- `FOREGROUND_SERVICE_SPECIAL_USE` (Android 14+) with a documented reason is the modern path; without it, `dataSync` or `connectedDevice` were the closest fallbacks. We use special-use.
+
+Verification plan: leave a test phone idle for 12+ hours with bound commitments active. After waking, verify both services are alive and the trie/snapshots are correctly arranged.
+
+### H9. Anti-tampering: do nothing
+
+A user can defeat Custody on Android by:
+
+- Force-stopping the service (Settings → Apps → Ember → Force stop)
+- Revoking Usage access
+- Disabling the VPN
+- Uninstalling Ember
+
+We do **none** of:
+
+- Re-asking for permissions automatically
+- Re-launching the service after force-stop (the OS prevents it for ~10 minutes anyway)
+- Detecting tampering and notifying via push
+- Anything that smells like surveillance
+
+Custody is an ascetical aid, not a jail. The user who tampers has already chosen to break their commitment; logging that as a fall is enough. The next examen surfaces it.
+
+### H10. Failure-mode telemetry: zero
+
+We collect no telemetry. We do not phone home about service kills, permission revocations, or OEM-kill events. The only way we learn about OEM problems is bug reports from users.
+
+This is a deliberate choice: privacy posture for Custody is conservative, especially because the feature implies the user has admitted a need (porn-blocking, focus issues). Telemetry, even anonymous, would compromise that posture.
+
+---
+
+## Architecture
+
+### File layout added in Phase H
+
+```
+apps/app/modules/ember-custody-android/android/src/main/java/me/dpgu/ember/custody/
+  oem/
+    OemProfile.kt                          Lookup table
+    OemDetector.kt                         Build.MANUFACTURER + version → profile
+    OemDeepLinks.kt                        Per-OEM Settings component names with fallback chain
+    OemMitigations.kt                      Programmatic checks (where possible)
+
+apps/app/src/features/custody/
+  android/
+    oemControl.ts                          JS facade for the OEM module
+  components/
+    OemMitigationsFlow.tsx                 The "Help Custody stay running" sub-flow
+    OemStepCard.tsx                        Reusable step UI
+    OemBanner.tsx                          Surfaces "service was killed by your phone" if detected on next foreground
+
+apps/app/store-listings/play-store/
+  custody-justification.txt                Reviewer-facing text
+  custody-permissions.md                   Per-permission justification
+  custody-demo.mp4                         The 90-second demo video
+```
+
+### JS bridge surface added in Phase H
+
+```typescript
+export const EmberCustodyAndroid: {
+  // ...existing F + G surface...
+  getOemProfile(): Promise<{
+    oem: string
+    needsAutoStart: boolean
+    needsDeepSleepExemption: boolean
+    needsLockInRecents: boolean
+  }>
+  openOemSetting(key: 'auto-start' | 'deep-sleep' | 'app-info'): Promise<void>
+  hasMitigation(key: 'battery-opt-out' | 'auto-start' | 'deep-sleep'): Promise<boolean | 'unknown'>
+}
+```
+
+`'unknown'` is the honest return for mitigations we can't programmatically verify (e.g., Samsung's deep-sleep allowlist isn't queryable).
+
+---
+
+## Tasks
+
+### T-H1. OEM detection + profiles
+
+`oem/OemProfile.kt`, `OemDetector.kt`. Define profiles for `samsung`, `xiaomi`, `oppo`, `vivo`, `huawei`, with the relevant booleans and component names. Stock Android profile has all booleans false. JS facade exposes via `getOemProfile()`.
+
+### T-H2. Per-OEM deep-link helper
+
+`oem/OemDeepLinks.kt`. Implements `openOemSetting(key)` with the fallback chain from H3. Returns success / fallback-level so the UI can show appropriate "manual instructions" copy when we land on a less-helpful Settings screen.
+
+### T-H3. `OemMitigationsFlow` UI
+
+`OemMitigationsFlow.tsx`. The "Help Custody stay running" sub-flow from H5. Reads `getOemProfile()`, conditionally renders each step. Each step uses `OemStepCard` with: explainer, screenshot for the target OEM, [Open setting] CTA, [I did it] confirmation.
+
+### T-H4. Mitigation status banner
+
+`OemBanner.tsx`. On every app foreground, calls `getMonitorStatus()` and `getVpnStatus()`. If either returns `'killed'` (the service was running and now isn't, despite snapshots saying it should be), surfaces a banner: "Your phone stopped Custody. Tap to fix." Tapping reopens the OemMitigationsFlow.
+
+To detect kills: each service writes a heartbeat to SharedPreferences every 30s while running. On app foreground, JS reads the heartbeats; if older than 2 minutes while snapshots say service should be running, treat as killed.
+
+### T-H5. Heartbeat plumbing
+
+In `EmberMonitorService` and `EmberVpnService`: a coroutine writes `lastHeartbeatAt = now` to SharedPreferences every 30s. Cheap; doesn't change service architecture.
+
+### T-H6. Stock Android verification
+
+On a Pixel running the latest two Android majors:
+
+- 12+ hour idle test: services alive, snapshots intact
+- Reboot test: services restart via boot receiver
+- Foreground service notification grouped correctly
+- Battery cost tracked over 24h (compare to a baseline week without Custody)
+
+### T-H7. Samsung One UI verification
+
+On a Galaxy S running One UI:
+
+- Run T-H6 tests
+- Plus: open "Apps that won't be put to sleep" → verify Ember appears after the OemMitigationsFlow ran
+- Plus: leave the phone in a drawer for 48h with no charger → verify services come back
+- Plus: Battery → Power saving mode (eco) → verify services still work or degrade gracefully
+
+### T-H8. Xiaomi MIUI / HyperOS verification
+
+On a Redmi or Mi running HyperOS:
+
+- Run T-H6 tests
+- Plus: verify auto-start permission flow lands on the right Settings page
+- Plus: lock-app-in-recents tip works (user pins; verify via subsequent battery test)
+- Plus: 48h idle test
+- Note: Xiaomi often disables Digital Wellbeing by default; verify Phase D's handoff still finds *something* usable
+
+### T-H9. Play Console submission package
+
+Compose `apps/app/store-listings/play-store/custody-justification.txt` per H6. Record `custody-demo.mp4` per H7. Update the listing copy with the Custody section. Submit. Plan for at least one revision cycle — Google reviewers ask sharper questions about the VPN justification than Apple typically does.
+
+### T-H10. Journal entries
+
+Document in `docs/journal.md`:
+
+- OEM-by-OEM kill behavior observations (what we saw, what fixed it)
+- Heartbeat-based kill detection — what false positives we hit
+- Play Console review back-and-forth (questions asked, answers given)
+- Battery cost numbers for each tier-1 OEM
+
+### T-H11. v2 release-notes copy
+
+Both en-US and pt-BR release notes for v2:
+
+> Custody is now active on Android. Block apps and websites with the same prayer-shield as on iOS. Tested on Pixel, Samsung, Xiaomi.
+
+Plus an in-app update card highlighting the new capability for users who already had Custody at v1.
+
+### T-H12. End-to-end final pass
+
+A full v2 verification pass on each tier-1 OEM:
+
+- Set up bound commitments with mixed targets (web + app + curated list)
+- Run for 48h with normal usage
+- Verify shields trigger for both web and app targets
+- Verify falls log records correctly
+- Verify pause + resume + override + suspension all work
+- Verify Examen and Confessio integration unchanged
+- Verify the OemBanner doesn't false-positive
+
+---
+
+## Verification
+
+- Tier-1 OEM matrix passes: Pixel, Samsung, Xiaomi.
+- Tier-2 OEMs work uncertified (smoke test on borrowed devices if available).
+- 48h idle survival on each tier-1 device with no charger.
+- Play Console approves on first or second revision.
+- Battery cost stays under +3% baseline over a typical day's usage.
+- Heartbeat-based kill detection has < 1% false-positive rate over a week.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Tier-1 device behavior changes after a Samsung / Xiaomi OS update | Heartbeat detection surfaces the regression on next foreground; OemMitigationsFlow re-runs. |
+| Play Console rejection on VPN justification specificity | Justification text already explicit; one revision cycle budgeted. |
+| Play Console rejection on `FOREGROUND_SERVICE_SPECIAL_USE` reasons | Reasons are pre-justified per H6; refine if requested. |
+| Per-OEM deep-link components break in a future OEM update | Fallback chain ensures the user always lands somewhere; `docs/journal.md` documents the maintenance cadence. |
+| Battery overhead too high on lower-end devices | Phase G's screen-on gating already handles the worst case; Phase H tunes the heartbeat cadence if needed. |
+| Heartbeat false-positives during Doze | Heartbeat threshold of 2 minutes is generous; if we still see false positives, raise to 5 minutes. |
+| Tier-2 OEM (Huawei, Honor) users hit a blocker | Document workaround in `docs/journal.md`; don't list as supported until verified. |
+| Review timing: Play Console + Apple App Review for the same v2 collide | Stagger submissions: Apple first (conservative reviewer schedule), Google second; release notes diff between platforms is fine. |


### PR DESCRIPTION
Add docs/features/custody.md with the full PRD for a discipline /
focus / porn-blocker surface ("Custody"). Catholic framing under the
Fidelity pillar. Differentiator vs Opal: the blocked screen renders
a prayer instead of a score.

iOS bound mode targets Apple Family Controls (Individual mode) via
kingstinct/react-native-device-activity with a custom Expo config
plugin and three extension targets (DeviceActivityMonitor,
ShieldConfiguration, ShieldAction). Android v2 path is VPN+DNS
plus UsageStatsManager + foreground service, explicitly avoiding
AccessibilityService after the Oct 30, 2025 Play Store policy.

Includes data model, integration map against existing plan-of-life
schedule rules / examen / confessio surfaces, sequenced phase plan
(A-E for v1, F-H for v2), and risk register.