### PR TITLE
Catholic Creators feature PRD + per-phase technical designs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,7 @@ Broad spectrum — from curious seekers to devout daily communicants. The app me
 
 ### Wisdom (Content & Tradition)
 
+- **Catholic Creators** — curated directory of orthodox priests/teachers (podcasts, YouTube, RSS), in-app player, doctrinal global search, and *Pray with [Creator]* guided prayers (see [creators/README.md](features/creators/README.md))
 - **Formation guides** — how to pray the Rosary, mental prayer, examination of conscience, lectio divina
 - **More spiritual classics** — expanding the library beyond Montfort and Liguori (see [PIPELINE.md](content/PIPELINE.md))
 - **Prayer history** — origin and tradition of each prayer and devotion
@@ -105,6 +106,7 @@ Broad spectrum — from curious seekers to devout daily communicants. The app me
 - [Architecture](ARCHITECTURE.md) — tech stack, content & libraries, data model, storage, folder structure
 - [Conventions](CONVENTIONS.md) — code style guide
 - [Features Overview](features/features-overview.md) — flow DSL, schedules, programs, plan of life, liturgical seasons
+- [Catholic Creators](features/creators/README.md) — directory + audio/video/article + global doctrinal search + Pray-with guided prayers (PRD + per-phase technical design docs)
 - [Content & Collections](features/corpus.md) — corpus author workflow, build pipeline, distribution
 - [Book Format](content/book-format.md) — book manifest, chapter format, ID conventions
 - [Design System](design/design-system.md) — colors, typography, illuminated manuscript aesthetic

--- a/docs/features/corpus.md
+++ b/docs/features/corpus.md
@@ -21,6 +21,8 @@ Every piece of content is a **first-class corpus item** with a stable, kind-pref
 | `of-data` | `of-data/calendar/sanctorale/_index` | `content/of-data/calendar/sanctorale/_index.json` |
 | `collection` | `collection/carmelite` | `content/collections/carmelite.json` |
 | `checkup` | `checkup/archetypes` | `content/checkup/archetypes.json` |
+| `creator` *(v1)* | `creator/padre-paulo-ricardo` | `content/creators/padre-paulo-ricardo/manifest.json` |
+| `playlist` *(v1.1)* | `playlist/lent-with-bishop-barron` | `content/playlists/lent-with-bishop-barron/manifest.json` |
 
 Content is sha256-hashed at build time and served as immutable blobs from `https://ember.dpgu.me/hearth/v2/blobs/{ab}/{cd}/{full-sha256}`. Catalog (`catalog.json`) is the master index — every item with its current manifest hash.
 
