### PR TITLE
Make corner flourish responsive to window width

### DIFF
--- a/apps/app/src/app/index.tsx
+++ b/apps/app/src/app/index.tsx
@@ -3,7 +3,7 @@ import { Image } from 'expo-image'
 import { useRouter } from 'expo-router'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Dimensions, Pressable } from 'react-native'
+import { Pressable, useWindowDimensions } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Text, useThemeName, View, YStack } from 'tamagui'
 
@@ -67,10 +67,11 @@ import { usePreferencesStore } from '@/stores/preferencesStore'
 
 const frameCornerDark = require('../../assets/textures/frame_corner_dark.png')
 const frameCornerLight = require('../../assets/textures/frame_corner_light.png')
-const screenWidth = Dimensions.get('window').width
-const cornerWidth = screenWidth
-const darkCornerHeight = cornerWidth / (1023 / 456)
-const lightCornerHeight = cornerWidth / (1584 / 672)
+// Matches ScreenLayout's content column maxWidth; clamping avoids the flourish
+// blowing up to full browser width on the web while the column stays centered.
+const cornerMaxWidth = 640
+const darkCornerAspect = 1023 / 456
+const lightCornerAspect = 1584 / 672
 
 export default function HomeScreen() {
   const { t } = useTranslation()
@@ -164,6 +165,10 @@ export default function HomeScreen() {
   const insets = useSafeAreaInsets()
   const noNotchTopPad = insets.top === 0 ? 32 : 0
 
+  const { width: windowWidth } = useWindowDimensions()
+  const cornerWidth = Math.min(windowWidth, cornerMaxWidth)
+  const cornerHeight = cornerWidth / (isDark ? darkCornerAspect : lightCornerAspect)
+
   return (
     <ScreenLayout>
       <View
@@ -175,7 +180,7 @@ export default function HomeScreen() {
       >
         <Image
           source={isDark ? frameCornerDark : frameCornerLight}
-          style={{ width: cornerWidth, height: isDark ? darkCornerHeight : lightCornerHeight }}
+          style={{ width: cornerWidth, height: cornerHeight }}
           contentFit="contain"
           accessibilityElementsHidden
         />


### PR DESCRIPTION
## Summary
Refactors the decorative corner flourish on the home screen to be responsive to window dimensions instead of using a static screen width. This ensures the flourish scales appropriately on web while respecting the `ScreenLayout`'s content column max-width constraint.

## Changes
- Replace static `Dimensions.get('window').width` with dynamic `useWindowDimensions()` hook
- Introduce `cornerMaxWidth` constant (640px) to match `ScreenLayout`'s content column constraint, preventing the flourish from expanding to full browser width on web
- Calculate `cornerWidth` as `Math.min(windowWidth, cornerMaxWidth)` to clamp the flourish size
- Extract aspect ratios (`darkCornerAspect`, `lightCornerAspect`) as named constants for clarity
- Compute `cornerHeight` dynamically in the component based on the selected theme's aspect ratio
- Simplify the Image style prop by computing height once instead of inline ternary

## Implementation Details
The flourish now recalculates its dimensions whenever the window is resized, ensuring proper scaling on responsive layouts. The max-width constraint keeps the flourish proportional to the centered content column on desktop/web while allowing it to fill available width on mobile.

https://claude.ai/code/session_01BFhd3knyjRdnmrMwFbVAv2