### PR TITLE
Fix empty content in cycle+prose book practices (catechetical-formation)

### DIFF
--- a/packages/content-engine/src/engine/flow.ts
+++ b/packages/content-engine/src/engine/flow.ts
@@ -13,8 +13,15 @@ import type {
   ResolveStep,
 } from '../types'
 import { resolveLanguageCandidates } from './book-language'
-import { composeVars, type EngineContext, type FlowContext, resolvePath } from './context'
+import {
+  composeVars,
+  type EngineContext,
+  type FlowContext,
+  getContextValue,
+  resolvePath,
+} from './context'
 import { resolveSection } from './resolve'
+import { getCycleIndex } from './sections/cycle'
 import { computeSelectedId, selectedItemAndId } from './sections/select'
 import { substituteInFlowSection, substituteTemplateVars } from './vars'
 
@@ -188,26 +195,33 @@ function collectBookChapterRefs(
           }
         }
         break
-      case 'cycle':
-        if (section.as === 'template' && section.sections) {
-          const cycleData = context.cycleData?.[section.data]
-          if (cycleData) {
-            const allEntries = Object.values(cycleData.entries).flat()
-            for (const entry of allEntries) {
-              const vars: Record<string, string | undefined> = {}
-              for (const [k, v] of Object.entries(entry as Record<string, unknown>)) {
-                if (typeof v === 'string') vars[k] = v
-              }
-              for (const s of section.sections) {
-                const substituted = substituteInFlowSection(s, vars)
-                walkSection(substituted)
-              }
-            }
-          } else {
-            for (const s of section.sections) walkSection(s)
-          }
+      case 'cycle': {
+        const cycleData = context.cycleData?.[section.data]
+        if (!cycleData) {
+          for (const s of section.sections) walkSection(s)
+          break
+        }
+        const contextValue = cycleData.contextKey
+          ? getContextValue(context, cycleData.contextKey)
+          : undefined
+        const entries = (
+          contextValue
+            ? (cycleData.entries[contextValue] ?? Object.values(cycleData.entries)[0])
+            : Object.values(cycleData.entries)[0]
+        ) as unknown[]
+        if (!entries?.length) break
+        const index = getCycleIndex(cycleData.indexBy, context.date, entries.length, context)
+        const entry = entries[index] as Record<string, unknown>
+        const vars: Record<string, string | undefined> = {}
+        for (const [k, v] of Object.entries(entry)) {
+          if (typeof v === 'string') vars[k] = v
+        }
+        for (const s of section.sections) {
+          const substituted = substituteInFlowSection(s, vars)
+          walkSection(substituted)
         }
         break
+      }
       case 'repeat':
         for (const s of section.sections) walkSection(s)
         break

--- a/packages/content-engine/src/engine/sections/__tests__/cycle.test.ts
+++ b/packages/content-engine/src/engine/sections/__tests__/cycle.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from 'vitest'
 import { flow, flowDef, makeContext, makeEngineContext } from '../../../__fixtures__/engine'
 import { type EngineContext, resolveFlow, resolveFlowAsync } from '../../../engine'
 
-describe('resolveFlowAsync — cycle template with prose+book', () => {
-  it('preloads book chapters from cycle template sections', async () => {
+describe('resolveFlowAsync — cycle with prose+book', () => {
+  it('preloads the current cycle entry chapter for prose+book sections', async () => {
     const cycleData = {
-      indexBy: 'fixed' as const,
+      indexBy: 'program-day' as const,
       entries: {
         default: [
           { chapterId: 'session-001' },
@@ -17,6 +17,7 @@ describe('resolveFlowAsync — cycle template with prose+book', () => {
 
     const context = makeContext({
       cycleData: { 'session-progression': cycleData },
+      programDay: 1,
     })
 
     const engineContext: EngineContext = {
@@ -34,7 +35,6 @@ describe('resolveFlowAsync — cycle template with prose+book', () => {
           {
             type: 'cycle',
             data: 'session-progression',
-            as: 'template',
             sections: [
               {
                 type: 'prose',
@@ -53,7 +53,7 @@ describe('resolveFlowAsync — cycle template with prose+book', () => {
     expect(result.length).toBe(1)
     expect(result[0].type).toBe('prose')
     if (result[0].type === 'prose') {
-      expect(result[0].text.primary).toContain('session-')
+      expect(result[0].text.primary).toBe('Content of session-002')
     }
   })
 


### PR DESCRIPTION
## Summary

The catechetical-formation program showed empty content on every day, even though the underlying book (My Catholic Faith) opened fine in the reader. Root cause was dead code left behind by commit 6d903b26 ("Drop cycle.as entirely").

`collectBookChapterRefs` in `packages/content-engine/src/engine/flow.ts` still gated the `cycle` branch on `section.as === 'template'`, but the `as` field was removed from the cycle type in that commit. After the removal, no cycle ever matched the gate, so chapter refs from `cycle > prose(book, chapter)` flows were never collected for preloading. At render time `case 'prose'` short-circuits because the sync `loadBookChapterText` is unset on the runtime engine context (only the async variant is wired in `apps/app/src/content/engineContext.ts:94`) — so the cycle returned empty primitives.

The book reader still worked because it loads chapter prose through a different path (`prefetchChapterProse` → `proseCache`), not via flow resolution.

## Fix

Rewrite the cycle case in `collectBookChapterRefs` to mirror the runtime resolver in `resolve.ts:198`: pick the entry for the current `programDay` / cycle index, substitute its fields into the cycle body, and walk only that subtree. Preloads exactly one chapter per day (not all 195) and works for any future cycle+prose+book practice.

## Test plan
- [x] `pnpm --filter @ember/content-engine test` — 157/157 pass
- [x] Updated `cycle.test.ts` to drop the obsolete `as: 'template'` shape and assert that `programDay` selects the correct entry
- [ ] Open the catechetical-formation practice in the app — day 1 shows lesson-001, day 2 shows lesson-002, etc.