@@ -72,6 +74,36 @@ Content is sha256-hashed at build time and served as immutable blobs from `https
 1. Drop a JSON file at `content/masses/of/<group>/<...>.json` containing the multilingual proper (7 languages inline: la / es / en / pt-BR / it / fr / de).
 2. The build splitter walks the JSON, emits one *shape* blob (language-independent metadata: rite, season, prefaceRefs, etc.) plus one blob per language with that language's expanded text. Localized leaves like `{ en: "...", pt-BR: "..." }` are detected automatically by key.
 3. A pt-BR-only user fetches `shape` + `pt-BR` blob = ~9KB instead of the original ~73KB.
+
+### Adding a creator (v1)
+
+A `creator` is editorial metadata about a Catholic priest / teacher / producer. It points at the creator's external feeds (podcast RSS, YouTube channel, blog) — episode/video/article lists are NOT in the corpus, only the creator's identity and channel pointers.
+
+1. Create `content/creators/<id>/`:
+   ```
+   manifest.json    # CreatorManifest — name, byline, bio, languages, channels[], links
+   avatar.webp      # 512×512 square
+   banner.webp      # optional 16:9 hero
+   ```
+2. The build hashes avatar/banner via the existing image pipeline. The manifest itself becomes a single hashed blob.
+3. Each `channels[]` entry is one of: `podcast` (with `feedUrl`), `youtube` (with `channelId`), or `rss` (with `feedUrl`). Mark Q&A-format podcasts with `format: 'qa'` to enable the search ranking boost.
+4. Articles default to summary-only display; opt a known-good blog into in-app full-text rendering with `channels[].fullText: true`.
+5. The new editor-curated creator becomes `creator/<id>` in the corpus. For permission-sensitive metadata (avatar usage, donate links) follow the editorial process — see `docs/features/creators/README.md` §2.
+
+### Adding a playlist (and guided prayer) (v1.1)
+
+A `playlist` is an editor-curated ordered set of media items. With `practiceBinding`, it becomes a *guided prayer* — audio that plays alongside an existing practice flow.
+
+1. Create `content/playlists/<id>/`:
+   ```
+   manifest.json    # PlaylistManifest — title, items[], optional practiceBinding
+   cover.webp       # 1:1 square cover art
+   audio.mp3        # optional self-hosted audio (one or more), referenced from items[] as kind: 'audio-blob'
+   ```
+2. `items[]` is a discriminated union: `feed-item` (refs an existing podcast/RSS episode), `youtube` (a video by id), `audio-blob` (self-hosted), `article`, or `corpus` (a ref into any other catalog item). A topical playlist might mix all five; a guided Rosary uses one `audio-blob` item plus a `practiceBinding`.
+3. `practiceBinding` (optional) makes this a guided prayer: it maps the parent practice's flow sections to playlist items (and optional `tStart/tEnd` time ranges within them). The build script validates that every `segments[*].sectionPath` resolves against the referenced practice's flow.
+4. **No AI voice cloning** — guided playlists must use real recorded audio, with explicit creator permission (recorded in `manifest.json` → `rights`). Editorial process treats this with the same care as book translation rights.
+5. See `docs/features/creators/phase-06-series.md` (editorial bundles) and `docs/features/creators/phase-07-pray-with.md` (guided prayers) for the full author workflow and the `sectionPath` semantics.
 
 ### Adding a collection
 

--- a/docs/features/creators/README.md
+++ b/docs/features/creators/README.md
@@ -1,0 +1,806 @@
+# Catholic Creators (Podcasts, Video, RSS, Playlists, Guided Prayers)
+
+PRD for the Creators feature: a curated directory of Catholic priests and content producers, an in-app audio/video/article reader, a global doctrinal search engine, and (in v1.1) editor-curated **Series** playlists and **Pray with [Creator]** guided prayers.
+
+For the corpus model see `docs/ARCHITECTURE.md` and `docs/features/corpus.md`. For practice flow concepts see `docs/features/features-overview.md`. For code style see `docs/CONVENTIONS.md`.
+
+> **This README is the PRD** — the *what* and *why*. Each phase has its own technical design doc with the *how*: major decisions, alternatives ruled out, file-level tasks, and verification.
+
+## Phase index
+
+### v1 — creators + audio/video/article + global search
+
+| Phase | Doc | Goal |
+|---|---|---|
+| 1 | [phase-01-plumbing.md](phase-01-plumbing.md) | New corpus kind `creator`, build-script walker, resolver/pinning extensions, SQLite tables, feed fetcher with three parsers + chapter-marker parsing, 2-3 seed creators. **No UI.** |
+| 2 | [phase-02-browse-ui.md](phase-02-browse-ui.md) | `creators/index` directory, `creators/[id]` profile, in-app audio player (background playback, mini-bar, full-screen), YouTube iframe player, article reader (summary-default + per-source allowlist). |
+| 3 | [phase-03-home-follows-offline.md](phase-03-home-follows-offline.md) | Follow / unfollow, Home `Latest` row, per-item pinning + per-creator `auto_pin_count`, storage management UI, network-aware UX. |
+| 4 | [phase-04-search-v1.md](phase-04-search-v1.md) | On-device FlexSearch over feed-items + corpus titles + chapter markers. Q&A boost, localized empty-state suggestions, recent searches. |
+| 5 | [phase-05-polish.md](phase-05-polish.md) | Speed / sleep timer / lock-screen metadata, skeleton + empty states, pt-BR parity, accessibility, background download. |
+
+### v1.1 — series + pray with + search enrichment
+
+| Phase | Doc | Goal |
+|---|---|---|
+| 6 | [phase-06-series.md](phase-06-series.md) | New corpus kind `playlist` (without `practiceBinding`), Browse `Series` row, profile `Series` tab, transitive pinning, search indexing of playlist titles + items. |
+| 7 | [phase-07-pray-with.md](phase-07-pray-with.md) | `practiceBinding` on playlists, `sectionPath` semantics spike, `GuidedAudioController`, voice selector on Rosary start, pinned cold-play. |
+| 8 | [phase-08-search-v11.md](phase-08-search-v11.md) | Curated canonical-question redirects, multilingual synonyms, full book-body + per-CCC-paragraph indexing. |
+
+### v2 — expansion (research-only stubs)
+
+| Phase | Doc | Goal |
+|---|---|---|
+| 9 | [phase-09-pray-with-expansion.md](phase-09-pray-with-expansion.md) | Stations / Chaplet / Angelus guided prayers; multi-day-program audio companions; per-section audio mode by default. |
+| 10 | [phase-10-search-v2-transcripts.md](phase-10-search-v2-transcripts.md) | Whisper-transcribed segment search — only if v1.1 search demonstrably falls short for ≥3 months. |
+
+---
+
+## Context
+
+**What's being added.** Ember today helps users build a rule of life and read the Catholic tradition in long-form (books, collections, prayers, propers). It does not yet meet users where many of them already form their souls daily: through Catholic priests and content producers on podcasts, YouTube, and blogs — and it does not yet let them *pray with* those priests.
+
+**Why now.** Three pillars shape Ember: Fidelity, Devotion, Wisdom. A Catholic creators feature is squarely in **Wisdom**. Podcasts and homily channels are the modern oral tradition; not surfacing them leaves a gap users will fill with secular apps that bury Catholic voices in noisy general-purpose feeds.
+
+**Three flagship moves elevate this from a feature to a category-defining product:**
+
+1. **Global Search — a catechetical answer engine, no ML required.** Many of the best Catholic creators publish in explicit Q&A format (PPR's *Resposta Católica*, *Pints With Aquinas* listener Q&As, *Catholic Answers Live*). Indexing nothing more than their episode titles and show notes — combined with editorial curation guaranteeing every result is faithful — produces a doctrinal search engine Google cannot match. The wow comes from *who* is in the index, not from clever ML.
+2. **Playlists & Guided Prayers — pray and listen *with* a creator.** Editor-curated playlists are the primitive: ordered sets of media (podcast episodes, YouTube videos, articles, self-hosted audio, corpus refs). A *Lenten retreat with Fr. Mike*, an *Advent series with Bishop Barron*, *Best of Resposta Católica on Confession* — all the same data model. The flagship special case is **guided prayers**: a playlist whose items carry per-section timestamps mapped to a practice flow, so the user can pray the Rosary along with Padre Paulo Ricardo's voice. One concept, many surfaces — and the bridge between Wisdom and Fidelity.
+3. **Aggressive offline support.** Pinning a creator means episodes, articles, search index, avatar, and any guided-prayer audio are all available at 7 a.m. Mass with no signal. Fidelity tools cannot fail when connectivity does.
+
+**Outcome.** Ember becomes the default home for the daily formation diet of a serious Catholic. Following a creator means their answers to your questions and their voice during your Rosary are one tap away — even on a plane.
+
+---
+
+## 1. Scope
+
+### In scope (v1)
+- **Editor-curated creator directory** shipped through the Hearth corpus.
+- **Three channel kinds** per creator: podcast (RSS audio), video (YouTube channel), text feed (RSS/Atom blog).
+- **Browse → Creators**: directory + per-creator profile pages.
+- **Native in-app audio player** with background playback, lock-screen controls, queue, resume, speed.
+- **In-app video playback** via embedded YouTube iframe player (web + WebView on native).
+- **Article reader** for RSS text — full text when feed permits, otherwise summary + WebView fallback.
+- **Follow** creators (local-only, no account).
+- **Pin episodes/articles** for offline listening/reading using the existing pinning system.
+- **Persistent "Now Playing" mini-bar** app-wide once audio is playing.
+- **Home-screen latest-content row**: a small horizontal feed of the most recent items across followed creators.
+- **Global Search v1**: title + description + show-notes search across episodes/videos/articles, plus corpus titles/headings (books, prayers, saints, catechism). Free per-question chapter-marker deep-linking when the feed exposes chapters. Always-available `🔍 Ask…` pill.
+- **Aggressive offline support** (see §8) — every surface degrades gracefully; pinned content works cold-start with airplane mode on.
+- **"Suggest a creator"** form (mailto / GitHub issue link) — no user-pasted RSS in v1.
+- **i18n**: en-US + pt-BR for all UI strings; creator metadata localized via the existing `LocalizedText` shape.
+
+### In scope (v1.1, follows ~2-4 weeks after v1)
+- **Series** (editorial playlists) — first-class corpus kind. Seed: a Lenten series, an Advent series, a topical "Best of *Resposta Católica*" bundle.
+- **Pray with [Creator]** (guided prayers) — playlists with `practiceBinding`. Rosary led by ≥1 seed creator, single-file + chapter-map mode. Voice selector on practice start. Pinnable for offline.
+- Search v1.1 enrichment: curated canonical-question redirects + question synonyms + full book bodies + every CCC paragraph in the index.
+
+### Out of scope (v1 and v1.1)
+- User-pasted arbitrary RSS / YouTube URLs.
+- Push notifications for new episodes.
+- Comments, ratings, social sharing.
+- Cross-device sync of progress / follows.
+- Native YouTube playback bypassing the iframe API (against YT ToS).
+- Algorithmic recommendations.
+- Whisper-transcribed transcript search (Phase C below — only if v1 search demonstrably falls short).
+- Semantic / vector search.
+
+---
+
+## 2. Curation & Editorial Policy
+
+**Editor-curated only at launch.** Creators are added via the corpus — same workflow as adding a book or a collection (`content/creators/<slug>/manifest.json`, built by `scripts/build-corpus.py`, deployed to Hearth).
+
+**Suggestion path.** A "Suggest a creator" link in Browse → Creators opens a GitHub issue template (or mailto fallback). The issue captures: name, role, language(s), podcast/YT/RSS URLs, why they belong. Editorial review applies the standard orthodoxy lens: the creator must be in good standing with the Church and faithful to the Magisterium. No heterodox or sedevacantist voices.
+
+**Initial seed list (~12-20 creators)** chosen for breadth across:
+- Languages (en-US + pt-BR — at least 4-5 lusophone voices).
+- Charisms (diocesan, Dominican, Franciscan, Jesuit, Carmelite, Opus Dei, monastic).
+- Formats (homily-only, formation lectures, **Q&A**, daily reflection, exegesis, catechesis).
+- Length (5-min daily ↔ 60-min lecture).
+
+**Q&A creators are a priority for v1** because their content powers the search wow (PPR *Resposta Católica*, *Catholic Answers Live*, *Pints With Aquinas* listener Q&As, etc.).
+
+**Guided-prayer creators are a separate editorial track**: each guided variant requires explicit permission to redistribute audio (or sourcing from the creator's existing public, permissively-licensed recordings).
+
+The seed list itself is decided by the maintainer; not part of this PRD beyond the criteria above.
+
+---
+
+## 3. Content Model
+
+The corpus is content-addressed and immutable; podcast feeds and YouTube channels are external and dynamic. We resolve this by storing **creator metadata, guided-prayer audio, and (later) search assets** in the corpus, and fetching **episode/video/article lists** live (with aggressive client caching).
+
+### 3.1 New catalog kind: `creator`
+
+Added to `CatalogItemKind` in `apps/app/src/content/manifestTypes.ts`:
+
+```ts
+type CreatorManifest = {
+  id: string                               // 'creator/fr-mike-schmitz'
+  name: LocalizedText
+  byline?: LocalizedText                   // 'Diocese of Duluth · Bible in a Year'
+  bio: LocalizedText                       // 1-3 paragraph bio
+  avatarHash?: BlobRef                     // square avatar, 512x512 webp
+  bannerHash?: BlobRef                     // optional 16:9 hero
+  languages: ('en-US' | 'pt-BR' | 'la')[]
+  charism?: string                         // 'diocesan' | 'dominican' | …
+  role?: string                            // 'priest' | 'religious' | 'lay-theologian'
+  channels: CreatorChannel[]
+  links?: { website?: string; donate?: string }
+  tags?: string[]
+}
+
+type CreatorChannel = {
+  kind: 'podcast' | 'youtube' | 'rss'
+  feedUrl?: string                         // podcast / rss
+  channelId?: string                       // youtube
+  title?: LocalizedText
+  format?: 'qa' | 'homily' | 'lecture' | 'reflection' | 'news' | 'mixed'
+  readMode?: 'full' | 'summary'            // rss only
+}
+```
+
+`CatalogEntry` hints (already supported) populate `name`, optional `author`, `tags`, plus a new optional `creatorRole` so the directory grid renders without fetching every manifest. Avatar/banner blobs flow through the existing image pipeline in `scripts/build-corpus.py` (same as book images).
+
+### 3.2 Live items: not in the corpus
+
+Episodes, videos, and articles are **never** stored in the corpus. They live in:
+- **External feeds** (podcast RSS, YouTube channel feed, blog RSS).
+- **Client-side cache** in SQLite.
+- **For pinned items**: file blob (mp3 / cached HTML / cached image) lives in `documentDirectory/blobs/`, keyed by `sha256(media_url)`. The existing `store.evictTo(budgetBytes, protectedHashes)` LRU is reused; pinned-episode hashes join the protected set.
+
+### 3.3 New catalog kind: `playlist` (v1.1)
+
+A playlist is an **editor-curated ordered set of media items**. It is the unified primitive for:
+- A topical bundle ("Best of *Resposta Católica* on Confession").
+- A seasonal series ("Lent with Bishop Barron — 40 daily reflections").
+- A multi-day program ("St. Joseph 30-day consecration audio companion").
+- A guided prayer ("Rosary with Padre Paulo Ricardo") — the same shape, plus practice-binding metadata.
+
+```ts
+type PlaylistManifest = {
+  id: string                              // 'playlist/lent-with-bishop-barron'
+  title: LocalizedText
+  description?: LocalizedText
+  coverHash?: BlobRef
+  curator: { kind: 'editorial' } | { kind: 'creator'; creatorId: string }
+  featuredCreatorIds?: string[]           // creators whose content appears
+  language: 'en-US' | 'pt-BR' | 'la' | 'mixed'
+  tags?: string[]                         // 'lent' | 'advent' | 'confession' | …
+  items: PlaylistItem[]
+  practiceBinding?: PracticeBinding       // present iff this is a guided prayer
+  rights?: 'creator-granted' | 'public-domain' | 'cc-by'  // when items include redistributed audio
+}
+
+type PlaylistItem =
+  | { kind: 'feed-item'; itemId: string; creatorId: string }   // ref to a podcast/RSS episode
+  | { kind: 'youtube';   videoId: string; creatorId?: string }
+  | { kind: 'audio-blob'; hash: string; size: number; durationS: number; title?: LocalizedText } // self-hosted audio (e.g., a guided Rosary track)
+  | { kind: 'article';   webUrl: string; rssItemId?: string }
+  | { kind: 'corpus';    ref: string }                        // 'prayer/our-father', 'book/.../chapter/...', etc.
+
+type PracticeBinding = {
+  practiceId: string                      // 'practice/rosary'
+  // Map flow sections to playlist items — and optionally to a [tStart,tEnd] inside that item.
+  segments: {
+    sectionPath: string                   // path inside the practice flow tree
+    itemIndex: number                     // index into items[]
+    tStart?: number                       // seconds; omit for full-item playback
+    tEnd?: number
+  }[]
+}
+```
+
+**Why this is one kind, not two:**
+- A *Lent series* uses `items` only, no `practiceBinding`. It's just an ordered listening experience.
+- A *guided Rosary* uses one `audio-blob` item plus a `practiceBinding` that maps each flow section to `{tStart, tEnd}` in that audio.
+- A *guided Stations* could use 14 `audio-blob` items + a `practiceBinding` with `itemIndex: 0..13` (no `tStart`).
+- Same browse UI, same pinning, same search indexing — and where appropriate, the same playlist surfaces inside a practice as a "voice / guided" option.
+
+**Where the metadata gets reused:**
+- Search indexes playlists by title, description, item titles → "Lent" returns "Lent with Bishop Barron."
+- Home highlights seasonal playlists ("Advent companion") at the right liturgical moment.
+- A creator profile's "Pray with" tab is just `playlists where curator.creatorId == creator OR creator is featured AND practiceBinding != null`.
+- A creator profile's "Series" tab is just `playlists featuring this creator`.
+- Plan of Life can later allow enrolling in a playlist as a 40-day rule.
+
+Playlists are first-class catalog items: kind `playlist`, hashed manifest in Hearth, pinnable, language-localized. Cover art and any self-hosted `audio-blob` items flow through the existing image / track-blob pipeline in `scripts/build-corpus.py`.
+
+### 3.4 New SQLite tables
+
+No formal migrations (per project policy). Idempotent `CREATE TABLE IF NOT EXISTS` on boot through `apps/app/src/db/client.ts`'s schema-bootstrap path.
+
+```sql
+CREATE TABLE IF NOT EXISTS creator_follows (
+  creator_id  TEXT PRIMARY KEY,
+  followed_at INTEGER NOT NULL,
+  auto_pin_count INTEGER DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS feed_items (
+  item_id      TEXT PRIMARY KEY,           -- sha256(channel + guid)
+  creator_id   TEXT NOT NULL,
+  channel_kind TEXT NOT NULL,
+  guid         TEXT NOT NULL,
+  title        TEXT NOT NULL,
+  summary      TEXT,
+  published_at INTEGER NOT NULL,
+  duration_s   INTEGER,
+  media_url    TEXT,
+  web_url      TEXT,
+  image_url    TEXT,
+  chapters_json TEXT,                       -- parsed chapter markers
+  raw_json     TEXT NOT NULL,
+  fetched_at   INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS feed_items_by_creator ON feed_items(creator_id, published_at DESC);
+CREATE INDEX IF NOT EXISTS feed_items_recent     ON feed_items(published_at DESC);
+
+CREATE TABLE IF NOT EXISTS media_progress (
+  item_id      TEXT PRIMARY KEY,
+  position_s   REAL NOT NULL,
+  duration_s   REAL,
+  completed_at INTEGER,
+  updated_at   INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS search_history (
+  query        TEXT NOT NULL,
+  searched_at  INTEGER NOT NULL,
+  PRIMARY KEY (query, searched_at)
+);
+
+-- Per-practice voice selection: which guided variant is preferred for this practice (v1.1)
+CREATE TABLE IF NOT EXISTS practice_voice (
+  practice_id  TEXT PRIMARY KEY,
+  guided_id    TEXT,                       -- null = silent
+  updated_at   INTEGER NOT NULL
+);
+```
+
+`item_id` and chapter-keyed deep-link IDs are **deterministic** so pinned local blobs survive reinstalls when device backups restore the documents directory.
+
+---
+
+## 4. UX
+
+### 4.1 Information architecture
+
+- **Browse** (`apps/app/src/app/browse/index.tsx`) gains:
+  - A `Creators` row near the top of the Wisdom section — horizontal scroll of creator avatars with name + byline.
+  - A `Latest from your creators` row appears **only if** the user follows ≥1 creator.
+- **New routes** under `apps/app/src/app/creators/`:
+  - `creators/index.tsx` — directory (grid + filter chips: language / charism / format).
+  - `creators/[creatorId].tsx` — profile page.
+  - `creators/[creatorId]/episode/[itemId].tsx` — episode/video/article detail.
+- **Search overlay**: full-screen modal `search` opened from the `🔍 Ask…` pill on home.
+- **Home** gets a **compact** `Latest` mini-row (3-5 items) above the fold's lower edge, hidden if the user follows nobody.
+- **Persistent Now-Playing mini-bar**: rendered in `_layout.tsx` above the navigation surface. Visible on every screen once audio is playing or paused.
+
+### 4.2 Creator profile page
+
+```
+[banner image, 16:9, soft fade]
+[avatar] Padre Paulo Ricardo                          [Follow ✓]
+         Sacerdote · Resposta Católica · pt-BR
+         [bio paragraph]
+
+[Tabs: Listen · Watch · Read · Series · Pray with]   ← only render tabs that exist; Series + Pray with are v1.1
+
+  Listen tab:    list of episodes, newest first, ▶ + ⋯ menu (Pin / Mark played)
+                 header action: "Pin latest 3 →" (sets auto_pin_count = 3)
+  Watch tab:     grid of YouTube videos → in-app iframe player
+  Read tab:      list of articles → article reader
+  Series tab:    (v1.1) editorial playlists featuring this creator — "Lent with Bishop Barron" etc.
+  Pray with tab: (v1.1) guided-prayer playlists led by this creator — "Rezar o Rosário com Padre Paulo Ricardo".
+                 ▶ button starts the practice with this voice selected.
+
+[Footer: external links — website, donate (discreet)]
+[Subtle "Suggest an edit" link → GitHub issue]
+```
+
+Reuses existing components: `AnimatedPressable`, `PageHeader`, `ScreenLayout`; `CollectionCard` patterns; `ReaderWebView` for articles + YouTube embed.
+
+### 4.3 Audio player (full screen)
+
+- Artwork hero, scrubbable progress, ±15s skip, speed (0.8 / 1.0 / 1.25 / 1.5 / 2.0), sleep timer, pin toggle, share-link, "open original."
+- Mini-bar shows: thumbnail · title · ▶/⏸ · ✕.
+- Background playback: `expo-av` `Audio.setAudioModeAsync({ staysActiveInBackground: true })`; Media Session API on web.
+
+### 4.4 Video player
+
+- YouTube **iframe player** in a `react-native-webview` on native; native `<iframe>` on web. Compliant with YT ToS — we don't proxy video.
+- Aspect-ratio container; PiP exit when scrolling.
+
+### 4.5 Article reader
+
+- **Default v1 path: summary-only.** Many Catholic blogs ship truncated RSS, and full-text rendering across paywalls / Cloudflare / inconsistent feed hygiene is a long tail we shouldn't fight on day one.
+- Per-source allowlist (in `creator/manifest.json` → `channels[].fullText: true`) opts a known-good feed into in-app `ReaderWebView` rendering with the Ember reader stylesheet.
+- All other feeds: summary + `Read on the web` → opens the original URL in WebView (or external browser on web).
+- Markable as read (`media_progress.completed_at`) regardless of mode.
+
+### 4.6 Latest mini-feed (Home)
+
+Cross-creator merge sorted by `published_at DESC`:
+- Up to 8 cards in a horizontal scroller.
+- Each card: 1:1 thumbnail · creator avatar overlay · title (2 lines) · 🎧/▶/📄 chip · duration if media.
+- Empty state when no follows: a CTA card linking to `/creators`.
+
+### 4.7 Voice selector on practice start (v1.1)
+
+When a practice has Pray-with playlists available in the user's language, the practice start screen surfaces a small voice control:
+
+```
+Rosary
+Today: Sorrowful Mysteries
+
+[ Voice: Silent ▾ ]      ← tap → sheet listing: Silent, Padre Paulo Ricardo, …
+                         ← persisted in practice_voice
+[Begin]
+```
+
+Selecting a voice persists for that practice. The next time the user starts the Rosary, the same voice is preselected.
+
+### 4.8 i18n strings
+
+All new copy lives in `apps/app/src/lib/i18n/locales/{en-US,pt-BR}.json` under `creators.*`, `search.*`, and `guided.*` namespaces. Creator-supplied bio / byline / channel titles use `LocalizedText` and resolve via `localizeContent()`.
+
+---
+
+## 5. Global Search — the killer feature
+
+### 5.1 The insight
+
+The Catholic creator ecosystem has already done the hard editorial work. The best priests and producers publish in **explicit Q&A or topical-question format** — every episode title is a real question a Catholic asked, with a faithful, magisterial answer:
+
+- **Padre Paulo Ricardo — *Resposta Católica*** (pt-BR): hundreds of episodes, each titled with a specific question. *"Posso comungar em pecado mortal?"*, *"O que é a graça santificante?"*, *"Como confessar pecados esquecidos?"* — that is already a searchable doctrinal manual.
+- **Pints With Aquinas listener Q&As**, **Catholic Answers Live**: same shape in English. Each episode title or chapter is a question.
+- **Fr. Chad Ripperger** lectures, **Fr. Gregory Pine** explainers, daily-reflection podcasts: questions and topics in titles.
+- **Catechism / Compendium chapter headings** are themselves Q-A pairs.
+
+**This means a serious catechetical search engine emerges from indexing nothing more than titles, descriptions, and show-notes — combined with editorial curation guaranteeing every result is faithful.** No transcription. No ML. Just curation × the right indexable surface.
+
+### 5.2 The vision
+
+One search box on the home screen. Type a question. Get hits across:
+- **Q&A episodes** where the title literally is the question.
+- **Topical homilies, lectures, articles** where the title or description names the topic.
+- **Catechism paragraphs / Compendium Q-A pairs / book chapters** in the corpus.
+- **Saints, prayers, practices** the user can act on.
+
+Type *"posso comungar em pecado mortal"* → first result is the PPR *Resposta Católica* episode of that exact name, ready to play. Type *"how do I prepare for Confession"* → results include a Pints With Aquinas episode, a *Catholic Answers Live* segment, the relevant CCC paragraphs, and the in-app Confession examen practice. **That is the wow** — and it ships in v1.
+
+### 5.3 Architecture (v1 — title + description + show-notes)
+
+No new corpus kind for indexes is needed yet. Search runs on data already on-device:
+
+- `feed_items.title`, `feed_items.summary`, `feed_items.chapters_json`.
+- `feed_items.creator_id` for filtering and credibility ranking.
+- Corpus content from warmed manifests at boot: book titles + chapter titles + TOC entries, prayer titles + sources, saint names, collection names, CCC paragraph headings, Mass propers names.
+
+**On-device index build at boot**:
+- A single **FlexSearch** in-memory index keyed by `(kind, id, segmentId?)` over the union above.
+- Per language: en-US and pt-BR each get their own index. Latin titles fold into both.
+- Rebuild incrementally on every successful feed refresh — only the touched creator's items re-index.
+- Cost target: < 50 ms cold-start over ~10k titles. Memory < 5 MB.
+- The indexer takes a kind-pluggable registry so v1.1 can add `playlist` without rewriting it.
+
+**Free per-question deep-linking from show notes**: many Q&A podcasts include chapter markers — either as the `<podcast:chapters>` namespace or as plain-text timestamp lists in `<description>` (`"00:00 Intro / 02:30 Pergunta 1: ... / 15:42 Pergunta 2: ..."`). The feed fetcher parses both and stores them in `feed_items.chapters_json`. Search returns hits at the **chapter level** (per-question), not just the episode level — with a timestamp, no transcription required. PPR-style Q&A shows become *per-question* searchable for free.
+
+**Ranking**: BM25 (FlexSearch's built-in) + a per-kind prior (Q&A-tagged creator content boosts on question-shaped queries; corpus content boosts on definitional queries) + recency for media items.
+
+**Privacy**: queries run entirely on-device. Nothing leaves the phone. No analytics on what users search.
+
+### 5.4 Q&A-format tagging
+
+The `format` field on `CreatorChannel` (see §3.1) is editorial metadata, not ML. Channels marked `format: 'qa'` boost on question-shaped queries (queries that start with "como", "o que", "posso", "what", "how", "can I", "should I", "why"). The directory can also filter by format, so users can browse "all Q&A creators."
+
+### 5.5 Search UI
+
+- **Home**: a discrete `🔍 Ask…` pill at the top, opening a full-screen search overlay. Reachable from any screen via a small icon in the navigation header.
+- **Result tabs**: `All · Q&A · Listen · Watch · Read · Books · Catechism · Saints · Prayers`.
+- **Result row anatomy**:
+  - Source icon + creator avatar (creator content) or content icon (corpus content).
+  - Title (the question, for Q&A channels).
+  - Subtitle: creator name / source.
+  - Timestamp chip when a chapter marker matched: `02:30 →` for the second question of an episode.
+- **Empty state** suggests example questions drawn from the actual highest-quality Q&A episodes of seed creators. Localized: pt-BR pulls from PPR; en-US from *Catholic Answers Live* / *Pints With Aquinas*. **The empty state itself becomes a starter catechetical FAQ** — tap a suggestion to play the answer.
+- **Recent searches** persist in `search_history`; clearable from Settings.
+
+### 5.6 Phased rollout
+
+- **Phase A — v1 (the wow ships here, no ML)**:
+  - On-device FlexSearch over feed_items + corpus titles/descriptions/show-notes.
+  - Chapter-marker parsing for free per-question deep-linking.
+  - `format: 'qa'` ranking boost.
+  - Localized question-suggestion empty state.
+- **Phase B — v1.1 (editorial enrichment)**:
+  - Curated **canonical-question redirects**: a small `content/answers/*.json` file maps frequent user questions to a top hand-picked episode/chapter/CCC paragraph. Hand-edited by maintainer; tiny effort, huge perceived quality.
+  - Multilingual question synonyms (e.g., "comunhão" ↔ "Eucaristia").
+  - Index full book bodies + every CCC paragraph (already on-device).
+- **Phase C — v2 (transcripts, only if needed)**:
+  - Optional Whisper transcription pipeline for top creators that *don't* publish Q&A-format titles.
+  - FlexSearch index extended with transcript segments + word-level timestamps.
+  - Scoped narrowly so we don't pay transcription cost for content that's already title-searchable.
+- **Phase D — v3 (semantic, only if measurably needed)**:
+  - Small on-device embedding model for queries whose lexical match is weak.
+  - Hybrid (BM25 + vector) retrieval. Privacy-preserving — local only.
+
+**The point: don't build Whisper until v1 search has run for a few months and we know which queries actually fail.** Editorial curation may already cover 80% of what users ask.
+
+### 5.7 Why this fits Ember's DNA
+
+- **Editor-curated → trustworthy**: only orthodox creators are indexed. Every result is a faithful answer. Google, Apple Podcasts, YouTube cannot say this.
+- **Cheap to ship**: title indexing is trivial. The wow comes from *who* is in the index.
+- **Offline-first**: the index is built on-device from already-cached data. Search works fully offline against any creator whose feed has been fetched once.
+- **Multilingual**: pt-BR and en-US from day one — and PPR alone is a flagship reason this matters.
+- **Privacy-respecting**: queries never leave the device.
+
+---
+
+## 6. Series & Pray with — playlists & guided prayers (v1.1)
+
+> Internally one `playlist` corpus kind. User-facing: editorial bundles surface as **Series**; practice-binding ones surface as **Pray with [Creator]**.
+
+### 6.1 Playlists — the primitive
+
+A playlist is an editor-curated ordered set of media items (see §3.3). It is the unified shape powering several distinct user experiences:
+
+- **Topical bundles** — *"Best of Resposta Católica on Confession"*, *"Bishop Barron on the Mass"*, *"How to read Scripture: 8 talks by Fr. Gregory Pine"*.
+- **Seasonal series** — *"Lent with Fr. Mike: 40 daily reflections"*, *"Advent companion 2026"*, *"Octave of Easter homilies"*.
+- **Multi-day programs** — audio companions to existing devotional programs (St. Joseph 30-day consecration, 54-day Rosary novena, Total Consecration to Mary).
+- **Guided prayers** (the flagship special case) — *"Pray the Rosary with Padre Paulo Ricardo"*, *"Stations of the Cross with Bishop Barron"*.
+
+Same data model. Same browse UI. Same pinning. Same search indexing. The only difference between a "Lent series" and a "guided Rosary" is whether `practiceBinding` is set.
+
+### 6.2 Where playlists surface
+
+| Surface | What appears | User label |
+|---|---|---|
+| Browse → new row | Featured editorial playlists, season-aware (Advent playlists in Advent, Lent in Lent). | **Series** |
+| Creator profile → tab | Playlists featuring this creator (no `practiceBinding`). | **Series** |
+| Creator profile → tab | Playlists by/featuring this creator that have `practiceBinding`. | **Pray with** |
+| Practice start screen → voice selector | Playlists with `practiceBinding.practiceId == this practice`, in the user's language. | (inline: "Pray with [Creator]") |
+| Home → seasonal hero | One liturgically-aligned playlist surfaced when relevant. | **Series** |
+| Search | Playlist titles + descriptions + item titles indexed alongside everything else. | (per-row label) |
+
+### 6.3 Guided Prayers — the killer special case
+
+A user opens the Rosary practice and sees: *"Rezar com Padre Paulo Ricardo"* / *"Pray with Bishop Robert Barron"*. They tap, the flow plays, and each Hail Mary, mystery announcement, and Glory Be is voiced by that creator. **The user prays *along with* the priest, not at the priest.** It's the difference between watching someone pray and praying yourself.
+
+**Why this matters.** Prayer is a school. The voice you pray with shapes your interior life. A novice praying alongside a recollected, faithful priest learns the Rosary's pace, gravity, and meditative rhythm in a way silent text or generic TTS cannot teach. It is **not just listening** — it is praying. That alignment with Ember's mission is rare, and it is the most distinctive thing a Catholic prayer app can offer. It is the bridge between **Wisdom** (creator content) and **Fidelity** (rule of life) — turning creators from voices you consume into companions in your spiritual life.
+
+**v1.1 coverage:**
+- **Rosary** (Joyful / Sorrowful / Glorious / Luminous, mystery selected by day, as today).
+- **Stations of the Cross**, **Divine Mercy Chaplet**, **Angelus** added in v2.
+
+The Liturgy of the Hours is v2-or-later.
+
+### 6.4 Architectural fit — playlist + `practiceBinding`, no new flow extension
+
+A guided prayer is a playlist with one or more `audio-blob` items and a `practiceBinding` mapping the parent practice's flow sections to playlist items (and optional intra-item time ranges). Two common shapes:
+
+1. **One continuous track** (cheapest for creators) — a single `audio-blob` item; `practiceBinding.segments[i].tStart/tEnd` defines section offsets within it. Player seeks to boundaries as the flow advances.
+2. **Per-section blobs** (cleanest re-recording) — N `audio-blob` items, one per flow section; `practiceBinding.segments[i].itemIndex` points to the right one; no `tStart` needed.
+
+Both are the same `PlaylistManifest`. The `GuidedAudioController` (in `apps/app/src/features/practice/guided/`) reads `practiceBinding`, listens to flow advance events, and tells the audio player to seek/play. **No change to the flow DSL itself** — the binding lives outside the flow, in the playlist. This keeps practice flows unaware of audio and avoids polluting `packages/content-engine/`.
+
+> ⚠️ **Open implementation question — `sectionPath` semantics.** `FlowSection` in `packages/content-engine/src/types.ts` is a structurally-nested discriminated union with no stable id on container nodes, and the flow renders dynamically (day-of-week selects, mystery cycles, fragment expansion, repeats). A naive index-path is fragile across these. **Before v1.1 implementation begins**, do a small spike: walk `RenderedSection`s for `practice/rosary` on each weekday and design `sectionPath` so it stably resolves under each mystery cycle. Two candidates: (a) add an optional stable `id` field to relevant FlowSection container types and address by id (a real but tiny DSL change), or (b) define `sectionPath` as a structural address that's invariant under the dynamic operators we use today (cycle index by mystery name, not by render order). Whichever we pick, the spike's output is a one-page note in `docs/features/guided-prayers.md` referenced by the build-script validator.
+
+Because the parent practice is unchanged, all of its existing capabilities — scheduling, completion tracking, plan-of-life integration, pause/resume, streaks, devotional metrics — apply for free.
+
+### 6.5 Content authoring
+
+```
+content/playlists/
+  lent-with-bishop-barron/
+    manifest.json                          # editorial bundle, no practiceBinding
+    cover.webp
+  rosario-com-padre-paulo-ricardo/
+    manifest.json                          # has practiceBinding -> practice/rosary
+    cover.webp
+    audio.mp3                              # continuous track, hashed as a blob
+```
+
+`scripts/build-corpus.py` gains a `build_playlists()` walker. Existing image and track blob pipelines are reused. The build script validates that any `practiceBinding.segments[i].sectionPath` actually resolves in the referenced practice's flow.
+
+### 6.6 UX during prayer
+
+- **Voice selector** on the practice start screen (see §4.7), populated from playlists where `practiceBinding.practiceId == this practice` and `language` matches.
+- **Auto-advance**: as each section completes (the creator finishes the prayer in the audio), the flow advances. The user stays in control — tap to advance early, hold to pause, swipe to repeat.
+- **Minimal in-prayer chrome**: a subtle `🔊 Padre Paulo Ricardo` chip; tap reveals a small control sheet (pause, ±5s, speed, exit voice → silent).
+- **Mid-prayer pause**: existing practice resume mechanism applies; on resume, audio re-cues to the current section's start.
+- **Speed**: 0.8× / 1.0× / 1.25× — user-controllable to match their own praying pace.
+- **Resume across sessions**: if the user paused at the 3rd Sorrowful Mystery yesterday, they resume there with audio re-cued.
+
+### 6.7 Offline
+
+- Pinning a playlist pulls cover art, any self-hosted `audio-blob` items, and (transitively) the underlying media for `feed-item` items if the user opts into "pin all items." A new `COLLECTORS['playlist']` entry handles the transitive walk.
+- Pinning a guided-prayer playlist therefore pins the audio that drives the guided practice — the whole guided Rosary plays cold, no network.
+- Pinning the parent practice (Rosary) optionally pins all its guided playlists — toggle in Settings.
+- Storage: a 25-min guided Rosary at 64 kbps mono ≈ 12 MB. Well within the 1 GB cap.
+
+### 6.8 Editorial / rights flow
+
+- Every playlist that redistributes audio (i.e., contains `audio-blob` items) requires explicit creator permission or permissively-licensed source material. Rights status is recorded in `PlaylistManifest.rights`.
+- Editorial process treats this with the same care as book translation rights.
+- **No AI voice cloning of creators**, ever.
+- Playlists made entirely of `feed-item` / `youtube` / `corpus` references don't redistribute anything new — they're curated lists pointing at existing public sources, no rights issue beyond the existing podcast/YT terms.
+
+### 6.9 Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Rights / consent | Editorial process — opt-in only; no AI cloning; rights status in manifest. |
+| Creator audio re-record | Content-addressed corpus; each version is a new hash; old hash still works for users who pinned it. |
+| Pace mismatch (creator prays faster than user) | User-controllable speed; auto-advance can be toggled off (manual progression with audio as accompaniment). |
+| Section-boundary timing errors | Build script validates `practiceBinding.segments[*].sectionPath` against the practice flow; small pad margin on `tStart/tEnd`. |
+| Storage bloat | ~12 MB per Rosary; 1 GB cap; per-creator local size visible in Settings. |
+| Stale `feed-item` refs (creator deletes an episode) | Resolver tolerates missing items; surfaces a soft "no longer available" state on that playlist row. |
+
+---
+
+## 7. Feed Fetching & Caching
+
+### 7.1 Refresh strategy
+- **On app foreground**, debounced to once per 30 minutes per creator: fetch the latest N=20 items per channel for every followed + featured creator.
+- **On profile open** for an unfollowed creator: fetch on demand; cache 6 hours.
+- **Manual pull-to-refresh** on profile and on home `Latest` row.
+- All fetches go through a single `feedFetcher` module with global rate-limiting (max 4 concurrent).
+
+### 7.2 Parsers
+- **Podcast RSS / Atom**: `apps/app/src/features/creators/feeds/podcast.ts` using `fast-xml-parser`. Parse `<title>`, `<itunes:image>`, `<enclosure url>`, `<itunes:duration>`, `<pubDate>`, `<guid>`, `<description>`, `<podcast:chapters>` (when present), and a regex pass over `<description>` for plain-text timestamp lists.
+- **YouTube channel**: public `feeds/videos.xml?channel_id=…` Atom feed — **no API key, no quota**. Parse `<entry>` with `media:thumbnail`, `yt:videoId`, `published`, `title`, `media:description`. Plain-text timestamp regex pass on description (YouTube chapters).
+- **Blog RSS / Atom**: same XML parser, dispatches on root element.
+
+### 7.3 Storage & TTL
+- Successful fetches upsert into `feed_items`. Keep at most the most recent 200 per creator (older rows pruned at refresh time).
+- Failed fetches keep stale rows visible with a soft "stale since …" chip.
+- `raw_json` allows schema evolution without re-parsing.
+
+### 7.4 Pinning (creator + item)
+
+A pinned episode triggers:
+1. Download `media_url` to `documentDirectory/blobs/<aa>/<bb>/<sha256(media_url)>`.
+2. Mark its hash protected via the existing pinning manager. New `COLLECTORS['creator']` (avatar + banner blobs), `COLLECTORS['feed-item']` (media + image), and `COLLECTORS['guided-flow']` (track + per-section audio).
+3. On player start, the player resolves `media_url` → local file URI if pinned, otherwise streams.
+
+YouTube videos are **not pinnable** (against YT ToS). Articles **are** pinnable. Guided-prayer audio **is** pinnable.
+
+---
+
+## 8. Offline & Local-First (deep dive)
+
+**Principle.** Every content type a user might want at Mass, on a flight, on retreat, or in the woods must work offline. Ember is a *fidelity* tool — spotty connectivity at 7 a.m. Mass cannot be a reason a user skips morning prayer or their daily Fr. Mike Schmitz episode. **If it shipped to your device, it works without a network. Full stop.**
+
+### 8.1 What's already offline today
+Catalog, prayers, practices, books, collections, Mass propers — all blob-cached and pinnable via the existing system. No regression.
+
+### 8.2 New offline surfaces
+
+| Surface | Offline behavior |
+|---|---|
+| Creator metadata (name, bio, avatar, banner) | Pulled in as part of catalog warm-up; pinning a creator guarantees avatar/banner are local. Directory renders fully offline. |
+| Episode lists (titles, dates, durations, art) | Cached in `feed_items` SQLite indefinitely. Last-known list shows offline; soft "stale since Tue 9pm" indicator if older than 24h. |
+| **Audio episodes** | User pins → mp3 downloads to local blob. Pinned episodes play offline with full mini-bar / lock-screen controls. |
+| Articles (RSS text) | Pinned articles cache HTML + inline images locally. |
+| YouTube videos | **Not pinnable** (against ToS). Profile labels videos as "online only." |
+| **Playlists** (incl. guided prayers, v1.1) | Pinning a playlist pulls cover art + any `audio-blob` items. With "include items" on, it transitively pulls feed-item media too. The whole guided Rosary plays cold; the whole Lenten series plays cold. |
+| **Search** | The on-device FlexSearch index is built from already-cached data — search works fully offline against any creator whose feed has been fetched once. |
+| Search history & follows | Local SQLite; always available. |
+
+### 8.3 Pinning ergonomics
+
+- Per-item pin (existing pattern, surfaced on every episode/article row).
+- **Per-creator auto-pin policy**: a one-tap "Pin latest 3" on the creator profile sets `creator_follows.auto_pin_count = 3`. New episodes auto-pin; oldest beyond N auto-unpins. No background magic — runs on each successful feed refresh.
+- **Wi-Fi-only download** toggle in Settings (default ON) protects cellular bills.
+- **Background download** (iOS background URL session, Android WorkManager) — deferred to v1.1 if not trivial; v1 downloads on foreground with a visible progress chip.
+
+### 8.4 Storage management UI
+
+Extends Settings → Storage:
+- Per-creator local size, oldest pinned episode date, count.
+- One-tap "free up X MB" that unpins least-recently-played episodes.
+- Soft cap stays at 200 MB by default but **bumps to 1 GB** if any podcast/video creator is followed (more realistic for media). User can override.
+
+### 8.5 Conflict-free behavior
+
+- LRU eviction never touches user-pinned blobs (existing protected-set guarantee).
+- Pinned episodes survive app reinstalls only when device-level backup includes the documents directory.
+- `media_progress` is small text — safe to back up unconditionally.
+
+### 8.6 First-run on flight mode
+
+- Catalog cache + warmed manifests serve everything except live feeds.
+- Followed creators show last-cached episode lists.
+- Pinned episodes / articles play and read without any network.
+- Pinned guided prayers run end-to-end with full audio.
+- Search across pinned creators returns hits, including chapter-marker deep-links.
+- Unpinned creators show last-cached lists with a stale chip.
+
+### 8.7 Network-aware UX
+
+- Subtle "offline" chip in the navigation header when no connectivity.
+- Tapping a non-pinned remote item shows a clear "needs internet" state instead of a silent loading spinner.
+- Refresh actions disable rather than fail noisily.
+- Once playback begins on a streamed episode, the player progressively caches what it has streamed so the user can scrub backward without re-fetching.
+
+---
+
+## 9. Technical Architecture (summary)
+
+| Concern | Approach |
+|---|---|
+| Catalog extension | New `creator` (v1) and `playlist` (v1.1) kinds in `CatalogItemKind` (`apps/app/src/content/manifestTypes.ts`). |
+| Build pipeline | `build_creators()` (v1) and `build_playlists()` (v1.1) walkers in `scripts/build-corpus.py`. Cover art and `audio-blob` items flow through the existing image/track-blob paths. The playlist builder validates `practiceBinding.segments[*].sectionPath` against the referenced practice's flow. |
+| Resolver | `resolveCreator(id)`, `loadCreator(id)`, `resolvePlaylist(id)`, `loadPlaylist(id)` in `apps/app/src/content/resolver.ts`. Creators and playlists warm in `warmDeferredManifests()`. |
+| Pinning | Extend `COLLECTORS` table in `apps/app/src/features/pinning/pinningManager.ts` with `creator`, `feed-item`, and (v1.1) `playlist` (transitively pulls cover, audio-blob items, and optionally feed-item media). |
+| Feed fetching | `apps/app/src/features/creators/feeds/` (`podcast.ts`, `youtube.ts`, `rss.ts`, `chapters.ts`, `fetcher.ts`). Foreground-triggered, SQLite-cached. |
+| Audio playback | `expo-av` for v1 (lighter, already pluggable). Re-evaluate `react-native-track-player` only if needed. |
+| Video playback | YouTube iframe inside `react-native-webview` on native; `<iframe>` on web. Reuses `ReaderWebView` patterns. |
+| Article reader | Reuses `ReaderWebView` (`apps/app/src/features/books/ReaderWebView.tsx`) with a creator-article CSS variant. |
+| Search runtime | `apps/app/src/features/search/` — `engine.ts` (FlexSearch builder + query), `hits.ts` (hydration + ranking), `useSearch.ts` hook. Index is in-memory, rebuilt on feed refresh. Kind-pluggable registry so v1.1 can add `playlist` without rewriting. |
+| Guided prayer engine (v1.1) | `GuidedAudioController` in `apps/app/src/features/practice/guided/` reads a playlist's `practiceBinding`, listens to flow advance events, and tells `expo-av` to seek/play. **No change to the flow DSL** — binding lives in the playlist, keeping `packages/content-engine/` audio-agnostic. |
+| State | Zustand store `apps/app/src/stores/creatorsStore.ts` (immer): `follows`, `feedItemsByCreator`, `latest`, `nowPlaying`, `progressById`, `voiceByPractice`. SQLite reads cached via TanStack Query. |
+| DB | New repos `apps/app/src/db/repositories/creators.ts`, `media.ts`, `practiceVoice.ts`. Idempotent `CREATE TABLE IF NOT EXISTS` on boot. |
+| i18n | Extend `apps/app/src/lib/i18n/locales/*` with `creators.*`, `search.*`, `guided.*` keys. |
+
+### Critical files to read before implementing
+- `apps/app/src/content/manifestTypes.ts` — kind union (`CatalogItemKind`); add `'creator'` and (v1.1) `'playlist'` here.
+- `apps/app/src/content/contentIndex.ts` — catalog index; new kinds register here, not just in the type union.
+- `apps/app/src/content/resolver.ts` and `store.ts` — resolution / blob cache.
+- `apps/app/src/features/pinning/pinningManager.ts` — `COLLECTORS` table.
+- `apps/app/src/features/books/ReaderWebView.tsx` — WebView abstraction reused for video + articles.
+- `apps/app/src/app/browse/index.tsx` — where the new `Creators`, `Latest`, and search-pill rows attach.
+- `apps/app/src/db/client.ts` — `CREATE TABLE IF NOT EXISTS` bootstrap on boot.
+- `apps/app/src/db/repositories/` — pattern to follow (existing: `practices.ts`, `cursors.ts`, `oblatio.ts`); new repos slot in here.
+- `packages/content-engine/src/types.ts` — `FlowSection` shape; relevant for the v1.1 `sectionPath` spike (no DSL change in v1).
+- `apps/app/src/features/practices/components/PracticeFlow.tsx` — `useAdvanceCursor` is where `GuidedAudioController` will hook flow-advance events in v1.1.
+- `scripts/build-corpus.py` — `build_collections()` is the pattern; insert `build_creators()` next to it (and `build_playlists()` in v1.1).
+- `apps/app/src/features/search/` — search engine module; design v1's indexer to take a kind-pluggable registry so v1.1 can add `playlist` without rewriting it.
+- `docs/features/corpus.md` and `docs/features/features-overview.md` — the docs we mirror and extend.
+
+---
+
+## 10. Privacy, Licensing, Compliance
+
+- **No tracking**. Follow state, progress, voice selection, and search queries are **local-only**. No analytics on listening, praying, or searching.
+- **Network calls** are limited to: Hearth corpus, podcast RSS hosts, YouTube Atom feed, blog RSS hosts, and (when streaming) creators' media CDNs. No proxying or rehosting.
+- **YouTube ToS**: respected via the iframe player exclusively; no audio-only extraction; no offline download of YT video.
+- **Podcast RSS** is publicly available by convention. Display attribution + link to the original host.
+- **Articles**: full text only when the feed includes it; summary-only feeds open the full article in WebView.
+- **Guided prayers**: explicit creator permission or permissively-licensed source material only. **No AI voice cloning.**
+- **Trademark / image rights**: avatars and banners sourced from the creator's public materials; explicit permission preferred. Editorial process treats this like book cover art.
+
+---
+
+## 11. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| RSS feed format drift breaks parsing | Tolerant parser; persist `raw_json` so we can re-parse without refetch; per-creator fallback to "open in browser." |
+| YouTube removes the public Atom feed | Documented fallback to YouTube Data API v3 (deferred — would need an API key + quota plan). |
+| App Store rejection over YT background audio | We don't attempt YT audio-only — we stream YT only via the official iframe player. |
+| Heterodox suggestion floods | Editorial review gate; no user-pasted RSS in v1. |
+| Feed-fetch network costs on cellular | Foreground-only refresh, debounced 30 min, capped concurrency; cellular "data saver" toggle. |
+| Storage growth from pinned episodes / guided audio | LRU soft cap (200 MB → 1 GB when media is followed); pinned media joins protected set; per-creator size visible in Settings. |
+| Search v1 quality on non-Q&A creators | Phase B canonical-question redirects; creator descriptions and corpus headings still hit; Phase C transcripts only if measurably needed. |
+| Article full-text fragility (paywalls / Cloudflare / inconsistent feeds) | Default to summary + "Read on the web"; per-creator `fullText` allowlist opts known-good feeds into in-app rendering. |
+| Guided-prayer audio rights | Editorial process; creator permission required; no AI cloning. |
+| Guided-prayer pace mismatch | Per-section auto-advance + user-controllable speed + manual progression mode. |
+| Guided-prayer section-boundary timing errors | Sanity-check `{tStart, tEnd}` ranges in the build script; add small pad margin; player seeks defensively. |
+| `sectionPath` instability under dynamic flow operators (cycles / day-of-week) | Pre-v1.1 spike defines stable addressing (creator-supplied id, or invariant structural address); build-script validator confirms across every weekday's mystery cycle. |
+| Player implementation complexity | Ship `expo-av` v1; only adopt `react-native-track-player` if we hit a concrete limitation. |
+
+---
+
+## 12. Phased Rollout
+
+### v1 launch
+
+**Phase 1 — Plumbing (no UI surface yet).**
+- New `creator` corpus kind, `build_creators()` in build-corpus.
+- Resolver + pinning extensions.
+- SQLite tables.
+- Feed fetcher with podcast + YouTube + RSS parsers; chapter-marker parsing.
+- 2-3 seed creators committed to `content/creators/`.
+
+**Phase 2 — Browse UI.**
+- `creators/index` directory and `creators/[id]` profile.
+- Listen / Watch / Read tabs with live feeds.
+- Audio player (full screen + mini-bar).
+- YouTube iframe player.
+- Article reader path.
+
+**Phase 3 — Home, follows & offline.**
+- Follow / unfollow + persistence.
+- Home `Latest` row.
+- Browse `Latest from your creators` row.
+- Per-item pinning + per-creator `auto_pin_count`.
+- Storage management UI.
+- Network-aware state across the app.
+
+**Phase 4 — Global Search v1 (the wow).**
+- Search overlay + result row + tabs.
+- On-device FlexSearch over feed_items + corpus titles/descriptions/show-notes.
+- Chapter-marker deep-linking.
+- `format: 'qa'` ranking boost.
+- Localized question-suggestion empty state.
+- `search_history` + recent searches.
+
+**Phase 5 — Polish.**
+- Speed / sleep timer / lock-screen metadata.
+- Skeleton + empty states.
+- pt-BR seed creators reach parity (≥40% of seed list lusophone).
+- Accessibility pass.
+- Background download (iOS / Android).
+
+**v1 ships here.** Each phase above is independent; nothing in Phase 1 is user-visible.
+
+### v1.1 (2-4 weeks after v1)
+
+**Phase 6 — Series (editorial playlists).**
+- `playlist` corpus kind + `build_playlists()` walker (no `practiceBinding` validation needed yet).
+- Browse `Series` row with seasonal awareness.
+- Creator profile `Series` tab.
+- 2-3 seed editorial playlists (Lenten series, topical bundle, Advent companion).
+- Pinning of playlists (transitive: cover + audio-blob items + optional feed-item media).
+- Search indexes playlist titles + descriptions + item titles.
+
+**Phase 7 — Pray with (guided prayers).**
+- Pre-implementation spike: define `sectionPath` semantics against dynamic flow tree (see §6.4).
+- Extend `playlist` validation to enforce `practiceBinding.segments[*].sectionPath` against the parent practice flow.
+- `GuidedAudioController` in `apps/app/src/features/practice/guided/` listens to flow advance, drives `expo-av` seek/play.
+- Voice selector on Rosary start, populated from playlists with `practiceBinding.practiceId == 'practice/rosary'` in the user's language.
+- Creator profile `Pray with` tab.
+- 1-2 seed guided-prayer playlists for the Rosary, single-track + chapter-map mode, with explicit creator permission.
+- Pinned guided Rosary plays cold (no network).
+
+**Phase 8 — Search v1.1 enrichment.**
+- Curated canonical-question redirects (`content/answers/*.json`).
+- Multilingual question synonyms.
+- Index full book bodies + every CCC paragraph.
+
+### v2
+
+**Phase 9 — Pray with expansion** — Stations / Chaplet / Angelus guided playlists; seasonal home hero; multi-day-program audio companions; per-section audio mode by default.
+
+**Phase 10 — Search v2 (transcripts), only if measurably needed.**
+
+---
+
+## 13. Verification
+
+- **Build**: `pnpm build:corpus` produces creator manifests, blobs, and catalog entries; `curl https://ember.dpgu.me/hearth/v2/catalog.json | jq '."creator/padre-paulo-ricardo"'` returns the expected entry.
+- **Resolver**: app boot warms creator manifests without blocking first paint (timing logged).
+- **Feeds**: with airplane mode off, opening a profile populates Listen/Watch/Read tabs from live feeds; with airplane mode on after one successful fetch, cached items render.
+- **Chapter parsing**: a fixture PPR feed with timestamp lists in `<description>` produces `feed_items.chapters_json` with the right `{tStart, title}` entries.
+- **Audio**: plays in background with lock-screen art + controls on iOS/Android; `media_progress` persists across app reload; pinned episode plays with **no network**.
+- **Video**: YouTube iframe loads on web and inside WebView on native.
+- **Pinning**: pinning a creator avatar makes the directory render offline; pinning an episode plays it offline; unpinning evicts the blob; auto-pin policy adds and trims correctly across feed refreshes.
+- **Offline cold start**: kill the app, enable airplane mode, relaunch. Followed creators render. Pinned episodes play. Pinned articles read. Pinned guided Rosary completes end-to-end. Search across pinned creators returns hits, including chapter-marker deep-links.
+- **Home**: with ≥1 follow, the Latest row appears and surfaces the most recent item per channel kind.
+- **Search v1**: with the v1 indexer warmed against ≥10k items per language (full seed corpus + cached feed items), typing *"posso comungar em pecado mortal"* returns the matching PPR *Resposta Católica* episode within 100 ms on a cold cache; tapping the chapter chip jumps the player to the right offset.
+- **Playlists** (v1.1): a seed editorial playlist appears in the Browse `Series` row; tapping opens its detail page; pinning the playlist (with "include items" on) makes every item playable offline.
+- **Guided Prayers** (v1.1): a `practiceBinding`-bearing playlist appears in the Rosary's voice selector; starting plays the first prayer's audio; advancing to the next decade re-cues audio at the next section boundary; pause/resume re-cues to the current section; offline (pinned) guided Rosary completes without network.
+- **Dynamic-flow `sectionPath`** (v1.1): start the guided Rosary on each weekday Mon-Sun; verify section boundaries align under each mystery cycle (Joyful / Sorrowful / Glorious / Luminous) with no off-by-one drift. Run with auto-advance on and again with manual progression.
+- **Build validation** (v1.1): an intentionally broken `practiceBinding.segments[i].sectionPath` causes `pnpm build:corpus` to fail with a clear error pointing at the playlist source file; same check passes for every weekday's mystery cycle.
+- **i18n**: switching to pt-BR translates all creator + search + guided UI; creator metadata that lacks pt-BR falls back to en-US.
+- **Tests**:
+  - Unit tests for the three feed parsers + chapter parser using fixture XML files (`apps/app/src/features/creators/feeds/__fixtures__/`).
+  - Unit tests for FlexSearch index build + ranking.
+  - Unit tests for `GuidedAudioController` section-boundary seeking (v1.1).
+  - End-to-end test for offline pinned playback (record-and-replay against a stub network).
+
+---
+
+## 14. Open Questions (non-blocking)
+
+1. Initial seed list of creators — drafted separately by maintainer.
+2. Final brand for the section: **Creators** vs. **Voices** vs. **Companions**. PRD assumes "Creators."
+3. Should followed-creator avatars get any subtle home-screen presence beyond the Latest row (e.g., an avatar strip)? Defaulting to **no** in v1.
+4. Donation links in profile footer — discreet text link or omit entirely? Defaulting to **discreet text link**.
+5. Per-question deep-links from chapter markers: should we render hits at the **chapter level** (one row per question in an episode) or **episode level** with a "jump to question" button? Defaulting to **chapter level** for Q&A-tagged channels and **episode level** otherwise.
+6. Guided Prayers — silent flow remains the default in v1.1; voice selector reveals creators (opt-in).
+7. Should users be able to create their own private playlists in v2 (mark-and-collect their favorite episodes)? Defaulting to **no**; revisit once we see usage.
+8. Transcripts (Search Phase C) — defer until v1.1 search has run for ≥3 months and we have a query log of failures.

--- a/docs/features/creators/phase-01-plumbing.md
+++ b/docs/features/creators/phase-01-plumbing.md
@@ -1,0 +1,408 @@
+# Phase 1 — Plumbing
+
+> Foundation phase. **Nothing user-visible ships in this phase.** Everything downstream depends on these primitives.
+
+**Goal.** Establish the data model, build pipeline, resolver, pinning, SQLite tables, and feed fetcher needed for creators. Land 2-3 seed creators in the corpus and verify the catalog/blob pipeline produces the expected output. After Phase 1, every subsequent UI phase builds on a known-good substrate.
+
+**Success criteria.**
+1. `pnpm build:corpus` produces `creator/<id>` catalog entries with avatar/banner blobs.
+2. App boot warms the new kind without measurable impact on first paint.
+3. `feedFetcher` ingests fixture XML for podcast / YouTube / RSS and writes correct rows to `feed_items`.
+4. Pinning a creator → avatar/banner blobs are protected from LRU eviction.
+5. All five new tables exist after a fresh DB bootstrap with no migration rollouts beyond the existing `0001_initial.sql`.
+
+---
+
+## 1. Major design decisions
+
+### 1.1 `creator` is a new first-class catalog kind, not a sub-type of `collection`
+
+**Decision.** Add `'creator'` to `CatalogItemKind` in `apps/app/src/content/manifestTypes.ts:14-26`.
+
+**Why.** A creator has structural metadata (channels, languages, charism, role, links) that has nothing to do with `CollectionItemManifest.sections`. Trying to overload collections would force every consumer of `CatalogItemKind` to disambiguate, and would block clean per-kind treatment in the directory grid, in pinning collectors, and in search ranking. Cost of a new kind is one line in the union plus one collector entry — far cheaper than the lifetime cost of an overloaded primitive.
+
+**Alternatives ruled out.**
+- *Reuse `collection`.* See above; structural mismatch.
+- *Inline creators inside `book.author` or similar.* No — creators are independent entities that exist before/independent of any specific work.
+
+### 1.2 Live items (episodes, videos, articles) are NOT in the corpus
+
+**Decision.** `feed_items` is a SQLite-only concept. Episode lists are fetched live from external feeds, cached in SQLite, and (when pinned) materialized as local file blobs keyed by `sha256(media_url)`. They never get a hash-addressed manifest in Hearth.
+
+**Why.** A podcast with a daily episode would force a corpus rebuild (and a 5KB+ catalog mutation) every day. Hash-addressing a stream that the upstream creator can edit, retract, or replace breaks the immutability contract that makes the corpus cheap and offline-friendly. SQLite gives us indexable, paginatable, cheaply-updatable storage for high-churn data — exactly what episode lists are.
+
+**Alternatives ruled out.**
+- *Treat each episode as a corpus blob.* Volatile data into immutable storage = constant catalog growth and cache thrash.
+- *Per-creator JSON snapshot blob refreshed daily.* Pre-fetches the world; defeats the demand-driven model.
+
+### 1.3 Append to existing `0001_initial.sql`, no new migration files
+
+**Decision.** New tables go into `apps/app/src/db/migrations/0001_initial.sql` (the file `client.ts:33` calls via `_db.execAsync`). All `CREATE TABLE IF NOT EXISTS` — idempotent on re-run.
+
+**Why.** Per `CLAUDE.md`: *"Currently this is a personal/solo project — do NOT add database migrations for schema changes unless explicitly asked."* The existing migration file is the bootstrap path; appending more `IF NOT EXISTS` statements keeps fresh installs and existing installs converging without versioning machinery.
+
+**Alternatives ruled out.**
+- *New `0002_creators.sql`.* Project policy says no.
+- *Programmatic schema management.* Premature complexity.
+
+### 1.4 Repository pattern split: event-sourced vs. raw SQLite
+
+**Decision.** Two tiers of new repos:
+
+- **Event-sourced** (small, user-action-driven): `creator_follows`, `practice_voice`, `search_history`. Use the existing `useEventStore.emit({ type: '...' })` pattern from `apps/app/src/db/repositories/practices.ts`.
+- **Direct SQLite** (high-volume, machine-driven): `feed_items`, `media_progress`. New repo helpers in `apps/app/src/db/repositories/feedItems.ts` and `mediaProgress.ts` use `_db` (`apps/app/src/db/client.ts`) directly with prepared statements.
+
+**Why.** Event sourcing each of ~2400 feed-item rows × refresh-every-30-min = unbounded event-log growth. Follows + voice selections are low-volume user actions where event sourcing's auditability is worth keeping. This split mirrors how the codebase already treats high-cardinality reads (cursors, completions) vs. user actions (practices).
+
+**Alternatives ruled out.**
+- *All event-sourced.* Event log explosion.
+- *All raw SQLite.* Loses the benefit existing repos get from `useEventStore`.
+
+### 1.5 Feed-item ID is `sha256(creator_id + ':' + guid)`, deterministic
+
+**Decision.** `feed_items.item_id = sha256(creator_id + ':' + guid)`. The same field is the sole stable cross-device identifier for an episode.
+
+**Why.** Reinstalls / device backups must restore pinned media to the same logical item. Hash-of-(creator+guid) is portable, doesn't depend on database row IDs, and survives RSS feed reordering. Using only `guid` would collide between creators that have shared an episode.
+
+### 1.6 Three-parser design with a shared dispatcher
+
+**Decision.** `apps/app/src/features/creators/feeds/` contains:
+
+```
+feeds/
+  fetcher.ts          # public entrypoint: refreshCreator(id) → fetch all channels
+  podcast.ts          # parses podcast RSS / Atom (itunes / podcast namespace)
+  youtube.ts          # parses YouTube Atom (feeds/videos.xml)
+  rss.ts              # parses generic blog RSS / Atom
+  chapters.ts         # parses chapter markers (podcast:chapters + plain-text regex)
+  xml.ts              # shared fast-xml-parser instance
+  rateLimit.ts        # global p-limit-style concurrency cap
+  __fixtures__/       # XML fixtures for unit tests
+```
+
+Each parser exposes the same shape: `parse(xml: string): FeedItemDraft[]`. The fetcher dispatches on `CreatorChannel.kind`, runs the parser, and the chapter-marker regex pass on the raw description.
+
+**Why.** Three feed shapes (podcast, YouTube, RSS) overlap in XML primitives but diverge in fields and namespaces. Forcing them through one normalizer creates a fat conditional; keeping them as siblings keeps each parser focused and unit-testable. The shared `xml.ts` ensures every parser sees the same XML option flags.
+
+**Alternatives ruled out.**
+- *One generic XML normalizer.* Forces lowest-common-denominator field set; loses YouTube `videoId`, podcast `enclosure`, etc.
+- *Per-creator custom parsers.* Combinatorial explosion as creators are added.
+
+### 1.7 YouTube uses public Atom feed, no API key
+
+**Decision.** YouTube channels are fetched from `https://www.youtube.com/feeds/videos.xml?channel_id=<id>` — a public XML endpoint, no auth, no quota.
+
+**Why.** Avoids quota-managing the YouTube Data API v3, avoids embedding an API key, sidesteps Apple's privacy requirements for third-party API keys. The public feed exposes the most-recent ~15 videos, sufficient for a "latest from this creator" surface. If YouTube removes this endpoint, fall back to the Data API (a separate spike, not this phase).
+
+### 1.8 Pinning uses a transitive collector contract identical to existing kinds
+
+**Decision.** Add three entries to `COLLECTORS` in `apps/app/src/features/pinning/pinningManager.ts:66-98`:
+
+```ts
+const COLLECTORS = {
+  // existing: collection, practice, chapter, book...
+  creator: (body, add) => {
+    const c = body as CreatorManifest
+    if (c.avatarHash) add(c.avatarHash)
+    if (c.bannerHash) add(c.bannerHash)
+    return [] // creators don't transitively pull other catalog items
+  },
+  'feed-item': (body, add) => {
+    // feed_items is SQLite-only, but pinning materializes media_url as a blob
+    const f = body as FeedItem
+    if (f.mediaHash) add(f.mediaHash)
+    if (f.imageHash) add(f.imageHash)
+    return []
+  },
+}
+```
+
+**Why.** The contract `(body, add) => string[]` (return = child catalog refs to recurse into) already encodes everything we need. `add()` registers blob hashes as protected; recursion handles transitive pinning of catalog children. We slot in cleanly.
+
+> **Note**: `feed-item` is *not* a `CatalogItemKind`. It's a virtual collector that the pinning manager dispatches on when a feed-item is pinned. The collector type signature accepts an arbitrary "kind" string so we can add it without polluting the catalog kind union.
+
+### 1.9 `feedFetcher` runs only on app foreground, debounced 30 min/creator
+
+**Decision.** No background scheduling in v1. A foreground listener triggers `refreshAllFollowed()` with a 30-min per-creator debounce stored in-memory; pull-to-refresh bypasses the debounce.
+
+**Why.** Background tasks (iOS background URL session, Android WorkManager) are platform-specific work we defer to Phase 5. Foreground-only refresh is sufficient for the daily formation use case ("open the app at 7am, see today's episode"), avoids battery and cellular surprise, and is verifiable with simple TanStack Query cache hooks.
+
+---
+
+## 2. Tasks
+
+### 2.1 Type & manifest plumbing
+
+1. Add `'creator'` to `CatalogItemKind` union in `apps/app/src/content/manifestTypes.ts:14-26`.
+2. Add `CreatorManifest`, `CreatorChannel`, `CreatorRole`, `CreatorCharism` types to `manifestTypes.ts`. Keep the channel-kind union narrow (`'podcast' | 'youtube' | 'rss'`) — adding more is a future change.
+3. Extend `CatalogEntry` (`manifestTypes.ts:27-46`) with two optional hint fields used by the directory grid: `creatorRole?: CreatorRole` and `creatorLanguages?: ('en-US' | 'pt-BR' | 'la')[]`. Both optional so existing consumers keep type-checking.
+4. Re-run `pnpm tsc -p apps/app` to confirm nothing in `contentIndex.ts`, `resolver.ts`, `pinningManager.ts`, or `browse/index.tsx` accidentally exhaustively-switches `CatalogItemKind` without a default branch (TS strict will flag).
+
+### 2.2 Catalog index registration
+
+5. In `apps/app/src/content/contentIndex.ts`, add `'creator'` to `RESIDENT_KINDS` (resolver.ts:41-47 in the explore report — confirm exact constant name in code). This makes creator manifests warm in-memory so the directory renders without per-card fetches.
+6. Add a `getCreators()` helper to `contentIndex.ts` mirroring the existing `getEntriesByKind('creator')` pattern. Call sites: directory route, profile route, search index builder.
+
+### 2.3 Resolver & store
+
+7. Add `loadCreator(id)` to `apps/app/src/content/resolver.ts` mirroring `loadCollection`:
+   - Resolve catalog entry → fetch manifest blob via `store.getJson(hash)`.
+   - Parse as `CreatorManifest`.
+   - Cache in resident map per `RESIDENT_KINDS`.
+8. Hook `'creator'` into `warmDeferredManifests()` (resolver.ts:94-98) so first-paint already has the directory data.
+9. No store.ts changes — blob cache is kind-agnostic.
+
+### 2.4 Pinning collectors
+
+10. Add the `creator` and `'feed-item'` entries to `COLLECTORS` in `apps/app/src/features/pinning/pinningManager.ts:66-98` per §1.8. Type-check the body arg via the new `CreatorManifest` import.
+11. Add a `pinnedFeedItemHashes()` helper to `pinningManager.ts` that walks `feed_items WHERE pinned = 1` (after we add the `pinned` column, see §2.5) and returns the union of their `mediaHash` and `imageHash` values. Feed it into the existing `store.evictTo(budgetBytes, protectedHashes)` call site.
+12. Bump the default soft cap **conditionally**: if any podcast/YT creator is followed, cap = 1 GB; otherwise = existing 200 MB. Compute on read; don't persist.
+
+### 2.5 SQLite schema
+
+13. Append to `apps/app/src/db/migrations/0001_initial.sql`:
+
+    ```sql
+    CREATE TABLE IF NOT EXISTS creator_follows (
+      creator_id  TEXT PRIMARY KEY,
+      followed_at INTEGER NOT NULL,
+      auto_pin_count INTEGER NOT NULL DEFAULT 0
+    );
+
+    CREATE TABLE IF NOT EXISTS feed_items (
+      item_id      TEXT PRIMARY KEY,
+      creator_id   TEXT NOT NULL,
+      channel_kind TEXT NOT NULL,
+      guid         TEXT NOT NULL,
+      title        TEXT NOT NULL,
+      summary      TEXT,
+      published_at INTEGER NOT NULL,
+      duration_s   INTEGER,
+      media_url    TEXT,
+      web_url      TEXT,
+      image_url    TEXT,
+      chapters_json TEXT,
+      raw_json     TEXT NOT NULL,
+      fetched_at   INTEGER NOT NULL,
+      pinned       INTEGER NOT NULL DEFAULT 0,
+      media_hash   TEXT,
+      image_hash   TEXT
+    );
+    CREATE INDEX IF NOT EXISTS feed_items_by_creator ON feed_items(creator_id, published_at DESC);
+    CREATE INDEX IF NOT EXISTS feed_items_recent     ON feed_items(published_at DESC);
+    CREATE INDEX IF NOT EXISTS feed_items_pinned     ON feed_items(pinned) WHERE pinned = 1;
+
+    CREATE TABLE IF NOT EXISTS media_progress (
+      item_id      TEXT PRIMARY KEY,
+      position_s   REAL NOT NULL,
+      duration_s   REAL,
+      completed_at INTEGER,
+      updated_at   INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS search_history (
+      query        TEXT NOT NULL,
+      searched_at  INTEGER NOT NULL,
+      PRIMARY KEY (query, searched_at)
+    );
+
+    CREATE TABLE IF NOT EXISTS practice_voice (
+      practice_id  TEXT PRIMARY KEY,
+      guided_id    TEXT,
+      updated_at   INTEGER NOT NULL
+    );
+    ```
+
+14. Verify `client.ts:33` `execAsync(initialMigration)` is idempotent — run on an existing DB and confirm no errors. (`IF NOT EXISTS` plus no `ALTER` statements means we're safe.)
+
+### 2.6 Repositories
+
+15. Create `apps/app/src/db/repositories/creators.ts` (event-sourced):
+    - `followCreator(creatorId)` → emits `{ type: 'CreatorFollowed', creatorId }`.
+    - `unfollowCreator(creatorId)` → emits `{ type: 'CreatorUnfollowed', creatorId }`.
+    - `setAutoPinCount(creatorId, count)` → emits `{ type: 'CreatorAutoPinCountSet', creatorId, count }`.
+    - `getFollows(): Map<string, FollowRecord>` reads from `useEventStore.getState()`.
+    - Events project into the existing event store; SQLite persistence is owned by `useEventStore`'s persistence layer (do not write directly to `creator_follows`).
+
+16. Create `apps/app/src/db/repositories/feedItems.ts` (raw SQLite):
+    - `upsertFeedItems(rows: FeedItemRow[])` — batched `INSERT OR REPLACE` in a single transaction.
+    - `getFeedItemsByCreator(creatorId, limit = 50): FeedItemRow[]`.
+    - `getRecentFeedItems(limit = 8): FeedItemRow[]` for the home Latest row (Phase 3).
+    - `pruneOlderThan(creatorId, keep = 200)`.
+    - `setPinned(itemId, pinned: boolean)`.
+    - All methods take a `_db` arg defaulted to the singleton — keeps tests injectable.
+
+17. Create `apps/app/src/db/repositories/mediaProgress.ts`:
+    - `getProgress(itemId)`.
+    - `recordProgress(itemId, positionS, durationS)`.
+    - `markCompleted(itemId)` (sets `completed_at = now`).
+
+18. Create `apps/app/src/db/repositories/practiceVoice.ts` (event-sourced):
+    - `getVoice(practiceId): string | undefined`.
+    - `setVoice(practiceId, guidedId | undefined)` → emits `{ type: 'PracticeVoiceSet', ... }`.
+    - Used in v1.1 (Phase 7); created here so Phase 7 doesn't need migration churn.
+
+### 2.7 Feed fetcher
+
+19. Create `apps/app/src/features/creators/feeds/xml.ts`: shared `fast-xml-parser` instance with options:
+
+    ```ts
+    new XMLParser({
+      ignoreAttributes: false,
+      attributeNamePrefix: '@_',
+      cdataPropName: '__cdata',
+      trimValues: true,
+      processEntities: true,
+    })
+    ```
+
+20. Create `feeds/podcast.ts` parsing standard RSS + iTunes namespace + (when present) the `podcast` namespace's `<podcast:chapters>` URL. Returns `FeedItemDraft[]` with normalized `{guid, title, summary, publishedAt, durationS, mediaUrl, imageUrl}`. Unit-test against three real-feed fixtures (PPR, Pints With Aquinas, Catholic Stuff).
+
+21. Create `feeds/youtube.ts` parsing the YouTube Atom feed: `<entry>` → `{guid: yt:videoId, title, summary: media:description, publishedAt: published, imageUrl: media:thumbnail@url}`. No duration field on the public Atom feed — fetched per-video would require the Data API; defer.
+
+22. Create `feeds/rss.ts` for generic blog feeds. Same `FeedItemDraft` shape; `mediaUrl` may be empty.
+
+23. Create `feeds/chapters.ts`:
+    - `parsePodcastChapters(jsonUrl): Promise<Chapter[]>` for the JSON `podcast:chapters` namespace.
+    - `parseInlineChapters(description: string): Chapter[]` regex-based for plain-text timestamp lists. Regex hits at minimum: `^(\d{1,2}:)?\d{1,2}:\d{2}\s+.+$` per line; permissive enough for `00:00 Intro`, `12:34 - title`, and `[12:34] title`.
+    - Output: `Chapter = { tStart: number, title: string }`.
+
+24. Create `feeds/fetcher.ts`:
+    - Public API: `refreshCreator(creatorId, { force?: boolean }): Promise<void>`.
+    - In-memory `lastRefreshedAt: Map<string, number>` enforces 30-min debounce unless `force=true`.
+    - Loads creator manifest via `loadCreator()`, iterates `channels[]`, dispatches to the right parser, writes via `feedItems.upsertFeedItems()`.
+    - Global concurrency cap (4 concurrent fetches) using a tiny p-limit-style helper (`feeds/rateLimit.ts`); avoids adding a dependency.
+    - Persists `chaptersJson` per item.
+
+25. Create `feeds/__fixtures__/`: real-world XML samples for one PPR podcast feed, one YouTube channel Atom feed, one blog Atom feed. Tests assert fixture → expected `FeedItemDraft[]` snapshot.
+
+### 2.8 Build pipeline
+
+26. Add `build_creators(b: BuildContext)` to `scripts/build-corpus.py`, slotted next to `build_collections()`. Pseudocode:
+
+    ```py
+    def build_creators(b):
+      for creator_dir in (b.content_root / 'creators').iterdir():
+        if not creator_dir.is_dir(): continue
+        cid = creator_dir.name
+        manifest_src = json.loads((creator_dir / 'manifest.json').read_text())
+
+        # Avatar / banner go through the existing image pipeline
+        if (creator_dir / 'avatar.webp').exists():
+          h, sz = b.write_blob((creator_dir / 'avatar.webp').read_bytes())
+          manifest_src['avatarHash'] = {'hash': h, 'size': sz}
+        if (creator_dir / 'banner.webp').exists():
+          h, sz = b.write_blob((creator_dir / 'banner.webp').read_bytes())
+          manifest_src['bannerHash'] = {'hash': h, 'size': sz}
+
+        manifest_src['id'] = f'creator/{cid}'
+        h, sz = b.write_json_blob(manifest_src)
+
+        entry = {
+          'kind': 'creator',
+          'hash': h,
+          'size': sz,
+          'name': manifest_src['name'],
+          'creatorRole': manifest_src.get('role'),
+          'creatorLanguages': manifest_src.get('languages'),
+          'tags': manifest_src.get('tags'),
+        }
+        b.add_catalog(f'creator/{cid}', entry)
+    ```
+
+27. Wire `build_creators(b)` into the top-level build orchestration in `scripts/build-corpus.py` (next to the `build_collections(b)` call). Run `pnpm build:corpus` and confirm catalog.json gains `creator/<id>` entries.
+
+28. Lint pass: `pnpm biome check --write content/creators/`.
+
+### 2.9 Seed creators (2-3, no permissions tangle)
+
+29. Create `content/creators/<id>/` for two seed creators picked for breadth (one en-US, one pt-BR), with public RSS/YT feeds and no rights complications:
+    - `manifest.json` (CreatorManifest shape from §3 of README).
+    - `avatar.webp` (512×512).
+    - `banner.webp` (1600×900) — optional.
+30. Pick channels that exercise all three parsers: a podcast RSS, a YouTube channel, and (where available) a blog feed. Even one creator with all three is fine for testing parser coverage.
+31. Maintainer holds the right to swap final picks; the seed list itself is not part of this PRD.
+
+### 2.10 Tests
+
+32. Unit tests under `apps/app/src/features/creators/feeds/__tests__/`:
+    - One per parser: snapshot `parse(fixtureXml)` against expected `FeedItemDraft[]`.
+    - `chapters.test.ts`: cover JSON `podcast:chapters`, plain-text timestamp lists with various separators.
+33. Repository tests under `apps/app/src/db/repositories/__tests__/`:
+    - `feedItems.test.ts`: upsert idempotency, prune behavior, ordering invariants.
+    - `mediaProgress.test.ts`: round-trip a progress record, mark completed.
+34. Integration test in `apps/app/src/features/creators/__tests__/refreshCreator.test.ts`:
+    - Stubs `fetch` with fixture responses for podcast + YT + RSS.
+    - Asserts `feed_items` reflects the union of all three.
+    - Asserts the 30-min debounce skips the second call within the window unless `force=true`.
+
+---
+
+## 3. Files touched / created
+
+### Created
+
+| Path | Purpose |
+|---|---|
+| `apps/app/src/features/creators/feeds/fetcher.ts` | Public refresh entrypoint |
+| `apps/app/src/features/creators/feeds/podcast.ts` | RSS / iTunes parser |
+| `apps/app/src/features/creators/feeds/youtube.ts` | YT Atom parser |
+| `apps/app/src/features/creators/feeds/rss.ts` | Generic blog parser |
+| `apps/app/src/features/creators/feeds/chapters.ts` | Chapter-marker parsing |
+| `apps/app/src/features/creators/feeds/xml.ts` | Shared parser instance |
+| `apps/app/src/features/creators/feeds/rateLimit.ts` | Concurrency cap |
+| `apps/app/src/features/creators/feeds/__fixtures__/*` | Test XML |
+| `apps/app/src/db/repositories/creators.ts` | Event-sourced follows |
+| `apps/app/src/db/repositories/feedItems.ts` | Raw-SQLite feed-items repo |
+| `apps/app/src/db/repositories/mediaProgress.ts` | Raw-SQLite progress repo |
+| `apps/app/src/db/repositories/practiceVoice.ts` | Event-sourced voice (used in v1.1) |
+| `content/creators/<id>/manifest.json` | Seed creator data |
+| `content/creators/<id>/avatar.webp` | Seed creator avatar |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `apps/app/src/content/manifestTypes.ts` | Add `'creator'` to `CatalogItemKind`; add `CreatorManifest`, `CreatorChannel` types; extend `CatalogEntry` hints |
+| `apps/app/src/content/contentIndex.ts` | Register `'creator'` in `RESIDENT_KINDS`; add `getCreators()` |
+| `apps/app/src/content/resolver.ts` | Add `loadCreator(id)`; include `'creator'` in `warmDeferredManifests` |
+| `apps/app/src/features/pinning/pinningManager.ts` | Add `creator` and `'feed-item'` collector entries; soft-cap bump logic; `pinnedFeedItemHashes()` |
+| `apps/app/src/db/migrations/0001_initial.sql` | Append five `CREATE TABLE IF NOT EXISTS` blocks + indexes |
+| `scripts/build-corpus.py` | Add `build_creators()`; call from top-level orchestration |
+| `apps/app/src/lib/i18n/locales/en-US.ts` | Stub `creators.*` namespace (filled in Phase 2) |
+| `apps/app/src/lib/i18n/locales/pt-BR.ts` | Stub `creators.*` namespace (filled in Phase 2) |
+
+---
+
+## 4. Open questions
+
+1. **Image format hash equivalence.** When a creator updates their avatar, the new file → new hash → new manifest hash → catalog mutation. Is that fine, or do we want avatar/banner to be content-addressed by URL not bytes? **Default: hash by bytes**, same as book images. Re-uploading the same image twice produces no change.
+2. **`feed_items` retention beyond 200/creator.** Some users may want longer history (e.g., "all of *Resposta Católica* since 2018"). For Phase 1, hard cap at 200 to prevent runaway storage. Revisit after observed usage.
+3. **YouTube duration.** The public Atom feed omits duration. Acceptable in v1; the player reads duration from the actual YT iframe once playback starts. Search ranking won't have video duration as a feature in v1.
+
+---
+
+## 5. Verification
+
+| Check | How |
+|---|---|
+| Type-safety | `pnpm tsc -p apps/app` passes with no `any` introduced. |
+| Build pipeline | `pnpm build:corpus` produces `creator/<id>` catalog entries; `jq '.items["creator/fr-mike-schmitz"]' _site/hearth/v2/catalog.json` shows expected shape. |
+| Resolver | App boot warms creator manifests; log timing. Confirm first paint ≤ pre-feature baseline + 5 ms. |
+| Pinning | `db.execAsync("UPDATE feed_items SET pinned = 1 WHERE item_id = ?", [id])` followed by `pinningManager.gc()` does not evict the pinned media hash. |
+| Schema | `sqlite3 ember.db ".tables"` shows the five new tables on a fresh install AND on an existing DB with prior schema. |
+| Parsers | `pnpm test apps/app/src/features/creators/feeds` — all snapshot tests green. |
+| Refresh | Fixture-stubbed integration test confirms multi-channel ingestion + debounce. |
+
+---
+
+## 6. Phase 1 → Phase 2 handoff
+
+After Phase 1, Phase 2 (Browse UI) can assume:
+- `getCreators()` returns hydrated creator hints from the catalog index.
+- `loadCreator(id)` resolves the full manifest.
+- `feedItems.getFeedItemsByCreator(id)` returns recent items.
+- `refreshCreator(id)` is callable from a route on first-mount or pull-to-refresh.
+- `mediaProgress` is ready for the player to write into.
+
+Nothing in Phase 2 needs to touch the build script, resolver, or pinning manager again.

--- a/docs/features/creators/phase-02-browse-ui.md
+++ b/docs/features/creators/phase-02-browse-ui.md
@@ -1,0 +1,276 @@
+# Phase 2 — Browse UI
+
+> The first user-visible phase. Phase 1 plumbing is now wrapped in routes, components, and three media players.
+
+**Goal.** Add a creators directory and per-creator profile, a native audio player with background playback, a YouTube iframe video player, and an article reader path. After Phase 2 a user can find a creator, play an episode, watch a video, and read an article — all without follows, search, or offline polish (those land in Phases 3-5).
+
+**Success criteria.**
+1. `Browse → Creators` row links to `creators/index`.
+2. `creators/[id]` profile shows all available channels with newest items per tab.
+3. Audio plays on iOS, Android, and web. iOS lock-screen controls and Now-Playing artwork work. Background audio survives screen-off.
+4. YouTube videos play inside the app via the iframe player on all three platforms.
+5. Articles open in either summary mode (default) or full-text mode (allowlisted feeds), with markable-as-read state.
+6. The persistent Now-Playing mini-bar appears once playback starts.
+
+**Dependencies.** Phase 1 — without `loadCreator`, `feedItems`, or `mediaProgress` repositories, none of this works.
+
+---
+
+## 1. Major design decisions
+
+### 1.1 Audio: `expo-av` over `react-native-track-player`
+
+**Decision.** Use `expo-av`'s `Audio.Sound` API for v1.
+
+**Why.**
+- Already in the Expo SDK 55+ baseline; no native module integration step.
+- Background playback (`Audio.setAudioModeAsync({ staysActiveInBackground: true })`) and lock-screen controls work out of the box on iOS via the `Now Playing Info Center`. Android: we set the foreground service via Expo's bundled config plugin.
+- Web Audio API support via the same module; no platform fork.
+- `react-native-track-player` would add ~2 MB to the bundle, an iOS background-mode plist edit, and a separate JS thread management story for ~zero v1 benefit (no queue, no gapless playback, no audio focus needs we can't get from `expo-av`).
+
+**Re-evaluate when.** If we hit (a) the need for true gapless transitions inside a playlist, (b) carplay/Android Auto integration, or (c) a measurable battery regression. None of those are v1 problems.
+
+### 1.2 Video: YouTube iframe player only
+
+**Decision.** Use the official YouTube IFrame API in `react-native-webview` on native and `<iframe>` on web. No `youtube-dl`, no audio-only extraction, no proxying.
+
+**Why.** YouTube ToS forbids extracting audio or rehosting video. The iframe player is the only path that's clearly compliant and that doesn't require an API key. The IFrame API exposes JS-postMessage-based control (play/pause/seek) sufficient for our needs. Apple's app review flags YouTube audio extraction patterns; ship the boring compliant thing.
+
+### 1.3 Article reader: summary by default, full-text by allowlist
+
+**Decision.** All RSS-text channels render in summary mode unless the creator manifest sets `channels[].fullText: true`. Full-text mode pipes feed HTML into a `ReaderWebView`; summary mode shows summary + an "Open original" button that loads the source URL in a WebView (or external browser on web).
+
+**Why.** Many Catholic blogs ship truncated RSS (summary-only), use Cloudflare paywalls for the full article, or have inconsistent CSS that breaks Ember's reader stylesheet. Trying to render every feed as full-text in v1 chases a long tail of breakage. Allowlisting per creator gives editorial control: a known-good feed (consent confirmed, CSS verified) opts in; everything else stays safe.
+
+### 1.4 Routing topology
+
+**Decision.** New routes under `apps/app/src/app/creators/`:
+
+```
+creators/
+  index.tsx                              # directory grid
+  [creatorId].tsx                        # profile (tabs)
+  [creatorId]/episode/[itemId].tsx       # detail (audio focus)
+  [creatorId]/video/[videoId].tsx        # detail (video focus)
+  [creatorId]/article/[itemId].tsx       # detail (article focus)
+```
+
+Three sibling detail routes (instead of one polymorphic route) so each can own its layout, header behavior, and back-stack semantics without runtime branching.
+
+**Why three routes, not one.** The audio detail screen is the player; the video detail screen is the iframe player; the article detail screen is the reader. Trying to host all three under a polymorphic `[itemId]` would force route-level conditionals that complicate deep links, sharing, and back-stack expectations.
+
+### 1.5 Now-Playing mini-bar lives at the layout level
+
+**Decision.** Render `<NowPlayingBar />` inside `apps/app/src/app/_layout.tsx`, above the navigation surface. Its visibility is driven by `creatorsStore.nowPlaying != null`.
+
+**Why.** The mini-bar must follow the user across every screen — Home, Browse, Settings, deep inside a practice flow. Layout-level mounting is the only way to keep it persistent without prop-drilling state through every route. The component itself remains thin (state read + tap routing).
+
+### 1.6 Player state lives in Zustand, not the route
+
+**Decision.** A single `creatorsStore` (Zustand + immer) holds `nowPlaying`, transport state, and per-item progress (transient). Route components subscribe to the slice they need.
+
+**Why.** Audio outlives a route — the user can navigate away from the detail screen and continue listening. Storing player state in route props or contexts would tear down on unmount. Zustand persists across navigation by default.
+
+### 1.7 Player uses pinned local file URI when available, streams otherwise
+
+**Decision.** On player start, the audio module asks `feedItems.getPinnedMediaUri(itemId)`. If present, load `file://...` URI; otherwise stream from `media_url`.
+
+**Why.** Existing pinning manager already protects pinned blob hashes from LRU eviction. Wiring playback to look at the local blob first means pinned items work cold without any new offline machinery. A single boolean check at start; no protocol-level shims.
+
+### 1.8 ReaderWebView reuse — no fork
+
+**Decision.** Reuse the existing `apps/app/src/features/books/ReaderWebView.tsx` `ReaderWebViewHandle` contract for the article reader and add a parallel `YouTubeIFrameView` that conforms to the same handle interface.
+
+**Why.** ReaderWebView already handles pagination messages, page tracking, and theming. Article reader needs none of that — but if we adopt the same handle, future improvements (font preferences, link handling) accrue once and work everywhere. The YouTube iframe is a different beast (no pagination), but exposing it through the same handle keeps the surface uniform: `loadSequence(html, page=0)` for articles maps cleanly to `loadSequence(embedHtml, 0)` for the YT iframe.
+
+---
+
+## 2. Tasks
+
+### 2.1 Browse integration
+
+1. Add `creatorsIds: string[]` (or equivalent) to `apps/app/src/app/browse/sectionLayout.ts`. Populate from `getCreators().map(c => c.id)`.
+2. Render a horizontal `Creators` row in `browse/index.tsx`, slotted between Formation and Themes. Reuse the existing `CardRow` component pattern. Card: avatar (circular), name (1-line), byline (1-line, dim).
+3. Tap → `router.push('/creators')`.
+
+### 2.2 Directory route
+
+4. Create `apps/app/src/app/creators/index.tsx`:
+   - `useQuery(['creators'], getCreators)` for the list.
+   - Filter chips above the grid: language (en-US / pt-BR / both), charism (multi-select), format (Q&A / lecture / homily / mixed). Filter chips read from `CatalogEntry` hints (`creatorLanguages`, `creatorRole`, plus a derived "has Q&A channel" boolean).
+   - Grid: 2 columns on mobile, 3-4 on web/tablet. Card = avatar + name + byline.
+   - Header action: `Suggest a creator →` opens `mailto:` (or `Linking.openURL` for the GitHub issue template URL stored in `apps/app/src/config/links.ts`).
+
+### 2.3 Profile route
+
+5. Create `apps/app/src/app/creators/[creatorId].tsx`:
+   - `useLocalSearchParams<{ creatorId: string }>()` → strip optional `creator/` prefix tolerantly.
+   - `useQuery(['creator', id], () => loadCreator(id))` for manifest.
+   - On first mount, `useMutation` triggers `refreshCreator(id)` (Phase 1 fetcher). Discard the result; the cache update flows through React Query observer.
+   - `useQuery(['feed-items', id], () => feedItems.getFeedItemsByCreator(id))` populates the tabs.
+6. Header: banner image (16:9, 50% gradient overlay), avatar overlapping bottom-left, `Follow ✓` button (Phase 3 wires the action; in this phase the button is rendered but a no-op). Bio paragraph below.
+7. Tabs: dynamic — render only the tabs whose channels the creator actually has (`channels[].kind`). Order: Listen, Watch, Read.
+   - Listen tab: `FeedItemList` rendering ▶ + ⋯ menu (Pin / Mark played) per row. Pin / mark-played buttons render but are wired in Phase 3.
+   - Watch tab: 2-col video grid, thumbnail + title.
+   - Read tab: list, title + 1-line summary excerpt + relative date.
+8. Footer: external links (`creatorManifest.links.website`, `links.donate`). "Suggest an edit" link → GitHub issue.
+
+### 2.4 Audio player
+
+9. Create `apps/app/src/features/creators/audio/audioPlayer.ts`:
+   - Wraps `expo-av`'s `Audio.Sound` API.
+   - On `play(itemId)`: resolve via `feedItems.getPinnedMediaUri(itemId)` → fall back to `feed_items.media_url`. Load → set position → play.
+   - Calls `Audio.setAudioModeAsync({ staysActiveInBackground: true, playsInSilentModeIOS: true, shouldDuckAndroid: true })` once on first play.
+   - Periodic `media_progress` upsert (every 5 s of playback) via `mediaProgress.recordProgress`.
+   - Web fallback: same module API; iOS-specific options become no-ops.
+10. Now-Playing metadata for iOS lock screen: `Audio.setIsEnabledAsync(true)` + we set `nowPlayingInfo` on each `play()` via the platform module — this requires a small native bridge. **For v1, accept iOS-only basic Now-Playing controls (play/pause); skip artwork & scrubbing on the lock screen if it requires native code beyond expo-av's surface. Push artwork+scrubbing into Phase 5.**
+
+11. Create `apps/app/src/features/creators/audio/AudioPlayerScreen.tsx`:
+    - Hero artwork (creator avatar OR episode `image_url`).
+    - Scrubbable `<Slider>` driven by player position polling at 1 Hz.
+    - Transport: ◀◀15 / ▶⏸ / ▶▶15 / speed (toggle 0.8 / 1.0 / 1.25 / 1.5 / 2.0) / sleep timer (off / 15 / 30 / 60 / end-of-episode) / pin (Phase 3 wires) / share / open-original.
+    - Source: `creatorsStore.nowPlaying`.
+12. Create `apps/app/src/features/creators/audio/NowPlayingBar.tsx`:
+    - Mounted in `apps/app/src/app/_layout.tsx`.
+    - Subscribes to `nowPlaying`. Hidden when null. ~56 px tall.
+    - Tap → `router.push('/creators/[id]/episode/[itemId]')`.
+    - Renders: thumbnail · title · ▶/⏸ · ✕ (close button stops playback and clears `nowPlaying`).
+
+### 2.5 YouTube video player
+
+13. Create `apps/app/src/features/creators/video/YouTubePlayer.tsx`:
+    - Native: `react-native-webview` rendering an HTML page with the IFrame Player API:
+      ```html
+      <div id="player"></div>
+      <script src="https://www.youtube.com/iframe_api"></script>
+      <script>
+        var player;
+        function onYouTubeIframeAPIReady() {
+          player = new YT.Player('player', {
+            videoId: '<%= videoId %>',
+            playerVars: { rel: 0, modestbranding: 1, playsinline: 1 },
+            events: { onStateChange: onStateChange, onError: onError }
+          });
+        }
+        function onStateChange(e) { window.ReactNativeWebView.postMessage(JSON.stringify({type:'state', state:e.data})); }
+        function onError(e)       { window.ReactNativeWebView.postMessage(JSON.stringify({type:'error', error:e.data})); }
+      </script>
+      ```
+    - Web: a plain `<iframe src="https://www.youtube.com/embed/<videoId>?...">`.
+    - Aspect-ratio container (16:9) with a small chrome footer (creator avatar + open-on-YouTube link).
+14. Create `apps/app/src/app/creators/[creatorId]/video/[videoId].tsx` rendering `<YouTubePlayer />`.
+
+### 2.6 Article reader
+
+15. Create `apps/app/src/features/creators/articles/ArticleReader.tsx`:
+    - Branch on `creatorChannel.fullText`:
+      - **Full-text path**: read `feed_items.summary` (which actually contains the full content for full-text feeds), wrap in a minimal HTML document with the Ember reader stylesheet, hand to `ReaderWebView` via `ReaderWebViewHandle`.
+      - **Summary path**: render summary in native Tamagui text + an `Open original` button (`Linking.openURL(web_url)` on web; `<WebView source={{ uri: web_url }}>` on native).
+    - Both paths: a `Mark as read` action calls `mediaProgress.markCompleted(itemId)`.
+16. Create `apps/app/src/app/creators/[creatorId]/article/[itemId].tsx` hosting `<ArticleReader />`.
+
+### 2.7 Now-Playing store
+
+17. Create `apps/app/src/stores/creatorsStore.ts` (Zustand + immer):
+
+    ```ts
+    type CreatorsState = {
+      nowPlaying?: { itemId: string; creatorId: string; title: string; imageUri?: string; durationS?: number }
+      isPlaying: boolean
+      positionS: number
+      speed: number
+      sleepTimerEndAt?: number
+      // Phase 3 adds: follows, latestFeed, voiceByPractice
+      play: (item: FeedItemRow) => Promise<void>
+      pause: () => Promise<void>
+      togglePlay: () => Promise<void>
+      seek: (s: number) => Promise<void>
+      setSpeed: (s: number) => Promise<void>
+      stop: () => Promise<void>
+    }
+    ```
+
+    Actions delegate to `audioPlayer.ts`; the store mirrors transport state only.
+
+### 2.8 i18n
+
+18. Fill `apps/app/src/lib/i18n/locales/en-US.ts` `creators.*` namespace: tab labels, empty-state copy, sleep-timer options, Suggest-a-creator copy.
+19. Mirror in `pt-BR.ts`. Use the `localizeContent()` helper for all `LocalizedText` shaped manifest fields (creator bio, byline, channel title) at render time.
+
+### 2.9 Tests
+
+20. Snapshot test for `creators/index.tsx` rendering with two seed creators.
+21. Component test for `NowPlayingBar` toggles via store actions.
+22. Manual-only tests for audio playback, YouTube iframe, and lock-screen controls — call these out in the verification checklist; automated coverage is impractical without device.
+
+---
+
+## 3. Files touched / created
+
+### Created
+
+| Path | Purpose |
+|---|---|
+| `apps/app/src/app/creators/index.tsx` | Directory route |
+| `apps/app/src/app/creators/[creatorId].tsx` | Profile route |
+| `apps/app/src/app/creators/[creatorId]/episode/[itemId].tsx` | Audio detail |
+| `apps/app/src/app/creators/[creatorId]/video/[videoId].tsx` | Video detail |
+| `apps/app/src/app/creators/[creatorId]/article/[itemId].tsx` | Article detail |
+| `apps/app/src/features/creators/audio/audioPlayer.ts` | `expo-av` wrapper |
+| `apps/app/src/features/creators/audio/AudioPlayerScreen.tsx` | Full-screen player |
+| `apps/app/src/features/creators/audio/NowPlayingBar.tsx` | Layout-level mini-bar |
+| `apps/app/src/features/creators/video/YouTubePlayer.tsx` | Iframe-based player |
+| `apps/app/src/features/creators/articles/ArticleReader.tsx` | Summary + full-text branches |
+| `apps/app/src/features/creators/components/CreatorCard.tsx` | Used by directory grid + Browse row |
+| `apps/app/src/features/creators/components/FeedItemList.tsx` | Listen/Watch/Read row |
+| `apps/app/src/stores/creatorsStore.ts` | Zustand + immer |
+| `apps/app/src/config/links.ts` | Suggest-a-creator GH URL constant |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `apps/app/src/app/_layout.tsx` | Mount `<NowPlayingBar />` above the nav surface |
+| `apps/app/src/app/browse/index.tsx` | Render Creators row from `sectionLayout.creatorsIds` |
+| `apps/app/src/app/browse/sectionLayout.ts` | Add `creatorsIds` |
+| `apps/app/src/lib/i18n/locales/en-US.ts` | Fill `creators.*` namespace |
+| `apps/app/src/lib/i18n/locales/pt-BR.ts` | Mirror |
+
+---
+
+## 4. Open questions
+
+1. **Lock-screen artwork and scrubbing on iOS.** `expo-av` exposes only basic now-playing info. Full artwork + remote scrubbing requires a small Expo config plugin or `expo-music-info` patch. **Push to Phase 5** unless we can confirm an out-of-the-box path.
+2. **YouTube iframe and Apple's PiP.** PiP works automatically on iOS Safari but is gated by user gesture in WKWebView. Acceptable for v1; revisit if maintainer asks.
+3. **Article-reader CSS override per creator.** A clean blog might want a creator-specific stylesheet. Defer; use the Ember reader stylesheet uniformly in v1.
+4. **Should the directory's "Suggest a creator" use mailto or GitHub issue URL?** Defaulting to GitHub issue with mailto fallback (some users have no `mailto` handler on iOS). Decide on launch.
+
+---
+
+## 5. Verification
+
+| Check | How |
+|---|---|
+| Directory renders | Open `/creators` with two seed creators committed; confirm grid + filters. |
+| Profile renders | Tap a creator; confirm tabs match channel kinds; first feed refresh populates tabs within 2 s on Wi-Fi. |
+| Audio plays in foreground | Tap ▶ on an episode; sound starts within 500 ms (cached) or 2 s (streaming). |
+| Audio plays in background | Lock the device mid-playback; audio continues. iOS lock-screen control panel shows ▶⏸. |
+| Audio plays from pinned blob | Set `feed_items.pinned = 1`, force airplane mode, tap ▶ — plays from local file. |
+| Video plays | Tap a video tile on profile; YT iframe loads on web + iOS + Android. Confirm CSS box reaches edges (no inner-content scroll). |
+| Article opens | Summary mode: shows summary + "Open original" button. Full-text mode (allowlisted): renders inside ReaderWebView. |
+| Mini-bar persistence | Start audio, navigate to Home, then to a Practice — mini-bar stays visible. |
+| Mini-bar dismiss | Tap ✕ — playback stops, mini-bar disappears. |
+| Progress persistence | Play 30 s of an episode, kill the app, reopen — `mediaProgress.position_s` reflects the last playback position. |
+| Speed change | 1.0× → 1.5× — pitch is preserved (default expo-av behavior). |
+| i18n | Toggle to pt-BR — tab labels, empty states, sleep-timer options translate; creator bios fall back to en-US if pt-BR absent. |
+
+---
+
+## 6. Phase 2 → Phase 3 handoff
+
+After Phase 2:
+- Players, profile, directory, mini-bar are all rendered. Follows are visual no-ops (button does nothing).
+- `creatorsStore` exists with transport state.
+- `mediaProgress` is being written by the audio player on every 5 s.
+
+Phase 3 wires the Follow button, the home Latest row, the per-creator auto-pin, and the network-aware UX.

--- a/docs/features/creators/phase-03-home-follows-offline.md
+++ b/docs/features/creators/phase-03-home-follows-offline.md
@@ -1,0 +1,245 @@
+# Phase 3 — Home, Follows & Offline
+
+> Wires up everything users actually do day-to-day: follow a creator, see their latest content on home, pin it for offline, and trust the app cold-start with airplane mode on.
+
+**Goal.** Activate the Follow button. Add a Home `Latest from your creators` row. Implement per-item and per-creator auto-pin. Add storage management UI. Make every screen network-aware.
+
+**Success criteria.**
+1. Follow / unfollow from profile or directory; persists across app reload.
+2. Home shows a `Latest` row only when ≥1 creator is followed; sorts by `published_at DESC` across all followed creators.
+3. Per-item pin toggle from any episode/article row; pinned items survive cold-start with airplane mode on.
+4. `Pin latest 3` on profile writes `creator_follows.auto_pin_count = 3`; subsequent feed refreshes auto-pin newest 3 and unpin anything older than the latest 3.
+5. Settings → Storage shows per-creator size, oldest pinned date, count.
+6. Toggling Wi-Fi-only download in Settings prevents cellular downloads.
+7. App-wide "offline" chip appears in nav when offline; non-pinned remote items show a clear "needs internet" state.
+
+**Dependencies.** Phase 1 (`creator_follows`, `feed_items.pinned`, `pinningManager`) and Phase 2 (`creatorsStore`, profile, directory, players).
+
+---
+
+## 1. Major design decisions
+
+### 1.1 Follow / unfollow is event-sourced; auto-pin policy is a derived projection
+
+**Decision.** `followCreator` and `unfollowCreator` emit events into `useEventStore`. Auto-pin policy is computed on-demand by walking `creator_follows` × `feed_items` per refresh; the `pinned` column on `feed_items` is updated as a side effect.
+
+**Why.** Follows are user actions where event sourcing's auditability matters. Auto-pin is *derived* state — given (follow set, auto_pin_count, recent items), the pin set is deterministic. Storing it as a projection means we can always recompute, which makes RSS reordering or a missed refresh non-fatal.
+
+### 1.2 Home `Latest` row reads from a `recent_feed_items` view, not by aggregating in JS
+
+**Decision.** Add a SQLite query helper `feedItems.getRecentForFollowed(limit = 8)`:
+
+```sql
+SELECT fi.* FROM feed_items fi
+INNER JOIN creator_follows cf ON cf.creator_id = fi.creator_id
+ORDER BY fi.published_at DESC
+LIMIT ?
+```
+
+**Why.** Aggregating in JS forces N queries (one per creator) and re-sorts in memory — fine for 5 creators, painful at 50. A single indexed JOIN is cheap (existing `feed_items_recent` index already covers it) and lets us paginate trivially in v1.1.
+
+### 1.3 Auto-pin policy is recomputed on every successful feed refresh
+
+**Decision.** After `feedFetcher.refreshCreator(id)` writes new rows, run:
+
+```ts
+async function reconcilePins(creatorId: string) {
+  const cf = await creators.getFollow(creatorId)
+  if (!cf || cf.autoPinCount === 0) return
+  const items = await feedItems.getFeedItemsByCreator(creatorId, cf.autoPinCount)
+  const targetIds = new Set(items.map(i => i.itemId))
+  const currentlyAutoPinned = await feedItems.getAutoPinnedByCreator(creatorId)
+  const toPin = items.filter(i => !currentlyAutoPinned.has(i.itemId))
+  const toUnpin = [...currentlyAutoPinned].filter(id => !targetIds.has(id))
+  await Promise.all([
+    ...toPin.map(i => pinFeedItem(i.itemId, { source: 'auto' })),
+    ...toUnpin.map(id => unpinFeedItem(id, { source: 'auto' })),
+  ])
+}
+```
+
+**Why.** Reconciling vs. the post-condition (top-N pinned) is idempotent and survives RSS shuffles, missed refreshes, and clock skew. Tracking *why* an item was pinned (`source: 'auto' | 'manual'`) ensures we never auto-unpin something the user manually pinned.
+
+### 1.4 Pinning a feed-item downloads media + image, marks `pinned = 1`
+
+**Decision.** `pinFeedItem(itemId)` does:
+1. Load row from `feed_items`.
+2. Skip download if Wi-Fi-only is on and we're on cellular (return a deferred-pin status).
+3. Download `media_url` → blob; compute SHA-256; write `feed_items.media_hash`.
+4. Download `image_url` → blob; write `feed_items.image_hash`.
+5. Set `feed_items.pinned = 1`, `feed_items.pin_source`, `feed_items.pinned_at`.
+6. The `'feed-item'` collector in pinning manager (see Phase 1, §1.8) makes those hashes protected on next GC pass.
+
+**Why.** Two-blob materialization (media + image) means the pinned episode renders correctly offline including art. The `pin_source` column lets reconcile distinguish auto vs. manual; `pinned_at` enables LRU on auto-pins if storage pressure mounts.
+
+### 1.5 Wi-Fi-only is a hard gate at download time, not a preference suggestion
+
+**Decision.** When Wi-Fi-only is on and the device is on cellular, `pinFeedItem` returns `'deferred'` and writes to a `pending_pins` queue. On next Wi-Fi reconnect (detected via `expo-network`'s `addNetworkStateListener`), the queue drains.
+
+**Why.** Cellular bills are real. A "preference" that downloads anyway when convenient is not a feature, it's a bug. Hard gate means trust.
+
+### 1.6 Network-aware UX uses `expo-network`, single source of truth
+
+**Decision.** A small `useNetworkState()` hook subscribes to `expo-network` and exposes `{ isOnline, type: 'wifi' | 'cellular' | 'none' }`. Every component that needs network awareness reads this hook.
+
+**Why.** Status bar chip, refresh disabling, "needs internet" placeholders, Wi-Fi-only gate all need the same answer. One hook prevents drift.
+
+### 1.7 Storage management UI is read-only + one-tap "free up X MB"
+
+**Decision.** Settings → Storage gains a Creators section listing each followed creator with:
+- Local size (sum of pinned media + image blob bytes).
+- Oldest pinned episode date.
+- Count of pinned episodes.
+- A `Free up X MB` action that unpins least-recently-played auto-pinned episodes until the budget is met.
+
+**Why.** Forces the heavy operation behind one explicit tap. No background "magic" that surprises the user.
+
+---
+
+## 2. Tasks
+
+### 2.1 Follow / unfollow
+
+1. Wire the `Follow` button on profile + directory to `creators.followCreator(id)` / `creators.unfollowCreator(id)`.
+2. Render the followed badge state from `useEventStore` selector.
+3. Trigger a single `refreshCreator(id, { force: true })` on first follow so the user sees content within seconds.
+
+### 2.2 Home Latest row
+
+4. Add `feedItems.getRecentForFollowed(limit = 8)` per §1.2.
+5. Create `apps/app/src/features/creators/home/LatestRow.tsx`:
+   - `useQuery(['latest', followedIds.join(',')])` for the list.
+   - Render only if `useEventStore.getState().followedCreators.size > 0`. Otherwise omit entirely (no empty-state CTA on Home — the directory's empty state covers discovery).
+   - Up to 8 horizontal cards. Each card: 1:1 thumbnail · creator avatar overlay · title (2 lines, ellipsis) · type chip (🎧 / ▶ / 📄) · duration if media.
+   - Tap → routes to the appropriate detail (audio / video / article).
+6. Mount the row in the Home screen above the fold's lower edge. (Confirm exact location with the maintainer; default: above the existing daily section.)
+
+### 2.3 Per-item pin
+
+7. Add a `pinFeedItem(itemId, { source: 'manual' | 'auto', force?: boolean })` helper in `apps/app/src/features/creators/pinning/feedItemPin.ts`.
+   - Performs §1.4 steps.
+   - Writes `feed_items.pinned`, `pin_source`, `pinned_at`.
+   - On Wi-Fi-only + cellular, returns `'deferred'` and inserts a row into `pending_pins`.
+8. Add a `unpinFeedItem(itemId, { source })` helper. Removes blob refs from the protected set on next GC; nukes `feed_items.media_hash` / `image_hash` to allow eviction.
+9. Append the schema to `0001_initial.sql`:
+
+   ```sql
+   ALTER TABLE feed_items ADD COLUMN pin_source TEXT;     -- 'manual' | 'auto'
+   ALTER TABLE feed_items ADD COLUMN pinned_at INTEGER;
+   CREATE TABLE IF NOT EXISTS pending_pins (
+     item_id TEXT PRIMARY KEY,
+     queued_at INTEGER NOT NULL
+   );
+   ```
+
+   ⚠️ `ALTER TABLE` is **not** idempotent. Wrap in a try/catch on bootstrap, or check `pragma table_info(feed_items)` first and skip if column exists. Pattern:
+
+   ```ts
+   await ensureColumn('feed_items', 'pin_source', 'TEXT')
+   await ensureColumn('feed_items', 'pinned_at', 'INTEGER')
+   ```
+
+   `ensureColumn` runs `pragma table_info` and conditionally executes `ALTER TABLE`. Lives in `db/client.ts` next to the migration runner. **Document this exception clearly** — it's the only place where we deviate from pure `IF NOT EXISTS` idempotency.
+
+10. Render a Pin toggle on every episode/article row + on the player screen.
+
+### 2.4 Auto-pin reconcile
+
+11. Add `creators.setAutoPinCount(creatorId, count)` event-sourced setter, wired to the profile's `Pin latest N` action sheet (options: 0 / 3 / 5 / 10 / 20).
+12. Add `reconcilePins(creatorId)` per §1.3 in `feedItemPin.ts`.
+13. Hook `reconcilePins` into the tail of `feedFetcher.refreshCreator(id)` — runs after the upsert.
+
+### 2.5 Wi-Fi-only + pending pins
+
+14. Add `useNetworkState()` hook in `apps/app/src/lib/network.ts` wrapping `expo-network`.
+15. Add a Wi-Fi-only toggle to Settings (default ON). Persists in `preferences['creators.wifiOnly']`.
+16. On Wi-Fi reconnect, drain `pending_pins` table — call `pinFeedItem(itemId)` for each row in age order.
+
+### 2.6 Storage UI
+
+17. Extend Settings → Storage with a Creators section. Per followed creator:
+    - Local size = `SUM(LENGTH(blob bytes))` over pinned media + image blob hashes (compute via `store` API; don't read filesystem directly).
+    - Oldest pinned episode date.
+    - Count.
+    - `Free up X MB` action: `unpinFeedItem` on least-recently-played auto-pinned items until the bytes-target is met. "Least-recently-played" = `MIN(media_progress.updated_at, feed_items.pinned_at)`; if neither, fall back to `feed_items.pinned_at ASC`.
+18. Soft cap bump (Phase 1 §2.4 #12) lights up automatically — no UI change needed beyond the existing settings cap field.
+
+### 2.7 Network-aware UX
+
+19. Add an "offline" chip in the navigation header when `isOnline === false`. Positioned next to existing header actions.
+20. On non-pinned remote items, show a "Needs internet" placeholder when offline (in player screen, video screen, article reader summary mode).
+21. Disable pull-to-refresh on profile + Home Latest row when offline (`refreshControl` disabled vs. failing).
+22. The streamed-audio progressive-cache that `expo-av` does by default is preserved — we don't fight it.
+
+### 2.8 Tests
+
+23. Repository tests for `feedItems.getRecentForFollowed` (sort + limit + JOIN correctness).
+24. `reconcilePins` test covering: increase, decrease, manual-pinned not removed, missing items.
+25. Network-aware UX test: mock `useNetworkState` to offline, assert chip + disabled refreshes.
+26. Wi-Fi-only deferral test: mock cellular, assert `pinFeedItem` returns `deferred` and writes to `pending_pins`.
+
+---
+
+## 3. Files touched / created
+
+### Created
+
+| Path | Purpose |
+|---|---|
+| `apps/app/src/features/creators/home/LatestRow.tsx` | Home row |
+| `apps/app/src/features/creators/pinning/feedItemPin.ts` | Pin / unpin / reconcile helpers |
+| `apps/app/src/features/creators/settings/StorageSection.tsx` | Settings → Storage Creators block |
+| `apps/app/src/lib/network.ts` | `useNetworkState` |
+| `apps/app/src/lib/db/ensureColumn.ts` | Idempotent `ALTER TABLE` helper |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `apps/app/src/db/migrations/0001_initial.sql` | `pending_pins` table; new columns guarded via `ensureColumn` at boot |
+| `apps/app/src/db/client.ts` | Run `ensureColumn` calls after main migration |
+| `apps/app/src/db/repositories/feedItems.ts` | Add `getRecentForFollowed`, `getAutoPinnedByCreator`, pin/unpin helpers |
+| `apps/app/src/db/repositories/creators.ts` | Add `setAutoPinCount` event |
+| `apps/app/src/features/creators/audio/audioPlayer.ts` | Read pinned local URI when present |
+| `apps/app/src/features/creators/feeds/fetcher.ts` | Call `reconcilePins` after each successful refresh |
+| `apps/app/src/app/_layout.tsx` | Mount network chip |
+| `apps/app/src/app/index.tsx` (Home) | Mount `<LatestRow />` |
+| `apps/app/src/app/creators/[creatorId].tsx` | Wire Follow + `Pin latest N` sheet |
+| `apps/app/src/app/settings/storage.tsx` | Render Creators storage section |
+
+---
+
+## 4. Open questions
+
+1. **Where exactly on Home does Latest go?** Above or below the daily section. **Default**: above (it's the user's primary daily-content surface). Confirm with maintainer.
+2. **Auto-pin: should the count be per-creator or global?** Per-creator (matches the user's stated mental model: "I want 3 PPR + 10 Bishop Barron"). Global cap can come later.
+3. **Streaming progressive cache TTL.** `expo-av`'s built-in cache is cleared on app eviction; do we want to persist? **Default**: no — pinning is the user-controlled contract; transient stream cache is opportunistic only.
+
+---
+
+## 5. Verification
+
+| Check | How |
+|---|---|
+| Follow persists | Follow a creator, kill the app, reopen — followed badge still shows. |
+| Latest row appears | Follow ≥1 creator with feed items; Latest row appears on Home with newest items. |
+| Latest row hidden | Unfollow all creators; Latest row disappears. |
+| Per-item pin → offline play | Pin an episode, force airplane mode, kill app, reopen, tap ▶ — plays from local blob. |
+| Auto-pin reconcile | Set `auto_pin_count = 3`, force-refresh feed; top 3 items have `pinned = 1`, oldest item that was previously auto-pinned has `pinned = 0`. |
+| Manual-pin survives reconcile | Manually pin a 5th item; raise auto_pin_count to 3; manual pin remains. |
+| Wi-Fi-only deferral | Enable Wi-Fi-only, disable Wi-Fi (cellular only), tap pin — item is queued, not downloaded. Reconnect Wi-Fi → download proceeds. |
+| Storage UI | Pin two episodes, open Settings → Storage; per-creator size matches sum of pinned blob bytes (±100 bytes). |
+| Free up X MB | Tap action; smallest LRU-rank pinned items are unpinned until the target is met. |
+| Offline chip | Airplane mode → chip appears in nav header. |
+| Needs-internet placeholder | Offline + tap a non-pinned video — placeholder shows, no spinner. |
+
+---
+
+## 6. Phase 3 → Phase 4 handoff
+
+After Phase 3:
+- Follows, Latest row, pinning, and offline UX all work.
+- `feed_items` is steadily-populated SQLite truth for ~12 followed creators × ~50 items each.
+- `useNetworkState` is the canonical network awareness signal.
+
+Phase 4 builds the search index over this stable substrate: `feed_items` + corpus titles + chapter markers, with FlexSearch as the runtime.

--- a/docs/features/creators/phase-04-search-v1.md
+++ b/docs/features/creators/phase-04-search-v1.md
@@ -1,0 +1,302 @@
+# Phase 4 — Global Search v1
+
+> The flagship of v1. **A doctrinal answer engine, no ML required.**
+
+**Goal.** Ship a single search box that searches across feed-item titles, descriptions, show notes, chapter markers, and corpus content (book titles + chapter titles, prayer titles, saint names, collection names, CCC paragraph headings, Mass propers names). Per-question deep-linking inside Q&A podcasts via parsed chapter markers. All on-device, privacy-preserving, fully offline against any creator whose feed has been fetched once.
+
+**Success criteria.**
+1. Typing *"posso comungar em pecado mortal"* (pt-BR) returns the matching PPR *Resposta Católica* episode in the top-3 results within 100 ms on a cold cache, with the chapter chip jumping the player to the right offset.
+2. Typing *"how do I prepare for confession"* (en-US) returns relevant podcast episodes + matching CCC paragraph headings + the Confession examen practice.
+3. Search works fully offline against pinned creators, including chapter-marker deep-linking.
+4. Q&A-tagged channels boost appropriately on question-shaped queries; corpus content boosts on definitional queries.
+5. Empty state suggests example questions tailored to the user's language.
+6. Recent searches persist and clearable from Settings.
+7. No query leaves the device.
+
+**Dependencies.** Phase 1 (`feed_items`, `chapters_json`, `format` field on `CreatorChannel`) and Phase 3 (followed creators producing meaningful index volume).
+
+---
+
+## 1. Major design decisions
+
+### 1.1 FlexSearch over MiniSearch / Lunr / SQLite FTS5
+
+**Decision.** Use **FlexSearch** (`flexsearch` npm package) as the on-device index.
+
+**Why.**
+- **Speed.** FlexSearch is empirically the fastest pure-JS full-text engine: well under 50 ms cold-start over ~10k titles in our target memory footprint.
+- **Tokenizer.** Built-in `forward` tokenizer handles partial-word matches (the user types `"comung"` and gets `"comungar"`). Lunr is whole-token only.
+- **Memory.** A `Document` index over title+summary+chapters across ~10k items lands at ~5 MB in our target. MiniSearch is comparable but slower; Lunr is heavier.
+- **Per-language profiles.** FlexSearch supports per-field language config (Portuguese stemmer, English stemmer). Critical for pt-BR + en-US parity.
+- **No native deps.** Pure JS — works on web, iOS, Android, and the test runner.
+
+**Alternatives ruled out.**
+- *SQLite FTS5.* Tempting (already on-device) but: (a) re-tokenizing on every refresh is slow without `MERGE`-like incremental support, (b) language profiles are limited, (c) cold-start startup-time is comparable but the `LIKE`/`MATCH` query API is more brittle.
+- *Lunr.js.* Slower indexer; whole-token only; weak partial-match.
+- *Server-side search.* Defeats privacy + offline goals.
+
+### 1.2 Single in-memory index, per-language; rebuilt incrementally on feed refresh
+
+**Decision.** Two `Document` indexes — `searchEnIndex` and `searchPtIndex`. Latin titles are inserted into both. On each successful `refreshCreator(id)`, only that creator's items are re-indexed (`remove(itemId)` + `add(itemId, doc)`).
+
+**Why.** A single global index loses per-language stemming nuance. Two indexes is a cheap doubling. Incremental updates avoid a full rebuild on each refresh; without it, a 12-creator app rebuilds a 10k-doc index every 30 minutes.
+
+### 1.3 Indexer takes a kind-pluggable registry
+
+**Decision.** The index builder accepts a list of `IndexableSource` adapters:
+
+```ts
+interface IndexableSource {
+  kind: string                                    // 'feed-item' | 'book' | 'prayer' | 'saint' | 'ccc' | 'collection' | 'practice' | 'mass-proper' | (v1.1) 'playlist'
+  iterate(): AsyncIterable<{
+    id: string                                    // e.g. 'feed-item/...' | 'prayer/our-father' | 'ccc/123'
+    docId: string                                 // unique document key for FlexSearch
+    language: 'en-US' | 'pt-BR' | 'la'
+    title: string
+    summary?: string
+    chapterMarker?: { tStart: number; title: string; parentItemId: string }   // chapter-level docs duplicate title
+    creatorId?: string                            // for ranking
+    qaFormat?: boolean                            // if true, boost on question-shaped queries
+    publishedAt?: number                          // recency boost
+  }>
+}
+```
+
+A registry of `IndexableSource[]` is composed at boot:
+
+```ts
+const sources: IndexableSource[] = [
+  feedItemsSource,
+  bookTitlesSource,
+  prayersSource,
+  saintsSource,
+  cccHeadingsSource,
+  collectionsSource,
+  practicesSource,
+  massPropersSource,
+  // v1.1: playlistsSource
+]
+```
+
+**Why.** Phase 6 adds `playlist` to the index — without a registry, we'd be rewriting the indexer. Each source isolates its data-extraction logic; the indexer doesn't care where docs come from.
+
+### 1.4 Chapter markers become first-class index docs (one doc per chapter)
+
+**Decision.** When `feed_items.chapters_json` is non-empty, each chapter becomes its own indexable doc with `docId = '<itemId>#<chapterIdx>'` and a `chapterMarker` field. The parent episode is *also* indexed at the episode level, but per-chapter docs win on chapter-title matches.
+
+**Why.** PPR's *Resposta Católica* publishes episodes with timestamp lists in the description: `"00:00 Intro / 02:30 Pergunta 1: Posso comungar em pecado mortal? / 15:42 Pergunta 2: ..."`. The user types *"posso comungar"* and expects to land on the **answer**, not the episode start. Per-chapter docs make this free — no transcription, no ML.
+
+**Result row UX**: the chapter doc renders as one row showing the chapter title with a `02:30 →` chip; tapping seeks the player. Episode-level matches render as a normal row.
+
+### 1.5 Q&A-format boost is a query-time multiplier on a per-channel flag
+
+**Decision.** Channels mark `format: 'qa'` editorially (Phase 1). At query time, if the query starts with a question-word (`como`, `o que`, `posso`, `what`, `how`, `can I`, `should I`, `why`), Q&A-tagged docs get a 1.4× score multiplier in the BM25 result.
+
+**Why.** Editorial metadata, not ML — cheap, explainable, easy to tune. Question-word detection is a small per-language regex. The 1.4× was chosen empirically: enough to pull the right Q&A episode above a longer corpus title that matched on raw tokens, but not so much that it crowds out clearly-better matches.
+
+### 1.6 Per-kind ranking priors
+
+**Decision.** Score = `BM25 × kindPrior × recencyBoost`, where:
+
+| Query shape | Kind boosts |
+|---|---|
+| Question (`"como confessar"`) | `feed-item-qa` 1.4×, `feed-item` 1.0×, `ccc` 1.2×, `prayer` 0.9×, `book` 0.9× |
+| Definitional (`"acedia"`, `"sanctifying grace"`) | `ccc` 1.5×, `book` 1.3×, `feed-item` 1.0×, `prayer` 0.9× |
+| Person (`"st thomas"`, `"padre"`) | `saint` 1.5×, `creator` 1.2×, `feed-item` 1.0× |
+
+**Why.** We have prior information about what the user is likely after based on query shape; throwing it away leaves real value on the table. The numbers come from a small offline test set we'll iterate on (see verification §5).
+
+### 1.7 Ranking math runs in JS, not in FlexSearch
+
+**Decision.** FlexSearch returns top-K (K=80) raw matches. JS post-processing applies kind priors, recency, Q&A boost, and produces the final ranked list.
+
+**Why.** FlexSearch's scoring API is limited and not easily configured per-kind. K=80 is wide enough that re-ranking finds the right top-10; small enough that the JS pass is sub-millisecond.
+
+### 1.8 Empty state = a starter catechetical FAQ
+
+**Decision.** When the user opens search with an empty input, render 6-8 example questions drawn from real seed-creator highest-quality Q&A episodes. Localized: pt-BR pulls from PPR; en-US from *Catholic Answers Live* / *Pints With Aquinas*. Tapping a suggestion fills the input AND triggers the search — answers play with one tap.
+
+**Why.** It's marketing-by-product: the empty state itself is a demo of the wow. New users understand the value in 3 seconds.
+
+### 1.9 No analytics, ever
+
+**Decision.** Queries persist to `search_history` only on-device. Nothing is sent anywhere. No "popular searches" feature based on aggregate data.
+
+**Why.** A doctrinal-search query log is *spiritually* sensitive. The user's questions about confession, addiction, doubt, despair, or sin are not data we will ever collect, transmit, or aggregate. Privacy is a feature, not a constraint to compromise.
+
+---
+
+## 2. Tasks
+
+### 2.1 Search engine
+
+1. Create `apps/app/src/features/search/engine.ts`:
+   - Initializes two `Document` indexes (FlexSearch) with per-language config.
+   - `addDocument(lang, doc)`, `removeDocument(lang, docId)`, `replaceDocumentsForCreator(lang, creatorId, docs)`.
+   - `query(lang, q, opts): RawHit[]` returns top-K=80 matches with field hits.
+
+   FlexSearch config:
+
+   ```ts
+   const enConfig = {
+     tokenize: 'forward',
+     stemmer: 'en',
+     filter: 'en',
+     document: {
+       id: 'docId',
+       index: ['title', 'summary', 'chapterMarker.title'],
+       store: ['kind', 'parentId', 'creatorId', 'qaFormat', 'publishedAt', 'chapterMarker', 'language', 'title'],
+     },
+   }
+   ```
+
+2. Create `apps/app/src/features/search/sources/`:
+   - `feedItemsSource.ts` — iterates `feed_items` + per-chapter docs from `chapters_json`. Reads `creator/<id>` manifest to enrich `qaFormat` and per-channel language.
+   - `bookTitlesSource.ts` — iterates resident book manifests' `book.json` (titles + TOC headings + chapter titles).
+   - `prayersSource.ts` — iterates `getEntriesByKind('prayer')`.
+   - `saintsSource.ts` — iterates the saints feed bundle.
+   - `cccHeadingsSource.ts` — iterates the bundled CCC structure for headings only (full-paragraph indexing is Phase 8).
+   - `collectionsSource.ts` — iterates `getEntriesByKind('collection')`.
+   - `practicesSource.ts` — iterates `getEntriesByKind('practice')`.
+   - `massPropersSource.ts` — iterates `of-data` for proper names.
+
+3. Create `apps/app/src/features/search/indexer.ts`:
+   - On boot (after `warmDeferredManifests`), iterates all sources and adds documents.
+   - Hooks `feedFetcher` post-refresh callback to call `replaceDocumentsForCreator`.
+   - Cold-start budget: ≤ 50 ms over ~10k docs across both languages. Profile and confirm.
+
+4. Create `apps/app/src/features/search/ranker.ts`:
+   - Detect query shape (question / definitional / person / generic).
+   - Apply kind priors, Q&A boost, recency boost.
+   - Return final ranked hits.
+
+5. Create `apps/app/src/features/search/hits.ts`:
+   - Hydrates ranked hits to renderable `SearchHit` objects: title, subtitle, source icon, creator avatar URL, chapter chip, route on tap.
+
+6. Create `apps/app/src/features/search/useSearch.ts` hook:
+   - Debounced query input (200 ms).
+   - `useQuery(['search', lang, q])` with `staleTime: 0` and a query-fn calling `engine.query` + `ranker.rank` + `hits.hydrate`.
+
+### 2.2 UI
+
+7. Create `apps/app/src/features/search/SearchPill.tsx`: a small `🔍 Ask…` pill rendered on Home (above the fold) and inside the navigation header on every screen via `_layout.tsx`. Tap → opens the search overlay.
+
+8. Create `apps/app/src/app/search.tsx` (full-screen modal):
+   - `SafeAreaView` with a tall `<TextInput>` that auto-focuses and shows a clear `✕`.
+   - Result tabs: `All · Q&A · Listen · Watch · Read · Books · Catechism · Saints · Prayers`. Tab counts shown when > 0.
+   - Result list with `<SearchResultRow />`.
+   - Empty state with 6-8 example questions drawn from a small `apps/app/src/features/search/empty-state.ts` constant (pt-BR / en-US).
+
+9. Create `apps/app/src/features/search/SearchResultRow.tsx`:
+   - Source icon + creator avatar (creator content) or content icon (corpus content).
+   - Title (the question for Q&A channels).
+   - Subtitle: creator name / source.
+   - Chapter chip when matched: `02:30 →`.
+
+10. Wire the chapter-chip tap: routes to the audio detail screen with a `seekTo` param; `audioPlayer.play(itemId, { startAt: chapter.tStart })` honors it.
+
+### 2.3 Recent searches
+
+11. `search_history` is already created in Phase 1. Add `repositories/searchHistory.ts`:
+    - `record(query)` (no-op if same query in last 30 s; dedupes).
+    - `recent(limit = 8)` returns most-recent unique queries.
+    - `clearAll()`.
+
+12. Render recent searches in the empty state above the example questions: `Recent: <query 1> · <query 2> · <query 3> · ...` with a `Clear` action.
+
+13. Add a Settings → Privacy "Clear search history" button calling `searchHistory.clearAll()`.
+
+### 2.4 Performance & telemetry
+
+14. Add `__DEV__`-only timing logs:
+    - Cold-start index build time.
+    - Per-query: tokenize / FlexSearch lookup / rank-hydrate / total. Log when total > 100 ms.
+15. Snapshot of index size in MB (counting Document store) on startup; log if > 8 MB so we catch creep early.
+
+### 2.5 Tests
+
+16. Unit tests for `ranker.ts`: each query shape → expected boost mix.
+17. Unit tests for chapter-marker indexing: PPR-fixture episode with timestamp description produces the right per-chapter docs and they match on chapter title.
+18. Snapshot test of seed-creator empty-state suggestions.
+19. Performance test: index 10k synthetic docs, run 100 queries, assert mean < 100 ms (skipped in CI by default — manual perf gate).
+20. Privacy test: a fixture network-listener asserts no outbound HTTP request fires from `engine.query`.
+
+---
+
+## 3. Files touched / created
+
+### Created
+
+| Path | Purpose |
+|---|---|
+| `apps/app/src/features/search/engine.ts` | FlexSearch wrapper |
+| `apps/app/src/features/search/indexer.ts` | Boot + refresh hooks |
+| `apps/app/src/features/search/ranker.ts` | Post-FlexSearch ranking |
+| `apps/app/src/features/search/hits.ts` | Hydration |
+| `apps/app/src/features/search/useSearch.ts` | Hook |
+| `apps/app/src/features/search/SearchPill.tsx` | Entry point |
+| `apps/app/src/features/search/SearchResultRow.tsx` | Result row |
+| `apps/app/src/features/search/empty-state.ts` | Localized starter questions |
+| `apps/app/src/features/search/sources/feedItemsSource.ts` | Live items |
+| `apps/app/src/features/search/sources/bookTitlesSource.ts` | Books |
+| `apps/app/src/features/search/sources/prayersSource.ts` | Prayers |
+| `apps/app/src/features/search/sources/saintsSource.ts` | Saints |
+| `apps/app/src/features/search/sources/cccHeadingsSource.ts` | CCC headings |
+| `apps/app/src/features/search/sources/collectionsSource.ts` | Collections |
+| `apps/app/src/features/search/sources/practicesSource.ts` | Practices |
+| `apps/app/src/features/search/sources/massPropersSource.ts` | Mass propers |
+| `apps/app/src/db/repositories/searchHistory.ts` | Recent searches |
+| `apps/app/src/app/search.tsx` | Full-screen modal |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `apps/app/src/features/creators/feeds/fetcher.ts` | Post-refresh callback into `indexer.replaceDocumentsForCreator` |
+| `apps/app/src/app/_layout.tsx` | Mount `<SearchPill />` in nav header |
+| `apps/app/src/app/index.tsx` (Home) | Mount `<SearchPill />` above the fold |
+| `apps/app/src/app/settings/privacy.tsx` | "Clear search history" action |
+| `apps/app/src/lib/i18n/locales/en-US.ts` | `search.*` namespace |
+| `apps/app/src/lib/i18n/locales/pt-BR.ts` | Mirror |
+
+### Dependencies
+
+Add to `apps/app/package.json`:
+- `flexsearch` (~70KB minified, no native deps)
+
+---
+
+## 4. Open questions
+
+1. **Stemmer choice for pt-BR.** FlexSearch ships a Portuguese profile (Portugal Portuguese). Brazilian Portuguese has small-but-real differences in inflection. Acceptable for v1; revisit if pt-BR results are visibly poor on common queries.
+2. **CCC paragraph headings only — when to add bodies?** Phase 8 (Search v1.1 enrichment). Don't bloat the v1 index.
+3. **Should chapter docs include the parent episode title?** Yes — boosts recall when the user's query matches the parent. Append parent title to `summary` for chapter docs.
+4. **Search across un-fetched creators.** Out of scope: search is over-on-device-cache only. Surfacing un-fetched suggestions ("12 more creators have content matching this") is a v1.1 idea, not a v1 must.
+
+---
+
+## 5. Verification
+
+| Check | How |
+|---|---|
+| Cold-start index | Boot the app fresh; confirm `__DEV__` timing log shows index build < 50 ms over 10k docs. |
+| Query latency | Type "comungar em pecado mortal" — total time logged < 100 ms; result is the right episode in top-3. |
+| Chapter-level deep-link | Tap a chapter chip — audio player opens AND seeks to `tStart` within 500 ms. |
+| Q&A boost | Query "como confessar" shows PPR Resposta Católica episode above a non-Q&A homily that mentions confession. |
+| Definitional boost | Query "acedia" surfaces CCC paragraph + book chapter above any podcast match. |
+| Localization | pt-BR locale: "como rezar o terço" returns Brazilian-Portuguese-tagged hits first. |
+| Recency tie-breaker | Two equally-relevant podcast episodes — the newer one ranks higher. |
+| Empty state | Open search with empty input — 6-8 localized example questions render. Tap one — search runs, plays the answer. |
+| Recent searches | Run 3 queries; close + reopen overlay — recent shows. Settings → Privacy → Clear; recent is empty. |
+| Privacy test | Wireshark / Charles run during 30 search sessions — zero outbound search traffic. |
+| Offline | Airplane mode + cold start: search returns hits across all pinned + previously-cached content, including chapter chips. |
+
+---
+
+## 6. Phase 4 → Phase 5 handoff
+
+After Phase 4:
+- The wow ships. Search across all on-device content works in 100 ms, on-device, in two languages.
+- The indexer architecture is ready for Phase 6 (`playlist`) and Phase 8 (canonical-question redirects + full bodies + synonyms) without rewrite.
+
+Phase 5 is polish: lock-screen artwork, sleep timer hardening, skeletons, accessibility, background download.

--- a/docs/features/creators/phase-05-polish.md
+++ b/docs/features/creators/phase-05-polish.md
@@ -1,0 +1,190 @@
+# Phase 5 — Polish
+
+> Last v1 phase. Closes the gap from "works" to "feels like a finished product." After Phase 5, **v1 ships.**
+
+**Goal.** Harden the player, complete pt-BR parity, fill skeleton/empty states, pass an accessibility review, and add background download for pinned media.
+
+**Success criteria.**
+1. iOS and Android lock-screen show artwork + scrubbable progress + ▶◀▶▶ controls.
+2. Sleep timer ends-of-episode option works precisely (no audio bleed).
+3. Every loading state has a skeleton; every empty state has copy + a CTA where appropriate.
+4. ≥40% of seed creators are lusophone; pt-BR translations cover every UI string.
+5. VoiceOver / TalkBack reads creator profile, player controls, and search results in the user's language.
+6. Pinning an episode while the app is backgrounded continues the download.
+
+**Dependencies.** Phases 1-4.
+
+---
+
+## 1. Major design decisions
+
+### 1.1 Lock-screen artwork via a small Expo config plugin (or `expo-music-info`)
+
+**Decision.** `expo-av` exposes `Audio.setNowPlayingInfoAsync({ title, artist, artwork, durationS })` on web and iOS via an Expo config-plugin ([deferred from Phase 2](phase-02-browse-ui.md#1-major-design-decisions)). On Android, the equivalent is a `MediaSession`/`MediaStyle` notification — wired through the same expo-av path.
+
+**Why.** Accept the "small native bridge" cost now (rather than swap to `react-native-track-player`) because the rest of the player has been stable across two phases.
+
+**Fallback if the bridge slips.** Keep v1's basic ▶⏸ controls (already working from Phase 2), defer scrubbing + artwork to v1.1. Communicate openly in release notes — not silently regress.
+
+### 1.2 Sleep-timer "end of episode" option uses `expo-av`'s `playbackStatus.didJustFinish`
+
+**Decision.** When sleep timer = `endOfEpisode`, set a one-shot `onPlaybackStatusUpdate` listener that calls `audioPlayer.stop()` on `didJustFinish`. Other timer values (15 / 30 / 60 min) use `setTimeout`.
+
+**Why.** Avoids manual position-polling for the end-of-episode case (would be off by up to 1 s). Status updates from `expo-av` are reliable for transport events.
+
+### 1.3 Skeletons mirror the final layout 1:1
+
+**Decision.** Each screen with async data has a `<Skeleton>` variant whose box layout matches the final content (avatar circle + 2 lines of text → grey circle + 2 grey rectangles). No spinners.
+
+**Why.** Layout-matching skeletons reduce perceived loading time and avoid layout-shift on render. Spinners imply nothing about the page that's loading.
+
+### 1.4 pt-BR parity is a hard launch gate
+
+**Decision.** v1 does not ship until ≥40% of seed creators are lusophone AND every `creators.*` / `search.*` string has a pt-BR translation reviewed by the maintainer.
+
+**Why.** The PPR-search wow is the killer demo *for pt-BR users*. Shipping with sparse pt-BR content kneecaps the demo. This is a launch gate, not a "nice to have."
+
+### 1.5 Background download via `expo-background-fetch` (best-effort)
+
+**Decision.** Pinning a media URL while backgrounded enqueues the job in `expo-background-fetch` with a minimum interval and a per-job timeout. iOS will surface this through a background URL session; Android via WorkManager — both managed by Expo.
+
+**Why.** Best-effort is honest. Foreground-pin with progress chip remains the primary path. Background fetch fills the obvious "I tapped pin and walked away" case without us re-implementing platform-specific download managers.
+
+### 1.6 Accessibility minimums
+
+**Decision.** Pre-launch checklist:
+- All interactive elements have `accessibilityLabel` (creator avatar in directory: `"Padre Paulo Ricardo, sacerdote, lusophone Q&A creator"`).
+- Color contrast ≥ 4.5:1 against backgrounds.
+- Touch targets ≥ 44×44pt.
+- VoiceOver announces transport state changes (Now Playing → "Playing, Posso comungar em pecado mortal").
+- Search input has `accessibilityHint` describing the action.
+
+**Why.** A prayer app must be accessible — many users are elderly. Skipping this in v1 sets a precedent we'd regret.
+
+---
+
+## 2. Tasks
+
+### 2.1 Player polish
+
+1. Add lock-screen artwork + scrubbing to `audioPlayer.ts` via `setNowPlayingInfoAsync`. Verify on iOS device + Android device.
+2. Implement sleep timer per §1.2. UI in `AudioPlayerScreen.tsx`: action sheet with options.
+3. Add a tiny `ProgressChip` to the player when playback is buffering — no full-screen spinner.
+4. Persist the user's last-used speed in `preferences['creators.playerSpeed']`; restore on next play.
+5. On `didJustFinish` for the last episode in a queue (queue is single-item in v1), surface a 3-second "Up next: <newest unpinned> from <creator>?" toast with a tap-to-play.
+
+### 2.2 Skeletons & empty states
+
+6. `creators/index.tsx`: skeleton grid (8 ghost cards) when `useQuery` is loading.
+7. `creators/[id]`: skeleton banner + skeleton tab list when manifest is loading.
+8. Listen / Watch / Read tabs: 4 ghost rows.
+9. Search overlay: while typing, ghost rows (8) for results.
+10. Latest row on Home: ghost cards (4) before first refresh completes.
+11. Empty states:
+    - Listen tab with no fetched items yet: copy "We're loading {{creator}}'s latest episodes…" + a manual refresh button.
+    - Search no-hits: copy "No results yet — Ember's catalog is curated. Have a creator in mind? Suggest one." + Suggest CTA.
+    - Latest row when followed but no items yet: skipped (the row hides entirely; no awkward "your followed creators have nothing" stub).
+
+### 2.3 i18n parity pass
+
+12. Audit `apps/app/src/lib/i18n/locales/en-US.ts` for any `creators.*` / `search.*` / `guided.*` keys missing from `pt-BR.ts`. Fill all gaps.
+13. Pass copy through the maintainer for tone — religious terminology in pt-BR is sensitive (don't say "pai" when "padre" is right).
+14. Pluralization: use ICU MessageFormat where counts vary ("1 episode" / "5 episódios").
+15. Date / duration formatting: `Intl.DateTimeFormat` and `Intl.RelativeTimeFormat` honor the active locale.
+
+### 2.4 pt-BR seed content
+
+16. Maintainer commits ≥4-5 lusophone seed creators to `content/creators/`.
+17. Confirm ≥40% of seed list ratio achieved.
+
+### 2.5 Accessibility
+
+18. Add `accessibilityLabel` + `accessibilityHint` to:
+    - Creator avatars (directory + Browse row).
+    - Tab buttons on profile.
+    - Player transport buttons.
+    - Pin / Mark-played / Suggest-edit menu items.
+    - Search input + result rows.
+19. Run iOS VoiceOver + Android TalkBack walkthroughs of: open directory → open profile → start audio → open search → tap result. Fix any unspoken or wrong-language announcements.
+20. Color-contrast audit using a tool (e.g., axe DevTools on web). Bump tokens as needed via `packages/ui` or design tokens.
+
+### 2.6 Background download
+
+21. Add `expo-background-fetch` config to `app.config.ts`.
+22. `feedItemPin.ts`: when pin is initiated and app is backgrounded, register a background-fetch task that resumes the download. Foreground = direct download (existing path).
+23. iOS: declare the `background-modes: fetch + processing` capability in app.json.
+24. Android: ensure WorkManager sufficient for ~50 MB downloads under metered constraints.
+25. Add a Settings → Storage toggle: `Allow background download` (default ON).
+
+### 2.7 Tests
+
+26. Snapshot tests for skeleton variants of every async screen.
+27. Component test verifying VoiceOver labels are present on all interactive elements (use `@testing-library/react-native`'s `getByA11yLabel`).
+28. Manual matrix:
+    - iOS 17+ device: lock-screen artwork, sleep-timer, background download.
+    - Android 13+ device: same.
+    - Web (Chrome + Safari): MediaSession metadata.
+
+---
+
+## 3. Files touched / created
+
+Mostly modifications:
+
+| Path | Change |
+|---|---|
+| `apps/app/src/features/creators/audio/audioPlayer.ts` | Lock-screen artwork, sleep timer end-of-episode |
+| `apps/app/src/features/creators/audio/AudioPlayerScreen.tsx` | Sleep-timer sheet, persisted speed |
+| `apps/app/src/features/creators/components/Skeleton*.tsx` | Per-screen skeletons |
+| `apps/app/src/features/creators/feeds/fetcher.ts` | Background-fetch hook |
+| `apps/app/src/features/creators/pinning/feedItemPin.ts` | Background download enqueue |
+| `apps/app/src/lib/i18n/locales/pt-BR.ts` | Parity pass |
+| `apps/app/app.config.ts` | Background-fetch capability |
+| `content/creators/<lusophone seeds>/` | Seed content |
+
+Created:
+
+| Path | Purpose |
+|---|---|
+| `apps/app/src/features/creators/components/SkeletonCreatorCard.tsx` | Directory ghost |
+| `apps/app/src/features/creators/components/SkeletonFeedRow.tsx` | Tab ghost |
+| `apps/app/src/features/search/SkeletonResultRow.tsx` | Search ghost |
+| `apps/app/src/features/creators/audio/UpNextToast.tsx` | End-of-episode chaining toast |
+
+---
+
+## 4. Open questions
+
+1. **Background download budget.** iOS background tasks are short and OS-budgeted. Set a per-pin timeout (60 s) and resume on next foreground if exceeded. Acceptable.
+2. **MediaSession on web (Firefox specifically).** Firefox's MediaSession support is incomplete. Accept degraded behavior on Firefox; Chrome/Safari/Edge are first-class.
+3. **VoiceOver pronunciation of pt-BR creator names.** Some screen readers mispronounce; we won't ship per-creator pronunciation hints in v1.
+
+---
+
+## 5. Verification
+
+| Check | How |
+|---|---|
+| Lock-screen art + scrub | iOS + Android device — start audio, lock screen, confirm artwork + scrubber + play/pause. |
+| Sleep-timer end-of-episode | Start a 5-min episode 4:30 in, set "end of episode" — audio stops at 5:00 ± 0.3 s. |
+| Skeletons | Throttle network in dev tools to Slow 3G — every screen shows skeletons during load. |
+| pt-BR parity | Toggle locale to pt-BR — every visible string is translated. Run a full walk: directory → profile → play → search. |
+| Lusophone ratio | `wc -l content/creators/*/manifest.json | grep -i 'pt-BR' | wc -l` — confirm ≥40% of seed creators. |
+| VoiceOver | iOS device with VoiceOver: walk profile → player. All interactive elements speak in user's language. |
+| Background download | Start a 50 MB pin, background the app, wait 60 s, foreground — pin completes. |
+| Bundle size | `pnpm build:web` — confirm bundle didn't bloat past +200 KB vs. Phase 4. |
+
+---
+
+## 6. v1 launch checklist
+
+After Phase 5, confirm before tagging v1:
+
+- [ ] All Phase 1-5 success criteria pass on iOS + Android + web.
+- [ ] Seed creators committed and approved by editorial.
+- [ ] pt-BR parity ≥40% lusophone seed.
+- [ ] No outstanding crash reports from internal device QA.
+- [ ] Privacy review: no analytics, no tracking, no query egress.
+- [ ] App Store / Play Store metadata updated (screenshots show the search wow + a creator profile).
+
+After v1 ships, watch metrics for ~2-4 weeks before starting Phase 6 (Series, v1.1).

--- a/docs/features/creators/phase-06-series.md
+++ b/docs/features/creators/phase-06-series.md
@@ -1,0 +1,265 @@
+# Phase 6 — Series (Editorial Playlists, v1.1)
+
+> First v1.1 phase. Adds **Series** — editorial bundles of media — as a first-class corpus kind.
+
+**Goal.** Add the `playlist` corpus kind without `practiceBinding`. Editor-curated playlists become browse-able as Series, surface on creator profiles, and are pinnable with transitive media materialization. Phase 7 adds `practiceBinding` to enable Pray-with on top of this same primitive.
+
+**Success criteria.**
+1. `pnpm build:corpus` produces `playlist/<id>` catalog entries with cover blobs.
+2. Browse → Series row surfaces 2-3 seed editorial playlists, prioritizing season-aware picks (Lent in Lent, Advent in Advent).
+3. Creator profile → Series tab lists playlists featuring that creator.
+4. Pinning a playlist transitively pins cover + audio-blob items + (with toggle) feed-item media.
+5. Search indexes playlist titles, descriptions, and item titles.
+6. Existing v1 features (creators, audio, search) are not regressed.
+
+**Dependencies.** All of v1 (Phases 1-5).
+
+---
+
+## 1. Major design decisions
+
+### 1.1 One corpus kind `playlist`, two user-facing labels
+
+**Decision.** Internal kind: `playlist`. Surface labels:
+- `practiceBinding` absent → user-facing "Series".
+- `practiceBinding` present (Phase 7) → user-facing "Pray with".
+
+**Why.** A playlist with audio items is structurally identical whether it's a Lenten retreat or a guided Rosary. Forcing two kinds means duplicate manifests, duplicate pinning collectors, duplicate search adapters. One primitive, two views.
+
+### 1.2 `PlaylistItem` is a discriminated union of five kinds
+
+**Decision.** As specified in [README §3.3](README.md#33-new-catalog-kind-playlist-v11), `PlaylistItem` is one of:
+- `feed-item` — references an existing podcast/RSS episode (resolved at runtime against `feed_items`).
+- `youtube` — references a YouTube video by id.
+- `audio-blob` — self-hosted audio (used for guided prayers in Phase 7; usable here too).
+- `article` — references an article by URL or RSS GUID.
+- `corpus` — a ref to any other catalog item (`prayer/our-father`, `book/.../chapter/...`).
+
+**Why.** An editorial playlist may mix feed episodes with corpus content (a Lenten retreat could include a book chapter on confession alongside a homily podcast). Forcing one item type would lose this composability. The runtime resolver dispatches per item kind to render the right preview.
+
+### 1.3 `feed-item` references can become stale; tolerate gracefully
+
+**Decision.** When a `feed-item` ref's `itemId` doesn't exist in local `feed_items` (creator deleted the episode, or user hasn't refreshed that creator yet), render the row as "no longer available" (greyed, non-tappable). Don't crash the playlist.
+
+**Why.** Editorial content lasts. Creator content can vanish. The playlist is the editorial intent; partial unavailability shouldn't break the whole listing.
+
+### 1.4 `build_playlists()` writes its manifest as a single JSON blob
+
+**Decision.** Cover image hashed separately (existing image pipeline). `audio-blob` items hashed individually (existing track-blob pipeline). The playlist manifest itself — including arrays of items with their item-kind discriminants — is a single JSON blob.
+
+**Why.** Matches the pattern of `build_collections()` and `build_practice_manifests()`. Consistent author workflow: drop a `manifest.json`, run build, get a hash. Per-item blob splitting adds complexity without payoff (playlists are small).
+
+### 1.5 Browse Series row uses the existing season-aware Hero pattern
+
+**Decision.** A `seasonalPlaylistsRow` reads the current liturgical season + current date and selects ≤4 playlists tagged `tags: ['lent']`, `tags: ['advent']`, etc. Other tagged playlists fill out the row in a stable order (curated weight).
+
+**Why.** Reuses the existing seasonal Hero / liturgical-season machinery — see `apps/app/src/features/seasons/`. Don't reinvent.
+
+### 1.6 Pinning a playlist is transitive but item-kind-aware
+
+**Decision.** `COLLECTORS['playlist']` walks `items[]`:
+- `feed-item` → enqueues an item-pin (uses Phase 3 `pinFeedItem`) **only if** the user opted into "Include items" on the playlist pin sheet.
+- `youtube` → never pinned (YT ToS; this is a hard rule).
+- `audio-blob` → blob hash registered as protected (always; the playlist depends on it).
+- `article` → enqueues an article pin if "Include items" is on.
+- `corpus` → recurse into the existing collector for that kind.
+
+**Why.** The default (no "Include items") just pins the manifest + cover. The user opts in to the larger transfer. We never silently rip podcast episodes or articles.
+
+### 1.7 Playlist search indexing reuses the `IndexableSource` registry from Phase 4
+
+**Decision.** Add `playlistsSource.ts` to `apps/app/src/features/search/sources/` per Phase 4 §1.3. Indexes title + description + item titles; per-language hits via the `language` field.
+
+**Why.** That's exactly what the registry pattern was designed for. No engine changes required.
+
+---
+
+## 2. Tasks
+
+### 2.1 Catalog kind & manifest
+
+1. Add `'playlist'` to `CatalogItemKind` in `apps/app/src/content/manifestTypes.ts:14-26`.
+2. Add `PlaylistManifest`, `PlaylistItem`, `PlaylistItemKind`, `PlaylistCurator` types per [README §3.3](README.md#33-new-catalog-kind-playlist-v11). Keep `practiceBinding` in the type but mark it `@since v1.1 (Phase 7)`.
+3. Add `'playlist'` to `RESIDENT_KINDS`.
+4. Add `loadPlaylist(id)` to `apps/app/src/content/resolver.ts`.
+5. Hook `'playlist'` into `warmDeferredManifests`.
+
+### 2.2 Build pipeline
+
+6. Add `build_playlists(b)` to `scripts/build-corpus.py`. Pseudocode:
+
+   ```py
+   def build_playlists(b):
+     for pdir in (b.content_root / 'playlists').iterdir():
+       if not pdir.is_dir(): continue
+       pid = pdir.name
+       m = json.loads((pdir / 'manifest.json').read_text())
+
+       if (pdir / 'cover.webp').exists():
+         h, sz = b.write_blob((pdir / 'cover.webp').read_bytes())
+         m['coverHash'] = {'hash': h, 'size': sz}
+
+       # audio-blob items: hash the file at the indicated path
+       for item in m.get('items', []):
+         if item.get('kind') == 'audio-blob' and 'path' in item:
+           audio_path = pdir / item['path']
+           h, sz = b.write_blob(audio_path.read_bytes())
+           item['hash'] = h
+           item['size'] = sz
+           del item['path']  # hash supersedes; manifest stays content-addressed
+
+       # cross-reference checks
+       _validate_playlist_refs(m, b.catalog)
+
+       m['id'] = f'playlist/{pid}'
+       h, sz = b.write_json_blob(m)
+       entry = {
+         'kind': 'playlist',
+         'hash': h,
+         'size': sz,
+         'name': m['title'],
+         'tags': m.get('tags', []),
+       }
+       b.add_catalog(f'playlist/{pid}', entry)
+   ```
+
+7. Implement `_validate_playlist_refs(m, catalog)` to check:
+   - `featuredCreatorIds[]` all exist as `creator/<id>` in catalog.
+   - `corpus` refs all exist in catalog.
+   - `feed-item` refs cannot be validated at build time (they're in SQLite at runtime). Accept and document.
+   - `practiceBinding` validation deferred to Phase 7.
+8. Add `_validate_playlist_refs` test fixtures: a valid playlist, a playlist with a missing creator ref (build should fail clearly), a playlist with a missing corpus ref (same).
+
+### 2.3 Pinning collector
+
+9. Add `playlist` collector to `apps/app/src/features/pinning/pinningManager.ts:66-98`:
+
+   ```ts
+   playlist: (body, add) => {
+     const p = body as PlaylistManifest
+     if (p.coverHash) add(p.coverHash)
+     // audio-blob items always materialize for the playlist to function
+     for (const item of p.items) {
+       if (item.kind === 'audio-blob') add({ hash: item.hash, size: item.size })
+     }
+     // corpus items recurse (return their refs to the recursive walker)
+     return p.items
+       .filter(i => i.kind === 'corpus')
+       .map(i => (i as CorpusPlaylistItem).ref)
+   },
+   ```
+
+10. The "Include items" toggle path is a separate `pinPlaylistWithItems(id)` in `apps/app/src/features/creators/pinning/playlistPin.ts`:
+    - Calls the pinning manager's standard `pinItem('playlist/<id>')`.
+    - Then iterates `items[]`:
+      - `feed-item` → `pinFeedItem(itemId)` (deferral via Wi-Fi-only honored).
+      - `youtube` → skipped.
+      - `article` → `pinArticle(itemId)` (writes to a local article cache table; small, no Wi-Fi gate beyond size).
+      - `audio-blob` → already covered by the manifest collector.
+      - `corpus` → already covered by recursion.
+
+### 2.4 Browse Series row & profile tab
+
+11. Add `apps/app/src/features/creators/series/SeriesRow.tsx`:
+    - Reads `getEntriesByKind('playlist')`.
+    - Filters by season tags via `useLiturgicalSeason()`.
+    - Up to 4 cards.
+    - Cards: cover image · title · "<creator> · <N items>" subtitle.
+12. Mount in `browse/index.tsx` between Formation and Themes. Add a `playlistIds` line to `sectionLayout.ts`.
+13. Add a Series tab to `creators/[creatorId].tsx`:
+    - Tab visible if `getPlaylistsFeaturing(creatorId).length > 0`.
+    - Renders the same `SeriesCard`.
+14. Add `apps/app/src/app/playlists/[playlistId].tsx` route — playlist detail:
+    - Cover hero + title + description + curator (creator avatar if present).
+    - List of items rendered per kind.
+    - `Pin` button → action sheet "Pin manifest only" / "Include all items (X MB)".
+
+### 2.5 Search indexing
+
+15. Create `apps/app/src/features/search/sources/playlistsSource.ts` per the Phase 4 §1.3 source contract:
+    - Iterates `getEntriesByKind('playlist')`, hydrates manifest, emits docs:
+      - One playlist-level doc per language present in `title.<lang>`.
+      - Per-item title docs are NOT created in v1.1 — they'd duplicate the parent feed-item / corpus-item titles already indexed. Item titles are concatenated into the parent doc's `summary` for recall.
+16. Register `playlistsSource` in the indexer composition.
+17. Add ranking prior for `playlist`: 1.0× for definitional and question queries; 1.2× for season-shaped queries (e.g., `"lent"`, `"advent"`).
+
+### 2.6 Seed playlists
+
+18. Maintainer commits 2-3 seed playlists to `content/playlists/`:
+    - One Lenten series (40-day daily reflections).
+    - One topical bundle ("Best of *Resposta Católica* on Confession").
+    - One Advent series.
+
+   Each `manifest.json` references existing seed creators' feed items by `feed-item` (so build doesn't need their audio).
+
+### 2.7 Tests
+
+19. Build-script tests verifying the validator catches missing refs.
+20. Resolver test: round-trip a playlist manifest.
+21. Pinning test: pin a playlist with `Include items: on` → assert all `audio-blob` hashes are protected AND `feed-item` items are queued for pin.
+22. Stale `feed-item` ref test: render a playlist whose `feed-item` ref isn't in local `feed_items` — row shows "no longer available" instead of crashing.
+23. Search integration test: query a Lenten playlist's title — the playlist appears in the All tab and a new Series tab.
+
+---
+
+## 3. Files touched / created
+
+### Created
+
+| Path | Purpose |
+|---|---|
+| `apps/app/src/features/creators/series/SeriesRow.tsx` | Browse Series row |
+| `apps/app/src/features/creators/series/SeriesCard.tsx` | Reusable card |
+| `apps/app/src/app/playlists/[playlistId].tsx` | Playlist detail route |
+| `apps/app/src/features/creators/pinning/playlistPin.ts` | Transitive pin + Include-items |
+| `apps/app/src/features/search/sources/playlistsSource.ts` | Indexer adapter |
+| `content/playlists/<id>/` | Seed playlists |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `apps/app/src/content/manifestTypes.ts` | Add `'playlist'` to union; manifest types |
+| `apps/app/src/content/contentIndex.ts` | Register `'playlist'` |
+| `apps/app/src/content/resolver.ts` | `loadPlaylist`; warm |
+| `apps/app/src/features/pinning/pinningManager.ts` | `playlist` collector |
+| `apps/app/src/app/browse/index.tsx` | Mount `<SeriesRow />` |
+| `apps/app/src/app/browse/sectionLayout.ts` | `playlistIds` |
+| `apps/app/src/app/creators/[creatorId].tsx` | Series tab |
+| `apps/app/src/features/search/indexer.ts` | Register playlistsSource |
+| `apps/app/src/features/search/ranker.ts` | Playlist priors |
+| `scripts/build-corpus.py` | `build_playlists`, validator, orchestration call |
+
+---
+
+## 4. Open questions
+
+1. **Should "Include all items" be per-pin or remembered per-playlist?** Default: per-pin (less surprise; user opts in each time).
+2. **Cross-creator "best of" attribution.** A "Best of Confession" playlist with episodes from 5 creators — how should the playlist credit them in browse cards? **Default**: show the curator (editorial) plus a "5 creators" pill.
+3. **Playlists in Plan of Life enrollment.** A 40-day Lenten playlist could be auto-enrolled as a daily plan. Defer; not in this phase.
+
+---
+
+## 5. Verification
+
+| Check | How |
+|---|---|
+| Build | `pnpm build:corpus` emits `playlist/<id>` entries; cover blobs present. |
+| Build validator | An intentionally broken seed playlist (bad creator ref) fails the build with a clear error pointing at the playlist source file. |
+| Series row | Browse → Series row renders; in March (Lent), Lenten playlists appear first. |
+| Profile Series tab | Padre Paulo Ricardo profile shows the topical "Best of *Resposta Católica*" playlist on his Series tab. |
+| Detail route | Tap a playlist → detail page renders cover + items list with correct icons per item kind. |
+| Pin manifest only | Pin without "Include items" — only cover + manifest are local. |
+| Pin with items | Pin with "Include items" — all `audio-blob` items download; `feed-item` items queue for pin (Wi-Fi-only honored). |
+| Stale ref | Manually delete a `feed-item` row, reopen playlist — that row shows "no longer available" without crash. |
+| Search | Query "Lent" — Lenten Series surfaces in All tab + Series sub-tab. |
+
+---
+
+## 6. Phase 6 → Phase 7 handoff
+
+After Phase 6:
+- The `playlist` corpus kind exists and is exercised by ≥3 seed playlists in production.
+- Build validation, pinning, and search indexing all work for playlists without `practiceBinding`.
+
+Phase 7 adds `practiceBinding` validation and the `GuidedAudioController` runtime — both targeted, no rewrite needed.

--- a/docs/features/creators/phase-07-pray-with.md
+++ b/docs/features/creators/phase-07-pray-with.md
@@ -1,0 +1,274 @@
+# Phase 7 — Pray with [Creator] (Guided Prayers, v1.1)
+
+> The flagship of v1.1 — **and the most architecturally delicate phase in the whole feature**. Adds `practiceBinding` to playlists, builds the runtime that drives the audio along with the practice flow, and gates everything on a tiny but real spike to define stable section addressing.
+
+**Goal.** A user opens the Rosary, taps "Pray with Padre Paulo Ricardo," and prays alongside that priest's voice. Each Hail Mary, mystery announcement, and Glory Be is voiced by the creator. Pause, skip, and resume keep audio aligned with the flow. Pinned guided Rosary plays cold-start with airplane mode on.
+
+**Success criteria.**
+1. Voice selector on the Rosary practice start screen lists all `practiceBinding`-bearing playlists for that practice in the user's language.
+2. Selecting a voice and starting the practice plays the creator's audio in sync with the flow.
+3. As the user advances sections (auto or manual), audio re-cues to the right boundary within ±300 ms.
+4. Pause / resume keep audio aligned with the current section.
+5. Mystery cycle correctness: praying the Sorrowful Mysteries on Tuesday produces audio aligned to the Sorrowful sections, not the Joyful ones.
+6. `pnpm build:corpus` fails clearly when a `practiceBinding.segments[*].sectionPath` doesn't resolve.
+7. A pinned guided Rosary completes end-to-end with no network.
+
+**Dependencies.** Phases 1-5 (creators + pinning + audio player), Phase 6 (`playlist` corpus kind).
+
+---
+
+## 1. Pre-implementation spike: `sectionPath` semantics
+
+> ⚠️ **Do not skip.** Doing this spike before writing controller code prevents weeks of rework.
+
+### The problem
+
+The Rosary practice flow is dynamic. Looking at `packages/content-engine/src/types.ts`'s `FlowSection`:
+- It's a structurally-nested discriminated union with no stable `id` on container nodes.
+- `select` chooses one of N branches at runtime (day-of-week → Joyful / Sorrowful / Glorious / Luminous).
+- `repeat` expands a template N times.
+- `cycle` rotates through state-driven options.
+- Fragments are inlined.
+
+A naive index-path (e.g., `0.body.2.body.3`) is fragile under all of these — the same logical "third Hail Mary of the second decade of the Sorrowful Mysteries" gets a different index path each day depending on which `select` branch resolved.
+
+The `select` node carries an `overrideKey: string` (per-day-of-week / per-mystery cycle keying). This is a real lever. So is `select.options[].id`. We have two viable design candidates.
+
+### Candidate A — structural address using `overrideKey` + `option.id`
+
+**Path syntax**:
+```
+mysteries[sorrowful]/decade[2]/hail-mary[3]
+```
+
+Where:
+- `mysteries` is the `overrideKey` of the top-level `select`.
+- `sorrowful` is the `id` of one of the `select.options[]`.
+- `decade[2]` resolves to the second `repeat` iteration in the chosen branch.
+- `hail-mary[3]` resolves to the third `repeat` iteration of the Hail Mary template inside that decade.
+
+Resolver implementation: a small visitor over `FlowSection` keeps a `path` accumulator; when entering a `select`, prefer `overrideKey + option.id`. When entering a `repeat`, the path includes `repeatIndex`.
+
+**Pros**: zero DSL change; addresses are invariant under flow re-ordering as long as `overrideKey` and `option.id` remain stable.
+
+**Cons**: introducing a new `repeat`-template that changes the count silently shifts paths. Editorial review must catch this.
+
+### Candidate B — opt-in `id` field on container FlowSection types
+
+**Path syntax**:
+```
+sorrowful/decade-2/hail-mary-3
+```
+
+Where every `select.option` and every `repeat` template can carry an `id?: string`. The build-script validator requires playlists to address only nodes that have an `id`. Other parts of the flow (those without an id) are unaddressable, which is fine — guided prayers only need to address what their audio chunks cover.
+
+**Pros**: explicit, robust to refactors. Practice authors think about which sections are guided-addressable.
+
+**Cons**: requires a (tiny) DSL change. Other practice flows must migrate if we extend Pray-with beyond the Rosary in v2.
+
+### Spike output
+
+Write `apps/app/src/features/practice/guided/sectionPath.ts` with:
+- A pure function `resolveSectionPath(flow, renderContext, sectionPath): RenderedSection | undefined`.
+- A pure function `enumerateAddressablePaths(flow): { path, label }[]` for use by the build validator.
+- Implementations for both Candidate A and Candidate B behind a tiny strategy flag.
+
+Spike validation:
+- Walk the existing `practice/rosary` flow on each weekday (Joyful / Sorrowful / Glorious).
+- For each weekday, render the flow → compute `sectionPath` for every prayer (Sign of the Cross, Apostles' Creed, Our Father, Hail Mary x10 per decade, Glory Be, Fatima Prayer, ...).
+- Confirm the same logical prayer always gets the same `sectionPath` regardless of the day's mystery cycle when the mystery is the same; produces different `sectionPath`s across mystery cycles.
+
+**Decision criterion.** Pick Candidate A unless the spike reveals a path-instability under existing flow operators. Default = Candidate A (no DSL change). If the spike fails Candidate A, fall back to Candidate B and add a one-line `id?: string` field to the relevant container types.
+
+**Document the result** in `docs/features/guided-prayers.md` (a new file) before any controller code is written.
+
+---
+
+## 2. Major design decisions
+
+### 2.1 `GuidedAudioController` is decoupled from `PracticeFlow.tsx`'s render loop
+
+**Decision.** `apps/app/src/features/practice/guided/GuidedAudioController.tsx` mounts inside the practice screen, listens to the same `RenderedSection` cursor that `PracticeFlow.tsx` uses, and drives the audio player. It does **not** modify `PracticeFlow.tsx`'s render or the flow engine's section walker.
+
+**Why.** Keeps `packages/content-engine/` audio-agnostic. Lets us iterate on guided behavior without churning the practice render path. Future practices that don't have guided variants pay zero cost.
+
+### 2.2 Cursor exposure: the controller subscribes to `currentRenderedSectionPath`
+
+**Decision.** Add a small `useCurrentSectionPath()` hook to `apps/app/src/features/practices/components/` that returns the path of the currently-rendered section as a stable string. The controller subscribes; when the path changes, the controller seeks audio to the matching segment's `tStart`.
+
+**Why.** The mutation in `useAdvanceCursor` already exists for advancing reading tracks (Phase 1 explore §4). Re-exposing the *current* position via a hook is additive — no public-API breakage.
+
+### 2.3 Auto-advance is opt-in per-user, on by default
+
+**Decision.** When auto-advance is on (default), the controller listens for `playbackStatus.didJustFinish` of each segment and advances the practice's section cursor. When off, audio plays through but the user advances manually via tap.
+
+**Why.** Pace. Some users pray faster than the recorded creator; auto-advance lets them set the rhythm by tapping ahead. Others prefer to pace alongside the creator. The setting is a single toggle — `Practice with auto-advance`.
+
+### 2.4 Audio segment boundaries have a small lookahead pad
+
+**Decision.** When seeking to `segment.tStart`, subtract a 250 ms lookahead pad. This avoids audible clipping at the start of the segment (creators don't always start *exactly* on the cue).
+
+**Why.** Creators don't time mark-to-mark to the millisecond; humans pause, breathe, take a sip. A small pad makes the experience feel intentional.
+
+### 2.5 Voice selector lives on the practice start screen, not in a global setting
+
+**Decision.** Selection is per-practice-instance: the user picks a voice on the Rosary start screen; persistence is in `practice_voice` (Phase 1) keyed by `practice_id`. Reset to "Silent" on every practice start? **No** — last-selected voice is preselected. The user can change it any time.
+
+**Why.** Sticky-but-changeable matches how a user actually relates to creators: "I always pray with Padre Paulo Ricardo, but tonight I'd like silence." One surface, one mental model.
+
+### 2.6 Build validation is not optional
+
+**Decision.** `build_playlists()` (Phase 6) gains a `practiceBinding` validator (when present):
+- Resolve every `segments[*].sectionPath` against the referenced practice's flow on each plausible context (e.g., each weekday for the Rosary).
+- Fail the build with a clear error pointing at the playlist source file if any path doesn't resolve.
+
+**Why.** A Pray-with playlist that crashes mid-prayer because a path drifted is a fidelity bug. Catch it at build time.
+
+### 2.7 Pinning a Pray-with playlist auto-pins the audio for cold-play
+
+**Decision.** Pinning a playlist with `practiceBinding` always materializes its `audio-blob` items (existing collector behavior from Phase 6 §1.6). No "include items" toggle for guided prayers — the audio IS the playlist's reason to exist.
+
+**Why.** Asking a user "do you want to include the prayer audio?" when they pin a guided Rosary is friction that exists for no reason. The decision was made the moment they tapped pin.
+
+### 2.8 No AI voice cloning, ever
+
+**Decision.** Recorded as a hard rule in `docs/features/creators/README.md` §6.8 and in this phase's editorial process. We will not synthesize a creator's voice or augment their audio with TTS.
+
+**Why.** Trust. A guided prayer where the priest's voice is fake is no longer a guided prayer — it's a deepfake. We will turn down opportunities that require this, and we'll never ship one.
+
+---
+
+## 3. Tasks
+
+### 3.1 The spike
+
+1. Create `apps/app/src/features/practice/guided/sectionPath.ts`:
+   - `resolveSectionPath(flow, renderContext, path)` (pure).
+   - `enumerateAddressablePaths(flow)` (pure).
+   - Two strategies behind a flag (`'overrideKey' | 'idField'`); default `'overrideKey'`.
+2. Run on `practice/rosary` flow for each weekday context. Verify path stability under each mystery cycle.
+3. Document the chosen strategy in a new `docs/features/guided-prayers.md`.
+4. **Gate**: Phases 7 task 5+ do not start until this doc lands.
+
+### 3.2 Validator extension
+
+5. Extend `_validate_playlist_refs` (Phase 6 §2.2 #7) to also handle `practiceBinding`:
+   - Load referenced practice's flow.
+   - For each plausible render context (e.g., each weekday for a select-by-day flow), `enumerateAddressablePaths` and intersect with `segments[*].sectionPath`.
+   - Fail clearly when a binding doesn't resolve for some context.
+6. Add a fixture playlist with an intentionally bad sectionPath; assert build fails with the file path + bad-path noted.
+
+### 3.3 GuidedAudioController
+
+7. Create `apps/app/src/features/practice/guided/GuidedAudioController.tsx`:
+   - Reads the active voice from `practiceVoice.getVoice(practiceId)`; loads the referenced playlist via `loadPlaylist`.
+   - Reads the playlist's `practiceBinding`; precomputes a `Map<sectionPath, segment>`.
+   - Subscribes to `useCurrentSectionPath()`.
+   - On path change, calls `audioPlayer.seekTo(segment.tStart - 0.25)` and (if not playing) `audioPlayer.play()`.
+   - On `playbackStatus.didJustFinish` for a single-track playlist when auto-advance is on, advances the practice's section cursor.
+   - On pause / resume, re-cues to the current section's `tStart`.
+8. Mount the controller inside `apps/app/src/features/practices/components/PracticeFlow.tsx` (or its parent), guarded by `voice != 'silent'`.
+
+### 3.4 Voice selector UI
+
+9. Create `apps/app/src/features/practice/guided/VoiceSelector.tsx`:
+   - Dropdown / sheet on practice start screen.
+   - Options: "Silent" + each `practiceBinding`-bearing playlist whose `language` matches user locale.
+   - Default = last-selected (`practiceVoice.getVoice(practiceId)` or `'silent'`).
+   - Persist on change.
+10. Mount in the practice start screen (`apps/app/src/app/practices/[practiceId].tsx` or equivalent).
+
+### 3.5 Profile Pray-with tab
+
+11. Add a Pray-with tab to `creators/[creatorId].tsx`:
+    - Visible if `getPlaylistsFeaturing(creatorId).filter(p => p.practiceBinding).length > 0`.
+    - Each row: cover + practice name + duration estimate.
+    - Tap → routes to the practice with the voice preselected (writes `practiceVoice` then routes).
+
+### 3.6 Seed Pray-with playlists
+
+12. Coordinate with creator(s) for permission + audio source.
+13. For at least one en-US creator and one pt-BR creator, produce a single-track Rosary recording.
+14. Build the `practiceBinding.segments[]` map by manual chapter timing — a small spreadsheet with `(sectionPath, tStart, tEnd)` rows that the manifest is generated from.
+15. Commit `content/playlists/<id>/`:
+    ```
+    manifest.json    # contains practiceBinding
+    cover.webp
+    audio.mp3        # single track
+    ```
+16. `pnpm build:corpus` → confirm validator passes.
+
+### 3.7 Tests
+
+17. Spike validation harness: render the Rosary on Mon-Sun, assert path resolution.
+18. Validator unit test: bad sectionPath surfaces clear error.
+19. Controller unit test:
+    - Mock `useCurrentSectionPath` to step through a flow.
+    - Assert `audioPlayer.seekTo` called with the right `tStart - 0.25` per step.
+    - Assert auto-advance fires on `didJustFinish` and pauses the audio at last segment end.
+20. Integration test (manual): pin a guided Rosary, force airplane mode, pray it through end-to-end.
+
+### 3.8 i18n
+
+21. Add `guided.*` namespace to `en-US.ts` and `pt-BR.ts`: voice selector copy, "Praying with [creator]" chip, control sheet labels.
+
+---
+
+## 4. Files touched / created
+
+### Created
+
+| Path | Purpose |
+|---|---|
+| `apps/app/src/features/practice/guided/sectionPath.ts` | Pure path resolver + enumerator |
+| `apps/app/src/features/practice/guided/GuidedAudioController.tsx` | Runtime |
+| `apps/app/src/features/practice/guided/VoiceSelector.tsx` | Practice start UI |
+| `apps/app/src/features/practice/guided/PrayingChip.tsx` | In-flow chip |
+| `docs/features/guided-prayers.md` | Spike output + sectionPath spec |
+| `content/playlists/<guided-rosary>/` | Seed Pray-with playlist (≥1 en + ≥1 pt) |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `apps/app/src/content/manifestTypes.ts` | `practiceBinding` formally activated (was deferred) |
+| `apps/app/src/db/repositories/practiceVoice.ts` | Hooked into start screen |
+| `apps/app/src/features/practices/components/PracticeFlow.tsx` | Add `useCurrentSectionPath` export; mount controller |
+| `apps/app/src/app/practices/[practiceId].tsx` | Mount `<VoiceSelector />` |
+| `apps/app/src/app/creators/[creatorId].tsx` | Pray-with tab |
+| `scripts/build-corpus.py` | `practiceBinding` validator branch |
+
+---
+
+## 5. Open questions
+
+1. **Per-section vs single-track recording.** Single-track is cheapest for creators (one continuous take). Per-section is cleaner editorial (re-record one prayer without redoing everything). Phase 7 supports both shapes; seed creators choose. Future creators get a recommendation in the editorial guide (`docs/features/guided-prayers.md`).
+2. **Mystery selection override.** Voice selector currently respects today's mystery. Should there be an in-flow override "today's chosen mystery: Sorrowful — switch to Joyful"? Defer; not blocking.
+3. **What happens if the user changes the practice flow's mystery mid-prayer?** Today the flow doesn't allow this; if it ever does, the controller must handle the path-change event and seek accordingly. The current event-driven design handles it — confirm in tests.
+
+---
+
+## 6. Verification
+
+| Check | How |
+|---|---|
+| Spike doc | `docs/features/guided-prayers.md` exists; documents chosen `sectionPath` strategy with worked examples for the Rosary on each weekday. |
+| Build validator | A fixture playlist with bad `sectionPath` fails build with file path. |
+| Voice selector | Open Rosary start → voice options include silent + 1+ creators in user's language. |
+| Auto-advance | Begin Rosary; audio leads; flow advances on each `didJustFinish`. Section boundaries align ±300 ms. |
+| Manual advance | Toggle auto-advance off; tap-advance — audio re-cues to next segment immediately. |
+| Pause/resume | Pause mid-Hail-Mary; resume; audio re-cues to the start of that Hail Mary. |
+| Mystery correctness | Pray on Tuesday (Sorrowful); audio matches Sorrowful, not Joyful. Repeat for Mon-Sun coverage. |
+| Pinned cold play | Pin guided Rosary; airplane mode; complete the practice end-to-end. |
+| Voice persistence | Pick voice X; close app; reopen; start Rosary — X preselected. |
+| Voice exit | Select silent mid-prayer via control sheet; audio stops; flow continues silently. |
+
+---
+
+## 7. Phase 7 → Phase 8 handoff
+
+After Phase 7:
+- Pray-with works end-to-end. Two seed creators have guided Rosaries in production.
+- The `sectionPath` semantics are documented and validated.
+
+Phase 8 enriches search with curated answers and full corpus body indexing — independent of guided prayers.

--- a/docs/features/creators/phase-08-search-v11.md
+++ b/docs/features/creators/phase-08-search-v11.md
@@ -1,0 +1,220 @@
+# Phase 8 — Search v1.1 Enrichment
+
+> Doctrinal-search quality pass. Three orthogonal upgrades to the Phase 4 indexer, each cheap to ship and high-value.
+
+**Goal.** Add (a) curated canonical-question redirects so the very most common queries always land on the maintainer's hand-picked answer, (b) multilingual question synonyms so paraphrases work, and (c) full book bodies + every CCC paragraph in the index so definitional queries hit the actual paragraphs.
+
+**Success criteria.**
+1. Querying any of ~50 maintainer-curated canonical questions returns the curated top hit in the #1 slot.
+2. Synonyms (e.g., `comunhão` ↔ `Eucaristia`, `confession` ↔ `reconciliation`) widen recall without poisoning precision.
+3. Searching for "acedia" returns the actual CCC paragraph 2733 (not just headings) and the relevant book chapters.
+4. Index size stays under ~12 MB (was ~5 MB in v1) — the body-indexing add is the heavy line.
+5. No regression on Phase 4 verification checks.
+
+**Dependencies.** Phase 4 (search engine + ranker + indexer registry).
+
+---
+
+## 1. Major design decisions
+
+### 1.1 Canonical-question redirects are corpus content, not app code
+
+**Decision.** Add a new flat dir `content/answers/<lang>/*.json`. Each file maps frequent user questions to a top hand-picked target (an `itemId`, a `feed-item#chapterIdx`, a CCC paragraph, a book chapter, etc.). Built into the corpus by a new walker; resident in-memory at runtime.
+
+```jsonc
+// content/answers/pt-BR/comungar-pecado-mortal.json
+{
+  "question": "posso comungar em pecado mortal",
+  "synonyms": ["comungar pecado mortal", "comunhão pecado", "comunhão estado de pecado"],
+  "target": {
+    "kind": "feed-item",
+    "id": "feed-item/<sha256>",
+    "chapterTStart": 150
+  },
+  "fallback": { "kind": "ccc", "id": "ccc/1385" }
+}
+```
+
+**Why.** Editorial truth ships through the same pipeline as creators and books. Maintainer can hand-curate ~50 redirects per language and ship updates in a normal corpus deploy without app updates. The `fallback` is a target that's always-present (e.g., a CCC paragraph) so the redirect still works for users who haven't fetched the relevant feed.
+
+**Alternatives ruled out.**
+- *Hard-coded JS table in the app.* Couples editorial content to app releases. Bad for the maintainer's ability to iterate.
+- *Network-fetched canonical map.* Defeats offline-first.
+
+### 1.2 Synonyms are corpus content too — bilingual JSON files
+
+**Decision.** `content/synonyms/<lang>/<topic>.json` lists canonical-term ↔ aliases.
+
+```json
+{
+  "topic": "eucharist",
+  "lang": "pt-BR",
+  "canonical": "Eucaristia",
+  "synonyms": ["comunhão", "Santíssimo Sacramento", "Pão da Vida"]
+}
+```
+
+At index time, when a doc mentions any synonym, the canonical term is added to the doc's `summary` field (so FlexSearch's `forward` tokenizer picks it up). At query time, expand the user's query with synonyms before sending to FlexSearch.
+
+**Why.** Two-sided expansion — index-time AND query-time — is overkill but cheap (synonyms are O(50) per language). It also means a user typing "comunhão" hits docs that mention "Eucaristia" and vice versa, no matter which side held the synonym.
+
+### 1.3 Full book bodies and CCC paragraphs go into the indexer at boot
+
+**Decision.** Two new sources:
+- `bookBodiesSource.ts` iterates resident book chapter blobs, splits on heading + paragraph boundaries, emits one doc per paragraph.
+- `cccParagraphsSource.ts` iterates the bundled CCC structure, emits one doc per paragraph (id `ccc/<num>`).
+
+**Why.** Phase 4 only indexed headings/titles to keep the index small. v1.1 has data showing many users type definitional queries — "acedia," "subsidiarity," "principle of double effect" — that won't match a heading but match perfectly against a paragraph body. Cost: ~7 MB more index, ~50 ms more cold-start. Acceptable.
+
+### 1.4 Memory budget guardrails
+
+**Decision.** On boot, after the index is built, log total size in `__DEV__`. If > 12 MB on warm-start, surface a console warning. If > 16 MB, drop the lowest-priority source (book bodies first) and warn.
+
+**Why.** Mobile devices with 4 GB RAM can survive 16 MB; older devices struggle. Hard cap with graceful degradation prevents OOM.
+
+### 1.5 Canonical-question lookup is a pre-FlexSearch hash check
+
+**Decision.** Before calling `engine.query`, normalize the input (lowercase, trim, strip diacritics) and look up in a `Map<normalized, AnswerEntry>`. On hit, render the canonical answer as the #1 result; still call FlexSearch for the rest of the page. On miss, normal flow.
+
+**Why.** O(1) lookup, sub-millisecond, no FlexSearch involvement. The canonical hit ALWAYS wins regardless of how good (or bad) FlexSearch's match would have been — the maintainer's editorial authority isn't subject to BM25.
+
+### 1.6 Body-indexed paragraphs stay separate documents from heading docs
+
+**Decision.** A book's chapter is now indexed at three levels — book title, chapter title, and per-paragraph. Each paragraph carries `parentId: 'book/<id>/chapter/<id>'` and `paragraphIdx`.
+
+**Why.** Heading-level matches still rank well because they're shorter, denser docs (BM25 favors them naturally for short queries). Paragraph-level matches kick in when the user's query terms only co-occur in body text. The user sees a hit row showing the chapter title with a "matches in paragraph 7" sub-line.
+
+---
+
+## 2. Tasks
+
+### 2.1 Canonical-question pipeline
+
+1. Add `'answer'` to `CatalogItemKind` in `manifestTypes.ts`.
+2. Add `AnswerManifest` type:
+
+   ```ts
+   type AnswerManifest = {
+     id: string                   // 'answer/<lang>/<slug>'
+     question: string             // canonical question, normalized lower-case
+     synonyms?: string[]
+     language: 'en-US' | 'pt-BR' | 'la'
+     target: AnswerTarget
+     fallback?: AnswerTarget
+   }
+   type AnswerTarget =
+     | { kind: 'feed-item'; id: string; chapterTStart?: number }
+     | { kind: 'ccc'; id: string }              // 'ccc/1385'
+     | { kind: 'book-chapter'; ref: string }    // 'book/<id>/chapter/<id>'
+     | { kind: 'corpus'; ref: string }
+   ```
+
+3. Walker in `scripts/build-corpus.py`: `build_answers(b)` iterates `content/answers/<lang>/*.json`, hashes each, registers `answer/<lang>/<slug>` catalog entries.
+4. Resolver: `loadAnswer(id)`; warm in `warmDeferredManifests`.
+5. At boot, build `Map<normalizedQuery, AnswerManifest>` covering question + synonyms.
+
+### 2.2 Synonyms pipeline
+
+6. Add `content/synonyms/<lang>/<topic>.json` files; build walker `build_synonyms(b)` registers as `synonym/<lang>/<topic>` catalog entries.
+7. Resolver: `loadSynonym`; warm.
+8. At boot, build two maps per language:
+   - `Map<term, canonical>` — used for query expansion.
+   - `Map<canonical, term[]>` — used for index-time enrichment of doc summaries.
+
+### 2.3 Search-engine integration
+
+9. Modify `apps/app/src/features/search/indexer.ts`:
+   - For each doc, append synonyms to `summary` based on `(canonical, alias[])` map.
+10. Modify `apps/app/src/features/search/useSearch.ts`:
+    - First step: normalize query and check the canonical-answer map. On hit, prepend a `CanonicalAnswerHit` to the result list.
+    - Second step: expand query with synonyms before passing to `engine.query`.
+
+11. Add `CanonicalAnswerHit` rendering to `SearchResultRow`:
+    - Distinct visual treatment (a small "Top answer · curated" badge).
+    - Tap routes per `target.kind` (audio with seek, CCC paragraph, book chapter, etc.).
+
+### 2.4 Body indexing
+
+12. Create `apps/app/src/features/search/sources/bookBodiesSource.ts`:
+    - Iterates resident book chapter content (already in resolver after Phase 1 explore §1).
+    - Splits on `\n\n` (paragraph) into ~200-word docs.
+    - Emits docs with `parentId: 'book/<id>/chapter/<id>'`, `paragraphIdx`, `summary` = first 280 chars of paragraph.
+
+13. Create `apps/app/src/features/search/sources/cccParagraphsSource.ts`:
+    - Iterates bundled CCC paragraphs.
+    - One doc per paragraph; `docId = 'ccc/<num>'`; `summary` = first 280 chars.
+
+14. Register both in `indexer.ts` source list.
+
+### 2.5 Memory guardrails
+
+15. Add `engine.estimateSize(): number` returning approximate index bytes (sum of stored doc fields).
+16. After build, log to `__DEV__`. On `> 12 MB` warn; on `> 16 MB` skip `bookBodiesSource` and re-build (one-time fallback).
+
+### 2.6 Maintainer-curated content
+
+17. Maintainer commits ~50 canonical questions (en-US) + ~50 (pt-BR) to `content/answers/`.
+18. Maintainer commits ~30 synonym topics per language to `content/synonyms/`.
+19. Run `pnpm build:corpus`; confirm catalog has the new entries.
+
+### 2.7 Tests
+
+20. Canonical-redirect test: query a curated question → top hit is the curated target.
+21. Synonym test: query "comunhão" → matches docs about "Eucaristia."
+22. Body-index test: query "acedia" → top results include CCC paragraph 2733 and the relevant book chapter.
+23. Memory-guard test: synthetically pump book bodies to push past 16 MB; assert warning fires and bookBodiesSource is dropped on next build.
+
+---
+
+## 3. Files touched / created
+
+### Created
+
+| Path | Purpose |
+|---|---|
+| `apps/app/src/features/search/sources/bookBodiesSource.ts` | Per-paragraph book index |
+| `apps/app/src/features/search/sources/cccParagraphsSource.ts` | Per-paragraph CCC index |
+| `apps/app/src/features/search/canonicalAnswers.ts` | `Map<query, AnswerManifest>` builder |
+| `apps/app/src/features/search/synonyms.ts` | Bidirectional synonym expansion |
+| `content/answers/<lang>/*.json` | Curated answers |
+| `content/synonyms/<lang>/*.json` | Synonym topics |
+
+### Modified
+
+| Path | Change |
+|---|---|
+| `apps/app/src/content/manifestTypes.ts` | Add `'answer'` and `'synonym'` kinds |
+| `apps/app/src/content/contentIndex.ts` | Register new kinds |
+| `apps/app/src/content/resolver.ts` | `loadAnswer`, `loadSynonym`, warm |
+| `apps/app/src/features/search/indexer.ts` | Index-time synonym enrichment; size guard |
+| `apps/app/src/features/search/useSearch.ts` | Pre-engine canonical lookup; query expansion |
+| `apps/app/src/features/search/SearchResultRow.tsx` | Render CanonicalAnswerHit |
+| `apps/app/src/features/search/ranker.ts` | New per-kind priors for body docs |
+| `scripts/build-corpus.py` | `build_answers`, `build_synonyms` |
+
+---
+
+## 4. Open questions
+
+1. **Curation cadence.** Editorial cost of maintaining ~100 canonical answers + 60 synonym topics is non-trivial. Default: monthly review pass. Track in `docs/journal.md`.
+2. **Per-paragraph search row UX.** Showing a chapter title with "matches in paragraph 7" — should we render a snippet? Yes, default 60 chars around the match (use FlexSearch's `highlight`).
+3. **Diacritic stripping.** pt-BR users routinely type without accents. Normalize both query and indexed-text to NFD-stripped lower-case.
+
+---
+
+## 5. Verification
+
+| Check | How |
+|---|---|
+| Curated redirect | Type a maintainer-curated question — top hit shows "Top answer · curated" badge. |
+| Synonym recall | Type "comunhão" in pt-BR — Eucaristia-tagged docs appear in results. |
+| Body match | Type "acedia" — CCC paragraph 2733 appears in top-3. |
+| Diacritic-insensitive | Type "comungar em pecado mortal" without accents — same hits as the accented query. |
+| Index size | Boot log shows total < 16 MB on a fully-loaded device. |
+| No regression | All Phase 4 verification checks still pass. |
+
+---
+
+## 6. Phase 8 → handoff
+
+After Phase 8, **v1.1 ships.** The next phases are v2 expansion stubs — research-only until v1.1 has run for ≥3 months and we have data on what users actually search for and pray with.

--- a/docs/features/creators/phase-09-pray-with-expansion.md
+++ b/docs/features/creators/phase-09-pray-with-expansion.md
@@ -1,0 +1,96 @@
+# Phase 9 — Pray-with Expansion (v2, research-only)
+
+> **Status: research-only stub.** Do not implement until v1.1 has run for ≥3 months and we have data showing demand.
+
+**Goal.** Extend the v1.1 Pray-with primitive beyond the Rosary to other devotions, and surface guided playlists as first-class home content.
+
+---
+
+## 1. Candidate scope
+
+### 1.1 Stations of the Cross
+
+- 14 sections + opening/closing prayers.
+- Per-section blob model fits naturally (`itemIndex: 0..13`, no `tStart` needed).
+- `practiceBinding.sectionPath` references each station's container via the strategy chosen in Phase 7's spike.
+
+### 1.2 Divine Mercy Chaplet
+
+- Smaller than the Rosary; 3 minutes-ish total.
+- Single-track recording is the cheapest creator path.
+
+### 1.3 Angelus
+
+- Three repeated Hail Marys around versicles. Tiny audio.
+
+### 1.4 Multi-day program audio companions
+
+- A 30-day St. Joseph consecration with daily ~5 min creator-led reflections.
+- Each day binds to one program day's flow.
+- Practice already supports per-day flows (`programs/days/day-NN.json`); Pray-with just adds an audio overlay.
+
+### 1.5 Per-section audio mode by default
+
+- Move from "single track + chapter map" being the default to "per-section blob" being the default.
+- Smaller blobs → better perceived perf (each segment downloads independently).
+- Editorial cost is higher for creators (re-record one prayer instead of one segment of a track).
+- Decide based on observed playback patterns post-v1.1.
+
+### 1.6 Seasonal home hero (Pray-with edition)
+
+- During Lent: Home shows "Pray today's Stations with [creator]?"
+- During Advent: "Pray today's Angelus with [creator]?"
+- Reuses existing seasonal hero infrastructure; new data source = guided playlists tagged for the active season.
+
+---
+
+## 2. Major design questions to resolve before implementation
+
+1. **Per-practice vs per-flow-section binding.** Stations has a fixed 14-section structure; Rosary has a dynamic mystery cycle. The spike from Phase 7 covers the Rosary case; need a parallel pass for Stations to confirm the path strategy works for static-structure flows too (it should — simpler case).
+
+2. **Cross-creator Pray-with layering.** Can a user mix voices — e.g., the Sign of the Cross from Bishop Barron, the Hail Marys from Padre Paulo Ricardo? Probably no in v2; nondeterministic editorial messy. Keep voices monolithic.
+
+3. **Pray-with for the Liturgy of the Hours.** Massive audio, complicated proper, multiple voice roles. **Defer to v3 minimum.** Not in this phase.
+
+4. **Storage at scale.** A user who pins 5 guided practices × 30 daily reflections × 12 MB ≈ 1.8 GB. Audit current cap behavior; surface a warning in storage UI before the user crosses 1 GB of pinned guided audio.
+
+---
+
+## 3. Pre-implementation prerequisites
+
+Before opening this phase:
+
+- [ ] v1.1 has shipped and is at ≥3 months of runtime.
+- [ ] Maintainer has telemetry-free signal (qualitative feedback, app reviews, journal entries) on which guided variants users want next.
+- [ ] At least one new creator has agreed to record a non-Rosary guided variant.
+- [ ] Phase 7's `sectionPath` documentation has held up under all v1.1 rosary-cycle changes (no regression).
+
+---
+
+## 4. Tasks (sketch)
+
+When this phase opens:
+
+1. Re-run the Phase 7 sectionPath spike against the target practice's flow.
+2. Coordinate with creators for audio source.
+3. Add seed `practiceBinding`-bearing playlists per devotion.
+4. Surface them on profile + voice selector + (where seasonal) home hero.
+5. Add a UX affordance for "pause between segments" in per-section mode (some users want a gap of 5-10 seconds before the next section to compose themselves).
+
+Detailed task list will be written when this phase opens.
+
+---
+
+## 5. Out-of-scope guardrails (still apply)
+
+- **No AI voice cloning.** This rule does not relax with scope expansion.
+- **No automatic enrollment.** A user pinning a guided playlist does NOT silently enroll them in a multi-day program; that remains an explicit action.
+- **No "smart suggestions" that recommend Pray-with in moments of vulnerability.** A prayer app must not exploit emotional state for engagement.
+
+---
+
+## 6. References
+
+- [Phase 7 — Pray with [Creator]](phase-07-pray-with.md) — the foundation this phase extends.
+- [README §6.3](README.md#63-guided-prayers--the-killer-special-case) — Pray-with mission statement.
+- `docs/features/guided-prayers.md` (Phase 7 spike output) — the `sectionPath` spec.

--- a/docs/features/creators/phase-10-search-v2-transcripts.md
+++ b/docs/features/creators/phase-10-search-v2-transcripts.md
@@ -1,0 +1,102 @@
+# Phase 10 — Search v2 (Transcripts)
+
+> **Status: research-only stub.** Do not implement until v1.1 search has run for ≥3 months and we have a query log showing what's failing.
+
+**Goal.** Extend search beyond titles/descriptions/show-notes/bodies into full Whisper-transcribed audio segments — but only for creators whose content doesn't title-search well today.
+
+---
+
+## 1. The hypothesis to falsify before building this
+
+The premise of v1 + v1.1 search is: **editorial curation × the right indexable surface beats ML.** Phase 10 only opens if we falsify that premise — i.e., if measurable user demand exists for queries that CANNOT be answered by curated content + title/body indexing.
+
+**Falsification test (run for ≥3 months post-v1.1):**
+
+- Maintainer reviews their own search-history (`search_history` table on their device) qualitatively. Note queries that returned zero or weak top-3 results.
+- Identify whether each missed query's *answer* exists in:
+  - A creator's existing podcast/video/article episode (not in title/description) → would be helped by transcripts.
+  - A book chapter not yet indexed → fixable via Phase 8 enrichment, no transcripts needed.
+  - A doctrinal gap in the seed list → fixable by curation.
+
+**Open Phase 10 only if** ≥30% of missed queries fall in the first bucket. Otherwise, redirect effort to enrichment + curation.
+
+---
+
+## 2. Major design questions
+
+### 2.1 Where does transcription happen?
+
+**Three options.**
+
+- **Server-side, batch, on the maintainer's machine.** Run Whisper locally over selected creators' episodes; commit the resulting transcript JSON to the corpus. Pros: zero on-device cost, deterministic quality. Cons: storage + compute on maintainer, doesn't update with new episodes without manual reruns.
+- **Client-side, on-device, on demand.** Run a small Whisper variant (Whisper-tiny or DistilWhisper) on the device when the user pins an episode. Pros: privacy-perfect, works for any followed creator. Cons: 100-500 MB model download, slow (≥1× realtime on phones), battery hit.
+- **Hybrid.** Server-batch for top creators (highest expected coverage); client-on-demand fallback for everyone else.
+
+**Default**: server-side, batch, scoped narrowly to creators whose v1.1 search performance is measurably weak. Client-side TTS gates on a separate research spike.
+
+### 2.2 Storage model for transcripts
+
+- Per-episode transcript JSON: `{ segments: [{ start, end, text }] }` — tiny (50 KB per 30-min episode).
+- Ship as a corpus blob keyed by feed-item id; resolve via the existing pinning system.
+- Index on the device when pinned.
+
+### 2.3 Index integration
+
+- New source `transcriptSegmentsSource.ts` per Phase 4's pluggable source registry.
+- Each segment is a doc with `parentId: 'feed-item/<id>'`, `tStart`, `tEnd`, `text`.
+- Search hit deep-links to the audio at `tStart` (mechanism already exists for chapter markers).
+
+### 2.4 Index size discipline
+
+Phase 8 already pushed index toward 12 MB. Transcripts can blow this up. Mitigation:
+
+- Index transcripts only for **pinned** episodes by default. User pins → segments enter the index.
+- For server-batched creators, a separate "transcript pack" is a pinnable catalog item — opt-in.
+- Memory cap of 24 MB total post-Phase-10. If exceeded, drop oldest unpinned-creator segments.
+
+### 2.5 Quality & responsibility
+
+- Whisper occasionally hallucinates; prayer/doctrinal terms in pt-BR are particularly mistranscribed (e.g., proper names, Latin inserts).
+- Show transcript matches with a small badge: "Transcribed by Ember — may contain errors."
+- Provide a "Report transcription error" link on each hit.
+
+---
+
+## 3. Pre-implementation prerequisites
+
+- [ ] Falsification test (§1) done with documented findings in `docs/journal.md`.
+- [ ] Maintainer has run Whisper locally over a small sample of pt-BR + en-US episodes; gauged quality.
+- [ ] Storage budget reviewed and accepted.
+- [ ] Phase 8's enrichment has been live for ≥3 months and remaining gaps clearly stem from un-titled audio content.
+
+---
+
+## 4. Tasks (sketch)
+
+When this phase opens:
+
+1. Pick top-N creators where transcription would help (per falsification analysis).
+2. Build a server-side script (`scripts/transcribe.py`) using `whisper` (CTranslate2 / faster-whisper preferred) to produce transcript JSON.
+3. Add `'transcript-pack'` corpus kind: a transcript pack groups transcripts for a creator, hashed and pinnable.
+4. Build walker `build_transcript_packs(b)`.
+5. Add `transcriptSegmentsSource.ts` to the indexer registry (gated on pin / pack resident).
+6. Add segment-level result rendering (audio + scrubbed-to-segment).
+7. Ship + monitor.
+
+Detailed task list will be written when this phase opens.
+
+---
+
+## 5. Out-of-scope guardrails
+
+- **No proprietary transcription APIs.** OpenAI's hosted Whisper API would phone home with audio data; not acceptable for the privacy contract. Use only locally-runnable Whisper variants.
+- **No identity-recognizing or speaker-diarization features.** We index *what was said*, not *who said it* via voice fingerprint.
+- **No transcript publication beyond Ember.** Transcripts ride the corpus distribution path, but we are not turning them into a public dataset.
+
+---
+
+## 6. References
+
+- [Phase 4 — Global Search v1](phase-04-search-v1.md) — base architecture.
+- [Phase 8 — Search v1.1 Enrichment](phase-08-search-v11.md) — preferred enrichment path before transcripts.
+- [README §5.6](README.md#56-phased-rollout) — search phasing.

--- a/docs/features/features-overview.md
+++ b/docs/features/features-overview.md
@@ -345,3 +345,5 @@ Stores: `preferencesStore` (all user preferences) and `navigationStore` (ephemer
 **i18n** — react-i18next with English + Brazilian Portuguese, ~150 keys, synchronous init. See `apps/app/src/lib/i18n/`.
 
 **Book Reader** — WebView with CSS column pagination for long-form prose. Each chapter is fetched as its own hash-addressed blob; markdown converted at runtime via `marked`. See `apps/app/src/features/books/bookReader.ts`.
+
+**Catholic Creators** *(planned, in design)* — Editor-curated directory of orthodox priests/teachers (podcast, YouTube, RSS). In-app audio (background playback, lock-screen), YouTube iframe player, article reader, on-device global doctrinal search (FlexSearch over feed-items + corpus + chapter markers), and (v1.1) Pray-with playlists for guided Rosary etc. New corpus kinds `creator` and `playlist`. See [creators/README.md](creators/README.md) for the PRD and per-phase technical designs.


### PR DESCRIPTION
Docs-first proposal for the Creators feature: curated directory of
Catholic priests/teachers (podcasts, YouTube, RSS), in-app
audio/video/article players, on-device global doctrinal search, and
(v1.1) editor-curated Series playlists + Pray-with guided prayers.

- docs/features/creators/README.md — PRD (mission, scope, content
  model, UX, search, playlists/guided prayers, offline, technical
  architecture, risks, phased rollout, verification, open questions)
- 10 per-phase technical design docs covering major decisions,
  alternatives ruled out, file-level tasks, and verification gates
- Cross-links from docs/README.md (Wisdom pillar), features-overview,
  and corpus.md (new "Adding a creator" / "Adding a playlist" sections)