### PR TITLE
Move completion button inside manuscript frame, relabel to Amen

### DIFF
--- a/apps/app/src/features/practices/components/PracticeFlow.tsx
+++ b/apps/app/src/features/practices/components/PracticeFlow.tsx
@@ -4,11 +4,10 @@ import { type FlowContext, resolveFlowAsync } from '@ember/content-engine'
 import { useQueries, useQuery } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { useRouter } from 'expo-router'
-import { Home } from 'lucide-react-native'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Pressable } from 'react-native'
-import { Text, useTheme, YStack } from 'tamagui'
+import { Text, YStack } from 'tamagui'
 import {
   AnimatedPressable,
   BibleReadingBlock,
@@ -133,7 +132,6 @@ export function PracticeFlow({
 }) {
   const { t } = useTranslation()
   const router = useRouter()
-  const theme = useTheme()
   const readingMargin = useReadingMargin()
   const logCompletionMutation = useLogCompletion()
   const advanceCursor = useAdvanceCursor()
@@ -442,18 +440,6 @@ export function PracticeFlow({
     <ImageViewerProvider>
       <ScreenLayout>
         <YStack gap="$lg" paddingVertical="$lg">
-          <YStack alignItems="center">
-            <Pressable
-              onPress={() => router.push('/')}
-              hitSlop={12}
-              accessibilityRole="link"
-              accessibilityLabel={t('a11y.home')}
-              testID="practice-home-button"
-            >
-              <Home size={20} color={theme.colorSecondary.val} />
-            </Pressable>
-          </YStack>
-
           <ManuscriptFrame>
             <YStack
               alignItems="center"
@@ -489,35 +475,33 @@ export function PracticeFlow({
               ))}
             </YStack>
 
+            {manifest.completion !== 'manual' && (
+              <YStack paddingHorizontal={readingMargin} paddingTop="$lg">
+                <AnimatedPressable
+                  onPress={handleComplete}
+                  disabled={logCompletionMutation.isPending}
+                  accessibilityRole="button"
+                  accessibilityLabel={t('office.amen')}
+                >
+                  <YStack
+                    backgroundColor="$accent"
+                    borderRadius="$md"
+                    borderWidth={1}
+                    borderColor="$accentSubtle"
+                    paddingVertical="$md"
+                    alignItems="center"
+                    opacity={logCompletionMutation.isPending ? 0.6 : 1}
+                  >
+                    <Text fontFamily="$heading" fontSize="$3" color="$background">
+                      {logCompletionMutation.isPending ? t('office.completing') : t('office.amen')}
+                    </Text>
+                  </YStack>
+                </AnimatedPressable>
+              </YStack>
+            )}
+
             <YStack paddingBottom="$lg" />
           </ManuscriptFrame>
-
-          {manifest.completion !== 'manual' && (
-            <YStack paddingHorizontal={readingMargin}>
-              <AnimatedPressable
-                onPress={handleComplete}
-                disabled={logCompletionMutation.isPending}
-                accessibilityRole="button"
-                accessibilityLabel={t('office.markComplete')}
-              >
-                <YStack
-                  backgroundColor="$accent"
-                  borderRadius="$md"
-                  borderWidth={1}
-                  borderColor="$accentSubtle"
-                  paddingVertical="$md"
-                  alignItems="center"
-                  opacity={logCompletionMutation.isPending ? 0.6 : 1}
-                >
-                  <Text fontFamily="$heading" fontSize="$3" color="$background">
-                    {logCompletionMutation.isPending
-                      ? t('office.completing')
-                      : t('office.markComplete')}
-                  </Text>
-                </YStack>
-              </AnimatedPressable>
-            </YStack>
-          )}
         </YStack>
 
         {showCompleteModal && manifest?.program && (

--- a/apps/app/src/lib/i18n/locales/en-US.ts
+++ b/apps/app/src/lib/i18n/locales/en-US.ts
@@ -211,7 +211,7 @@ export default {
     compline: 'Compline',
     back: 'Office',
     completed: 'Completed',
-    markComplete: 'Mark as Complete',
+    amen: 'Amen',
     completing: 'Completing...',
     fallbackNotice: 'Showing Douay-Rheims (offline) \u2014 selected translation unavailable',
     cccLabel: 'Catechism of the Catholic Church, {{start}}-{{end}}',

--- a/apps/app/src/lib/i18n/locales/pt-BR.ts
+++ b/apps/app/src/lib/i18n/locales/pt-BR.ts
@@ -212,7 +212,7 @@ export default {
     compline: 'Completas',
     back: 'Of\u00edcio',
     completed: 'Conclu\u00eddo',
-    markComplete: 'Marcar como Conclu\u00eddo',
+    amen: 'Am\u00e9m',
     completing: 'Concluindo...',
     fallbackNotice:
       'Mostrando Douay-Rheims (offline) \u2014 tradu\u00e7\u00e3o selecionada indispon\u00edvel',


### PR DESCRIPTION
Drops the standalone home icon at the top of the practice runner and
moves the completion CTA inside the ManuscriptFrame card. The button
now reads Amen / Amém instead of Mark as Complete, fitting a prayer
context better than a task checkbox.