### PR TITLE
Fix day-carousel/liturgical-day mismatch between midnight and 4am

### DIFF
--- a/apps/app/src/app/(tabs)/(today,explore,library,you,search)/index.tsx
+++ b/apps/app/src/app/(tabs)/(today,explore,library,you,search)/index.tsx
@@ -56,13 +56,12 @@ import {
 import type { ChecklistItem } from '@/features/plan-of-life/components/PracticeChecklist'
 import { useSaintOfDayReading } from '@/features/saints'
 import { useCurrentHour } from '@/hooks/useCurrentHour'
-import { useToday } from '@/hooks/useToday'
+import { useStableToday, useToday } from '@/hooks/useToday'
 import { localizeContent } from '@/lib/i18n'
 import {
   getCelebrationsForDate,
   getLiturgicalSeason,
   type LiturgicalCalendarForm,
-  normalizeDate,
   useObligations,
 } from '@/lib/liturgical'
 import { parseSlotKey } from '@/lib/slotKey'
@@ -78,8 +77,6 @@ const lightCornerAspect = 1584 / 672
 
 export default function HomeScreen() {
   const { t } = useTranslation()
-  const realNow = normalizeDate(new Date())
-  const realToday = format(realNow, 'yyyy-MM-dd')
   const now = useToday()
   const selectedDate = format(now, 'yyyy-MM-dd')
   const currentBlock = getCurrentTimeBlock(useCurrentHour())
@@ -87,8 +84,7 @@ export default function HomeScreen() {
   const liturgicalCalendar = usePreferencesStore(
     (s) => s.liturgicalCalendar,
   ) as LiturgicalCalendarForm
-  const persistedTimeTravelDate = usePreferencesStore((s) => s.persistedTimeTravelDate)
-  const anchorDate = persistedTimeTravelDate ?? realToday
+  const anchorDate = format(useStableToday(), 'yyyy-MM-dd')
   const setTimeTravelEphemeral = usePreferencesStore((s) => s.setTimeTravelDateEphemeral)
   const router = useRouter()
   const slots = useSlots()

--- a/apps/app/src/hooks/useToday.ts
+++ b/apps/app/src/hooks/useToday.ts
@@ -19,14 +19,34 @@ import { usePreferencesStore } from '@/stores/preferencesStore'
  * See `features/angelus/hooks.ts` for the pattern.
  */
 export function useToday(): Date {
-  const timeTravelDate = usePreferencesStore((s) => s.timeTravelDate)
-  if (timeTravelDate) return normalizeDate(parseISO(timeTravelDate))
+  const ephemeral = usePreferencesStore((s) => s.timeTravelDate)
+  const stable = useStableToday()
+  if (ephemeral) return normalizeDate(parseISO(ephemeral))
+  return stable
+}
+
+/**
+ * Like {@link useToday}, but ignores the ephemeral overlay set by transient
+ * UI (e.g. the day scrubber's pan-driven selection). Use this for anchors
+ * that must stay put while the user scrubs — re-centering a carousel on a
+ * date that moves with every snap would yank the strip under their finger.
+ */
+export function useStableToday(): Date {
+  const persisted = usePreferencesStore((s) => s.persistedTimeTravelDate)
+  if (persisted) return normalizeDate(parseISO(persisted))
   return logicalDay(new Date())
 }
 
 /** Non-hook version of {@link useToday}. Same 4am-cutoff + midnight caveat. */
 export function getToday(): Date {
-  const timeTravelDate = usePreferencesStore.getState().timeTravelDate
-  if (timeTravelDate) return normalizeDate(parseISO(timeTravelDate))
+  const ephemeral = usePreferencesStore.getState().timeTravelDate
+  if (ephemeral) return normalizeDate(parseISO(ephemeral))
+  return getStableToday()
+}
+
+/** Non-hook version of {@link useStableToday}. */
+export function getStableToday(): Date {
+  const persisted = usePreferencesStore.getState().persistedTimeTravelDate
+  if (persisted) return normalizeDate(parseISO(persisted))
   return logicalDay(new Date())
 }


### PR DESCRIPTION
## Summary

At ~1am the home screen's day carousel highlighted Monday (new civil day) while the liturgical banner still read "6º Domingo do Tempo Comum" (Sunday). The app's documented convention is that a new day starts at **4am, not midnight** (see `useToday()` docstring), but the carousel anchor was reading `new Date()` separately with civil-midnight rules. Between 00:00–03:59 the two diverged.

- Split `useToday()` into `useStableToday()` (persisted-only, no ephemeral overlay) + `useToday()` (= stable + ephemeral). Both share a single `logicalDay(new Date())` call, so the 4am rule lives in exactly one place.
- Home screen now derives the carousel anchor from `useStableToday()` instead of an inline `new Date()` read. The stable variant ignores ephemeral pan-state so the carousel strip doesn't shift under the user's finger while scrubbing.

## Test plan
- [ ] Daytime (no time travel): carousel and liturgical banner agree
- [ ] 1am simulation: both sit on yesterday's civil date
- [ ] Scrub the carousel: banner tracks each snap; strip itself stays anchored
- [ ] "Today" pill returns to logical-today and clears ephemeral time-travel
- [ ] Persisted time-travel: carousel + banner both sit on the persisted date