### PR TITLE
Fix referenced prayers rendering empty when expanded

### DIFF
--- a/apps/app/src/components/prayer/CollapsiblePrayer.tsx
+++ b/apps/app/src/components/prayer/CollapsiblePrayer.tsx
@@ -48,7 +48,7 @@ export function CollapsiblePrayer<T>({
       </Pressable>
       {expanded && (
         <YStack paddingLeft="$lg" gap="$sm">
-          {sections && renderSection ? (
+          {sections && sections.length > 0 && renderSection ? (
             sections.map((s, i) => renderSection(s, i))
           ) : (
             <BilingualBlock content={text} renderText={(t) => <PrayerLines text={t} />} />


### PR DESCRIPTION
## Summary
- In the Morning Offering (and any practice that references prayers), expanding a referenced prayer like **Our Father** or **Hail Mary** showed nothing — the prayer text never appeared.
- Root cause: a single-inline referenced prayer reaches `CollapsiblePrayer` with an empty `sections` **array** (set by `preprocessFlow`), not `undefined`. The expanded-body guard `sections && renderSection` treats the empty array as truthy, so it maps over an empty array (renders nothing) and never falls through to the `text` branch where the prayer body lives. Multi-section referenced prayers worked only because their array was non-empty.
- Fix: guard on `sections.length > 0` instead of truthiness in `apps/app/src/components/prayer/CollapsiblePrayer.tsx`.

## Test plan
- [ ] Open **Morning Offering**, tap each referenced prayer (Our Father, Hail Mary, Angele Dei, St. Michael, Apostles' Creed, Hail Holy Queen, Sign of the Cross) → full text displays.
- [ ] Regression: a practice referencing a **multi-section** prayer still renders its nested sections when expanded.
- [ ] Inline prayers (the offering text, Acts of Faith/Hope/Charity) are unchanged.