### PR TITLE
Fix concurrent feed refresh racing on shared SQLite transaction

### DIFF
--- a/apps/app/src/lib/db-shared/manager.ts
+++ b/apps/app/src/lib/db-shared/manager.ts
@@ -65,6 +65,23 @@ let realDb: Awaited<ReturnType<typeof openDatabaseAsync>> | undefined
 let isLeader = false
 const leaderReady = deferred<void>()
 
+/**
+ * Serialize `withTransactionAsync` calls against the leader's single
+ * connection. expo-sqlite's `withTransactionAsync` is documented as
+ * non-exclusive — concurrent calls race on BEGIN/COMMIT/ROLLBACK and surface
+ * as "cannot rollback - no transaction is active" when the directory fans out
+ * multiple `refreshCreator` writes at once.
+ */
+let txChain: Promise<unknown> = Promise.resolve()
+function serializeTx<T>(task: () => Promise<T>): Promise<T> {
+  const result = txChain.then(task, task)
+  txChain = result.then(
+    () => {},
+    () => {},
+  )
+  return result
+}
+
 const pending = new Map<string, PendingEntry>()
 const subscribers = new Set<(payload: CrossTabPayload) => void>()
 
@@ -140,11 +157,13 @@ async function serveRequest(msg: RequestMessage) {
         break
       case 'runBatchInTx': {
         const db = realDb
-        await db.withTransactionAsync(async () => {
-          for (const s of msg.statements) {
-            await db.runAsync(s.sql, s.params ?? [])
-          }
-        })
+        await serializeTx(() =>
+          db.withTransactionAsync(async () => {
+            for (const s of msg.statements) {
+              await db.runAsync(s.sql, s.params ?? [])
+            }
+          }),
+        )
         break
       }
     }
@@ -246,9 +265,11 @@ function makeProxy(): EmberDb {
       if (statements.length === 0) return
       if (isLeader && realDb) {
         const db = realDb
-        await db.withTransactionAsync(async () => {
-          for (const s of statements) await db.runAsync(s.sql, s.params ?? [])
-        })
+        await serializeTx(() =>
+          db.withTransactionAsync(async () => {
+            for (const s of statements) await db.runAsync(s.sql, s.params ?? [])
+          }),
+        )
         return
       }
       await sendRequest({ method: 'runBatchInTx', statements })

--- a/apps/app/src/lib/db-shared/native-adapter.ts
+++ b/apps/app/src/lib/db-shared/native-adapter.ts
@@ -6,8 +6,14 @@ import type { EmberDb, Statement } from './protocol'
  * Wraps the real `SQLiteDatabase` (native) so it satisfies `EmberDb`.
  * The only departure is `runBatchInTx`, which composes `withTransactionAsync`
  * + `runAsync` so call sites have a single API across native and web.
+ *
+ * `withTransactionAsync` is documented as non-exclusive and can be interrupted
+ * by other async queries — concurrent calls race on BEGIN/COMMIT/ROLLBACK and
+ * surface as "cannot rollback - no transaction is active". We serialize
+ * batched-transaction calls per connection to prevent that race.
  */
 export function adaptNativeDb(db: SQLiteDatabase): EmberDb {
+  const serialize = createSerialQueue()
   return {
     execAsync: (sql) => db.execAsync(sql),
     runAsync: (sql, params = []) => db.runAsync(sql, params),
@@ -16,11 +22,25 @@ export function adaptNativeDb(db: SQLiteDatabase): EmberDb {
     closeAsync: () => db.closeAsync(),
     runBatchInTx: async (statements: Statement[]) => {
       if (statements.length === 0) return
-      await db.withTransactionAsync(async () => {
-        for (const s of statements) {
-          await db.runAsync(s.sql, s.params ?? [])
-        }
-      })
+      await serialize(() =>
+        db.withTransactionAsync(async () => {
+          for (const s of statements) {
+            await db.runAsync(s.sql, s.params ?? [])
+          }
+        }),
+      )
     },
+  }
+}
+
+function createSerialQueue() {
+  let tail: Promise<unknown> = Promise.resolve()
+  return async function serialize<T>(task: () => Promise<T>): Promise<T> {
+    const result = tail.then(task, task)
+    tail = result.then(
+      () => {},
+      () => {},
+    )
+    return result
   }
 }


### PR DESCRIPTION
## Summary

Fixes the **"cannot rollback - no transaction is active"** error that appears on creator profiles when their feed refresh kicks off (e.g. Bispo Robert Barron screen).

expo-sqlite's `withTransactionAsync` is documented as non-exclusive — it just brackets work with `BEGIN`/`COMMIT`/`ROLLBACK` on a single connection. The creators directory fans out `refreshCreator` for every catalog entry (bounded by `creatorLimiter` to 4 concurrent), and each one writes via `upsertFeedItems` → `runBatchInTx` → `withTransactionAsync`. Two overlapping calls race: one `BEGIN`s, the second's `BEGIN` fails ("cannot start a transaction within a transaction"), both catch handlers fire `ROLLBACK`, and the second `ROLLBACK` surfaces as "cannot rollback - no transaction is active".

Serialize `runBatchInTx` per connection so transactions never overlap:
- **Native adapter**: per-instance `createSerialQueue()` chains transactions via a tail promise (handles rejection so failures don't break the chain).
- **Web manager**: module-level `serializeTx` shared between the leader's local fast path (`makeProxy().runBatchInTx`) and its cross-tab serve path (`serveRequest` → `runBatchInTx`), both of which touch the same `realDb`.

Same protection covers `emitBatch` — the other `runBatchInTx` caller — so events can no longer race feed-item upserts either.

## Test plan
- [ ] Open the creators directory (`/creators`) — no transaction errors during the mass refresh
- [ ] Open a creator profile (e.g. Bispo Robert Barron) on first mount — feed loads, no red error banner
- [ ] Pull-to-refresh on a creator profile — still works
- [ ] Open multiple tabs (web) to exercise the cross-tab serve path — feeds still refresh cleanly
- [x] `pnpm test src/lib/db-shared/manager.test.ts` — all 4 tests pass
- [x] `pnpm biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)