### PR TITLE
fix(splash): register expo-splash-screen plugin so launch uses splash-icon

### DIFF
--- a/apps/app/app.json
+++ b/apps/app/app.json
@@ -7,16 +7,6 @@
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
-    "splash": {
-      "image": "./assets/splash-icon.png",
-      "resizeMode": "contain",
-      "backgroundColor": "#0E0D0C",
-      "dark": {
-        "image": "./assets/splash-icon.png",
-        "resizeMode": "contain",
-        "backgroundColor": "#0E0D0C"
-      }
-    },
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "me.dpgu.ember",
@@ -46,7 +36,19 @@
       "expo-sqlite",
       "expo-font",
       "expo-notifications",
-      "@react-native-community/datetimepicker"
+      "@react-native-community/datetimepicker",
+      [
+        "expo-splash-screen",
+        {
+          "image": "./assets/splash-icon.png",
+          "resizeMode": "contain",
+          "backgroundColor": "#0E0D0C",
+          "dark": {
+            "image": "./assets/splash-icon.png",
+            "backgroundColor": "#0E0D0C"
+          }
+        }
+      ]
     ],
     "extra": {
       "router": {},


### PR DESCRIPTION
The legacy top-level "splash" block in app.json was deprecated in SDK 50
and is unreliable in SDK 55 — without expo-splash-screen in the plugins
array, the iOS native launch screen fell back to the app icon
(icon.png), so the orange flame card flashed before BootLoadingScreen
took over.

Move the splash config into an expo-splash-screen plugin entry. The
splash now matches BootLoadingScreen: #0E0D0C background with the small
centered flame from splash-icon.png.