### PR TITLE
Saint of the Day: localize name, show today's reflection, tab between saints

### DIFF
--- a/apps/app/src/features/explore/ExploreFeed.tsx
+++ b/apps/app/src/features/explore/ExploreFeed.tsx
@@ -8,7 +8,7 @@ import type { CatalogEntry } from '@/content/manifestTypes'
 import { useCatalogVersion } from '@/content/useCatalogVersion'
 import { collectionHref, warmCollection } from '@/features/collections'
 import { CreatorGridCard } from '@/features/creators/components/CreatorGridCard'
-import { saintOfDayNames } from '@/features/saints'
+import { saintOfDay } from '@/features/saints'
 import { useToday } from '@/hooks/useToday'
 import { localizeContent } from '@/lib/i18n'
 import { getLiturgicalSeason, type LiturgicalCalendarForm } from '@/lib/liturgical'
@@ -121,16 +121,17 @@ export function ExploreFeed() {
   // Saint of the Day — the fixed day-by-day saint from Pictorial Lives of the
   // Saints (distinct from the liturgical celebration above). Opens the
   // `saint-of-the-day` practice (today's life + reflection from the book).
-  const saintReadingName =
-    saintOfDayNames[
+  const saintEntry =
+    saintOfDay[
       `${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
     ]
-  if (saintReadingName) {
+  if (saintEntry) {
+    const reflection = saintEntry.reflection ? localizeContent(saintEntry.reflection) : undefined
     blocks.push({
       key: 'saint',
       label: t('explore.saintOfDay'),
-      title: saintReadingName,
-      subtitle: t('explore.saintReadingTagline'),
+      title: localizeContent(saintEntry.name),
+      subtitle: reflection ?? t('explore.saintReadingTagline'),
       tone: toneForKey('saint-of-the-day'),
       onPress: () =>
         router.push({ pathname: '/pray/[practiceId]', params: { practiceId: 'saint-of-the-day' } }),

--- a/apps/app/src/features/home/components/SaintOfDayCard.tsx
+++ b/apps/app/src/features/home/components/SaintOfDayCard.tsx
@@ -34,7 +34,7 @@ export function SaintOfDayCard() {
           {reading.name}
         </Typography>
         <Typography variant="whisper" fontSize="$2" maxWidth={520} numberOfLines={3}>
-          {t('explore.saintReadingTagline')}
+          {reading.reflection ?? t('explore.saintReadingTagline')}
         </Typography>
       </YStack>
     </Pressable>

--- a/apps/app/src/features/saints/data/saintOfDayNames.ts
+++ b/apps/app/src/features/saints/data/saintOfDayNames.ts
@@ -1,370 +1,3389 @@
-// AUTO-GENERATED from content/books/pictorial-lives-of-saints/book.json — do not edit by hand.
-// Primary saint per calendar day (MM-DD) as titled in Pictorial Lives of the Saints.
-export const saintOfDayNames: Record<string, string> = {
-  '01-01': 'The Circumcision of our Lord',
-  '01-02': 'St. Fulgentius, Bishop',
-  '01-03': 'St. Genevieve, Virgin',
-  '01-04': 'St. Titus, Bishop',
-  '01-05': 'St. Simeon Stylites',
-  '01-06': 'The Epiphany of Our Lord',
-  '01-07': 'St. Lucian, Martyr',
-  '01-08': 'St. Apollinaris, the Apologist, Bishop',
-  '01-09': 'Ss. Julian and Basilissa, Martyrs',
-  '01-10': 'St. William, Archbishop',
-  '01-11': 'St. Theodosius, The Cenobiarch',
-  '01-12': 'St. Aelred, Abbot',
-  '01-13': 'St. Veronica of Milan',
-  '01-14': 'St. Hilary of Poitiers',
-  '01-15': 'St. Paul, the First Hermit',
-  '01-16': 'St. Honoratus, Archbishop',
-  '01-17': 'St. Antony, Patriarch of Monks',
-  '01-18': "St. Peter's Chair at Rome",
-  '01-19': 'St. Canutus, King, Martyr',
-  '01-20': 'St. Sebastian, Martyr',
-  '01-21': 'St. Agnes, Virgin, Martyr',
-  '01-22': 'St. Vincent, Martyr',
-  '01-23': 'St. Raymund of Pennafort',
-  '01-24': 'St. Timothy, Bishop, Martyr',
-  '01-25': 'The Conversion of St. Paul',
-  '01-26': 'St. Polycarp, Bishop, Martyr',
-  '01-27': 'St. John Chrysostom',
-  '01-28': 'St. Cyril of Alexandria',
-  '01-29': 'St. Francis of Sales',
-  '01-30': 'St. Bathildes, Queen',
-  '01-31': 'St. Marcella, Widow',
-  '02-01': 'St. Bridgid, Abbess, and Patroness of Ireland',
-  '02-02': 'The Purification, Commonly Called Candlemas-Day',
-  '02-03': 'St. Blase, Bishop and Martyr',
-  '02-04': 'St. Jane of Valois',
-  '02-05': 'St. Agatha, Virgin, Martyr',
-  '02-06': 'St. Dorothy, Virgin, Martyr',
-  '02-07': 'St. Romuald, Abbot',
-  '02-08': 'St. John of Matha',
-  '02-09': 'St. Apollonia and the Martyrs of Alexandria',
-  '02-10': 'St. Scholastica, Abbess',
-  '02-11': 'St. Severinus, Abbot of Agaunum',
-  '02-12': 'St. Benedict of Anian',
-  '02-13': 'St. Catherine of Ricci',
-  '02-14': 'St. Valentine, Priest and Martyr',
-  '02-15': 'Sts. Faustinus and Jovita, Martyrs',
-  '02-16': 'Blessed John de Britto, Martyr',
-  '02-17': 'St. Flavian, Bishop, Martyr',
-  '02-18': 'St. Simeon, Bishop, Martyr',
-  '02-19': 'St. Barbatus, Bishop',
-  '02-20': 'St. Eucherius, Bishop',
-  '02-21': 'St. Severianus, Martyr, Bishop',
-  '02-22': "St. Peter's Chair at Antioch",
-  '02-23': 'St. Peter Damian',
-  '02-24': 'St. Matthias, Apostle',
-  '02-25': 'St. Tarasius',
-  '02-26': 'St. Porphyry, Bishop',
-  '02-27': 'St. Leander, Bishop',
-  '02-28': 'Sts. Romanus and Lupicinus, Abbots',
-  '02-29': 'St. Oswald, Bishop',
-  '03-01': 'St. David, Bishop',
-  '03-02': 'St. Simplicius, Pope',
-  '03-03': 'St. Cunegundes, Empress',
-  '03-04': 'St. Casimir, King',
-  '03-05': 'Sts. Adrian and Eubulus, Martyrs',
-  '03-06': 'St. Colette, Virgin',
-  '03-07': 'St. Thomas Aquinas',
-  '03-08': 'St. John of God',
-  '03-09': 'St. Frances of Rome',
-  '03-10': 'The Forty Martyrs of Sebaste',
-  '03-11': 'St. Eulogius, Martyr',
-  '03-12': 'St. Gregory the Great',
-  '03-13': 'St. Euphrasia, Virgin',
-  '03-14': 'St. Maud. Queen',
-  '03-15': 'St. Zachary, Pope',
-  '03-16': 'Sts. Abraham and Mary',
-  '03-17': 'St. Patrick, Bishop, Apostle of Ireland',
-  '03-18': 'St. Cyril of Jerusalem',
-  '03-19': 'St. Joseph, Spouse of the Blessed Virgin and Patron of the Universal Church',
-  '03-20': 'St. Wulfran, Archbishop',
-  '03-21': 'St. Benedict, Abbot',
-  '03-22': 'St. Catharine of Sweden, Virgin',
-  '03-23': 'Sts. Victorian and Others, Martyrs',
-  '03-24': 'St. Simon, Infant Martyr',
-  '03-25': 'The Annunciation of the Blessed Virgin Mary',
-  '03-26': 'St. Ludger, Bishop',
-  '03-27': 'St. John of Egypt',
-  '03-28': 'St. Gontran, King',
-  '03-29': 'Sts. Jonas, Barachisius, and their Companions, Martyrs',
-  '03-30': 'St. John Climacus',
-  '03-31': 'St. Benjamin, Deacon, Martyr',
-  '04-01': 'St. Hugh, Bishop',
-  '04-02': 'St. Francis of Paula',
-  '04-03': 'St. Richard of Chichester',
-  '04-04': 'St. Isidore, Archbishop',
-  '04-05': 'St. Vincent Ferrer',
-  '04-06': 'St. Celestine, Pope',
-  '04-07': 'St. Hegesippus, a Primitive Father',
-  '04-08': 'St. Perpetuus, Bishop',
-  '04-09': 'St. Mary of Egypt',
-  '04-10': 'St. Bademus, Martyr',
-  '04-11': 'St. Leo the Great',
-  '04-12': 'St. Julius, Pope',
-  '04-13': 'St. Hermenegild, Martyr',
-  '04-14': 'St. Benezet, or Little Bennet',
-  '04-15': 'St. Paternus, Bishop',
-  '04-16': 'Eighteen Martyrs of Saragossa, and St. Encratis, or Engratia, Virgin, Martyr',
-  '04-17': 'St. Anicetus, Pope, Martyr',
-  '04-18': 'St. Apollonius, Martyr',
-  '04-19': 'St. Elphege, Archbishop',
-  '04-20': 'St. Marcellinus, Bishop',
-  '04-21': 'St. Anselm, Archbishop',
-  '04-22': 'St. Soter, Pope, Martyr',
-  '04-23': 'St. George, Martyr',
-  '04-24': 'St. Fidelis of Sigmaringen',
-  '04-25': 'St. Mark, Evangelist',
-  '04-26': 'Sts. Cletus and Marcellinus, Popes, Martyrs',
-  '04-27': 'St. Zita, Virgin',
-  '04-28': 'St. Paul of the Cross',
-  '04-29': 'St. Peter, Martyr',
-  '04-30': 'St. Catherine of Siena',
-  '05-01': 'Sts. Philip and James, Apostles',
-  '05-02': 'St. Athanasius, Bishop',
-  '05-03': 'The Discovery of the Holy Cross',
-  '05-04': 'St. Monica',
-  '05-05': 'St. Pius V',
-  '05-06': 'St. John Before the Latin Gate',
-  '05-07': 'St. Stanislas, Bishop, Martyr',
-  '05-08': 'The Apparition of St. Michael the Archangel',
-  '05-09': 'St. Gregory Nazianzen',
-  '05-10': 'St. Antoninus, Bishop',
-  '05-11': 'St. Mammertus, Archbishop',
-  '05-12': 'St. Epiphanius, Archbishop',
-  '05-13': 'St. John the Silent',
-  '05-14': 'St. Pachomius, Abbot',
-  '05-15': 'Sts. Peter and Dionysia',
-  '05-16': 'St. John Nepomucen',
-  '05-17': 'St. Paschal Baylon',
-  '05-18': 'St. Venantius, Martyr',
-  '05-19': 'St. Peter Celestine',
-  '05-20': 'St. Bernardine of Siena',
-  '05-21': 'St. Hospitius, Recluse',
-  '05-22': 'St. Yvo, Confessor',
-  '05-23': 'St. Julia, Virgin, Martyr',
-  '05-24': 'Sts. Donatian and Rogatian, Martyrs',
-  '05-25': 'St. Gregory VII',
-  '05-26': 'St. Philip Neri',
-  '05-27': 'St. Mary Magdalen of Pazzi',
-  '05-28': 'St. Germanus, Bishop',
-  '05-29': 'St. Cyril, Martyr',
-  '05-30': 'St. Felix I., Pope and Martyr',
-  '05-31': 'St. Petronilla, Virgin',
-  '06-01': 'St. Justin, Martyr',
-  '06-02': 'Sts. Pothinus, Bishop, Sanctus, Attalus, Blandina, and the other Martyrs of Lyons',
-  '06-03': 'St. Clotilda, Queen',
-  '06-04': 'St. Francis Caracciolo',
-  '06-05': 'St. Boniface, Bishop, Martyr',
-  '06-06': 'St. Norbert, Bishop',
-  '06-07': 'St. Robert of Newminster',
-  '06-08': 'St. Medard, Bishop',
-  '06-09': 'Sts. Primus and Felicianus, Martyrs',
-  '06-10': 'St. Margaret of Scotland',
-  '06-11': 'St. Barnabas, Apostle',
-  '06-12': 'St. John of St. Fagondez',
-  '06-13': 'St. Antony of Padua',
-  '06-14': 'St. Basil the Great',
-  '06-15': 'Sts. Vitus, Crescentia, and Modestus, Martyrs',
-  '06-16': 'St. John Francis Regis',
-  '06-17': 'St. Avitus, Abbot',
-  '06-18': 'Sts. Marcus and Marcellianus, Martyrs',
-  '06-19': 'St. Juliana Falconieri',
-  '06-20': 'St. Silverius, Pope and Martyr',
-  '06-21': 'St. Aloysius Gonzaga',
-  '06-22': 'St. Paulinus of Nola',
-  '06-23': 'St. Etheldreda, Abbess',
-  '06-24': 'St. John the Baptist',
-  '06-25': 'St. Prosper of Aquitaine. St William of Monte-Vergine',
-  '06-26': 'Sts. John and Paul, Martyrs',
-  '06-27': 'St. Ladislas, King',
-  '06-28': 'St. Irenæus, Bishop, Martyr',
-  '06-29': 'St. Peter, Apostle',
-  '06-30': 'St. Paul',
-  '07-01': 'St. Gal, Bishop',
-  '07-02': 'The Visitation of the Blessed Virgin',
-  '07-03': 'St. Heliodorus, Bishop',
-  '07-04': 'St. Bertha, Widow, Abbess',
-  '07-05': 'St. Peter of Luxemburg',
-  '07-06': 'St. Goar, Priest',
-  '07-07': 'St. Pantænus, Father of the Church',
-  '07-08': 'St. Elizabeth of Portugal',
-  '07-09': 'St. Ephrem, Deacon',
-  '07-10': 'The Seven Brothers, Martyrs, and St. Felicitas, their Mother',
-  '07-11': 'St. James, Bishop',
-  '07-12': 'St. John Gualbert',
-  '07-13': 'St. Eugenius, Bishop',
-  '07-14': 'St. Bonaventure',
-  '07-15': 'St. Henry, Emperor',
-  '07-16': 'St. Simon Stock',
-  '07-17': 'St. Alexius',
-  '07-18': 'St. Camillus Of Lellis',
-  '07-19': 'St. Vincent of Paul',
-  '07-20': 'St. Margaret, Virgin and Martyr',
-  '07-21': 'St. Victor, Martyr',
-  '07-22': 'St. Mary Magdalen',
-  '07-23': 'St. Apollinaris, Bishop and Martyr',
-  '07-24': 'St. Christina, Virgin and Martyr',
-  '07-25': 'St. James, Apostle',
-  '07-26': 'St. Anne',
-  '07-27': 'St. Pantaleon, Martyr',
-  '07-28': 'Sts. Nazarius and Celsus, Martyrs',
-  '07-29': 'St. Martha, Virgin',
-  '07-30': 'St. Germanus, Bishop',
-  '07-31': 'St. Ignatius of Loyola',
-  '08-01': "St. Peter's Chains",
-  '08-02': 'St. Stephen, Pope and Martyr',
-  '08-03': "The Finding of St. Stephen's Relics",
-  '08-04': 'St. Dominic',
-  '08-05': 'The Dedication of St. Mary ad Nives',
-  '08-06': 'The Transfiguration of Our Lord',
-  '08-07': 'St. Cajetan',
-  '08-08': 'St. Cyriacus and His Companions, Martyrs',
-  '08-09': 'St. Romanus, Martyr',
-  '08-10': 'St. Laurence, Martyr',
-  '08-11': 'Sts. Tiburtius and Susanna, Martyrs',
-  '08-12': 'St. Clare, Abbess',
-  '08-13': 'St. Radegundes, Queen',
-  '08-14': 'St. Eusebius, Priest',
-  '08-15': 'The Assumption of the Blessed Virgin Mary',
-  '08-16': 'St. Hyacinth',
-  '08-17': 'St. Liberatus, Abbot, and Six Monks, Martyrs',
-  '08-18': 'St. Helena, Empress; St. Agapetus, Martyr',
-  '08-19': 'St. Louis, Bishop',
-  '08-20': 'St. Bernard',
-  '08-21': 'St. Jane Frances de Chantal',
-  '08-22': 'St. Symphorian, Martyr',
-  '08-23': 'St. Philip Benizi',
-  '08-24': 'St. Bartholomew, Apostle',
-  '08-25': 'St. Louis, King',
-  '08-26': 'St. Zephyrinus, Pope and Martyr',
-  '08-27': 'St. Joseph Calasanctius',
-  '08-28': 'St. Augustine of Hippo',
-  '08-29': 'The Beheading of St. John the Baptist',
-  '08-30': 'St. Rose of Lima',
-  '08-31': 'St. Raymund Nonnatus',
-  '09-01': 'St. Giles, Abbot',
-  '09-02': 'St. Stephen, King',
-  '09-03': 'St. Seraphia, Virgin and Martyr',
-  '09-04': 'St. Rosalia, Virgin',
-  '09-05': 'St. Laurence Justinian',
-  '09-06': 'St. Eleutherius, Abbot',
-  '09-07': 'St. Cloud, Confessor',
-  '09-08': 'The Nativity of the Blessed Virgin',
-  '09-09': 'St. Omer, Bishop',
-  '09-10': 'St. Nicholas of Tolentino',
-  '09-11': 'St. Paphnutius, Bishop',
-  '09-12': 'St. Guy of Anderlecht',
-  '09-13': 'St. Eulogius, Patriarch of Alexandria',
-  '09-14': 'The Exaltation of the Holy Cross of Our Lord Jesus Christ',
-  '09-15': 'St. Catherine of Genoa',
-  '09-16': 'St. Cyprian, Bishop, Martyr',
-  '09-17': 'St. Lambert, Bishop, Martyr',
-  '09-18': 'St. Thomas of Villanova',
-  '09-19': 'St. Januarius, Martyr',
-  '09-20': 'Sts. Eustachius and Companions, Martyrs',
-  '09-21': 'St. Matthew, Apostle',
-  '09-22': 'The Theban Legion',
-  '09-23': 'St. Thecla, Virgin, Martyr',
-  '09-24': 'The Blessed Virgin Mary of Mercy',
-  '09-25': 'St. Firmin, Bishop, Martyr. St. Finbarr, Bishop',
-  '09-26': 'Sts. Cyprian and Justina, Martyrs',
-  '09-27': 'Sts. Cosmas and Damian, Martyrs',
-  '09-28': 'St. Wenceslas, Martyr',
-  '09-29': 'St. Michael, Archangel',
-  '09-30': 'St. Jerome, Doctor',
-  '10-01': 'St. Remigius, Bishop',
-  '10-02': 'The Holy Guardian Angels',
-  '10-03': 'St. Gerard, Abbot',
-  '10-04': 'St. Francis of Assisi',
-  '10-05': 'St. Placid, Martyr',
-  '10-06': 'St. Bruno',
-  '10-07': 'St. Mark, Pope',
-  '10-08': 'St. Bridget of Sweden',
-  '10-09': 'St. Dionysius and his Companions, Martyrs. St. Louis Bertrand',
-  '10-10': 'St. Francis Borgia',
-  '10-11': 'St. Tarachus and his Companions',
-  '10-12': 'St. Wilfrid, Bishop',
-  '10-13': 'St. Edward the Confessor',
-  '10-14': 'St. Callistus, Pope, Martyr',
-  '10-15': 'St. Teresa',
-  '10-16': 'St. Gall, Abbot',
-  '10-17': 'St. Hedwige. Saint Margaret Mary Alacoque',
-  '10-18': 'St. Luke',
-  '10-19': 'St. Peter of Alcantara',
-  '10-20': 'St. John Cantius',
-  '10-21': 'St. Ursula, Virgin and Martyr',
-  '10-22': 'St. Mello, Bishop. St. Hilarion, Abbot',
-  '10-23': 'St. Theodoret, Martyr',
-  '10-24': 'St. Magloire, Bishop',
-  '10-25': 'Sts. Crispin and Crispinian, Martyrs',
-  '10-26': 'St. Evaristus, Pope and Martyr',
-  '10-27': 'St. Frumentius, Bishop',
-  '10-28': 'Sts. Simon and Jude',
-  '10-29': 'St. Narcissus, Bishop',
-  '10-30': 'St. Marcellus, the Centurion, Martyr',
-  '10-31': 'St. Quintin, Martyr',
-  '11-01': 'All-Saints',
-  '11-02': 'All-Souls',
-  '11-03': 'St. Hubert, Bishop',
-  '11-04': 'St. Charles Borromeo',
-  '11-05': 'St. Bertille, Abbess',
-  '11-06': 'St. Leonard',
-  '11-07': 'St. Willibrord',
-  '11-08': 'The Feast of the Holy Relics',
-  '11-09': 'St. Theodore Tyro, Martyr',
-  '11-10': '10: St. Andrew Avellino',
-  '11-11': 'St. Martin of Tours',
-  '11-12': 'St. Martin, Pope',
-  '11-13': 'St. Stanislas Kostka',
-  '11-14': 'St. Didacus',
-  '11-15': 'St. Gertrude, Abbess',
-  '11-16': 'St. Edmund of Canterbury',
-  '11-17': 'St. Gregory Thaumaturgus',
-  '11-18': 'St. Odo of Cluny',
-  '11-19': 'St. Elizabeth of Hungary',
-  '11-20': 'St. Felix of Valois',
-  '11-21': 'The Presentation of the Blessed Virgin Mary',
-  '11-22': 'St. Cecilia, Virgin, Martyr',
-  '11-23': 'St. Clement of Rome',
-  '11-24': 'St. John of the Cross',
-  '11-25': 'St. Catherine of Alexandria',
-  '11-26': 'St. Peter of Alexandria, Bishop, Martyr',
-  '11-27': 'St. Maximus, Bishop',
-  '11-28': 'St. James of La Marca of Ancona',
-  '11-29': 'St. Saturninus, Martyr',
-  '11-30': 'St. Andrew, Apostle',
-  '12-01': 'St. Eligius',
-  '12-02': 'St. Bibiana, Virgin, Martyr',
-  '12-03': 'St. Francis Xavier',
-  '12-04': 'St. Barbara, Virgin, Martyr',
-  '12-05': 'St. Sabas, Abbot',
-  '12-06': 'St. Nicholas of Bari',
-  '12-07': 'St. Ambrose, Bishop',
-  '12-08': 'The Feast of the Immaculate Conception',
-  '12-09': 'St. Leocadia, Virgin, Martyr',
-  '12-10': 'St. Eulalia, Virgin, Martyr',
-  '12-11': 'St. Damasus, Pope',
-  '12-12': 'St. Valery, Abbot. St. Finian, Bishop',
-  '12-13': 'St. Lucy, Virgin, Martyr',
-  '12-14': 'St. Nicasius, Archbishop, and his Companions, Martyrs',
-  '12-15': 'St. Mesmin',
-  '12-16': 'St. Eusebius, Bishop',
-  '12-17': 'St. Olympias, Widow',
-  '12-18': 'St. Gatian, Bishop',
-  '12-19': 'St. Nemesion, Martyr',
-  '12-20': 'St. Philogonius, Bishop',
-  '12-21': 'St. Thomas, Apostle',
-  '12-22': 'St. Ischyrion, Martyr',
-  '12-23': 'St. Servulus',
-  '12-24': 'St. Delphinus, Bishop. Sts. Thrasilla and Emiliana, Virgins',
-  '12-25': 'The Nativity of Christ, or Christmas Day',
-  '12-26': 'St. Stephen, First Martyr',
-  '12-27': 'St. John, Evangelist',
-  '12-28': 'The Holy Innocents',
-  '12-29': 'St. Thomas of Canterbury',
-  '12-30': 'St. Sabinus, Bishop, and his Companions, Martyrs',
-  '12-31': 'St. Sylvester, Pope',
+// AUTO-GENERATED by scripts/build-saint-of-day.mjs — do not edit by hand.
+// Per-day saint name + first available reflection from Pictorial Lives of the Saints.
+export type SaintOfDayEntry = {
+  name: { 'en-US': string; 'pt-BR': string }
+  reflection?: { 'en-US': string; 'pt-BR': string }
+}
+
+export const saintOfDay: Record<string, SaintOfDayEntry> = {
+  '01-01': {
+    name: { 'en-US': 'The Circumcision of our Lord', 'pt-BR': 'A Circuncisão de Nosso Senhor' },
+    reflection: {
+      'en-US':
+        'Let us profit by the circumstance of the new year, and of the wonderful renewal wrought in the world by the great mystery of this day, to renew in our hearts an increase of fervor and of generosity in the service of God. May this year be one of fervor and of progress! It will go by rapidly, like that which has just ended. If God permits us to see its end, how glad and happy we shall be to have passed it holily!',
+      'pt-BR':
+        'Aproveitemos a circunstância do ano novo, e da maravilhosa renovação operada no mundo pelo grande mistério deste dia, para renovar em nossos corações um acréscimo de fervor e de generosidade no serviço de Deus. Seja este ano um ano de fervor e de progresso! Ele passará rapidamente, como aquele que acaba de findar. Se Deus nos permitir ver o seu fim, quão contentes e felizes ficaremos por tê-lo passado santamente!',
+    },
+  },
+  '01-02': {
+    name: {
+      'en-US': 'St. Fulgentius, Bishop · St. Macarius of Alexandria',
+      'pt-BR': 'São Fulgêncio, Bispo · São Macário de Alexandria',
+    },
+    reflection: {
+      'en-US':
+        'Each year may bring us fresh changes and trials; let us learn from St. Fulgentius to receive all that happens as from the hand of God, and appointed for our salvation.',
+      'pt-BR':
+        'Cada ano pode trazer-nos novas mudanças e provações; aprendamos com São Fulgêncio a receber tudo o que acontece como vindo da mão de Deus, e ordenado para a nossa salvação.',
+    },
+  },
+  '01-03': {
+    name: { 'en-US': 'St. Genevieve, Virgin', 'pt-BR': 'Santa Genoveva, Virgem' },
+    reflection: {
+      'en-US':
+        'Genevieve was only a poor peasant girl, but Christ dwelt in her heart. She was anointed with His Spirit, and with power; she went about doing good, and God was with her.',
+      'pt-BR':
+        'Genoveva era apenas uma pobre camponesa, mas Cristo habitava em seu coração. Foi ungida com Seu Espírito, e com poder; andou fazendo o bem, e Deus estava com ela.',
+    },
+  },
+  '01-04': {
+    name: {
+      'en-US': 'St. Titus, Bishop · St. Gregory, Bishop',
+      'pt-BR': 'São Tito, Bispo · São Gregório, Bispo',
+    },
+    reflection: {
+      'en-US':
+        'Saints win their empire over the hearts of men by their wide and affectionate sympathy. This was the characteristic gift of St. Titus, as it was of St. Paul, St. Francis Xavier, and many others.',
+      'pt-BR':
+        'Os santos conquistam seu império sobre os corações dos homens por sua ampla e afetuosa simpatia. Este foi o dom característico de São Tito, como o foi de São Paulo, de São Francisco Xavier, e de muitos outros.',
+    },
+  },
+  '01-05': {
+    name: { 'en-US': 'St. Simeon Stylites', 'pt-BR': 'São Simeão Estilita' },
+    reflection: {
+      'en-US':
+        'St. Augustine says: "This is the business of our life: by effort and by toil, by prayer and supplication, to advance in the grace of God, till we come to that height of perfection in which with clean hearts we may behold God."',
+      'pt-BR':
+        'Santo Agostinho diz: "Este é o negócio de nossa vida: por esforço e por labuta, por oração e súplica, avançar na graça de Deus, até que cheguemos àquela altura de perfeição em que, com corações puros, possamos contemplar a Deus."',
+    },
+  },
+  '01-06': {
+    name: { 'en-US': 'The Epiphany of Our Lord', 'pt-BR': 'A Epifania de Nosso Senhor' },
+    reflection: {
+      'en-US':
+        'Admire the almighty power of this little Child, Who from His cradle makes known His coming to the shepherds and magi—to the shepherds by means of His angel, to the magi by a star in the East. Admire the docility of these kings. Jesus is born; behold them at His feet? Let us be little, let us hide ourselves, and the divine strength will be granted to us. Let us be docile and quick in following divine inspirations, and we shall then become wise of the wisdom of God, powerful in His almighty power.',
+      'pt-BR':
+        'Admirai o poder todo-poderoso deste pequeno Menino, que desde Seu berço dá a conhecer Sua vinda aos pastores e aos magos — aos pastores por meio de Seu anjo, aos magos por uma estrela no Oriente. Admirai a docilidade destes reis. Jesus nasce; ei-los a Seus pés. Sejamos pequenos, escondamo-nos, e a força divina nos será concedida. Sejamos dóceis e prontos em seguir as inspirações divinas, e tornar-nos-emos então sábios da sabedoria de Deus, poderosos em Seu poder todo-poderoso.',
+    },
+  },
+  '01-07': {
+    name: { 'en-US': 'St. Lucian, Martyr', 'pt-BR': 'São Luciano, Mártir' },
+    reflection: {
+      'en-US':
+        'If we would keep our faith pure, we must study its holy truths. We cannot detect falsehood till we know and love the truth; and to us the truth is not an abstraction, but a Person, Jesus Christ, God and Man.',
+      'pt-BR':
+        'Se quisermos manter pura a nossa fé, devemos estudar suas santas verdades. Não podemos detectar a falsidade enquanto não conhecemos e amamos a verdade; e, para nós, a verdade não é uma abstração, mas uma Pessoa, Jesus Cristo, Deus e Homem.',
+    },
+  },
+  '01-08': {
+    name: {
+      'en-US': 'St. Apollinaris, the Apologist, Bishop',
+      'pt-BR': 'Santo Apolinário, o Apologista, Bispo',
+    },
+    reflection: {
+      'en-US':
+        '"Therefore I say unto you, all things whatsoever you ask when you pray, believe that you shall receive: and they shall come unto you."',
+      'pt-BR':
+        '"Por isso vos digo: tudo quanto pedirdes orando, crede que o recebereis, e ser-vos-á concedido."',
+    },
+  },
+  '01-09': {
+    name: {
+      'en-US': 'Ss. Julian and Basilissa, Martyrs',
+      'pt-BR': 'São Julião e Santa Basilissa, Mártires',
+    },
+    reflection: {
+      'en-US':
+        'God often rewards men for works that are pleasing in His sight by giving them grace and opportunity to do other works higher still. St. Augustine said, "I have never seen a compassionate and charitable man die a bad death."',
+      'pt-BR':
+        'Deus muitas vezes recompensa os homens pelas obras que lhe são agradáveis, dando-lhes graça e ocasião de realizar outras obras ainda mais elevadas. Santo Agostinho disse: "Nunca vi morrer de má morte um homem compassivo e caridoso."',
+    },
+  },
+  '01-10': {
+    name: { 'en-US': 'St. William, Archbishop', 'pt-BR': 'São Guilherme, Arcebispo' },
+    reflection: {
+      'en-US':
+        'The champions of faith prove the truth of their teaching no less by the holiness of their lives than by the force of their arguments. Never forget that to convert others we must first see to our own souls.',
+      'pt-BR':
+        'Os campeões da fé provam a verdade de seu ensino não menos pela santidade de sua vida do que pela força de seus argumentos. Nunca te esqueças de que, para converter os outros, devemos primeiro cuidar de nossa própria alma.',
+    },
+  },
+  '01-11': {
+    name: { 'en-US': 'St. Theodosius, The Cenobiarch', 'pt-BR': 'São Teodósio, o Cenobiarca' },
+    reflection: {
+      'en-US':
+        'St. Theodosius, for the sake of charity, sacrificed all he most prized—his home for the love of God, and his solitude for the love of his neighbor. Can ours be true charity if it costs us little or nothing?',
+      'pt-BR':
+        'São Teodósio, por amor da caridade, sacrificou tudo o que mais prezava — o seu lar pelo amor de Deus, e a sua solidão pelo amor do próximo. Pode ser verdadeira a nossa caridade, se pouco ou nada nos custa?',
+    },
+  },
+  '01-12': {
+    name: { 'en-US': 'St. Aelred, Abbot', 'pt-BR': 'Santo Elredo, Abade' },
+    reflection: {
+      'en-US':
+        'When a man has given himself to God, God gives back friendship with all His other gifts a hundredfold. Friends are then loved no longer for themselves only, but for God, and that with a love lively and tender; for God can easily purify feeling. It is not feeling, but self-love, which corrupts friendship.',
+      'pt-BR':
+        'Quando um homem se entregou a Deus, Deus lhe devolve a amizade, com todos os seus outros dons, cêntuplo. Os amigos são então amados não mais por si mesmos somente, mas por Deus, e isso com um amor vivo e terno; pois Deus pode facilmente purificar o sentimento. Não é o sentimento, mas o amor-próprio, que corrompe a amizade.',
+    },
+  },
+  '01-13': {
+    name: { 'en-US': 'St. Veronica of Milan', 'pt-BR': 'Santa Verônica de Milão' },
+    reflection: {
+      'en-US':
+        'When Veronica was urged in sickness to accept some exemption from her labors, her one answer was, "I must work while I can, while I have time." Dare we, then, waste ours?',
+      'pt-BR':
+        'Quando Verônica era instada, na doença, a aceitar alguma dispensa de seus labores, sua única resposta era: "Devo trabalhar enquanto posso, enquanto tenho tempo." Ousaremos, então, desperdiçar o nosso?',
+    },
+  },
+  '01-14': {
+    name: { 'en-US': 'St. Hilary of Poitiers', 'pt-BR': 'Santo Hilário de Poitiers' },
+    reflection: {
+      'en-US':
+        'Like St. Hilary, we, too, are called to a lifelong contest with heretics; we shall succeed in proportion as we combine hatred of heresy, with compassion for its victims.',
+      'pt-BR':
+        'Assim como Santo Hilário, também nós somos chamados a um combate de toda a vida contra os hereges; teremos êxito na medida em que combinarmos o ódio à heresia com a compaixão por suas vítimas.',
+    },
+  },
+  '01-15': {
+    name: { 'en-US': 'St. Paul, the First Hermit', 'pt-BR': 'São Paulo, o Primeiro Eremita' },
+    reflection: {
+      'en-US':
+        'We shall never repent of having trusted in God, for He cannot fail those who lean on Him; nor shall We ever trust in ourselves without being deceived.',
+      'pt-BR':
+        "Nunca nos arrependeremos de ter confiado em Deus, pois Ele não pode faltar àqueles que se apoiam n'Ele; nem jamais confiaremos em nós mesmos sem sermos enganados.",
+    },
+  },
+  '01-16': {
+    name: { 'en-US': 'St. Honoratus, Archbishop', 'pt-BR': 'Santo Honorato, Arcebispo' },
+    reflection: {
+      'en-US':
+        'The soul cannot truly serve God while it is involved in the distractions and pleasures of the world. St. Honoratus knew this, and chose to be a servant of Christ his Lord. Resolve, in whatever state you are, to live absolutely detached from the world, and to separate yourself as much as possible from it.',
+      'pt-BR':
+        'A alma não pode verdadeiramente servir a Deus enquanto está envolvida nas distrações e nos prazeres do mundo. Santo Honorato sabia disso, e escolheu ser servo de Cristo, seu Senhor. Resolve, em qualquer estado em que te encontres, viver absolutamente desapegado do mundo, e separar-te dele tanto quanto possível.',
+    },
+  },
+  '01-17': {
+    name: {
+      'en-US': 'St. Antony, Patriarch of Monks',
+      'pt-BR': 'Santo Antão, Patriarca dos Monges',
+    },
+    reflection: {
+      'en-US':
+        'The more violent were the assaults of temptation suffered by St. Antony, the more firmly did he grasp his weapons, namely, mortification and prayer. Let us imitate him in this if we wish to obtain victories like his.',
+      'pt-BR':
+        'Quanto mais violentos eram os assaltos da tentação sofridos por Santo Antão, tanto mais firmemente empunhava ele as suas armas, a saber, a mortificação e a oração. Imitemo-lo nisto, se quisermos obter vitórias como as suas.',
+    },
+  },
+  '01-18': {
+    name: { 'en-US': "St. Peter's Chair at Rome", 'pt-BR': 'A Cátedra de São Pedro em Roma' },
+    reflection: {
+      'en-US':
+        "As one of God's greatest mercies to His Church, let us earnestly beg of Him to raise up in it zealous pastors, eminently replenished with His Spirit, with which He animated His apostles.",
+      'pt-BR':
+        'Como uma das maiores misericórdias de Deus para com a sua Igreja, peçamos-lhe encarecidamente que suscite nela pastores zelosos, eminentemente repletos de seu Espírito, com o qual animou os seus apóstolos.',
+    },
+  },
+  '01-19': {
+    name: { 'en-US': 'St. Canutus, King, Martyr', 'pt-BR': 'São Canuto, Rei, Mártir' },
+    reflection: {
+      'en-US':
+        'The soul of a man is endowed with many noble powers, and feels a keen joy in their exercise; but the keenest joy we are capable of feeling consists in prostrating all our powers of mind and heart in humblest adoration before the majesty of God.',
+      'pt-BR':
+        'A alma do homem é dotada de muitas faculdades nobres, e sente uma viva alegria no seu exercício; mas a mais viva alegria que somos capazes de sentir consiste em prostrar todas as faculdades do espírito e do coração na mais humilde adoração diante da majestade de Deus.',
+    },
+  },
+  '01-20': {
+    name: { 'en-US': 'St. Sebastian, Martyr', 'pt-BR': 'São Sebastião, Mártir' },
+    reflection: {
+      'en-US':
+        'Your ordinary occupations will give you opportunities of laboring for the faith. Ask help from St. Sebastian. He was not a priest nor a religious, but a soldier.',
+      'pt-BR':
+        'As tuas ocupações ordinárias te darão oportunidades de trabalhar pela fé. Pede auxílio a São Sebastião. Ele não era sacerdote nem religioso, mas soldado.',
+    },
+  },
+  '01-21': {
+    name: { 'en-US': 'St. Agnes, Virgin, Martyr', 'pt-BR': 'Santa Inês, Virgem, Mártir' },
+    reflection: {
+      'en-US':
+        'Her innocence endeared St. Agnes to Christ, as it has endeared her to His Church ever since. Even as penitents we may imitate this innocence of hers in our own degree. Let us strictly guard our eyes, and Christ, when He sees that we keep our hearts pure for love of Him, will renew our youth and give us back the years which the canker-worm has wasted.',
+      'pt-BR':
+        'A sua inocência tornou Santa Inês querida a Cristo, como a tornou querida à sua Igreja desde então. Mesmo como penitentes podemos imitar essa inocência sua na nossa própria medida. Guardemos estritamente os nossos olhos, e Cristo, ao ver que conservamos os nossos corações puros por amor a Ele, renovará a nossa juventude e nos devolverá os anos que o verme roedor desperdiçou.',
+    },
+  },
+  '01-22': {
+    name: { 'en-US': 'St. Vincent, Martyr', 'pt-BR': 'São Vicente, Mártir' },
+    reflection: {
+      'en-US':
+        'Do you wish to be at peace amidst suffering and temptation? Then make it your principal endeavor to grow in habits of prayer and in union with Christ. Have confidence in Him. He will make you victorious over your spiritual enemies and over yourself. He will enlighten your darkness and sweeten your sufferings, and in your solitude and desolation He will draw nigh to you with His holy angels.',
+      'pt-BR':
+        "Desejas estar em paz em meio ao sofrimento e à tentação? Então faze do teu principal empenho crescer nos hábitos de oração e na união com Cristo. Tem confiança n'Ele. Ele te fará vitorioso sobre os teus inimigos espirituais e sobre ti mesmo. Iluminará a tua escuridão e adoçará os teus sofrimentos, e na tua solidão e desolação se aproximará de ti com os seus santos anjos.",
+    },
+  },
+  '01-23': {
+    name: { 'en-US': 'St. Raymund of Pennafort', 'pt-BR': 'São Raimundo de Penafort' },
+    reflection: {
+      'en-US':
+        'Ask St. Raymund to protect you from that fearful servitude, worse than any bodily slavery, which even one sinful habit tends to form.',
+      'pt-BR':
+        'Pede a São Raimundo que te proteja daquela terrível servidão, pior do que qualquer escravidão corporal, que mesmo um só hábito pecaminoso tende a formar.',
+    },
+  },
+  '01-24': {
+    name: { 'en-US': 'St. Timothy, Bishop, Martyr', 'pt-BR': 'São Timóteo, Bispo, Mártir' },
+    reflection: {
+      'en-US':
+        'St. Paul, in writing to Timothy, a faithful and well-tried servant of God, and a bishop now getting on in years, addresses him as a child, and seems most anxious about his perseverance in faith and piety. The letters abound in minute personal instructions for this end. It is therefore remarkable what great stress the Apostle lays on the avoiding of idle talk, and on the application to holy reading. These are his chief topics. Over and over again he exhorts his son Timothy to "avoid tattlers and busybodies; to give no heed to novelties; to shun profane and vain babblings, but to hold the form of sound words; to be an example in word and conversation; to attend to reading, to exhortation, and to doctrine."',
+      'pt-BR':
+        'São Paulo, ao escrever a Timóteo, servo fiel e bem provado de Deus, e bispo já entrado em anos, dirige-se a ele como a uma criança, e parece sumamente solícito quanto à sua perseverança na fé e na piedade. As cartas abundam em minuciosas instruções pessoais para esse fim. É, portanto, notável a grande ênfase que o Apóstolo põe em evitar a conversa ociosa, e na aplicação à leitura santa. Estes são os seus principais temas. Repetidas vezes exorta o seu filho Timóteo a "evitar os faladores e os intrometidos; a não dar atenção às novidades; a fugir das tagarelices profanas e vãs, mas a guardar a forma das sãs palavras; a ser um exemplo na palavra e na conversação; a aplicar-se à leitura, à exortação e à doutrina."',
+    },
+  },
+  '01-25': {
+    name: { 'en-US': 'The Conversion of St. Paul', 'pt-BR': 'A Conversão de São Paulo' },
+    reflection: {
+      'en-US':
+        'Listen to the words of the "*Imitation of Christ*," and let them sink into your heart: "He who would keep the grace of God, let him be grateful for grace when it is given, and patient when it is taken away. Let him pray that it may be given back to him, and be careful and humble, lest he lose it."',
+      'pt-BR':
+        'Escuta as palavras da "*Imitação de Cristo*", e deixa que penetrem no teu coração: "Aquele que quiser conservar a graça de Deus, seja grato pela graça quando lhe é dada, e paciente quando lhe é retirada. Ore para que lhe seja devolvida, e seja cuidadoso e humilde, para não a perder."',
+    },
+  },
+  '01-26': {
+    name: { 'en-US': 'St. Polycarp, Bishop, Martyr', 'pt-BR': 'São Policarpo, Bispo, Mártir' },
+    reflection: {
+      'en-US':
+        'If we love Jesus Christ, we shall love the Church and hate heresy, which rends His mystical body, and destroys the souls for which He died. Like St. Polycarp, we shall maintain our constancy in the faith by loves of Jesus Christ, Who is its author and its finisher.',
+      'pt-BR':
+        'Se amamos a Jesus Cristo, amaremos a Igreja e odiaremos a heresia, que dilacera o seu corpo místico, e destrói as almas pelas quais Ele morreu. Como São Policarpo, manteremos a nossa constância na fé pelo amor a Jesus Cristo, que é o seu autor e o seu consumador.',
+    },
+  },
+  '01-27': {
+    name: { 'en-US': 'St. John Chrysostom', 'pt-BR': 'São João Crisóstomo' },
+    reflection: {
+      'en-US':
+        'We should try to understand that the most productive work in the whole day, both for time and eternity, is that involved in hearing Mass. St. John Chrysostom felt this so keenly that he allowed no consideration of venerable usage to interfere with the easiness of hearing Mass.',
+      'pt-BR':
+        'Devemos procurar compreender que a obra mais produtiva de todo o dia, tanto para o tempo quanto para a eternidade, é aquela que está em ouvir a Missa. São João Crisóstomo sentia isto tão vivamente que não permitiu que nenhuma consideração de venerável costume interferisse na facilidade de ouvir a Missa.',
+    },
+  },
+  '01-28': {
+    name: { 'en-US': 'St. Cyril of Alexandria', 'pt-BR': 'São Cirilo de Alexandria' },
+    reflection: {
+      'en-US':
+        "The Incarnation is the mystery of God's dwelling within us, and therefore should be the dearest object of our contemplation. It was the passion of St. Cyril's life; for it he underwent toil and persecution, and willingly sacrificed credit and friends.",
+      'pt-BR':
+        'A Encarnação é o mistério da habitação de Deus em nós, e por isso deve ser o objeto mais querido da nossa contemplação. Foi a paixão da vida de São Cirilo; por ela suportou labores e perseguições, e de bom grado sacrificou o crédito e os amigos.',
+    },
+  },
+  '01-29': {
+    name: { 'en-US': 'St. Francis of Sales', 'pt-BR': 'São Francisco de Sales' },
+    reflection: {
+      'en-US':
+        '"You will catch more flies," St. Francis used to say, "with a spoonful of honey than with a hundred barrels of vinegar. Were there anything better or fairer on earth than gentleness, Jesus Christ would have taught it us; and yet He has given us only two lessons to learn of Him—meekness and humility of heart."',
+      'pt-BR':
+        '"Apanharás mais moscas", costumava dizer São Francisco, "com uma colherada de mel do que com cem barris de vinagre. Se houvesse algo melhor ou mais belo na terra do que a brandura, Jesus Cristo no-lo teria ensinado; e, contudo, Ele nos deu apenas duas lições a aprender d\'Ele — mansidão e humildade de coração."',
+    },
+  },
+  '01-30': {
+    name: { 'en-US': 'St. Bathildes, Queen', 'pt-BR': 'Santa Batildes, Rainha' },
+    reflection: {
+      'en-US':
+        'In all that we do, let God and His holy will be always before our eyes, and our only aim and desire be to please Him.',
+      'pt-BR':
+        'Em tudo o que fizermos, estejam sempre diante dos nossos olhos Deus e a sua santa vontade, e seja o nosso único intento e desejo agradar-Lhe.',
+    },
+  },
+  '01-31': {
+    name: { 'en-US': 'St. Marcella, Widow', 'pt-BR': 'Santa Marcela, Viúva' },
+  },
+  '02-01': {
+    name: {
+      'en-US': 'St. Bridgid, Abbess, and Patroness of Ireland · St. Ignatius, Bishop, Martyr',
+      'pt-BR': 'Santa Brígida, Abadessa e Padroeira da Irlanda · Santo Inácio, Bispo, Mártir',
+    },
+    reflection: {
+      'en-US':
+        "Outward resemblance to Our Lady was St. Bridgid's peculiar privilege; but all are bound to grow like her in interior purity of heart. This grace St. Bridgid has obtained in a wonderful degree for the daughters of her native land, and will never fail to procure for all her devout clients.",
+      'pt-BR':
+        'A semelhança exterior com Nossa Senhora foi o privilégio peculiar de Santa Brígida; mas todos estão obrigados a crescer como ela na pureza interior do coração. Esta graça Santa Brígida obteve em grau admirável para as filhas de sua terra natal, e jamais deixará de obtê-la para todos os seus devotos clientes.',
+    },
+  },
+  '02-02': {
+    name: {
+      'en-US': 'The Purification, Commonly Called Candlemas-Day',
+      'pt-BR': 'A Purificação, Comumente Chamada Dia de Candelária',
+    },
+    reflection: {
+      'en-US':
+        'Let us strive to imitate the humility of the ever-blessed Mother of God, remembering that humility is the path which leads to abiding peace and brings us near to the consolations of God.',
+      'pt-BR':
+        'Esforcemo-nos por imitar a humildade da sempre bendita Mãe de Deus, lembrando-nos de que a humildade é o caminho que conduz à paz permanente e nos aproxima das consolações de Deus.',
+    },
+  },
+  '02-03': {
+    name: { 'en-US': 'St. Blase, Bishop and Martyr', 'pt-BR': 'São Brás, Bispo e Mártir' },
+    reflection: {
+      'en-US':
+        'There is no sacrifice which, by the aid of grace, human nature is not capable of accomplishing. When St. Paul complained to God of the violence of the temptation, God answered, "My grace is sufficient for thee, for power is made perfect in infirmity."',
+      'pt-BR':
+        'Não há sacrifício que, com o auxílio da graça, a natureza humana não seja capaz de realizar. Quando São Paulo se queixou a Deus da violência da tentação, Deus respondeu: "A minha graça te basta, pois o poder se aperfeiçoa na fraqueza."',
+    },
+  },
+  '02-04': {
+    name: { 'en-US': 'St. Jane of Valois', 'pt-BR': 'Santa Joana de Valois' },
+    reflection: {
+      'en-US':
+        'During the lifetime of St. Jane, the Angelus was established in France. The sound of the thrice each day gave her hope in her sorrow, and fostered in her the desire still further to honor the Incarnation. How often might we derive grace from the same beautiful devotion, so enriched by the Church, yet neglected by so many Christians!',
+      'pt-BR':
+        'Durante a vida de Santa Joana, o Angelus foi instituído na França. O som das três vezes a cada dia dava-lhe esperança em sua dor, e fomentava nela o desejo de honrar ainda mais a Encarnação. Quantas vezes poderíamos haurir graça da mesma bela devoção, tão enriquecida pela Igreja, e contudo negligenciada por tantos cristãos!',
+    },
+  },
+  '02-05': {
+    name: {
+      'en-US': 'St. Agatha, Virgin, Martyr · The Martyrs of Japan',
+      'pt-BR': 'Santa Ágata, Virgem, Mártir · Os Mártires do Japão',
+    },
+    reflection: {
+      'en-US':
+        'Purity is a gift of God: we can gain it and preserve it only by care and diligence in avoiding all that may prove an incentive to sin.',
+      'pt-BR':
+        'A pureza é um dom de Deus: só podemos obtê-la e conservá-la pelo cuidado e pela diligência em evitar tudo o que possa ser um incentivo ao pecado.',
+    },
+  },
+  '02-06': {
+    name: { 'en-US': 'St. Dorothy, Virgin, Martyr', 'pt-BR': 'Santa Doroteia, Virgem, Mártir' },
+    reflection: {
+      'en-US':
+        'Do you wish to be safe in the pleasures and happy in the troubles of the world? Pray for heavenly desires, and say, with St. Philip, "Paradise, Paradise!"',
+      'pt-BR':
+        'Desejas estar seguro nos prazeres e feliz nas tribulações do mundo? Ora por desejos celestiais, e dize, com São Filipe: "Paraíso, Paraíso!"',
+    },
+  },
+  '02-07': {
+    name: { 'en-US': 'St. Romuald, Abbot', 'pt-BR': 'São Romualdo, Abade' },
+    reflection: {
+      'en-US':
+        "St. Romuald's life teaches us that, if we only follow the impulse of the Holy Spirit, we shall easily find good everywhere, even on the most unlikely occasions. Our own sins, the sins of others, their ill will against us, or our own mistakes and misfortunes, are equally capable of leading us, with softened hearts, to the feet of God's mercy and love.",
+      'pt-BR':
+        'A vida de São Romualdo nos ensina que, se apenas seguirmos o impulso do Espírito Santo, facilmente encontraremos o bem em toda parte, ainda nas ocasiões mais improváveis. Os nossos próprios pecados, os pecados dos outros, a má vontade deles para conosco, ou os nossos próprios erros e infortúnios, são igualmente capazes de conduzir-nos, com o coração abrandado, aos pés da misericórdia e do amor de Deus.',
+    },
+  },
+  '02-08': {
+    name: { 'en-US': 'St. John of Matha', 'pt-BR': 'São João de Matha' },
+    reflection: {
+      'en-US':
+        'Let us never forget that our blessed Lord bade us love our neighbor not only as ourselves, but as He loved us, Who afterwards sacrificed Himself for us.',
+      'pt-BR':
+        'Jamais nos esqueçamos de que o nosso bendito Senhor nos ordenou amar o próximo não somente como a nós mesmos, mas como Ele nos amou, Ele que depois Se sacrificou por nós.',
+    },
+  },
+  '02-09': {
+    name: {
+      'en-US': 'St. Apollonia and the Martyrs of Alexandria',
+      'pt-BR': 'Santa Apolônia e os Mártires de Alexandria',
+    },
+    reflection: {
+      'en-US':
+        'Many saints, who were not martyrs, have longed to shed their blood for Christ. We, too, may pray for some portion of their spirit; and the least suffering for the faith, borne with humility and courage, is the proof that Christ has heard our prayer.',
+      'pt-BR':
+        'Muitos santos, que não foram mártires, anelaram derramar o seu sangue por Cristo. Nós também podemos orar por alguma porção de seu espírito; e o menor sofrimento pela fé, suportado com humildade e coragem, é a prova de que Cristo ouviu a nossa oração.',
+    },
+  },
+  '02-10': {
+    name: { 'en-US': 'St. Scholastica, Abbess', 'pt-BR': 'Santa Escolástica, Abadessa' },
+    reflection: {
+      'en-US':
+        'Our relatives must be loved in and for God; otherwise the purest affection becomes inordinate and is so much taken from Him.',
+      'pt-BR':
+        'Os nossos parentes devem ser amados em Deus e por Deus; do contrário, o mais puro afeto torna-se desordenado e é, nessa medida, subtraído a Ele.',
+    },
+  },
+  '02-11': {
+    name: { 'en-US': 'St. Severinus, Abbot of Agaunum', 'pt-BR': 'São Severino, Abade de Agauno' },
+    reflection: {
+      'en-US':
+        'God loads with His favor those who delight in exercising mercy. "According to thy ability be merciful: if thou hast much, give abundantly; if thou hast little, take care even so to bestow willingly a little."',
+      'pt-BR':
+        'Deus cumula com o seu favor aqueles que se deleitam em exercer a misericórdia. "Conforme a tua possibilidade, sê misericordioso: se tens muito, dá abundantemente; se tens pouco, cuida ainda assim de dar de boa vontade um pouco."',
+    },
+  },
+  '02-12': {
+    name: { 'en-US': 'St. Benedict of Anian', 'pt-BR': 'São Bento de Aniane' },
+    reflection: {
+      'en-US':
+        'The decay of monastic discipline and its restoration by St. Benedict prove that none are safe from loss of fervor, but that all can regain it by fidelity to grace.',
+      'pt-BR':
+        'A decadência da disciplina monástica e a sua restauração por São Bento provam que ninguém está a salvo da perda do fervor, mas que todos o podem recobrar pela fidelidade à graça.',
+    },
+  },
+  '02-13': {
+    name: { 'en-US': 'St. Catherine of Ricci', 'pt-BR': 'Santa Catarina de Ricci' },
+    reflection: {
+      'en-US':
+        'If we truly love Jesus crucified, we must long, as did St. Catherine, to release the Holy Souls whom He has redeemed but has left to our charity to set free.',
+      'pt-BR':
+        'Se verdadeiramente amamos a Jesus crucificado, devemos ansiar, como Santa Catarina, por libertar as Santas Almas que Ele redimiu, mas que deixou à nossa caridade para que as ponhamos em liberdade.',
+    },
+  },
+  '02-14': {
+    name: {
+      'en-US': 'St. Valentine, Priest and Martyr',
+      'pt-BR': 'São Valentim, Sacerdote e Mártir',
+    },
+    reflection: {
+      'en-US':
+        'In the cause of justice and truth, prudence should not be held in account; otherwise prudence is mere human respect. St. Paul says: "The wisdom of the flesh is death."',
+      'pt-BR':
+        'Na causa da justiça e da verdade, a prudência não deve ser levada em conta; do contrário, a prudência é mero respeito humano. São Paulo diz: "A sabedoria da carne é morte."',
+    },
+  },
+  '02-15': {
+    name: {
+      'en-US': 'Sts. Faustinus and Jovita, Martyrs',
+      'pt-BR': 'São Faustino e São Jovita, Mártires',
+    },
+    reflection: {
+      'en-US':
+        'The spirit of Christ is a spirit of martyrdom—at least of mortification and penance. It is always the spirit of the cross. The more we share in the suffering life of Christ, the greater share we inherit in His spirit, and in the fruit of His death. To souls mortified to their senses and disengaged from earthly things, God gives frequent foretastes of the sweetness of eternal life, and the most ardent desires of possessing Him in His glory. This is the spirit of martyrdom, which entitles a Christian to a happy resurrection and to the bliss of the life to come.',
+      'pt-BR':
+        'O espírito de Cristo é um espírito de martírio — ao menos de mortificação e penitência. É sempre o espírito da cruz. Quanto mais participamos da vida sofredora de Cristo, maior parte herdamos do seu espírito e do fruto de sua morte. Às almas mortificadas para os seus sentidos e desprendidas das coisas terrenas, Deus dá frequentes antegostos da doçura da vida eterna e os mais ardentes desejos de possuí-Lo em sua glória. Este é o espírito de martírio, que dá ao cristão direito a uma feliz ressurreição e à bem-aventurança da vida vindoura.',
+    },
+  },
+  '02-16': {
+    name: {
+      'en-US': 'Blessed John de Britto, Martyr · St. Onesimus, Disciple of St. Paul',
+      'pt-BR': 'Beato João de Brito, Mártir · Santo Onésimo, Discípulo de São Paulo',
+    },
+    reflection: {
+      'en-US':
+        '"It is a great honor, a great glory to serve God, and to contemn all things for God. They will have a great grace who freely subject themselves to God\'s most holy will."—*The Imitation of Christ*.',
+      'pt-BR':
+        '"É uma grande honra, uma grande glória servir a Deus e desprezar todas as coisas por Deus. Terão uma grande graça os que livremente se submetem à santíssima vontade de Deus." — *A Imitação de Cristo*.',
+    },
+  },
+  '02-17': {
+    name: { 'en-US': 'St. Flavian, Bishop, Martyr', 'pt-BR': 'São Flaviano, Bispo, Mártir' },
+    reflection: {
+      'en-US':
+        "By his unswerving loyalty to the Vicar of Christ, Flavian held fast to the truth and gained the martyr's crown. Let us learn from him to turn instinctively to that one true guide in all matters concerning our salvation.",
+      'pt-BR':
+        'Por sua inabalável lealdade ao Vigário de Cristo, Flaviano apegou-se firmemente à verdade e ganhou a coroa do martírio. Aprendamos com ele a voltar-nos instintivamente para aquele único guia verdadeiro em todas as matérias concernentes à nossa salvação.',
+    },
+  },
+  '02-18': {
+    name: { 'en-US': 'St. Simeon, Bishop, Martyr', 'pt-BR': 'São Simeão, Bispo, Mártir' },
+    reflection: {
+      'en-US':
+        'We bear the name of Christians, but are full of the spirit of worldlings, and our actions are infected with the poison of the world. We secretly seek ourselves, even when we flatter ourselves that God is our only aim; and whilst we undertake to convert the world, we suffer it to pervert us. When shall we begin to study to crucify our passions and die to ourselves, that we may lay a solid foundation of true virtue and establish its reign in our hearts?',
+      'pt-BR':
+        'Trazemos o nome de cristãos, mas estamos cheios do espírito dos mundanos, e as nossas ações estão infectadas com o veneno do mundo. Buscamo-nos secretamente a nós mesmos, ainda quando nos lisonjeamos de que Deus é o nosso único fim; e enquanto empreendemos converter o mundo, deixamos que ele nos perverta. Quando começaremos a estudar como crucificar as nossas paixões e morrer para nós mesmos, a fim de lançarmos um sólido fundamento de verdadeira virtude e estabelecermos o seu reinado em nossos corações?',
+    },
+  },
+  '02-19': {
+    name: { 'en-US': 'St. Barbatus, Bishop', 'pt-BR': 'São Barbato, Bispo' },
+    reflection: {
+      'en-US':
+        'St. Augustine says: "When the enemy has been cast out of your hearts, renounce him, not only in word, but in work; not only by the sound of the lips, but in every act of your life."',
+      'pt-BR':
+        'Santo Agostinho diz: "Quando o inimigo houver sido expulso de vossos corações, renunciai-o, não somente em palavra, mas em obra; não somente pelo som dos lábios, mas em cada ato de vossa vida."',
+    },
+  },
+  '02-20': {
+    name: { 'en-US': 'St. Eucherius, Bishop', 'pt-BR': 'Santo Euquério, Bispo' },
+    reflection: {
+      'en-US':
+        'Nothing softens the soul and weakens piety so much as frivolous indulgence. God has revealed what high store He sets by "retirement" in these words: "I will lead her into solitude, and I will speak to her heart."',
+      'pt-BR':
+        'Nada amolece a alma e enfraquece a piedade tanto quanto a indulgência frívola. Deus revelou em quão alta conta tem o "retiro" nestas palavras: "Eu a levarei à solidão, e falarei ao seu coração."',
+    },
+  },
+  '02-21': {
+    name: { 'en-US': 'St. Severianus, Martyr, Bishop', 'pt-BR': 'São Severiano, Mártir, Bispo' },
+    reflection: {
+      'en-US':
+        'With what floods of tears can we sufficiently bewail so grievous a misfortune, and implore the divine mercy in behalf of so many souls! How ought we to be alarmed at the consideration of so many dreadful examples of God\'s inscrutable judgments, and tremble for ourselves! "Let him who stands beware lest he fall" "Hold fast what thou hast," says the oracle of the Holy Ghost to every one of us, "lest another bear away thy crown."',
+      'pt-BR':
+        'Com que torrentes de lágrimas poderemos lamentar suficientemente tão grave infortúnio, e implorar a divina misericórdia em favor de tantas almas! Como devemos alarmar-nos ante a consideração de tantos terríveis exemplos dos inescrutáveis juízos de Deus, e tremer por nós mesmos! "Aquele que está de pé acautele-se para que não caia." "Conserva firmemente o que tens", diz o oráculo do Espírito Santo a cada um de nós, "para que outro não leve a tua coroa."',
+    },
+  },
+  '02-22': {
+    name: {
+      'en-US': "St. Peter's Chair at Antioch",
+      'pt-BR': 'A Cátedra de São Pedro em Antioquia',
+    },
+    reflection: {
+      'en-US':
+        'On this festival we are especially bound to adore and thank the Divine Goodness for the establishment and propagation of His Church, and earnestly to pray that in His mercy He preserve the same, and dilate its pale, that His name may be glorified by all nations, and by all hearts, to the boundaries of the earth, for His divine honor and the salvation of souls, framed to His divine image, and the price of His adorable blood.',
+      'pt-BR':
+        'Nesta festividade estamos especialmente obrigados a adorar e a agradecer à Divina Bondade pelo estabelecimento e propagação de Sua Igreja, e a rogar fervorosamente que em Sua misericórdia a preserve, e dilate seus limites, para que Seu nome seja glorificado por todas as nações, e por todos os corações, até os confins da terra, para Sua divina honra e a salvação das almas, formadas à Sua divina imagem, e preço de Seu adorável sangue.',
+    },
+  },
+  '02-23': {
+    name: {
+      'en-US': 'St. Peter Damian · St. Serenus, a Gardener, Martyr',
+      'pt-BR': 'São Pedro Damião · São Sereno, um Jardineiro, Mártir',
+    },
+    reflection: {
+      'en-US':
+        'The Saints studied, not in order to be accounted learned, but to become perfect. This only is wisdom and true greatness, to account ourselves as ignorant, and to adhere in all things to the teachings and instincts of the Church.',
+      'pt-BR':
+        'Os Santos estudavam, não para serem tidos por eruditos, mas para se tornarem perfeitos. Esta é a única sabedoria e a verdadeira grandeza: considerarmo-nos ignorantes, e aderir em todas as coisas aos ensinamentos e instintos da Igreja.',
+    },
+  },
+  '02-24': {
+    name: { 'en-US': 'St. Matthias, Apostle', 'pt-BR': 'São Matias, Apóstolo' },
+    reflection: {
+      'en-US':
+        "Our ignorance of many points in St. Matthias's life serves to fix the attention all the more firmly upon these two—the occasion of his call to the apostolate, and the fact of his perseverance. We then naturally turn in thought to our own vocation and our own end.",
+      'pt-BR':
+        'Nossa ignorância de muitos pontos da vida de São Matias serve para fixar a atenção tanto mais firmemente sobre estes dois — a ocasião de seu chamado ao apostolado, e o fato de sua perseverança. Voltamo-nos então naturalmente em pensamento para a nossa própria vocação e o nosso próprio fim.',
+    },
+  },
+  '02-25': {
+    name: { 'en-US': 'St. Tarasius', 'pt-BR': 'São Tarásio' },
+    reflection: {
+      'en-US':
+        'The highest praise which Scripture pronounces on the holy man Job is comprised in these words, "He was simple and upright."',
+      'pt-BR':
+        'O mais alto louvor que a Escritura pronuncia sobre o santo homem Jó está contido nestas palavras: "Era simples e reto."',
+    },
+  },
+  '02-26': {
+    name: { 'en-US': 'St. Porphyry, Bishop', 'pt-BR': 'São Porfírio, Bispo' },
+    reflection: {
+      'en-US':
+        'All superstitious searching into secret things is forbidden by the First Commandment equally with the worship of any false god. Let us ask St. Porphyry for a great zeal in keeping this commandment, lest we be led away, as so many are, by a curious and prying mind.',
+      'pt-BR':
+        'Toda indagação supersticiosa de coisas ocultas é proibida pelo Primeiro Mandamento igualmente com o culto de qualquer falso deus. Peçamos a São Porfírio um grande zelo em guardar este mandamento, para que não sejamos desviados, como tantos o são, por uma mente curiosa e indiscreta.',
+    },
+  },
+  '02-27': {
+    name: { 'en-US': 'St. Leander, Bishop', 'pt-BR': 'São Leandro, Bispo' },
+  },
+  '02-28': {
+    name: {
+      'en-US': 'Sts. Romanus and Lupicinus, Abbots',
+      'pt-BR': 'São Romano e São Lupicino, Abades',
+    },
+  },
+  '02-29': {
+    name: { 'en-US': 'St. Oswald, Bishop', 'pt-BR': 'Santo Osvaldo, Bispo' },
+    reflection: {
+      'en-US':
+        'A soul without discipline is like a ship without a helm; she must inevitably strike unawares upon the rocks, founder on the shoals, or float unknowingly into the harbor of the enemy.',
+      'pt-BR':
+        'Uma alma sem disciplina é como um navio sem leme; ela inevitavelmente há de chocar-se de improviso contra os rochedos, naufragar nos baixios, ou flutuar sem o saber para o porto do inimigo.',
+    },
+  },
+  '03-01': {
+    name: {
+      'en-US': 'St. David, Bishop · St. Albinus, Bishop',
+      'pt-BR': 'São David, Bispo · Santo Albino, Bispo',
+    },
+    reflection: {
+      'en-US':
+        'With whatever virtues a man may be endowed, he will discover, if he considers himself attentively, a sufficient depth of misery to afford cause for deep humility; but Jesus Christ says, "He that humbleth himself shall be exalted."',
+      'pt-BR':
+        'Com quaisquer virtudes que um homem possa estar dotado, ele descobrirá, se se considerar atentamente, profundidade suficiente de miséria para fornecer causa de profunda humildade; mas Jesus Cristo diz: "Aquele que se humilha será exaltado."',
+    },
+  },
+  '03-02': {
+    name: { 'en-US': 'St. Simplicius, Pope', 'pt-BR': 'São Simplício, Papa' },
+    reflection: {
+      'en-US':
+        '"He that trusteth in God shall fare never the worse," saith the Wise Man in the Book of Ecclesiasticus.',
+      'pt-BR':
+        '"Aquele que confia em Deus jamais terá pior sorte", diz o Sábio no Livro do Eclesiástico.',
+    },
+  },
+  '03-03': {
+    name: { 'en-US': 'St. Cunegundes, Empress', 'pt-BR': 'Santa Cunegundes, Imperatriz' },
+    reflection: {
+      'en-US':
+        'Detachment of the mind, at least, is needful to those who cannot venture on an effectual renunciation. "So likewise every one of you," saith Jesus Christ, "that doth not renounce all that he possesseth, cannot be My disciple."',
+      'pt-BR':
+        'O desapego do espírito, ao menos, é necessário àqueles que não podem aventurar-se a uma renúncia efetiva. "Assim, pois, qualquer um de vós", diz Jesus Cristo, "que não renuncia a tudo o que possui, não pode ser meu discípulo."',
+    },
+  },
+  '03-04': {
+    name: { 'en-US': 'St. Casimir, King', 'pt-BR': 'São Casimiro, Rei' },
+    reflection: {
+      'en-US':
+        "Let the study of St. Casimir's life make us increase in devotion to the most pure Mother of God—a sure means of preserving holy purity.",
+      'pt-BR':
+        'Que o estudo da vida de São Casimiro nos faça crescer na devoção à puríssima Mãe de Deus — meio seguro de preservar a santa pureza.',
+    },
+  },
+  '03-05': {
+    name: {
+      'en-US': 'Sts. Adrian and Eubulus, Martyrs',
+      'pt-BR': 'Santo Adrião e Santo Êubulo, Mártires',
+    },
+    reflection: {
+      'en-US':
+        'It is in vain that we take the name of Christians, or pretend to follow Christ, unless we carry our crosses after Him. It is in vain that we hope to share in His glory, and in His kingdom, if we accept not the condition. We cannot arrive at heaven by any other road but that which Christ held, Who bequeathed His cross to all His elect as their portion and inheritance in this world.',
+      'pt-BR':
+        'É em vão que tomamos o nome de cristãos, ou pretendemos seguir a Cristo, a não ser que levemos as nossas cruzes após Ele. É em vão que esperamos partilhar de sua glória e de seu reino, se não aceitamos a condição. Não podemos chegar ao céu por outra estrada senão aquela que Cristo trilhou, o qual legou a sua cruz a todos os seus eleitos como sua porção e herança neste mundo.',
+    },
+  },
+  '03-06': {
+    name: { 'en-US': 'St. Colette, Virgin', 'pt-BR': 'Santa Coleta, Virgem' },
+    reflection: {
+      'en-US':
+        "One of the greatest tests of being a good Catholic is zeal for the Church and, devotion to Christ's Vicar.",
+      'pt-BR':
+        'Uma das maiores provas de ser um bom católico é o zelo pela Igreja e a devoção ao Vigário de Cristo.',
+    },
+  },
+  '03-07': {
+    name: { 'en-US': 'St. Thomas Aquinas', 'pt-BR': 'São Tomás de Aquino' },
+    reflection: {
+      'en-US':
+        'The knowledge of God is for all, but hidden treasures are reserved for those who have ever followed the Lamb.',
+      'pt-BR':
+        'O conhecimento de Deus é para todos, mas tesouros ocultos estão reservados para aqueles que sempre seguiram o Cordeiro.',
+    },
+  },
+  '03-08': {
+    name: { 'en-US': 'St. John of God', 'pt-BR': 'São João de Deus' },
+    reflection: {
+      'en-US':
+        'God often rewards men for works that are pleasing in His sight by giving them grace and opportunity to do other works higher still. St. John of God used to attribute his conversion, and the graces which enabled him to do such great works, to his self-denying charity in Africa.',
+      'pt-BR':
+        'Deus muitas vezes recompensa os homens pelas obras que lhe são agradáveis dando-lhes graça e oportunidade de fazer outras obras ainda mais elevadas. São João de Deus costumava atribuir a sua conversão, e as graças que o capacitaram a fazer obras tão grandes, à sua caridade abnegada na África.',
+    },
+  },
+  '03-09': {
+    name: { 'en-US': 'St. Frances of Rome', 'pt-BR': 'Santa Francisca Romana' },
+    reflection: {
+      'en-US':
+        'God has appointed an angel to guard each one of us, to whose warnings we are bound to attend. Let us listen to his voice here, and we shall see him hereafter when he leads us before the throne of God.',
+      'pt-BR':
+        'Deus designou um anjo para guardar a cada um de nós, a cujas advertências estamos obrigados a atender. Ouçamos a sua voz aqui, e o veremos no porvir, quando ele nos conduzir diante do trono de Deus.',
+    },
+  },
+  '03-10': {
+    name: { 'en-US': 'The Forty Martyrs of Sebaste', 'pt-BR': 'Os Quarenta Mártires de Sebaste' },
+    reflection: {
+      'en-US':
+        'All who live the life of grace are one in Christ. But besides this there are many specialties—of religion, of community life, or at least of aspirations in prayer, and pious works. Thank God if He has bound you to others by these spiritual ties; remember the character you have to support, and pray that the bond which unites you here may last for eternity.',
+      'pt-BR':
+        'Todos os que vivem a vida da graça são um só em Cristo. Mas, além disto, há muitas particularidades — de religião, de vida em comunidade, ou ao menos de aspirações na oração e nas obras piedosas. Dai graças a Deus se Ele vos uniu a outros por esses laços espirituais; lembrai-vos do papel que tendes a sustentar, e orai para que o vínculo que vos une aqui possa durar pela eternidade.',
+    },
+  },
+  '03-11': {
+    name: { 'en-US': 'St. Eulogius, Martyr', 'pt-BR': 'Santo Eulógio, Mártir' },
+    reflection: {
+      'en-US':
+        'Beg of God, through the intercession of these holy martyrs, the gift of perseverance. Their example will supply you with an admirable rule for obtaining this crowning gift. Remember that you have renounced the world and the devil once for all at your Baptism. Do not hesitate; do not look back; do not listen to suggestions against faith or virtue; but advance, day by day, along the road which you have chosen, to God Who is your portion forever.',
+      'pt-BR':
+        'Pedi a Deus, pela intercessão destes santos mártires, o dom da perseverança. O exemplo deles vos fornecerá uma admirável regra para obter este dom que tudo coroa. Lembrai-vos de que renunciastes ao mundo e ao demônio de uma vez por todas no vosso Batismo. Não hesiteis; não olheis para trás; não escuteis sugestões contra a fé ou a virtude; mas avançai, dia após dia, pela estrada que escolhestes, para Deus, que é a vossa porção para sempre.',
+    },
+  },
+  '03-12': {
+    name: { 'en-US': 'St. Gregory the Great', 'pt-BR': 'São Gregório Magno' },
+    reflection: {
+      'en-US':
+        'The champions of faith prove the truth of their teaching no less by the holiness of their lives than by the force of their arguments. Never forget that to convert others you must first see to your own soul.',
+      'pt-BR':
+        'Os campeões da fé provam a verdade do seu ensino não menos pela santidade de suas vidas do que pela força de seus argumentos. Nunca esqueçais que, para converter os outros, deveis primeiro cuidar de vossa própria alma.',
+    },
+  },
+  '03-13': {
+    name: { 'en-US': 'St. Euphrasia, Virgin', 'pt-BR': 'Santa Eufrásia, Virgem' },
+  },
+  '03-14': {
+    name: { 'en-US': 'St. Maud. Queen', 'pt-BR': 'Santa Maud, Rainha' },
+    reflection: {
+      'en-US':
+        'The beginning of true virtue is most ardently to desire it, and to ask it of God with the utmost assiduity and earnestness. Fervent prayer, holy meditation, and reading pious books, are the principal means by which this virtue is to be constantly improved, and the interior life of the soul to be strengthened.',
+      'pt-BR':
+        'O princípio da verdadeira virtude é desejá-la com o maior ardor, e pedi-la a Deus com a máxima assiduidade e seriedade. A oração fervorosa, a santa meditação e a leitura de livros piedosos são os principais meios pelos quais esta virtude há de ser constantemente aperfeiçoada, e a vida interior da alma fortalecida.',
+    },
+  },
+  '03-15': {
+    name: { 'en-US': 'St. Zachary, Pope', 'pt-BR': 'São Zacarias, Papa' },
+  },
+  '03-16': {
+    name: { 'en-US': 'Sts. Abraham and Mary', 'pt-BR': 'Santo Abraão e Santa Maria' },
+    reflection: {
+      'en-US':
+        "Oh, that we realized the omnipotence of prayer! Every soul was created to glorify God eternally; and it is in the power of every one to add by the salvation of his neighbor to the glory of God. Let us make good use of this talent of prayer, lest our brother's blood be required of us at the last.",
+      'pt-BR':
+        'Oh, se compreendêssemos a onipotência da oração! Cada alma foi criada para glorificar a Deus eternamente; e está no poder de cada um acrescentar, pela salvação do próximo, à glória de Deus. Façamos bom uso deste talento da oração, para que o sangue de nosso irmão não nos seja pedido no último dia.',
+    },
+  },
+  '03-17': {
+    name: {
+      'en-US': 'St. Patrick, Bishop, Apostle of Ireland',
+      'pt-BR': 'São Patrício, Bispo, Apóstolo da Irlanda',
+    },
+    reflection: {
+      'en-US':
+        'By the instrumentality of St. Patrick the Faith is now as fresh in Ireland, even in this cold nineteenth century, as when it was first planted. Ask him to obtain for you the special grace of his children—to prefer the loss of every earthly good to the least compromise in matters of faith.',
+      'pt-BR':
+        'Pela instrumentalidade de São Patrício, a Fé está hoje tão viva na Irlanda, mesmo neste frio século dezenove, como quando foi plantada pela primeira vez. Pedi-lhe que vos obtenha a graça especial de seus filhos — preferir a perda de todo bem terreno ao menor compromisso em matéria de fé.',
+    },
+  },
+  '03-18': {
+    name: { 'en-US': 'St. Cyril of Jerusalem', 'pt-BR': 'São Cirilo de Jerusalém' },
+    reflection: {
+      'en-US':
+        '"As a stout staff," says St. John Chrysostom, "supports the trembling limbs of a feeble old man, so does faith sustain our vacillating mind, lest it be tossed about by sinful hesitation and perplexity."',
+      'pt-BR':
+        '"Como um robusto bordão", diz São João Crisóstomo, "sustenta os membros trêmulos de um velho débil, assim a fé sustenta a nossa mente vacilante, para que não seja sacudida pela hesitação e a perplexidade pecaminosas."',
+    },
+  },
+  '03-19': {
+    name: {
+      'en-US': 'St. Joseph, Spouse of the Blessed Virgin and Patron of the Universal Church',
+      'pt-BR': 'São José, Esposo da Santíssima Virgem e Patrono da Igreja Universal',
+    },
+    reflection: {
+      'en-US':
+        'St. Joseph, the shadow of the Eternal Father upon earth, the protector of Jesus in His home at Nazareth, and a lover of all children for the sake of the Holy Child, should be the chosen guardian and pattern of every true Christian family.',
+      'pt-BR':
+        'São José, a sombra do Pai Eterno sobre a terra, o protetor de Jesus em Seu lar em Nazaré, e amante de todas as crianças pelo amor do Santo Menino, deve ser o guardião e modelo escolhido de toda verdadeira família cristã.',
+    },
+  },
+  '03-20': {
+    name: { 'en-US': 'St. Wulfran, Archbishop', 'pt-BR': 'São Wulfrano, Arcebispo' },
+    reflection: {
+      'en-US':
+        'In every age the Catholic Church is a missionary church. She has received the world for her inheritance, and in our own days many missioners have watered with their blood the lands in which they labored. Help the propagation of the faith by alms, and above all by prayers. You will quicken your own faith and gain a part in the merits of the glorious apostolate.',
+      'pt-BR':
+        'Em toda época, a Igreja Católica é uma igreja missionária. Recebeu o mundo por sua herança, e em nossos próprios dias muitos missionários regaram com seu sangue as terras em que labutaram. Auxiliai a propagação da fé com esmolas, e acima de tudo com orações. Avivareis a vossa própria fé e ganhareis parte nos méritos do glorioso apostolado.',
+    },
+  },
+  '03-21': {
+    name: { 'en-US': 'St. Benedict, Abbot', 'pt-BR': 'São Bento, Abade' },
+    reflection: {
+      'en-US':
+        'The Saints never feared to undertake any work, however arduous, for God, because, distrusting self, they relied for assistance and support wholly upon prayer.',
+      'pt-BR':
+        'Os Santos nunca temeram empreender obra alguma, por mais árdua que fosse, por Deus, porque, desconfiando de si mesmos, confiavam para o auxílio e o sustento inteiramente na oração.',
+    },
+  },
+  '03-22': {
+    name: {
+      'en-US': 'St. Catharine of Sweden, Virgin',
+      'pt-BR': 'Santa Catarina da Suécia, Virgem',
+    },
+    reflection: {
+      'en-US':
+        'Whoever has to dwell in the world stands in need of great prudence; the Holy Scripture itself assures us that "the knowledge of the holy is prudence."',
+      'pt-BR':
+        'Quem quer que tenha de habitar no mundo necessita de grande prudência; a própria Sagrada Escritura assegura-nos que "a ciência do santo é prudência."',
+    },
+  },
+  '03-23': {
+    name: {
+      'en-US': 'Sts. Victorian and Others, Martyrs',
+      'pt-BR': 'Santos Vitoriano e Outros, Mártires',
+    },
+  },
+  '03-24': {
+    name: { 'en-US': 'St. Simon, Infant Martyr', 'pt-BR': 'São Simão, Mártir Infante' },
+    reflection: {
+      'en-US':
+        "Learn from the infant martyrs that, however weak you may be, you still can suffer for Christ's sake.",
+      'pt-BR':
+        'Aprendei dos mártires infantes que, por mais fracos que sejais, podeis ainda sofrer por amor de Cristo.',
+    },
+  },
+  '03-25': {
+    name: {
+      'en-US': 'The Annunciation of the Blessed Virgin Mary',
+      'pt-BR': 'A Anunciação da Santíssima Virgem Maria',
+    },
+    reflection: {
+      'en-US':
+        'From the example of the Blessed Virgin in this mystery, how ardent a love ought we to conceive of purity and humility! The Holy Ghost is invited by purity to dwell in souls, but is chased away by the filth of the contrary vice. Humility is the foundation of a spiritual life. By it Mary was prepared for the extraordinary graces and all virtues with which she was enriched, and for the eminent dignity of Mother of God.',
+      'pt-BR':
+        'Do exemplo da Santíssima Virgem neste mistério, quão ardente amor devemos conceber pela pureza e pela humildade! O Espírito Santo é convidado pela pureza a habitar nas almas, mas é expulso pela imundície do vício contrário. A humildade é o fundamento da vida espiritual. Por ela foi Maria preparada para as graças extraordinárias e todas as virtudes com que foi enriquecida, e para a eminente dignidade de Mãe de Deus.',
+    },
+  },
+  '03-26': {
+    name: { 'en-US': 'St. Ludger, Bishop', 'pt-BR': 'São Ludgero, Bispo' },
+    reflection: {
+      'en-US':
+        'Prayer is an action so sublime and supernatural that the Church in her Canonical Hours teaches us to begin it by a fervent petition of grace to perform it well. What an insolence and mockery is it to join with this petition an open disrespect and a neglect of all necessary precautions against distractions! We ought never to appear before God, to tender Him our homages or supplications, without trembling, and without being deaf to all creatures and shutting all our senses to every object that can distract our minds from God.',
+      'pt-BR':
+        'A oração é uma ação tão sublime e sobrenatural que a Igreja, em suas Horas Canônicas, ensina-nos a iniciá-la com uma fervorosa petição de graça para realizá-la bem. Que insolência e zombaria é juntar a esta petição um desrespeito manifesto e a negligência de todas as precauções necessárias contra as distrações! Jamais deveríamos comparecer diante de Deus, para Lhe render nossas homenagens ou súplicas, sem tremor, e sem estar surdos a todas as criaturas e fechar todos os nossos sentidos a todo objeto que possa distrair nossas mentes de Deus.',
+    },
+  },
+  '03-27': {
+    name: { 'en-US': 'St. John of Egypt', 'pt-BR': 'São João do Egito' },
+    reflection: {
+      'en-US':
+        'The Saints examine themselves by the perfections of God, and do penance. We judge our conduct by the standard of other men, and rest satisfied with it. Yet it is by the divine holiness alone that we shall be judged when we die.',
+      'pt-BR':
+        'Os Santos examinam-se à luz das perfeições de Deus, e fazem penitência. Nós julgamos nossa conduta pelo padrão dos outros homens, e ficamos satisfeitos com ela. Contudo, é unicamente pela santidade divina que seremos julgados quando morrermos.',
+    },
+  },
+  '03-28': {
+    name: { 'en-US': 'St. Gontran, King', 'pt-BR': 'São Gontrão, Rei' },
+    reflection: {
+      'en-US':
+        'There is no means of salvation more reliable than the practice of mercy, since Our Lord has said it: "Blessed are the merciful, for they shall find mercy."',
+      'pt-BR':
+        'Não há meio de salvação mais seguro do que a prática da misericórdia, pois Nosso Senhor o disse: "Bem-aventurados os misericordiosos, porque alcançarão misericórdia."',
+    },
+  },
+  '03-29': {
+    name: {
+      'en-US': 'Sts. Jonas, Barachisius, and their Companions, Martyrs',
+      'pt-BR': 'São Jonas, São Baraquísio e seus Companheiros, Mártires',
+    },
+    reflection: {
+      'en-US':
+        'Those powerful motives which supported the martyrs under the sharpest torments ought to inspire us with patience, resignation, and holy joy under sickness and all crosses or trials. Nothing is more heroic in the practice of Christian virtue, nothing more precious in the sight of God, than the sacrifice of patience, submission, constant fidelity, and charity in a state of suffering.',
+      'pt-BR':
+        'Aqueles poderosos motivos que sustentaram os mártires sob os mais agudos tormentos devem inspirar-nos paciência, resignação e santa alegria na enfermidade e em todas as cruzes ou provações. Nada é mais heroico na prática da virtude cristã, nada mais precioso aos olhos de Deus, do que o sacrifício da paciência, da submissão, da constante fidelidade e da caridade num estado de sofrimento.',
+    },
+  },
+  '03-30': {
+    name: { 'en-US': 'St. John Climacus', 'pt-BR': 'São João Clímaco' },
+    reflection: {
+      'en-US':
+        '"Cast not from thee, my brother," says the *Imitation of Christ*," the sure hope of attaining to the spiritual life; still hast thou the time and the means."',
+      'pt-BR':
+        '"Não afastes de ti, meu irmão", diz a *Imitação de Cristo*, "a segura esperança de alcançar a vida espiritual; ainda tens o tempo e os meios."',
+    },
+  },
+  '03-31': {
+    name: { 'en-US': 'St. Benjamin, Deacon, Martyr', 'pt-BR': 'São Benjamim, Diácono, Mártir' },
+    reflection: {
+      'en-US':
+        'We entreat you, O most holy martyrs, who cheerfully suffered most cruel torments for God our Saviour and His love, on which account you are now most intimately and familiarly united to Him, that you pray to the Lord for us miserable sinners, covered with filth, that He infuse into us the grace of Christ, that it may enlighten our souls that we may love Him.',
+      'pt-BR':
+        'Suplicamos-vos, ó santíssimos mártires, que alegremente sofrestes os mais cruéis tormentos por Deus nosso Salvador e por Seu amor, motivo pelo qual estais agora mui íntima e familiarmente unidos a Ele, que rogueis ao Senhor por nós, miseráveis pecadores, cobertos de imundície, para que Ele infunda em nós a graça de Cristo, a fim de que ela ilumine nossas almas para que O amemos.',
+    },
+  },
+  '04-01': {
+    name: { 'en-US': 'St. Hugh, Bishop', 'pt-BR': 'Santo Hugo, Bispo' },
+    reflection: {
+      'en-US':
+        'Let us learn from the example of the Saints to shun the tumult of the world as much as our circumstances will allow, and give ourselves up to the exercises of holy solitude, prayer, and pious reading.',
+      'pt-BR':
+        'Aprendamos com o exemplo dos Santos a fugir do tumulto do mundo tanto quanto nossas circunstâncias o permitam, e a entregar-nos aos exercícios da santa solidão, da oração e da leitura piedosa.',
+    },
+  },
+  '04-02': {
+    name: { 'en-US': 'St. Francis of Paula', 'pt-BR': 'São Francisco de Paula' },
+    reflection: {
+      'en-US':
+        'Rely in all difficulties upon God. That which enabled St. Francis to work miracles will in proportion do wonders for yourself, by giving you strength and consolation.',
+      'pt-BR':
+        'Confia em todas as dificuldades em Deus. Aquilo que capacitou São Francisco a operar milagres fará, na devida proporção, maravilhas por ti mesmo, dando-te força e consolação.',
+    },
+  },
+  '04-03': {
+    name: { 'en-US': 'St. Richard of Chichester', 'pt-BR': 'São Ricardo de Chichester' },
+    reflection: {
+      'en-US':
+        'As a brother, as chancellor, and as bishop, St. Richard faithfully performed each duty of his state without a thought of his own interests. Neglect of duty is the first sign of that self-love which ends with the loss of grace.',
+      'pt-BR':
+        'Como irmão, como chanceler e como bispo, São Ricardo cumpriu fielmente cada dever de seu estado sem um pensamento sequer em seus próprios interesses. A negligência do dever é o primeiro sinal daquele amor-próprio que termina com a perda da graça.',
+    },
+  },
+  '04-04': {
+    name: { 'en-US': 'St. Isidore, Archbishop', 'pt-BR': 'Santo Isidoro, Arcebispo' },
+    reflection: {
+      'en-US':
+        'The strength of temptation usually lies in the fact that its object is something flattering to our pride, soothing to our sloth, or in some way attractive to the meaner passions. St. Isidore teaches us to listen neither to the promptings of nature nor the plausible advice of friends when they contradict the voice of God.',
+      'pt-BR':
+        'A força da tentação reside geralmente no fato de que seu objeto é algo lisonjeiro ao nosso orgulho, suavizante à nossa preguiça, ou de algum modo atraente às paixões mais baixas. Santo Isidoro ensina-nos a não escutar nem os impulsos da natureza nem o plausível conselho dos amigos, quando contradizem a voz de Deus.',
+    },
+  },
+  '04-05': {
+    name: { 'en-US': 'St. Vincent Ferrer', 'pt-BR': 'São Vicente Ferrer' },
+    reflection: {
+      'en-US':
+        '"Whatever you do," said St. Vincent, "think not of yourself, but of God." In this spirit he preached, and God spoke by him; in this spirit, if we listen, we shall hear the voice of God.',
+      'pt-BR':
+        '"Faças o que fizeres", dizia São Vicente, "não penses em ti mesmo, mas em Deus." Neste espírito ele pregava, e Deus falava por ele; neste espírito, se escutarmos, ouviremos a voz de Deus.',
+    },
+  },
+  '04-06': {
+    name: { 'en-US': 'St. Celestine, Pope', 'pt-BR': 'São Celestino, Papa' },
+    reflection: {
+      'en-US':
+        'Vigilance is truly needful to those to whom the care of souls has been confided. "Blessed are the servants whom the Lord at His coming shall find watching."',
+      'pt-BR':
+        'A vigilância é verdadeiramente necessária àqueles a quem foi confiado o cuidado das almas. "Bem-aventurados os servos que o Senhor, ao chegar, encontrar vigilantes."',
+    },
+  },
+  '04-07': {
+    name: {
+      'en-US': 'St. Hegesippus, a Primitive Father · Blessed Herman Joseph of Steinfeld',
+      'pt-BR': 'São Hegésipo, um Padre Primitivo · Beato Hermano José de Steinfeld',
+    },
+    reflection: {
+      'en-US':
+        'Do not approach our Blessed Mother with set prayers only. Be intimate with her; confide in her; commend to her every want and every project, small as well as great. It is a childlike reliance and a trustful appeal which she delights to reward.',
+      'pt-BR':
+        'Não te aproximes de nossa Mãe bendita somente com orações decoradas. Sê íntimo dela; confia nela; recomenda-lhe toda necessidade e todo projeto, tanto os pequenos quanto os grandes. É uma confiança de criança e um apelo cheio de fé que ela se compraz em recompensar.',
+    },
+  },
+  '04-08': {
+    name: { 'en-US': 'St. Perpetuus, Bishop', 'pt-BR': 'São Perpétuo, Bispo' },
+    reflection: {
+      'en-US':
+        'The smart of poverty, says a spiritual writer, is allayed even more by one word of true sympathy than by the alms we give. Alms coldly and harshly given irritate rather than soothe. Even when we cannot give, words of kindness are as a precious balm; and when we can give, they are the salt and seasoning of our alms.',
+      'pt-BR':
+        'A dor da pobreza, diz um escritor espiritual, é aliviada mais ainda por uma palavra de verdadeira simpatia do que pela esmola que damos. A esmola dada com frieza e aspereza irrita em vez de aliviar. Mesmo quando não podemos dar, as palavras de bondade são como um bálsamo precioso; e quando podemos dar, são elas o sal e o tempero de nossas esmolas.',
+    },
+  },
+  '04-09': {
+    name: {
+      'en-US': 'St. Mary of Egypt · St. John the Almoner',
+      'pt-BR': 'Santa Maria Egipcíaca · São João, o Esmoler',
+    },
+    reflection: {
+      'en-US':
+        "Blessed John Colombini was converted to God by reading St. Mary's life. Let us, too, learn from her not to be content with confessing and lamenting our sins, but to fly from what leads us to commit them.",
+      'pt-BR':
+        'O Beato João Colombini converteu-se a Deus lendo a vida de Santa Maria. Aprendamos nós também com ela a não nos contentarmos com confessar e lamentar os nossos pecados, mas a fugir daquilo que nos leva a cometê-los.',
+    },
+  },
+  '04-10': {
+    name: { 'en-US': 'St. Bademus, Martyr', 'pt-BR': 'São Bademo, Mártir' },
+    reflection: {
+      'en-US':
+        'Oh! what ravishing delights does the soul taste which is accustomed, by a familiar habit, to converse in the heaven of its own interior with the Three Persons of the adorable Trinity! Worldlings wonder how holy solitaries can pass their whole time buried in the most profound solitude and silence. But those who have had any experience of this happiness are surprised, with far greater reason, how it is possible that any souls which are created to converse eternally with God should here live in constant dissipation, seldom entertaining a devout thought of Him Whose charms and sweet conversation eternally ravish all the blessed.',
+      'pt-BR':
+        'Oh! que arrebatadoras delícias prova a alma que está acostumada, por um hábito familiar, a conversar no céu de seu próprio interior com as Três Pessoas da adorável Trindade! Os mundanos admiram-se de como os santos solitários podem passar todo o seu tempo sepultados na mais profunda solidão e silêncio. Mas aqueles que tiveram alguma experiência desta felicidade espantam-se, com razão muito maior, de como é possível que quaisquer almas, que foram criadas para conversar eternamente com Deus, vivam aqui em constante dissipação, raramente acolhendo um pensamento devoto Daquele cujos encantos e doce conversa eternamente arrebatam todos os bem-aventurados.',
+    },
+  },
+  '04-11': {
+    name: { 'en-US': 'St. Leo the Great', 'pt-BR': 'São Leão Magno' },
+    reflection: {
+      'en-US':
+        'Leo loved to ascribe all the fruits of his unsparing labors to the glorious chief of the apostles, who, he often declared, lives and governs in his successors.',
+      'pt-BR':
+        'Leão amava atribuir todos os frutos de seus incansáveis trabalhos ao glorioso chefe dos apóstolos, que, segundo muitas vezes declarava, vive e governa em seus sucessores.',
+    },
+  },
+  '04-12': {
+    name: { 'en-US': 'St. Julius, Pope', 'pt-BR': 'São Júlio, Papa' },
+  },
+  '04-13': {
+    name: { 'en-US': 'St. Hermenegild, Martyr', 'pt-BR': 'São Hermenegildo, Mártir' },
+    reflection: {
+      'en-US':
+        'St. Hermenegild teaches us that constancy and sacrifice are the best arguments for the Faith, and the surest way to win souls to God.',
+      'pt-BR':
+        'São Hermenegildo nos ensina que a constância e o sacrifício são os melhores argumentos pela Fé, e o caminho mais seguro para ganhar almas para Deus.',
+    },
+  },
+  '04-14': {
+    name: { 'en-US': 'St. Benezet, or Little Bennet', 'pt-BR': 'São Benezet, ou o Pequeno Bennet' },
+    reflection: {
+      'en-US':
+        'Let us pray for perseverance in good works. St. Augustine says, "When the Saints pray in the words which Christ taught, they ask for little else than the gift of perseverance."',
+      'pt-BR':
+        'Oremos pela perseverança nas boas obras. Santo Agostinho diz: "Quando os Santos oram com as palavras que Cristo ensinou, pouco mais pedem do que o dom da perseverança."',
+    },
+  },
+  '04-15': {
+    name: { 'en-US': 'St. Paternus, Bishop', 'pt-BR': 'São Paterno, Bispo' },
+    reflection: {
+      'en-US':
+        'The greatest sacrifices imposed by the love of peace will appear as naught if we call to mind the example of Our Saviour, and remember His words, "Blessed are the peacemakers, for they shall be called the children of God."',
+      'pt-BR':
+        'Os maiores sacrifícios impostos pelo amor da paz parecerão coisa nenhuma se chamarmos à memória o exemplo de Nosso Salvador, e nos lembrarmos de Suas palavras: "Bem-aventurados os pacíficos, porque serão chamados filhos de Deus."',
+    },
+  },
+  '04-16': {
+    name: {
+      'en-US': 'Eighteen Martyrs of Saragossa, and St. Encratis, or Engratia, Virgin, Martyr',
+      'pt-BR': 'Dezoito Mártires de Saragoça, e Santa Êncratis, ou Engrácia, Virgem, Mártir',
+    },
+    reflection: {
+      'en-US':
+        'Men do not pursue temporal goods at haphazard, or by fits and starts. Let us be as punctual and orderly in the service of God, not casting about for new paths, but perfecting our ordinary devotions. If we persevere in these, Paradise is ours.',
+      'pt-BR':
+        'Os homens não buscam os bens temporais ao acaso, nem por arrancos. Sejamos igualmente pontuais e ordenados no serviço de Deus, não andando à procura de novos caminhos, mas aperfeiçoando as nossas devoções ordinárias. Se nelas perseverarmos, o Paraíso é nosso.',
+    },
+  },
+  '04-17': {
+    name: { 'en-US': 'St. Anicetus, Pope, Martyr', 'pt-BR': 'Santo Aniceto, Papa, Mártir' },
+    reflection: {
+      'en-US':
+        'If, after making the most solemn protestations of inviolable friendship and affection for a fellow-creature, we should the next moment revile and contemn him, without having received any provocation or affront, and this habitually, would not the whole world justly call our protestations hypocrisy, and our pretended friendship a mockery? Let us by this rule judge if our love of God be sovereign, so long as our inconstancy betrays the insincerity of our hearts.',
+      'pt-BR':
+        'Se, depois de fazer os mais solenes protestos de inviolável amizade e afeição por um semelhante, no momento seguinte o injuriássemos e o desprezássemos, sem termos recebido qualquer provocação ou afronta, e isto habitualmente, não chamaria o mundo inteiro, com justiça, nossos protestos de hipocrisia e nossa pretensa amizade de zombaria? Julguemos por esta regra se nosso amor de Deus é soberano, enquanto nossa inconstância trai a insinceridade de nossos corações.',
+    },
+  },
+  '04-18': {
+    name: { 'en-US': 'St. Apollonius, Martyr', 'pt-BR': 'Santo Apolônio, Mártir' },
+    reflection: {
+      'en-US':
+        'It is the prerogative of the Christian religion to inspire men with such resolution, and form them to such heroism, that they rejoice to sacrifice their life to truth. This is not the bare force and exertion of nature, but the undoubted power of the Almighty, Whose strength is thus made perfect in weakness. Every Christian ought, by his manner, to bear witness to the sanctity of his faith. Such would be the force of universal good example, that no libertine or infidel could withstand it.',
+      'pt-BR':
+        'É prerrogativa da religião cristã inspirar nos homens tal resolução, e formá-los a tal heroísmo, que se regozijam de sacrificar a vida pela verdade. Isto não é a simples força e o esforço da natureza, mas o indubitável poder do Todo-Poderoso, cuja força assim se aperfeiçoa na fraqueza. Todo cristão deveria, por seu modo de viver, dar testemunho da santidade de sua fé. Tal seria a força do bom exemplo universal, que nenhum libertino ou infiel poderia resistir-lhe.',
+    },
+  },
+  '04-19': {
+    name: { 'en-US': 'St. Elphege, Archbishop', 'pt-BR': 'Santo Elfego, Arcebispo' },
+    reflection: {
+      'en-US':
+        'Those who are in high positions should consider themselves as stewards rather than masters of the wealth or power intrusted to them for the benefit of the poor and weak. St. Elphege died rather than extort his ransom from the poor tenants of the Church lands.',
+      'pt-BR':
+        'Aqueles que ocupam altas posições devem considerar-se mais administradores do que senhores da riqueza ou do poder a eles confiados para o benefício dos pobres e fracos. Santo Elfego preferiu morrer a extorquir seu resgate dos pobres rendeiros das terras da Igreja.',
+    },
+  },
+  '04-20': {
+    name: { 'en-US': 'St. Marcellinus, Bishop', 'pt-BR': 'São Marcelino, Bispo' },
+    reflection: {
+      'en-US':
+        'Though you may not be called upon to preach, at least endeavor to set a good example, remembering that deeds often speak louder than words.',
+      'pt-BR':
+        'Embora possais não ser chamados a pregar, ao menos esforçai-vos por dar bom exemplo, lembrando-vos de que as obras falam muitas vezes mais alto do que as palavras.',
+    },
+  },
+  '04-21': {
+    name: { 'en-US': 'St. Anselm, Archbishop', 'pt-BR': 'Santo Anselmo, Arcebispo' },
+    reflection: {
+      'en-US':
+        "Whoever, like St. Anselm, contends for the Church's rights, is fighting on the side of God against the tyranny of Satan.",
+      'pt-BR':
+        'Quem quer que, como Santo Anselmo, contenda pelos direitos da Igreja está lutando ao lado de Deus contra a tirania de Satanás.',
+    },
+  },
+  '04-22': {
+    name: {
+      'en-US': 'St. Soter, Pope, Martyr · St. Leonides, Martyr',
+      'pt-BR': 'São Sótero, Papa, Mártir · São Leônides, Mártir',
+    },
+  },
+  '04-23': {
+    name: { 'en-US': 'St. George, Martyr', 'pt-BR': 'São Jorge, Mártir' },
+    reflection: {
+      'en-US':
+        "\"What shall I say of fortitude, without which neither wisdom nor justice is of any worth? Fortitude is not of the body, but is a constancy of soul; wherewith we are conquerors in righteousness, patiently bear all adversities, and in prosperity are not puffed up. This fortitude he lacks who is overcome by pride, anger, greed, drunkenness, and the like. Neither have they fortitude who when in adversity make shift to escape at their souls’ expense; wherefore the Lord saith, 'Fear not those who kill the body, but cannot kill the soul.' In like manner those who are puffed up in prosperity and abandon themselves to excessive joviality cannot be called strong. For how can they be called strong who cannot hide and repress the heart's emotion? Fortitude is never conquered, or if conquered, is not fortitude.\"—*St. Bruno*.",
+      'pt-BR':
+        '"Que direi da fortaleza, sem a qual nem a sabedoria nem a justiça têm valor algum? A fortaleza não é do corpo, mas é uma constância da alma; pela qual somos vencedores na retidão, suportamos com paciência todas as adversidades e na prosperidade não nos envaidecemos. Carece desta fortaleza aquele que é vencido pelo orgulho, pela ira, pela cobiça, pela embriaguez e coisas semelhantes. Tampouco têm fortaleza os que, na adversidade, recorrem a expedientes para escapar à custa de suas almas; pelo que diz o Senhor: \'Não temais aqueles que matam o corpo, mas não podem matar a alma.\' Do mesmo modo, os que se envaidecem na prosperidade e se entregam a uma excessiva jovialidade não podem ser chamados fortes. Pois como podem ser chamados fortes os que não conseguem esconder e reprimir a emoção do coração? A fortaleza nunca é vencida, ou, se vencida, não é fortaleza."—*São Bruno*.',
+    },
+  },
+  '04-24': {
+    name: { 'en-US': 'St. Fidelis of Sigmaringen', 'pt-BR': 'São Fidélis de Sigmaringen' },
+    reflection: {
+      'en-US':
+        'We delight in decorating the altars of God with flowers, lights, and jewels, and it is right to do so; but if we wish to offer to God gifts of higher value, let us, in imitation of St. Fidelis, save the souls who but for us would be lost; for so we shall offer Him, as it were, the jewels of paradise.',
+      'pt-BR':
+        'Comprazemo-nos em adornar os altares de Deus com flores, luzes e joias, e é justo fazê-lo; mas se desejamos oferecer a Deus dádivas de maior valor, salvemos, à imitação de São Fidélis, as almas que, não fosse por nós, estariam perdidas; pois assim lhe ofereceremos, por assim dizer, as joias do paraíso.',
+    },
+  },
+  '04-25': {
+    name: { 'en-US': 'St. Mark, Evangelist', 'pt-BR': 'São Marcos, Evangelista' },
+    reflection: {
+      'en-US':
+        'Learn from St. Mark to keep the image of the Son of man ever before your mind, and to ponder every syllable which fell from His lips.',
+      'pt-BR':
+        'Aprende de São Marcos a manter sempre diante de tua mente a imagem do Filho do homem, e a ponderar cada sílaba que caiu de seus lábios.',
+    },
+  },
+  '04-26': {
+    name: {
+      'en-US': 'Sts. Cletus and Marcellinus, Popes, Martyrs',
+      'pt-BR': 'São Cleto e São Marcelino, Papas, Mártires',
+    },
+    reflection: {
+      'en-US':
+        'It is a fundamental maxim of the Christian morality, and a truth which Christ has established in the clearest terms and in innumerable passages of the Gospel, that the cross or sufferings and mortification are the road to eternal bliss. They, therefore, who lead not here a crucified and mortified life are unworthy ever to possess the unspeakable joys of His kingdom. Our Lord Himself, our model and our head, walked in this path, and His great Apostle puts us in mind that He entered into bliss only by His blood and by the cross.',
+      'pt-BR':
+        'É máxima fundamental da moral cristã, e verdade que Cristo estabeleceu nos termos mais claros e em inúmeras passagens do Evangelho, que a cruz, ou os sofrimentos e a mortificação, são o caminho para a bem-aventurança eterna. Aqueles, portanto, que não levam aqui uma vida crucificada e mortificada são indignos de jamais possuir as inefáveis alegrias de seu reino. O próprio Nosso Senhor, nosso modelo e nossa cabeça, caminhou por esta senda, e seu grande Apóstolo nos lembra que ele entrou na bem-aventurança somente por seu sangue e por sua cruz.',
+    },
+  },
+  '04-27': {
+    name: { 'en-US': 'St. Zita, Virgin', 'pt-BR': 'Santa Zita, Virgem' },
+    reflection: {
+      'en-US':
+        '"What must I do to be saved?" said a certain one in fear of damnation. "Work and pray, pray and work," a voice replied, "and thou shalt be saved." The whole life of St. Zita teaches us this truth.',
+      'pt-BR':
+        '"Que devo fazer para me salvar?" disse certa pessoa, temendo a condenação. "Trabalha e ora, ora e trabalha", respondeu uma voz, "e serás salvo." Toda a vida de Santa Zita nos ensina esta verdade.',
+    },
+  },
+  '04-28': {
+    name: {
+      'en-US': 'St. Paul of the Cross · St. Vitalis, Martyr',
+      'pt-BR': 'São Paulo da Cruz · São Vital, Mártir',
+    },
+    reflection: {
+      'en-US':
+        'We are not all called to the sacrifice of martyrdom; but we are all bound to make our lives a continued sacrifice of ourselves to God, and to perform every action in this perfect spirit of sacrifice. Thus we shall both live and die to God, perfectly resigned to His holy will in all His appointments.',
+      'pt-BR':
+        'Nem todos somos chamados ao sacrifício do martírio; mas todos estamos obrigados a fazer de nossa vida um contínuo sacrifício de nós mesmos a Deus, e a realizar cada ação neste perfeito espírito de sacrifício. Assim viveremos e morreremos para Deus, perfeitamente resignados à Sua santa vontade em todas as Suas disposições.',
+    },
+  },
+  '04-29': {
+    name: {
+      'en-US': 'St. Peter, Martyr · St. Hugh, Abbot of Cluny',
+      'pt-BR': 'São Pedro, Mártir · Santo Hugo, Abade de Cluny',
+    },
+    reflection: {
+      'en-US':
+        'From a boy St. Peter boldly professed his faith among heretics. He spent his life in preaching the faith to heretics, and received the glorious and long-desired crown of martyrdom from heretics. We are surrounded by heretics. Are we courageous, firm, zealous, full of prayer for their conversion, unflinching in our profession of faith?',
+      'pt-BR':
+        'Desde menino São Pedro professou ousadamente sua fé entre hereges. Passou a vida pregando a fé aos hereges, e recebeu de hereges a gloriosa e tão desejada coroa do martírio. Estamos rodeados de hereges. Somos corajosos, firmes, zelosos, cheios de oração pela conversão deles, inabaláveis em nossa profissão de fé?',
+    },
+  },
+  '04-30': {
+    name: { 'en-US': 'St. Catherine of Siena', 'pt-BR': 'Santa Catarina de Sena' },
+    reflection: {
+      'en-US':
+        'The seraphic St. Catherine willingly sacrificed the delights of contemplation to labor for the Church and the Apostolic See. How deeply do the troubles of the Church and the consequent loss of souls afflict us? How often do we pray for the Church and the Pope?',
+      'pt-BR':
+        'A seráfica Santa Catarina de bom grado sacrificou os deleites da contemplação para trabalhar pela Igreja e pela Sé Apostólica. Quão profundamente nos afligem os males da Igreja e a consequente perda de almas? Quão frequentemente oramos pela Igreja e pelo Papa?',
+    },
+  },
+  '05-01': {
+    name: {
+      'en-US': 'Sts. Philip and James, Apostles',
+      'pt-BR': 'São Filipe e São Tiago, Apóstolos',
+    },
+    reflection: {
+      'en-US':
+        'The Church commemorates on the same day Sts. Philip and James, whose bodies lie side by side at Rome. They represent to us two aspects of Christian holiness. The first preaches faith, the second works; the one holy aspirations, the other purity of heart.',
+      'pt-BR':
+        'A Igreja comemora no mesmo dia São Filipe e São Tiago, cujos corpos jazem lado a lado em Roma. Eles nos representam dois aspectos da santidade cristã. O primeiro prega a fé, o segundo as obras; um as santas aspirações, o outro a pureza de coração.',
+    },
+  },
+  '05-02': {
+    name: { 'en-US': 'St. Athanasius, Bishop', 'pt-BR': 'Santo Atanásio, Bispo' },
+    reflection: {
+      'en-US':
+        'The Catholic Faith, says St. Augustine, is more precious far than all the riches and treasures of earth; more glorious and greater than all its honors, all its possessions. This it is which saves sinners, gives light to the blind, restores penitents, perfects the just, and is the crown of martyrs.',
+      'pt-BR':
+        'A Fé Católica, diz Santo Agostinho, é muito mais preciosa do que todas as riquezas e tesouros da terra; mais gloriosa e maior do que todas as suas honras, todas as suas posses. É ela que salva os pecadores, dá luz aos cegos, restaura os penitentes, aperfeiçoa os justos, e é a coroa dos mártires.',
+    },
+  },
+  '05-03': {
+    name: { 'en-US': 'The Discovery of the Holy Cross', 'pt-BR': 'A Descoberta da Santa Cruz' },
+    reflection: {
+      'en-US':
+        'In every pious undertaking the beginning merely does not suffice. "Whoso shall persevere unto the end, he shall be saved."',
+      'pt-BR':
+        'Em todo empreendimento piedoso o mero começo não basta. "Quem perseverar até o fim, esse será salvo."',
+    },
+  },
+  '05-04': {
+    name: { 'en-US': 'St. Monica', 'pt-BR': 'Santa Mônica' },
+    reflection: {
+      'en-US':
+        "It is impossible to set any bounds to what persevering prayer may do. It gives man a share in the Divine Omnipotence. St. Augustine's soul lay bound in the chains of heresy and impurity, both of which had by long habit grown inveterate. They were broken by his mother's prayers.",
+      'pt-BR':
+        'É impossível pôr limites ao que a oração perseverante pode fazer. Ela dá ao homem uma participação na Onipotência Divina. A alma de Santo Agostinho jazia presa nas cadeias da heresia e da impureza, ambas tornadas inveteradas por longo hábito. Foram quebradas pelas orações de sua mãe.',
+    },
+  },
+  '05-05': {
+    name: { 'en-US': 'St. Pius V', 'pt-BR': 'São Pio V' },
+    reflection: {
+      'en-US':
+        '"Thy cross, O Lord, is the source of all blessings, the cause of all graces: by it the faithful find strength in weakness, glory in shame, life in death."—St. Leo.',
+      'pt-BR':
+        '"Tua cruz, ó Senhor, é a fonte de todas as bênçãos, a causa de todas as graças: por ela os fiéis encontram força na fraqueza, glória na vergonha, vida na morte." — São Leão.',
+    },
+  },
+  '05-06': {
+    name: { 'en-US': 'St. John Before the Latin Gate', 'pt-BR': 'São João ante a Porta Latina' },
+    reflection: {
+      'en-US':
+        'St. John suffered above the other Saints a martyrdom of love, being a martyr, and more than a martyr, at the foot of the cross of his divine Master. All his sufferings were by love and compassion imprinted in his soul, and thus shared by him. O singular happiness, to have stood under the cross of Christ! O extraordinary privilege, to have suffered martyrdom in the person of Jesus, and been eye-witness of all He did or endured! If nature revolt within us against suffering, let us call to mind those words of the divine Master: "Thou knowest not now wherefore; but thou shalt know hereafter."',
+      'pt-BR':
+        'São João sofreu, acima dos demais Santos, um martírio de amor, sendo mártir, e mais que mártir, ao pé da cruz de seu divino Mestre. Todos os seus sofrimentos foram, por amor e compaixão, impressos em sua alma, e assim por ele partilhados. Ó singular felicidade, ter estado sob a cruz de Cristo! Ó extraordinário privilégio, ter sofrido o martírio na pessoa de Jesus, e ter sido testemunha ocular de tudo o que Ele fez ou padeceu! Se a natureza se revolta dentro de nós contra o sofrimento, recordemos aquelas palavras do divino Mestre: "Não sabes agora por quê; mas o saberás depois."',
+    },
+  },
+  '05-07': {
+    name: { 'en-US': 'St. Stanislas, Bishop, Martyr', 'pt-BR': 'São Estanislau, Bispo, Mártir' },
+    reflection: {
+      'en-US':
+        'The safest correction of vice is a blameless life. Yet there are times when silence would make us answerable for the sins of others. At such times let us, in the name of God, rebuke the offender without fear.',
+      'pt-BR':
+        'A mais segura correção do vício é uma vida irrepreensível. Contudo, há ocasiões em que o silêncio nos tornaria responsáveis pelos pecados dos outros. Em tais ocasiões, repreendamos, em nome de Deus, o transgressor sem temor.',
+    },
+  },
+  '05-08': {
+    name: {
+      'en-US': 'The Apparition of St. Michael the Archangel',
+      'pt-BR': 'A Aparição de São Miguel Arcanjo',
+    },
+    reflection: {
+      'en-US':
+        'St. Michael is not only the protector of the Church, but of every faithful soul. He defeated the devil by humility: we are enlisted in the same warfare. His arms were humility and ardent love of God: the same must be our weapons. We ought to regard this archangel as our leader under God: and, courageously resisting the devil in all his assaults, to cry out, Who can be compared to God?',
+      'pt-BR':
+        'São Miguel não é apenas o protetor da Igreja, mas de toda alma fiel. Ele venceu o demônio pela humildade: nós estamos alistados na mesma guerra. Suas armas eram a humildade e o ardente amor de Deus: as mesmas devem ser as nossas armas. Devemos considerar este arcanjo como nosso chefe sob Deus; e, resistindo corajosamente ao demônio em todos os seus assaltos, clamar: Quem se pode comparar a Deus?',
+    },
+  },
+  '05-09': {
+    name: { 'en-US': 'St. Gregory Nazianzen', 'pt-BR': 'São Gregório Nazianzeno' },
+    reflection: {
+      'en-US':
+        '"We must overcome our enemies," said St. Gregory, "by gentleness; win them over by forbearance. Let them be punished by their own conscience, not by our wrath. Let us not at once wither the fig-tree, from which a more skilful gardener may yet entice fruit."',
+      'pt-BR':
+        '"Devemos vencer nossos inimigos", disse São Gregório, "pela brandura; conquistá-los pela tolerância. Sejam eles punidos por sua própria consciência, não por nossa ira. Não murchemos de imediato a figueira, da qual um jardineiro mais hábil ainda poderá obter fruto."',
+    },
+  },
+  '05-10': {
+    name: { 'en-US': 'St. Antoninus, Bishop', 'pt-BR': 'Santo Antonino, Bispo' },
+    reflection: {
+      'en-US':
+        '"Alms-deeds," says St. Augustine, "comprise every kind of service rendered to our neighbor who needs such assistance. He who supports a lame man bestows an alms on him with his feet; he who guides a blind man does him a charity with his eyes; he who carries an invalid or an old man upon his shoulders imparts to him an alms of his strength. Hence none are so poor but they may bestow an alms on the wealthiest man in the world."',
+      'pt-BR':
+        '"As obras de esmola", diz Santo Agostinho, "compreendem toda espécie de serviço prestado ao nosso próximo que de tal auxílio necessita. Quem ampara um coxo dá-lhe uma esmola com os pés; quem guia um cego faz-lhe uma caridade com os olhos; quem carrega um inválido ou um ancião sobre os ombros transmite-lhe uma esmola de sua força. Por isso ninguém é tão pobre que não possa dar uma esmola ao homem mais rico do mundo."',
+    },
+  },
+  '05-11': {
+    name: { 'en-US': 'St. Mammertus, Archbishop', 'pt-BR': 'São Mamerto, Arcebispo' },
+    reflection: {
+      'en-US':
+        '"Know ye that the Lord will hear your prayers, if you continue with perseverance in fastings and prayers in the sight of the Lord" (Judith iv. 11).',
+      'pt-BR':
+        '"Sabei que o Senhor ouvirá vossas orações, se perseverardes constantes em jejuns e orações na presença do Senhor" (Judite iv. 11).',
+    },
+  },
+  '05-12': {
+    name: { 'en-US': 'St. Epiphanius, Archbishop', 'pt-BR': 'Santo Epifânio, Arcebispo' },
+    reflection: {
+      'en-US':
+        '"In this is charity: not as though we had loved God, but because He hath first loved us."',
+      'pt-BR':
+        '"Nisto está a caridade: não como se tivéssemos nós amado a Deus, mas porque Ele primeiro nos amou."',
+    },
+  },
+  '05-13': {
+    name: { 'en-US': 'St. John the Silent', 'pt-BR': 'São João, o Silencioso' },
+    reflection: {
+      'en-US':
+        'A love of Christian silence is a proof that a soul makes it her chiefest delight to be occupied on God, and finds no comfort like that of conversing with Him. This is the paradise of all devout souls.',
+      'pt-BR':
+        'O amor do silêncio cristão é prova de que uma alma faz da ocupação com Deus a sua maior delícia, e não encontra consolo igual ao de conversar com Ele. Este é o paraíso de todas as almas devotas.',
+    },
+  },
+  '05-14': {
+    name: { 'en-US': 'St. Pachomius, Abbot', 'pt-BR': 'São Pacômio, Abade' },
+    reflection: {
+      'en-US':
+        '"To live in great simplicity," said St. Pachomius, "and in a wise ignorance, is exceeding wise."',
+      'pt-BR':
+        '"Viver em grande simplicidade", disse São Pacômio, "e numa sábia ignorância, é sumamente sábio."',
+    },
+  },
+  '05-15': {
+    name: { 'en-US': 'Sts. Peter and Dionysia', 'pt-BR': 'São Pedro e Santa Dionísia' },
+    reflection: {
+      'en-US':
+        'The martyrs were even like us, with natures which shrank from suffering. They were patient under it because they looked to the eternal recompense, and endured as seeing Him Who is invisible.',
+      'pt-BR':
+        'Os mártires eram em tudo como nós, com naturezas que recuavam diante do sofrimento. Eram pacientes sob ele porque olhavam para a recompensa eterna, e suportavam como vendo Aquele que é invisível.',
+    },
+  },
+  '05-16': {
+    name: { 'en-US': 'St. John Nepomucen', 'pt-BR': 'São João Nepomuceno' },
+    reflection: {
+      'en-US':
+        'St. John, who by his invincible sacramental silence won his crown, teaches us to prefer torture and death to offending the Creator with our tongue. How many times each day do we forfeit grace and strength by sins of speech!',
+      'pt-BR':
+        'São João, que por seu invencível silêncio sacramental ganhou sua coroa, ensina-nos a preferir a tortura e a morte a ofender o Criador com nossa língua. Quantas vezes por dia perdemos graça e força por pecados da palavra!',
+    },
+  },
+  '05-17': {
+    name: { 'en-US': 'St. Paschal Baylon', 'pt-BR': 'São Pascoal Baylon' },
+    reflection: {
+      'en-US':
+        'St. Paschal teaches us never to suffer a day to pass without visiting Jesus in the narrow chamber where He, Whom the heaven itself cannot contain, abides day and night for our sake.',
+      'pt-BR':
+        'São Pascoal ensina-nos a nunca deixar passar um dia sem visitar Jesus na estreita morada onde Ele, a quem o próprio céu não pode conter, permanece dia e noite por amor de nós.',
+    },
+  },
+  '05-18': {
+    name: { 'en-US': 'St. Venantius, Martyr', 'pt-BR': 'São Venâncio, Mártir' },
+    reflection: {
+      'en-US':
+        'Love of suffering marks the most perfect degree in the love of God. Our Lord Himself was consumed with the desire to suffer, because He burnt with the love of God. We must begin with patience and detachment. At last we shall learn to love the sufferings which conform us to the Passion of our Redeemer.',
+      'pt-BR':
+        'O amor do sofrimento marca o grau mais perfeito no amor de Deus. O próprio Nosso Senhor era consumido pelo desejo de sofrer, porque ardia com o amor de Deus. Devemos começar pela paciência e pelo desapego. Por fim aprenderemos a amar os sofrimentos que nos conformam à Paixão de nosso Redentor.',
+    },
+  },
+  '05-19': {
+    name: { 'en-US': 'St. Peter Celestine', 'pt-BR': 'São Pedro Celestino' },
+    reflection: {
+      'en-US':
+        '"Whoso," says the *Imitation of Christ*, "withdraweth himself from acquaintances and friends, to him will God draw near with His holy angels."',
+      'pt-BR':
+        '"Aquele que", diz a *Imitação de Cristo*, "se afasta dos conhecidos e amigos, dele se aproximará Deus com Seus santos anjos."',
+    },
+  },
+  '05-20': {
+    name: { 'en-US': 'St. Bernardine of Siena', 'pt-BR': 'São Bernardino de Siena' },
+    reflection: {
+      'en-US':
+        'Let us learn from the life of St. Bernardine the power of the Holy Name in life and death.',
+      'pt-BR':
+        'Aprendamos da vida de São Bernardino o poder do Santíssimo Nome na vida e na morte.',
+    },
+  },
+  '05-21': {
+    name: { 'en-US': 'St. Hospitius, Recluse', 'pt-BR': 'Santo Hospício, Recluso' },
+    reflection: {
+      'en-US':
+        'If we do not love penitence for its own sake, let us love it on account of our sins; for we should "work out our salvation in fear and trembling."',
+      'pt-BR':
+        'Se não amamos a penitência por si mesma, amemo-la por causa de nossos pecados; pois devemos "operar a nossa salvação com temor e tremor."',
+    },
+  },
+  '05-22': {
+    name: { 'en-US': 'St. Yvo, Confessor', 'pt-BR': 'Santo Ivo, Confessor' },
+    reflection: {
+      'en-US':
+        'St. Yvo was a Saint amidst the dangers of the world; but he preserved his virtue untainted only by arming himself carefully against them, by conversing assiduously with God in prayer and holy meditation, and by most watchfully shunning the snares of bad company. Without this precaution all the instructions of parents and all other means of virtue are ineffectual; and the soul is sure to split against this rock which does not steer wide of it.',
+      'pt-BR':
+        'Santo Ivo foi um Santo em meio aos perigos do mundo; mas conservou sua virtude incólume somente armando-se cuidadosamente contra eles, conversando assiduamente com Deus na oração e na santa meditação, e fugindo com a maior vigilância dos laços das más companhias. Sem esta precaução, todas as instruções dos pais e todos os outros meios de virtude são ineficazes; e a alma certamente se despedaçará contra este escolho se dele não se desviar bem ao largo.',
+    },
+  },
+  '05-23': {
+    name: { 'en-US': 'St. Julia, Virgin, Martyr', 'pt-BR': 'Santa Júlia, Virgem, Mártir' },
+    reflection: {
+      'en-US':
+        'St. Julia, whether free or a slave, whether in prosperity or in adversity, was equally fervent and devout. She adored all the sweet designs of Providence; and far from complaining, she never ceased to praise and thank God under all His holy appointments, making them always the means of her virtue and sanctification. God, by an admirable chain of events, raised her by her fidelity to the honor of the saints, and to the dignity of a virgin and martyr.',
+      'pt-BR':
+        'Santa Júlia, fosse livre ou escrava, fosse na prosperidade ou na adversidade, era igualmente fervorosa e devota. Adorava todos os doces desígnios da Providência; e, longe de queixar-se, nunca cessava de louvar e agradecer a Deus sob todas as Suas santas disposições, fazendo delas sempre o meio de sua virtude e santificação. Deus, por uma admirável cadeia de acontecimentos, elevou-a por sua fidelidade à honra dos santos e à dignidade de virgem e mártir.',
+    },
+  },
+  '05-24': {
+    name: {
+      'en-US': 'Sts. Donatian and Rogatian, Martyrs',
+      'pt-BR': 'São Donaciano e São Rogaciano, Mártires',
+    },
+    reflection: {
+      'en-US':
+        'Three things are pleasing unto God and man: concord among brethren, the love of parents, and the union of man and wife.',
+      'pt-BR':
+        'Três coisas são agradáveis a Deus e aos homens: a concórdia entre os irmãos, o amor dos pais, e a união do homem e da mulher.',
+    },
+  },
+  '05-25': {
+    name: { 'en-US': 'St. Gregory VII', 'pt-BR': 'São Gregório VII' },
+    reflection: {
+      'en-US':
+        'Eight hundred years are passed since St. Gregory died, and we see the same conflict renewed before our eyes. Let us learn from him to suffer any persecution from the world or the state, rather than betray the rights of the Holy See.',
+      'pt-BR':
+        'Oitocentos anos se passaram desde que São Gregório morreu, e vemos o mesmo conflito renovar-se diante de nossos olhos. Aprendamos com ele a sofrer qualquer perseguição do mundo ou do estado, antes que trair os direitos da Santa Sé.',
+    },
+  },
+  '05-26': {
+    name: {
+      'en-US': 'St. Philip Neri · St. Augustine, Apostle of England',
+      'pt-BR': 'São Filipe Neri · Santo Agostinho, Apóstolo da Inglaterra',
+    },
+    reflection: {
+      'en-US':
+        'Philip wished his children to serve God, like the first Christians, in gladness of heart. He said this was the true filial spirit; this expands the soul, giving it liberty and perfection in action, power over temptations, and fuller aid to perseverance.',
+      'pt-BR':
+        'Filipe desejava que seus filhos servissem a Deus, como os primeiros cristãos, na alegria do coração. Dizia ser este o verdadeiro espírito filial; ele dilata a alma, dando-lhe liberdade e perfeição na ação, poder sobre as tentações, e auxílio mais pleno à perseverança.',
+    },
+  },
+  '05-27': {
+    name: {
+      'en-US': 'St. Mary Magdalen of Pazzi · Venerable Bede',
+      'pt-BR': 'Santa Maria Madalena de Pazzi · Venerável Beda',
+    },
+    reflection: {
+      'en-US':
+        'St. Mary Magdalen of Pazzi was so filled with the love of God that her sisters in the monastery observed it in her love of themselves, and called her "the Mother of Charity" and "the Charity of the Monastery."',
+      'pt-BR':
+        'Santa Maria Madalena de Pazzi estava de tal modo cheia do amor de Deus que suas irmãs no mosteiro o observavam em seu amor por elas, e a chamavam "a Mãe da Caridade" e "a Caridade do Mosteiro."',
+    },
+  },
+  '05-28': {
+    name: { 'en-US': 'St. Germanus, Bishop', 'pt-BR': 'São Germano, Bispo' },
+    reflection: {
+      'en-US':
+        '"In the churches bless ye God the Lord. From Thy temple kings shall offer presents to Thee."',
+      'pt-BR':
+        '"Nas assembleias bendizei a Deus, o Senhor. Do Teu templo os reis Te oferecerão presentes."',
+    },
+  },
+  '05-29': {
+    name: { 'en-US': 'St. Cyril, Martyr', 'pt-BR': 'São Cirilo, Mártir' },
+    reflection: {
+      'en-US':
+        'Ask Our Lord to make all earthly joy insipid, and to fill you with the constant desire of heaven. This desire will make labor easy and suffering light. It will make you fervent and detached, and bring you even here a foretaste of that eternal joy and peace to which you are hastening.',
+      'pt-BR':
+        'Pedi a Nosso Senhor que torne insípida toda alegria terrena, e que vos encha do constante desejo do céu. Este desejo tornará fácil o labor e leve o sofrimento. Ele vos tornará fervorosos e desprendidos, e vos trará, ainda aqui, uma antegustação daquela alegria e paz eternas para as quais vos apressais.',
+    },
+  },
+  '05-30': {
+    name: { 'en-US': 'St. Felix I., Pope and Martyr', 'pt-BR': 'São Félix I, Papa e Mártir' },
+    reflection: {
+      'en-US':
+        'The example of Our Saviour and of all His saints ought to encourage us under all trials to suffer with patience and even with joy. We shall soon begin to feel that it is sweet to tread in the steps of a God-man, and shall find that if we courageously take up our crosses, He will make them light by sharing the burden with us.',
+      'pt-BR':
+        'O exemplo de Nosso Salvador e de todos os Seus santos deve encorajar-nos, em todas as provações, a sofrer com paciência e até com alegria. Em breve começaremos a sentir que é doce caminhar nos passos de um Deus-homem, e haveremos de descobrir que, se corajosamente tomarmos as nossas cruzes, Ele as tornará leves ao partilhar conosco o fardo.',
+    },
+  },
+  '05-31': {
+    name: { 'en-US': 'St. Petronilla, Virgin', 'pt-BR': 'Santa Petronilha, Virgem' },
+    reflection: {
+      'en-US':
+        'With the saints the great end for which they lived was always present to their minds, and they thought every moment lost in which they did not make some advances toward eternal bliss. How will their example condemn at the last day the trifling fooleries and the greatest part of the conversation and employments of the world, which aim at nothing but present amusements, and forget the only important affair—the business of eternity.',
+      'pt-BR':
+        'Para os santos, o grande fim para o qual viviam estava sempre presente em suas mentes, e julgavam perdido todo momento em que não faziam algum avanço rumo à bem-aventurança eterna. Como o seu exemplo há de condenar, no último dia, as fúteis tolices e a maior parte das conversas e ocupações do mundo, que não visam senão divertimentos presentes e esquecem o único assunto importante — o negócio da eternidade.',
+    },
+  },
+  '06-01': {
+    name: {
+      'en-US': 'St. Justin, Martyr · St. Pamphilus, Martyr',
+      'pt-BR': 'São Justino, Mártir · São Pânfilo, Mártir',
+    },
+    reflection: {
+      'en-US':
+        'We have received the gift of faith with little labor of our own. Let us learn how to value it from those who reached it after long search, and lived in the misery of a world which did not know God. Let us fear, as St. Justin did, the account we shall have to render for the gift of God.',
+      'pt-BR':
+        'Recebemos o dom da fé com pouco trabalho de nossa parte. Aprendamos a valorizá-lo daqueles que a alcançaram após longa busca, e que viveram na miséria de um mundo que não conhecia a Deus. Temamos, como temeu São Justino, a conta que haveremos de prestar pelo dom de Deus.',
+    },
+  },
+  '06-02': {
+    name: {
+      'en-US': 'Sts. Pothinus, Bishop, Sanctus, Attalus, Blandina, and the other Martyrs of Lyons',
+      'pt-BR': 'São Potino, Bispo, Sanctus, Atalo, Blandina e os demais Mártires de Lião',
+    },
+    reflection: {
+      'en-US':
+        'In early times the Christians were called the children of joy. Let us seek the joy of the Holy Spirit to sweeten suffering, to temper earthly delight, till we enter into the joy of Our Lord.',
+      'pt-BR':
+        'Nos tempos primitivos, os cristãos eram chamados filhos da alegria. Busquemos a alegria do Espírito Santo para adoçar o sofrimento, para temperar o deleite terreno, até que entremos na alegria de Nosso Senhor.',
+    },
+  },
+  '06-03': {
+    name: { 'en-US': 'St. Clotilda, Queen', 'pt-BR': 'Santa Clotilde, Rainha' },
+    reflection: {
+      'en-US':
+        'St. Peter defines the mission of the Christian woman; to win the heart of those who believe not the word.',
+      'pt-BR':
+        'São Pedro define a missão da mulher cristã: ganhar o coração daqueles que não creem na palavra.',
+    },
+  },
+  '06-04': {
+    name: { 'en-US': 'St. Francis Caracciolo', 'pt-BR': 'São Francisco Caracciolo' },
+    reflection: {
+      'en-US':
+        'It is for men, and not for angels, that our blessed Lord resides upon the altar. Yet angels throng our churches to worship Him while men desert Him. Learn from St. Francis to avoid such ingratitude, and to spend, as he did, every possible moment before the Most Holy Sacrament.',
+      'pt-BR':
+        'É pelos homens, e não pelos anjos, que Nosso bendito Senhor reside sobre o altar. Contudo, os anjos enchem as nossas igrejas para adorá-Lo, enquanto os homens O abandonam. Aprende com São Francisco a evitar tal ingratidão, e a passar, como ele passou, todo momento possível diante do Santíssimo Sacramento.',
+    },
+  },
+  '06-05': {
+    name: { 'en-US': 'St. Boniface, Bishop, Martyr', 'pt-BR': 'São Bonifácio, Bispo, Mártir' },
+    reflection: {
+      'en-US':
+        "St. Boniface teaches us how the love of Christ changes all things. It was for Christ's sake that he toiled for souls, preferring poverty to riches, labor to rest, suffering to pleasure, death to life, that by dying he might live with Christ.",
+      'pt-BR':
+        'São Bonifácio ensina-nos como o amor de Cristo transforma todas as coisas. Foi por amor de Cristo que ele se afadigou pelas almas, preferindo a pobreza às riquezas, o trabalho ao repouso, o sofrimento ao prazer, a morte à vida, para que, morrendo, pudesse viver com Cristo.',
+    },
+  },
+  '06-06': {
+    name: { 'en-US': 'St. Norbert, Bishop', 'pt-BR': 'São Norberto, Bispo' },
+    reflection: {
+      'en-US':
+        "Reparation for the injuries offered to the Blessed Sacrament was the aim of St. Norbert's great work of reform—in himself, in the clergy, and in the faithful. How much does our present worship repair for our own past irreverences, and for the outrages offered by others to the Blessed Eucharist.",
+      'pt-BR':
+        'A reparação pelas injúrias feitas ao Santíssimo Sacramento foi o alvo da grande obra de reforma de São Norberto — em si mesmo, no clero e nos fiéis. Quanto repara o nosso culto presente pelas nossas próprias irreverências passadas, e pelos ultrajes feitos por outros à Santíssima Eucaristia.',
+    },
+  },
+  '06-07': {
+    name: {
+      'en-US': 'St. Robert of Newminster · St. Claude, Archbishop',
+      'pt-BR': 'São Roberto de Newminster · São Cláudio, Arcebispo',
+    },
+    reflection: {
+      'en-US':
+        'Reason and authority prove that virtue ought to be practised. But facts alone prove that it is practised; and this is why examples have more power to move our souls, and why our individual actions are of such fearful importance for others as well as for ourselves.',
+      'pt-BR':
+        'A razão e a autoridade provam que a virtude deve ser praticada. Mas só os fatos provam que ela é praticada; e é por isso que os exemplos têm maior poder para mover as nossas almas, e por que as nossas ações individuais são de tão temível importância para os outros, tanto quanto para nós mesmos.',
+    },
+  },
+  '06-08': {
+    name: { 'en-US': 'St. Medard, Bishop', 'pt-BR': 'São Medardo, Bispo' },
+    reflection: {
+      'en-US':
+        'The Church takes delight in styling her founder "THE AMIABLE JESUS," and He likewise says of Himself, "I am meek and humble of heart."',
+      'pt-BR':
+        'A Igreja deleita-se em chamar o seu fundador "O AMÁVEL JESUS," e Ele mesmo diz de Si: "Sou manso e humilde de coração."',
+    },
+  },
+  '06-09': {
+    name: {
+      'en-US': 'Sts. Primus and Felicianus, Martyrs · St. Columba, or Columkille, Abbot',
+      'pt-BR': 'São Primo e São Feliciano, Mártires · São Columba, ou Columkille, Abade',
+    },
+    reflection: {
+      'en-US':
+        'A soul which truly loves God regards all the things of this world as nothing. The loss of goods, the disgrace of the world, torments, sickness, and other afflictions are bitter to the senses, but appear light to him that loves. If we cannot bear our trials with patience and silence, it is because we love God only in words. "One who is slothful and lukewarm complains of everything, and calls the lightest precepts hard," says Thomas à Kempis.',
+      'pt-BR':
+        'Uma alma que verdadeiramente ama a Deus considera como nada todas as coisas deste mundo. A perda dos bens, a desonra do mundo, os tormentos, a doença e outras aflições são amargos aos sentidos, mas parecem leves àquele que ama. Se não podemos suportar as nossas provações com paciência e silêncio, é porque amamos a Deus apenas em palavras. "Aquele que é preguiçoso e tíbio queixa-se de tudo, e chama duros os mais leves preceitos", diz Tomás de Kempis.',
+    },
+  },
+  '06-10': {
+    name: { 'en-US': 'St. Margaret of Scotland', 'pt-BR': 'Santa Margarida da Escócia' },
+    reflection: {
+      'en-US':
+        'All perfection consists in keeping a guard upon the heart. Wherever we are, we can make a solitude in our hearts, detach ourselves from the world, and converse familiarly with God. Let us take St. Margaret for our example and encouragement.',
+      'pt-BR':
+        'Toda a perfeição consiste em manter uma guarda sobre o coração. Onde quer que estejamos, podemos fazer uma solidão em nossos corações, desapegar-nos do mundo, e conversar familiarmente com Deus. Tomemos Santa Margarida como nosso exemplo e encorajamento.',
+    },
+  },
+  '06-11': {
+    name: { 'en-US': 'St. Barnabas, Apostle', 'pt-BR': 'São Barnabé, Apóstolo' },
+    reflection: {
+      'en-US':
+        "St. Barnabas's life is full of suggestions to us who live in days when once more the abundant alms of the faithful are sorely needed by the whole Church, from the Sovereign Pontiff to the poor children in our streets.",
+      'pt-BR':
+        'A vida de São Barnabé está cheia de sugestões para nós, que vivemos em dias nos quais, mais uma vez, as abundantes esmolas dos fiéis são duramente necessárias a toda a Igreja, desde o Soberano Pontífice até as pobres crianças de nossas ruas.',
+    },
+  },
+  '06-12': {
+    name: { 'en-US': 'St. John of St. Fagondez', 'pt-BR': 'São João de São Fagondez' },
+    reflection: {
+      'en-US':
+        'All men desire peace, but those alone enjoy it who, like St. John, are completely dead to themselves, and love to bear all things for Christ.',
+      'pt-BR':
+        'Todos os homens desejam a paz, mas só a gozam aqueles que, como São João, estão completamente mortos para si mesmos, e amam suportar todas as coisas por Cristo.',
+    },
+  },
+  '06-13': {
+    name: { 'en-US': 'St. Antony of Padua', 'pt-BR': 'Santo Antônio de Pádua' },
+    reflection: {
+      'en-US':
+        'Let us love to pray and labor unseen, and cherish in the secret of our hearts the graces of God and the growth of our immortal souls. Like St. Antony, let us attend to this, and leave the rest to God.',
+      'pt-BR':
+        'Amemos orar e trabalhar despercebidos, e cultivemos no segredo de nossos corações as graças de Deus e o crescimento de nossas almas imortais. Como Santo Antônio, atendamos a isto, e deixemos o resto a Deus.',
+    },
+  },
+  '06-14': {
+    name: { 'en-US': 'St. Basil the Great', 'pt-BR': 'São Basílio Magno' },
+    reflection: {
+      'en-US':
+        '"Fear God," says the *Imitation of Christ*, "and thou shalt have no need of being afraid of any man."',
+      'pt-BR':
+        '"Teme a Deus", diz a *Imitação de Cristo*, "e não terás necessidade de temer homem algum."',
+    },
+  },
+  '06-15': {
+    name: {
+      'en-US': 'Sts. Vitus, Crescentia, and Modestus, Martyrs',
+      'pt-BR': 'São Vito, Santa Crescência e São Modesto, Mártires',
+    },
+    reflection: {
+      'en-US':
+        'What happiness for an infant to be formed naturally to all virtue, and for the spirit of simplicity, meekness, goodness, and piety to be moulded in its tender frame! Such a foundation being well laid, further graces are abundantly communicated, and a soul improves daily these seeds, and rises to the height of Christian virtue often without experiencing severe conflicts of the passions.',
+      'pt-BR':
+        'Que felicidade para uma criança ser formada naturalmente para toda virtude, e ter o espírito de simplicidade, mansidão, bondade e piedade moldado em sua tenra estrutura! Estando bem lançado tal fundamento, novas graças são abundantemente comunicadas, e uma alma aprimora diariamente estas sementes, e eleva-se à altura da virtude cristã, muitas vezes sem experimentar severos conflitos das paixões.',
+    },
+  },
+  '06-16': {
+    name: { 'en-US': 'St. John Francis Regis', 'pt-BR': 'São João Francisco Regis' },
+    reflection: {
+      'en-US':
+        'When St. John Francis was struck in the face by a sinner whom he was reproving, he replied, "If you only knew me, you would give me much more than that." His meekness converted the man, and it is in this spirit that he teaches us to win souls to God. How much might we do if we could forget our own wants in remembering those of others, and put our trust in God!',
+      'pt-BR':
+        'Quando São João Francisco foi golpeado no rosto por um pecador a quem repreendia, respondeu: "Se tu apenas me conhecesses, dar-me-ias muito mais do que isso." A sua mansidão converteu o homem, e é neste espírito que ele nos ensina a ganhar almas para Deus. Quanto poderíamos fazer se pudéssemos esquecer as nossas próprias necessidades ao lembrar as dos outros, e pôr a nossa confiança em Deus!',
+    },
+  },
+  '06-17': {
+    name: { 'en-US': 'St. Avitus, Abbot', 'pt-BR': 'Santo Ávito, Abade' },
+  },
+  '06-18': {
+    name: {
+      'en-US': 'Sts. Marcus and Marcellianus, Martyrs',
+      'pt-BR': 'São Marco e São Marceliano, Mártires',
+    },
+    reflection: {
+      'en-US':
+        'We know not what we are till we have been tried. It costs nothing to say we love God above all things, and to show the courage of martyrs at a distance from the danger; but that love is sincere which has stood the proof. "Persecution shows who is a hireling, and who a true pastor," says St. Bernard.',
+      'pt-BR':
+        'Não sabemos o que somos até termos sido provados. Nada custa dizer que amamos a Deus acima de todas as coisas, e mostrar a coragem dos mártires à distância do perigo; mas é sincero aquele amor que resistiu à prova. "A perseguição mostra quem é mercenário e quem é verdadeiro pastor", diz São Bernardo.',
+    },
+  },
+  '06-19': {
+    name: { 'en-US': 'St. Juliana Falconieri', 'pt-BR': 'Santa Juliana Falconieri' },
+    reflection: {
+      'en-US':
+        '"Meditate often," says St. Paul of the Cross, "on the sorrows of the holy Mother, sorrows inseparable from those of her beloved Son. If you seek the Cross, there you will find the Mother; and where the Mother is, there also is the Son."',
+      'pt-BR':
+        '"Medita com frequência", diz São Paulo da Cruz, "nas dores da santa Mãe, dores inseparáveis das de seu amado Filho. Se buscas a Cruz, ali encontrarás a Mãe; e onde está a Mãe, ali também está o Filho."',
+    },
+  },
+  '06-20': {
+    name: { 'en-US': 'St. Silverius, Pope and Martyr', 'pt-BR': 'São Silvério, Papa e Mártir' },
+  },
+  '06-21': {
+    name: { 'en-US': 'St. Aloysius Gonzaga', 'pt-BR': 'São Luís Gonzaga' },
+    reflection: {
+      'en-US':
+        "Cardinal Bellarmine, the Saint's confessor, testified that he had never mortally offended God. Yet he chastised his body rigorously, rose at night to pray, and shed many tears for his sins. Pray that, not having followed his innocence, you may yet imitate his penance.",
+      'pt-BR':
+        'O Cardeal Belarmino, confessor do Santo, testemunhou que ele jamais ofendera mortalmente a Deus. Contudo, castigava o corpo rigorosamente, levantava-se de noite para orar, e derramava muitas lágrimas pelos seus pecados. Ora para que, não tendo seguido a sua inocência, possas ao menos imitar a sua penitência.',
+    },
+  },
+  '06-22': {
+    name: { 'en-US': 'St. Paulinus of Nola', 'pt-BR': 'São Paulino de Nola' },
+    reflection: {
+      'en-US':
+        '"Go to Campania," writes St. Augustine; "there study Paulinus, that choice servant of God. With what generosity, with what still greater humility, he has flung from him the burden of this world\'s grandeurs to take on him the yoke of Christ, and in His service how serene and unobtrusive his life!"',
+      'pt-BR':
+        '"Vai à Campânia", escreve Santo Agostinho; "ali estuda Paulino, aquele eleito servo de Deus. Com que generosidade, com que humildade ainda maior, lançou de si o fardo das grandezas deste mundo para tomar sobre si o jugo de Cristo, e no serviço d\'Ele quão serena e discreta a sua vida!"',
+    },
+  },
+  '06-23': {
+    name: { 'en-US': 'St. Etheldreda, Abbess', 'pt-BR': 'Santa Eteldreda, Abadessa' },
+    reflection: {
+      'en-US':
+        'The soul cannot truly serve God while it is involved in the distractions and pleasures of the world. Etheldreda knew this, and chose rather to be a servant of Christ her Lord than the mistress of an earthly court. Resolve, in whatever state you are, to live absolutely detached from the world, and to separate yourself as much as possible from it.',
+      'pt-BR':
+        'A alma não pode verdadeiramente servir a Deus enquanto está envolvida nas distrações e nos prazeres do mundo. Eteldreda sabia disto, e preferiu ser serva de Cristo seu Senhor a ser senhora de uma corte terrena. Resolve, em qualquer estado em que te encontres, viver absolutamente desapegado do mundo, e separar-te dele tanto quanto possível.',
+    },
+  },
+  '06-24': {
+    name: { 'en-US': 'St. John the Baptist', 'pt-BR': 'São João Batista' },
+    reflection: {
+      'en-US':
+        'St. John was great before God because he forgot himself and lived for Jesus Christ, Who is the source of all greatness. Remember that you are nothing; your own will and your own desires can only lead to misery and sin. Therefore sacrifice every day some one of your natural inclinations to the Sacred Heart of Our Lord, and learn little by little to lose yourself in Him.',
+      'pt-BR':
+        "São João foi grande diante de Deus porque se esqueceu de si mesmo e viveu para Jesus Cristo, que é a fonte de toda grandeza. Lembra-te de que nada és; a tua própria vontade e os teus próprios desejos só podem conduzir à miséria e ao pecado. Sacrifica, pois, cada dia alguma de tuas inclinações naturais ao Sagrado Coração de Nosso Senhor, e aprende pouco a pouco a perder-te n'Ele.",
+    },
+  },
+  '06-25': {
+    name: {
+      'en-US': 'St. Prosper of Aquitaine. St William of Monte-Vergine',
+      'pt-BR': 'São Próspero da Aquitânia. São Guilherme de Monte-Vergine',
+    },
+  },
+  '06-26': {
+    name: { 'en-US': 'Sts. John and Paul, Martyrs', 'pt-BR': 'São João e São Paulo, Mártires' },
+    reflection: {
+      'en-US':
+        'The Saints always accounted that they had done nothing for Christ so long as they had not resisted to blood, and by pouring forth the last drop completed their sacrifice. Every action of our lives ought to spring from this fervent motive, and we should consecrate ourselves to the divine service with our whole strength; we must always bear in mind that we owe to God all that we are, and, after all we can do, are unprofitable servants, and do only what we are bound to do.',
+      'pt-BR':
+        'Os Santos sempre julgaram que nada haviam feito por Cristo enquanto não tivessem resistido até ao sangue, e, derramando a última gota, completado o seu sacrifício. Cada ação da nossa vida deveria brotar deste fervoroso motivo, e deveríamos consagrar-nos ao serviço divino com todas as nossas forças; devemos sempre ter em mente que devemos a Deus tudo o que somos, e que, depois de tudo o que possamos fazer, somos servos inúteis, e fazemos apenas aquilo que estamos obrigados a fazer.',
+    },
+  },
+  '06-27': {
+    name: { 'en-US': 'St. Ladislas, King', 'pt-BR': 'São Ladislau, Rei' },
+    reflection: {
+      'en-US':
+        'The Saints filled all their moments with good works and great actions; and, whilst they labored for an immortal crown, the greatest share of worldly happiness of which this life is capable fell in their way without being even looked for by them. In their afflictions themselves virtue afforded them the most solid comfort, pointed out the remedy, and converted their tribulations into the greatest advantages.',
+      'pt-BR':
+        'Os Santos enchiam todos os seus momentos de boas obras e de grandes ações; e, enquanto labutavam por uma coroa imortal, a maior porção da felicidade mundana de que esta vida é capaz lhes vinha ao encontro sem que sequer a procurassem. Nas suas próprias aflições, a virtude lhes proporcionava o mais sólido consolo, apontava-lhes o remédio, e convertia as suas tribulações nas maiores vantagens.',
+    },
+  },
+  '06-28': {
+    name: { 'en-US': 'St. Irenæus, Bishop, Martyr', 'pt-BR': 'Santo Irineu, Bispo, Mártir' },
+    reflection: {
+      'en-US':
+        'Fathers and mothers, and heads of families, spiritual and temporal, should bear in mind that inferiors "will not be corrected by words" alone, but that example is likewise needful.',
+      'pt-BR':
+        'Pais e mães, e chefes de família, espirituais e temporais, devem ter em mente que os inferiores "não serão corrigidos apenas por palavras", mas que o exemplo também é necessário.',
+    },
+  },
+  '06-29': {
+    name: { 'en-US': 'St. Peter, Apostle', 'pt-BR': 'São Pedro, Apóstolo' },
+    reflection: {
+      'en-US':
+        'Peter still lives on in his successors, and rules and feeds the flock committed to him. The reality of our devotion to him is the surest test of the purity of our faith.',
+      'pt-BR':
+        'Pedro ainda vive nos seus sucessores, e governa e apascenta o rebanho que lhe foi confiado. A realidade da nossa devoção a ele é a prova mais segura da pureza da nossa fé.',
+    },
+  },
+  '06-30': {
+    name: { 'en-US': 'St. Paul', 'pt-BR': 'São Paulo' },
+    reflection: {
+      'en-US':
+        "St. Paul complains that all seek the things which are their own, and not the things which are Christ's. See if these words apply to you, and resolve to give yourself without reserve to God.",
+      'pt-BR':
+        'São Paulo lamenta que todos buscam as coisas que são suas, e não as coisas que são de Cristo. Vê se estas palavras se aplicam a ti, e resolve dar-te sem reservas a Deus.',
+    },
+  },
+  '07-01': {
+    name: { 'en-US': 'St. Gal, Bishop', 'pt-BR': 'São Galo, Bispo' },
+  },
+  '07-02': {
+    name: {
+      'en-US': 'The Visitation of the Blessed Virgin',
+      'pt-BR': 'A Visitação da Santíssima Virgem',
+    },
+    reflection: {
+      'en-US':
+        'Whilst with the Church we praise God for the mercies and wonders which He wrought in this mystery, we ought to apply ourselves to the imitation of the virtues of which Mary sets us a perfect example. From her we ought particularly to learn the lessons by which we shall sanctify our visits and conversation, actions which are to so many Christians the sources of innumerable dangers and sins.',
+      'pt-BR':
+        'Enquanto, com a Igreja, louvamos a Deus pelas misericórdias e maravilhas que Ele operou neste mistério, devemos aplicar-nos à imitação das virtudes das quais Maria nos dá um perfeito exemplo. Dela devemos particularmente aprender as lições pelas quais santificaremos nossas visitas e conversações, ações que são, para tantos cristãos, fontes de inumeráveis perigos e pecados.',
+    },
+  },
+  '07-03': {
+    name: { 'en-US': 'St. Heliodorus, Bishop', 'pt-BR': 'Santo Heliodoro, Bispo' },
+  },
+  '07-04': {
+    name: { 'en-US': 'St. Bertha, Widow, Abbess', 'pt-BR': 'Santa Berta, Viúva, Abadessa' },
+  },
+  '07-05': {
+    name: { 'en-US': 'St. Peter of Luxemburg', 'pt-BR': 'São Pedro de Luxemburgo' },
+    reflection: {
+      'en-US':
+        'St. Peter teaches us how, by self-denial, rank, riches, the highest dignities, and all this world can give, may serve to make a Saint.',
+      'pt-BR':
+        'São Pedro nos ensina como, pela abnegação, a posição, as riquezas, as mais altas dignidades, e tudo o que este mundo pode dar, podem servir para fazer um Santo.',
+    },
+  },
+  '07-06': {
+    name: {
+      'en-US': 'St. Goar, Priest · St. Palladius, Bishop, Apostle of the Scots',
+      'pt-BR': 'São Goar, Sacerdote · São Paládio, Bispo, Apóstolo dos Escotos',
+    },
+    reflection: {
+      'en-US':
+        'St. Palladius surmounted every obstacle which a fierce nation had opposed to the establishment of the kingdom of Jesus Christ. Ought not our hearts to be impressed with the most lively sentiments of love and gratitude to our merciful God for having raised up such great and zealous men, by whose ministry the light of true faith has been conveyed to us?',
+      'pt-BR':
+        'São Paládio superou todo obstáculo que uma nação feroz havia oposto ao estabelecimento do reino de Jesus Cristo. Não deveriam nossos corações ficar impressos com os mais vivos sentimentos de amor e gratidão a nosso misericordioso Deus, por haver suscitado homens tão grandes e tão zelosos, por cujo ministério a luz da verdadeira fé nos foi transmitida?',
+    },
+  },
+  '07-07': {
+    name: {
+      'en-US': 'St. Pantænus, Father of the Church',
+      'pt-BR': 'São Panteno, Padre da Igreja',
+    },
+    reflection: {
+      'en-US':
+        '"Have a care that none lead you astray by a false philosophy," says St. Paul, for philosophy without religion is a vain thing.',
+      'pt-BR':
+        '"Tomai cuidado para que ninguém vos engane com uma falsa filosofia," diz São Paulo, pois a filosofia sem religião é coisa vã.',
+    },
+  },
+  '07-08': {
+    name: { 'en-US': 'St. Elizabeth of Portugal', 'pt-BR': 'Santa Isabel de Portugal' },
+    reflection: {
+      'en-US':
+        'In the Holy Sacrifice of the Altar St. Elizabeth daily found strength to bear with sweetness suspicion and cruelty; and by that same Holy Sacrifice her innocence was proved. What succor do we forfeit by neglect of daily Mass!',
+      'pt-BR':
+        'No Santo Sacrifício do Altar, Santa Isabel encontrava diariamente forças para suportar com doçura a suspeita e a crueldade; e por esse mesmo Santo Sacrifício foi provada a sua inocência. Que socorro perdemos pela negligência da Missa diária!',
+    },
+  },
+  '07-09': {
+    name: { 'en-US': 'St. Ephrem, Deacon', 'pt-BR': 'Santo Efrém, Diácono' },
+    reflection: {
+      'en-US':
+        'Humility is the path which leads to abiding peace and brings us near to the consolations of God.',
+      'pt-BR':
+        'A humildade é a vereda que conduz à paz duradoura e nos aproxima das consolações de Deus.',
+    },
+  },
+  '07-10': {
+    name: {
+      'en-US': 'The Seven Brothers, Martyrs, and St. Felicitas, their Mother',
+      'pt-BR': 'Os Sete Irmãos, Mártires, e Santa Felicidade, sua Mãe',
+    },
+    reflection: {
+      'en-US':
+        'What afflictions do parents daily meet with from the disorders into which their children fall through their own bad example or neglect! Let them imitate the earnestness of St. Felicitas in forming to perfect virtue the tender souls which God hath committed to their charge, and with this Saint they will have the greatest of all comforts in them, and will by His grace count as many Saints in their family as they are blessed with children.',
+      'pt-BR':
+        'Que aflições os pais encontram diariamente nas desordens em que seus filhos caem por seu próprio mau exemplo ou negligência! Imitem eles o empenho de Santa Felicidade em formar para a perfeita virtude as tenras almas que Deus confiou aos seus cuidados, e com esta Santa terão nelas o maior de todos os consolos, e, por Sua graça, contarão em sua família tantos Santos quantos forem os filhos com que são abençoados.',
+    },
+  },
+  '07-11': {
+    name: { 'en-US': 'St. James, Bishop', 'pt-BR': 'São Tiago, Bispo' },
+  },
+  '07-12': {
+    name: { 'en-US': 'St. John Gualbert', 'pt-BR': 'São João Gualberto' },
+    reflection: {
+      'en-US':
+        'The heroic act which merited for St. John Gualbert his conversion was the forgiveness of his enemy. Let us imitate him in this virtue, resolving never to revenge ourselves in deed, in word, or in thought.',
+      'pt-BR':
+        'O ato heroico que mereceu para São João Gualberto sua conversão foi o perdão de seu inimigo. Imitemo-lo nesta virtude, resolvendo nunca nos vingar por ato, por palavra, ou por pensamento.',
+    },
+  },
+  '07-13': {
+    name: { 'en-US': 'St. Eugenius, Bishop', 'pt-BR': 'São Eugênio, Bispo' },
+    reflection: {
+      'en-US':
+        '"Alms shall be a great confidence before the Most High God to them that give it. Water quencheth a flaming fire, and alms resisteth sin."',
+      'pt-BR':
+        '"A esmola será uma grande confiança diante do Deus Altíssimo para os que a dão. A água apaga o fogo abrasador, e a esmola resiste ao pecado."',
+    },
+  },
+  '07-14': {
+    name: { 'en-US': 'St. Bonaventure', 'pt-BR': 'São Boaventura' },
+    reflection: {
+      'en-US':
+        '"The fear of God," says St. Bonaventure, "forbids a man to give his heart to transitory things, which are the true seeds of sin."',
+      'pt-BR':
+        '"O temor de Deus", diz São Boaventura, "proíbe ao homem entregar seu coração às coisas transitórias, que são as verdadeiras sementes do pecado."',
+    },
+  },
+  '07-15': {
+    name: { 'en-US': 'St. Henry, Emperor', 'pt-BR': 'Santo Henrique, Imperador' },
+    reflection: {
+      'en-US':
+        'St. Henry deprived himself of many things to enrich the house of God. We clothe ourselves in purple and fine linen, and leave Jesus in poverty and neglect.',
+      'pt-BR':
+        'Santo Henrique privou-se de muitas coisas para enriquecer a casa de Deus. Nós nos vestimos de púrpura e linho fino, e deixamos Jesus na pobreza e no abandono.',
+    },
+  },
+  '07-16': {
+    name: { 'en-US': 'St. Simon Stock', 'pt-BR': 'São Simão Stock' },
+    reflection: {
+      'en-US':
+        'To enjoy the privileges of the scapular, it is sufficient that it be received lawfully and worn devoutly. How, then, can any one fail to profit by a devotion so easy, so simple, and so wonderfully blessed? "He that shall overcome, shall thus be clothed in white garments, and I will not blot out his name out of the book of life, and I will confess his name before My Father and before His angels" (Apoc. iii. 5).',
+      'pt-BR':
+        'Para gozar dos privilégios do escapulário, basta que seja recebido legitimamente e usado com devoção. Como, então, pode alguém deixar de aproveitar uma devoção tão fácil, tão simples e tão maravilhosamente abençoada? "O que vencer será assim vestido de vestes brancas, e não apagarei seu nome do livro da vida, e confessarei seu nome diante de Meu Pai e diante de Seus anjos" (Apoc. iii. 5).',
+    },
+  },
+  '07-17': {
+    name: { 'en-US': 'St. Alexius', 'pt-BR': 'Santo Aleixo' },
+    reflection: {
+      'en-US':
+        'We must always be ready to sacrifice our dearest and best natural affections in obedience to the call of our heavenly Father. "Call none your father upon earth, for one is your Father in heaven" (Matt. xxiii. 9). Our Lord has taught us this not by words only, but by His own example and by that of His Saints.',
+      'pt-BR':
+        'Devemos estar sempre prontos a sacrificar nossas mais caras e melhores afeições naturais em obediência ao chamado de nosso Pai celestial. "A ninguém chameis vosso pai sobre a terra, porque um só é vosso Pai, que está nos céus" (Mt. xxiii. 9). Nosso Senhor ensinou-nos isto não apenas por palavras, mas por Seu próprio exemplo e pelo de Seus Santos.',
+    },
+  },
+  '07-18': {
+    name: { 'en-US': 'St. Camillus Of Lellis', 'pt-BR': 'São Camilo de Lélis' },
+    reflection: {
+      'en-US':
+        'St. Camillus venerated the sick as living images of Christ, and by ministering to them in this spirit did penance for the sins of his youth, led a life precious in merit, and from a violent and quarrelsome soldier became a gentle and tender Saint.',
+      'pt-BR':
+        'São Camilo venerava os enfermos como imagens vivas de Cristo, e, servindo-os neste espírito, fez penitência pelos pecados de sua juventude, levou uma vida preciosa em mérito, e de soldado violento e briguento tornou-se um Santo manso e terno.',
+    },
+  },
+  '07-19': {
+    name: { 'en-US': 'St. Vincent of Paul', 'pt-BR': 'São Vicente de Paulo' },
+    reflection: {
+      'en-US':
+        'Most people who profess piety ask advice of directors about their prayers and spiritual exercises. Few inquire whether they are not in danger of damnation from neglect of works of charity.',
+      'pt-BR':
+        'A maioria das pessoas que professam a piedade pede conselho aos diretores acerca de suas orações e exercícios espirituais. Poucas indagam se não estão em perigo de condenação por negligenciar as obras de caridade.',
+    },
+  },
+  '07-20': {
+    name: {
+      'en-US': 'St. Margaret, Virgin and Martyr · St. Jerome Emiliani',
+      'pt-BR': 'Santa Margarida, Virgem e Mártir · São Jerônimo Emiliani',
+    },
+    reflection: {
+      'en-US':
+        'Let us learn from St. Jerome to exert ourselves in behalf of the many hundred children whose souls are perishing around us for want of some one to show them the way to heaven.',
+      'pt-BR':
+        'Aprendamos com São Jerônimo a empenhar-nos em favor das muitas centenas de crianças cujas almas perecem ao nosso redor por falta de alguém que lhes mostre o caminho do céu.',
+    },
+  },
+  '07-21': {
+    name: { 'en-US': 'St. Victor, Martyr', 'pt-BR': 'São Vítor, Mártir' },
+  },
+  '07-22': {
+    name: { 'en-US': 'St. Mary Magdalen', 'pt-BR': 'Santa Maria Madalena' },
+    reflection: {
+      'en-US':
+        '"Compunction of heart," says St. Bernard, "is a treasure infinitely to be desired, and an unspeakable gladness to the heart. It is healing to the soul; it is remission of sins; it brings back again the Holy Spirit into the humble and loving heart."',
+      'pt-BR':
+        '"A compunção do coração", diz São Bernardo, "é um tesouro infinitamente para ser desejado, e uma indizível alegria para o coração. É cura para a alma; é remissão dos pecados; traz de volta o Espírito Santo ao coração humilde e amoroso."',
+    },
+  },
+  '07-23': {
+    name: {
+      'en-US': 'St. Apollinaris, Bishop and Martyr',
+      'pt-BR': 'Santo Apolinário, Bispo e Mártir',
+    },
+    reflection: {
+      'en-US':
+        'The virtue of the Saints was true and heroic, because humble and proof against all trials. Persevere in your good resolutions: it is not enough to begin well; you must so continue to the end.',
+      'pt-BR':
+        'A virtude dos Santos era verdadeira e heroica, porque humilde e à prova de todas as provações. Perseverai em vossas boas resoluções: não basta começar bem; deveis assim continuar até o fim.',
+    },
+  },
+  '07-24': {
+    name: {
+      'en-US': 'St. Christina, Virgin and Martyr',
+      'pt-BR': 'Santa Cristina, Virgem e Mártir',
+    },
+  },
+  '07-25': {
+    name: { 'en-US': 'St. James, Apostle', 'pt-BR': 'São Tiago, Apóstolo' },
+    reflection: {
+      'en-US':
+        'We must all desire a place in the kingdom of our Father; but can we drink the chalice which He holds out to each? *Possumus*, we must say with St. James—"We can"—but only in the strength of Him Who has drunk it first for us.',
+      'pt-BR':
+        'Todos devemos desejar um lugar no reino de nosso Pai; mas podemos beber o cálice que Ele estende a cada um? *Possumus*, devemos dizer com São Tiago — "Podemos" — mas somente na força Daquele que o bebeu primeiro por nós.',
+    },
+  },
+  '07-26': {
+    name: { 'en-US': 'St. Anne', 'pt-BR': 'Santa Ana' },
+    reflection: {
+      'en-US':
+        'St. Anne is glorious among the Saints, not only as the mother of Mary, but because she gave Mary to God. Learn from her to reverence a divine vocation as the highest privilege, and to sacrifice every natural tie, however holy, at the call of God.',
+      'pt-BR':
+        'Santa Ana é gloriosa entre os Santos, não só como mãe de Maria, mas porque deu Maria a Deus. Aprende com ela a reverenciar uma vocação divina como o mais alto privilégio, e a sacrificar todo laço natural, por mais santo que seja, ao chamado de Deus.',
+    },
+  },
+  '07-27': {
+    name: { 'en-US': 'St. Pantaleon, Martyr', 'pt-BR': 'São Pantaleão, Mártir' },
+    reflection: {
+      'en-US': '"With the elect thou shalt be elect, and with the perverse wilt be perverted."',
+      'pt-BR': '"Com os eleitos serás eleito, e com os perversos serás pervertido."',
+    },
+  },
+  '07-28': {
+    name: {
+      'en-US': 'Sts. Nazarius and Celsus, Martyrs',
+      'pt-BR': 'São Nazário e São Celso, Mártires',
+    },
+    reflection: {
+      'en-US':
+        'The martyrs died as the outcasts of the world, but are crowned by God with immortal honor. The glory of the world is false and transitory, and an empty bubble or shadow, but that of virtue is true, solid, and permanent, even in the eyes of men.',
+      'pt-BR':
+        'Os mártires morreram como párias do mundo, mas são coroados por Deus com honra imortal. A glória do mundo é falsa e transitória, e uma bolha ou sombra vazia, mas a da virtude é verdadeira, sólida e permanente, mesmo aos olhos dos homens.',
+    },
+  },
+  '07-29': {
+    name: { 'en-US': 'St. Martha, Virgin', 'pt-BR': 'Santa Marta, Virgem' },
+    reflection: {
+      'en-US':
+        'When Martha received Jesus into her house, she was naturally busy in preparations for such a Guest. Mary sat at His feet, intent alone on listening to His gracious words. Her sister thought that the time required other service than this, and asked our Lord to bid Mary help in serving. Once again Jesus spoke in defence of Mary. "Martha, Martha," He said, "thou art lovingly anxious about many things; be not over-eager; do thy chosen work with recollectedness. Judge not Mary. Hers is the good part, the one only thing really necessary. Thine will be taken away, that something better be given thee." The life of action ceases when the body is laid down; but the life of contemplation endures and is perfected in heaven.',
+      'pt-BR':
+        'Quando Marta recebeu Jesus em sua casa, naturalmente se ocupou nos preparativos para tal Hóspede. Maria estava sentada a Seus pés, atenta unicamente a escutar Suas graciosas palavras. Sua irmã julgava que o momento exigia outro serviço que não este, e pediu a nosso Senhor que ordenasse a Maria que ajudasse a servir. Mais uma vez Jesus falou em defesa de Maria. "Marta, Marta", disse Ele, "andas amorosamente ansiosa por muitas coisas; não te apresses demais; faze a obra que escolheste com recolhimento. Não julgues Maria. A dela é a boa parte, a única coisa realmente necessária. A tua te será tirada, para que algo melhor te seja dado." A vida da ação cessa quando o corpo é deposto; mas a vida da contemplação perdura e se aperfeiçoa no céu.',
+    },
+  },
+  '07-30': {
+    name: { 'en-US': 'St. Germanus, Bishop', 'pt-BR': 'São Germano, Bispo' },
+    reflection: {
+      'en-US':
+        '"Hold the form of sound words, which thou hast heard of me in faith, and in the love which is in Christ Jesus" (II. Tim. i. 13).',
+      'pt-BR':
+        '"Conserva o modelo das sãs palavras que de mim ouviste, na fé e no amor que está em Cristo Jesus" (II Tim. i. 13).',
+    },
+  },
+  '07-31': {
+    name: { 'en-US': 'St. Ignatius of Loyola', 'pt-BR': 'Santo Inácio de Loiola' },
+    reflection: {
+      'en-US':
+        'Ask St. Ignatius to obtain for you the grace to desire ardently the greater glory of God, even though it may cost you much suffering and humiliation.',
+      'pt-BR':
+        'Peça a Santo Inácio que vos obtenha a graça de desejar ardentemente a maior glória de Deus, ainda que vos custe muito sofrimento e humilhação.',
+    },
+  },
+  '08-01': {
+    name: { 'en-US': "St. Peter's Chains", 'pt-BR': 'As Cadeias de São Pedro' },
+    reflection: {
+      'en-US':
+        'This miracle affords a confirmation of the divine promise, "If two of you shall consent upon earth concerning anything whatsoever they shall ask, it shall be done to them by My Father Who is in heaven."',
+      'pt-BR':
+        'Este milagre oferece uma confirmação da promessa divina: "Se dois de vós se puserem de acordo na terra sobre qualquer coisa que pedirem, ser-lhes-á concedida por Meu Pai que está nos céus."',
+    },
+  },
+  '08-02': {
+    name: {
+      'en-US': 'St. Stephen, Pope and Martyr · St. Alphonsus Liguori',
+      'pt-BR': 'São Estêvão, Papa e Mártir · Santo Afonso de Ligório',
+    },
+    reflection: {
+      'en-US':
+        'Let us do with all our heart the duty of each day, leaving the result to God, as well as the care of the future.',
+      'pt-BR':
+        'Façamos de todo o coração o dever de cada dia, deixando o resultado a Deus, bem como o cuidado do futuro.',
+    },
+  },
+  '08-03': {
+    name: {
+      'en-US': "The Finding of St. Stephen's Relics",
+      'pt-BR': 'O Achado das Relíquias de Santo Estêvão',
+    },
+    reflection: {
+      'en-US':
+        'St. Austin, speaking of the miracles of St. Stephen, addresses himself to his flock as follows: "Let us so desire to obtain temporal blessings by his intercession that we may merit, in imitating him, those which are eternal."',
+      'pt-BR':
+        'Santo Agostinho, falando dos milagres de Santo Estêvão, dirige-se ao seu rebanho assim: "Desejemos de tal modo obter, por sua intercessão, as bênçãos temporais, que mereçamos, ao imitá-lo, aquelas que são eternas."',
+    },
+  },
+  '08-04': {
+    name: { 'en-US': 'St. Dominic', 'pt-BR': 'São Domingos' },
+    reflection: {
+      'en-US':
+        '"God has never," said St. Dominic, "refused me what I have asked;" and he has left us the Rosary, that we may learn, with Mary\'s help, to pray easily and simply in the same holy trust.',
+      'pt-BR':
+        '"Deus nunca", dizia São Domingos, "me recusou o que pedi;" e ele nos deixou o Rosário, para que aprendamos, com o auxílio de Maria, a orar fácil e simplesmente na mesma santa confiança.',
+    },
+  },
+  '08-05': {
+    name: {
+      'en-US': 'The Dedication of St. Mary ad Nives',
+      'pt-BR': 'A Dedicação de Santa Maria ad Nives',
+    },
+    reflection: {
+      'en-US':
+        'To render our supplications the more efficacious, we ought to unite them in spirit to those of all fervent penitents and devout souls, in invoking this advocate for sinners.',
+      'pt-BR':
+        'Para tornar nossas súplicas mais eficazes, devemos uni-las em espírito às de todos os fervorosos penitentes e almas devotas, ao invocar esta advogada dos pecadores.',
+    },
+  },
+  '08-06': {
+    name: {
+      'en-US': 'The Transfiguration of Our Lord',
+      'pt-BR': 'A Transfiguração de Nosso Senhor',
+    },
+    reflection: {
+      'en-US':
+        "From the contemplation of this glorious mystery we ought to conceive a true idea of future happiness; if this once possess our souls, we will think nothing of any difficulties or labors we can meet with here, but regard with great indifference all the goods and evils of this life, provided we can but secure our portion in the kingdom of God's glory.",
+      'pt-BR':
+        'Da contemplação deste glorioso mistério devemos conceber uma verdadeira ideia da felicidade futura; se esta uma vez possuir nossas almas, nada pensaremos de quaisquer dificuldades ou trabalhos que aqui possamos encontrar, mas consideraremos com grande indiferença todos os bens e males desta vida, contanto que possamos assegurar a nossa porção no reino da glória de Deus.',
+    },
+  },
+  '08-07': {
+    name: { 'en-US': 'St. Cajetan', 'pt-BR': 'São Caetano' },
+    reflection: {
+      'en-US':
+        "Imitate St. Cajetan's devotion to our blessed Lady, by invoking her aid before every work.",
+      'pt-BR':
+        'Imita a devoção de São Caetano a Nossa Senhora, invocando seu auxílio antes de cada obra.',
+    },
+  },
+  '08-08': {
+    name: {
+      'en-US': 'St. Cyriacus and His Companions, Martyrs · Blessed Peter Favre',
+      'pt-BR': 'São Ciríaco e Seus Companheiros, Mártires · Beato Pedro Favre',
+    },
+    reflection: {
+      'en-US':
+        'To honor the martyrs and duly celebrate their festivals, we must learn their spirit and study to imitate them according to the circumstances of our state. We must, like them, resist evil, must subdue our passions, suffer afflictions with patience, and bear with others without murmuring or complaining. The cross is the ladder by which we must ascend to heaven.',
+      'pt-BR':
+        'Para honrar os mártires e celebrar devidamente suas festividades, devemos aprender seu espírito e procurar imitá-los conforme as circunstâncias de nosso estado. Devemos, como eles, resistir ao mal, devemos subjugar nossas paixões, sofrer as aflições com paciência, e suportar os outros sem murmurar ou reclamar. A cruz é a escada pela qual devemos subir ao céu.',
+    },
+  },
+  '08-09': {
+    name: { 'en-US': 'St. Romanus, Martyr', 'pt-BR': 'São Romano, Mártir' },
+    reflection: {
+      'en-US':
+        'We are bound to glorify God by our lives, and Christ commands that our good works shine before men. It was the usual saying of the apostle St. Matthias, "The faithful sins if his neighbor sins." Such ought to be the zeal of every one to instruct and edify his neighbor by word and example.',
+      'pt-BR':
+        'Estamos obrigados a glorificar a Deus por nossa vida, e Cristo manda que nossas boas obras brilhem diante dos homens. Era o dito habitual do apóstolo São Matias: "O fiel peca se seu próximo peca." Tal deve ser o zelo de cada um para instruir e edificar seu próximo por palavra e exemplo.',
+    },
+  },
+  '08-10': {
+    name: { 'en-US': 'St. Laurence, Martyr', 'pt-BR': 'São Lourenço, Mártir' },
+    reflection: {
+      'en-US':
+        "Our Lord appears before us in the persons of the poor. Charity to them is a great sign of predestination. It is almost impossible, the holy Fathers assure us, for any one who is charitable to the poor for Christ's sake to perish.",
+      'pt-BR':
+        'Nosso Senhor aparece diante de nós nas pessoas dos pobres. A caridade para com eles é um grande sinal de predestinação. É quase impossível, asseguram-nos os santos Padres, que qualquer um que seja caritativo para com os pobres por amor de Cristo venha a perecer.',
+    },
+  },
+  '08-11': {
+    name: {
+      'en-US': 'Sts. Tiburtius and Susanna, Martyrs',
+      'pt-BR': 'São Tibúrcio e Santa Susana, Mártires',
+    },
+    reflection: {
+      'en-US':
+        'Sufferings were to the martyrs the most distinguishing mercy, extraordinary graces, and sources of the greatest crowns and glory. All afflictions which God sends are in like manner the greatest mercies and blessings; they are the most precious talents to be improved by us to the increasing of our love and affection to God, and the exercise of the most heroic virtues of self-denial, patience, humility, resignation, and penance.',
+      'pt-BR':
+        'Os sofrimentos foram para os mártires a mais distinta misericórdia, graças extraordinárias, e fontes das maiores coroas e glória. Todas as aflições que Deus envia são, de igual modo, as maiores misericórdias e bênçãos; são os mais preciosos talentos a serem aproveitados por nós para o crescimento de nosso amor e afeição a Deus, e o exercício das mais heroicas virtudes da abnegação, paciência, humildade, resignação, e penitência.',
+    },
+  },
+  '08-12': {
+    name: { 'en-US': 'St. Clare, Abbess', 'pt-BR': 'Santa Clara, Abadessa' },
+    reflection: {
+      'en-US':
+        'In a luxurious and effeminate age, the daughters of St. Clare still bear the noble title of poor, and preach by their daily lives the poverty of Jesus Christ.',
+      'pt-BR':
+        'Numa época luxuriosa e efeminada, as filhas de Santa Clara ainda ostentam o nobre título de pobres, e pregam por sua vida cotidiana a pobreza de Jesus Cristo.',
+    },
+  },
+  '08-13': {
+    name: { 'en-US': 'St. Radegundes, Queen', 'pt-BR': 'Santa Radegundes, Rainha' },
+  },
+  '08-14': {
+    name: { 'en-US': 'St. Eusebius, Priest', 'pt-BR': 'Santo Eusébio, Sacerdote' },
+    reflection: {
+      'en-US':
+        'Let us learn, from the example of the Saints, courage in the service of God. He calls upon us to endure suffering of body and of mind, if it is necessary, to prove our fidelity to Him; and He promises to support us by His strength, His light, and His heavenly consolation.',
+      'pt-BR':
+        'Aprendamos, do exemplo dos Santos, a coragem no serviço de Deus. Ele nos chama a suportar o sofrimento de corpo e de mente, se for necessário, para provar nossa fidelidade a Ele; e promete sustentar-nos por Sua força, Sua luz, e Sua celestial consolação.',
+    },
+  },
+  '08-15': {
+    name: {
+      'en-US': 'The Assumption of the Blessed Virgin Mary',
+      'pt-BR': 'A Assunção da Santíssima Virgem Maria',
+    },
+    reflection: {
+      'en-US':
+        'Whilst we contemplate, in profound sentiments of veneration, astonishment, and praise, the glory to which Mary is raised by her triumph on this day, we ought, for our own advantage, to consider by what means she arrived at this sublime degree of honor and happiness, that we may walk in her steps. No other way is open to us. The same path which conducted her to glory will also lead us thither; we shall be partners in her reward if we copy her virtues.',
+      'pt-BR':
+        'Enquanto contemplamos, em profundos sentimentos de veneração, assombro e louvor, a glória à qual Maria é elevada por seu triunfo neste dia, devemos, para nosso próprio proveito, considerar por que meios ela chegou a este sublime grau de honra e felicidade, a fim de que caminhemos sobre seus passos. Nenhum outro caminho nos está aberto. A mesma senda que a conduziu à glória também nos levará até lá; seremos partícipes de sua recompensa se copiarmos suas virtudes.',
+    },
+  },
+  '08-16': {
+    name: { 'en-US': 'St. Hyacinth', 'pt-BR': 'São Jacinto' },
+    reflection: {
+      'en-US':
+        'St. Hyacinth teaches us to employ every effort in the service of God, and to rely for success not on our own industry, but on the prayer of His Immaculate Mother.',
+      'pt-BR':
+        'São Jacinto nos ensina a empregar todo esforço no serviço de Deus, e a confiar para o êxito não em nossa própria diligência, mas na oração de sua Imaculada Mãe.',
+    },
+  },
+  '08-17': {
+    name: {
+      'en-US': 'St. Liberatus, Abbot, and Six Monks, Martyrs',
+      'pt-BR': 'São Liberato, Abade, e Seis Monges, Mártires',
+    },
+    reflection: {
+      'en-US':
+        '"Let none of you suffer as a murderer, or a thief, or a railer, or a coveter of other men\'s things; but if as a Christian, let him not be ashamed, but let him glorify God in that name."',
+      'pt-BR':
+        '"Nenhum de vós padeça como homicida, ou ladrão, ou maldizente, ou cobiçoso das coisas alheias; mas, se padecer como cristão, não se envergonhe, antes glorifique a Deus nesse nome."',
+    },
+  },
+  '08-18': {
+    name: {
+      'en-US': 'St. Helena, Empress; St. Agapetus, Martyr',
+      'pt-BR': 'Santa Helena, Imperatriz; Santo Agapito, Mártir',
+    },
+    reflection: {
+      'en-US':
+        'St. Helena thought it the glory of her life to find the cross of Christ, and to raise a temple in its honor. How many Christians in these days are ashamed to make this life-giving sign, and to confess themselves the followers of the Crucified!',
+      'pt-BR':
+        'Santa Helena considerava a glória de sua vida encontrar a cruz de Cristo, e erguer um templo em sua honra. Quantos cristãos nestes dias se envergonham de fazer este sinal vivificante, e de confessar-se seguidores do Crucificado!',
+    },
+  },
+  '08-19': {
+    name: { 'en-US': 'St. Louis, Bishop', 'pt-BR': 'São Luís, Bispo' },
+  },
+  '08-20': {
+    name: { 'en-US': 'St. Bernard', 'pt-BR': 'São Bernardo' },
+    reflection: {
+      'en-US':
+        'St. Bernard used to say to those who applied for admission to the monastery, "If you desire to enter here, leave at the threshold the body you have brought with you from the world; here there is room only for your soul." Let us constantly ask ourselves St. Bernard\'s daily question, "To what end didst thou come hither?"',
+      'pt-BR':
+        'São Bernardo costumava dizer aos que pediam admissão ao mosteiro: "Se desejais entrar aqui, deixai no limiar o corpo que trouxestes convosco do mundo; aqui há lugar somente para a vossa alma." Façamos a nós mesmos constantemente a pergunta diária de São Bernardo: "A que fim vieste tu aqui?"',
+    },
+  },
+  '08-21': {
+    name: { 'en-US': 'St. Jane Frances de Chantal', 'pt-BR': 'Santa Joana Francisca de Chantal' },
+    reflection: {
+      'en-US':
+        'Profit by the successive trials of life to gain the strength and courage of St. Jane Frances, and they will become stepping-stones from earth to heaven.',
+      'pt-BR':
+        'Aproveita as sucessivas provações da vida para ganhar a força e a coragem de Santa Joana Francisca, e elas se tornarão degraus da terra para o céu.',
+    },
+  },
+  '08-22': {
+    name: { 'en-US': 'St. Symphorian, Martyr', 'pt-BR': 'São Sinforiano, Mártir' },
+    reflection: {
+      'en-US':
+        'The Catholic religion teaches us to be subject to every rightful authority. But no earthly authority has any right against Christ and His Church. If we are accused of sedition or disobedience because we are faithful to our religion, then we must choose as St. Symphorian chose, and obey God rather than man.',
+      'pt-BR':
+        'A religião católica nos ensina a estar sujeitos a toda autoridade legítima. Mas nenhuma autoridade terrena tem direito algum contra Cristo e sua Igreja. Se formos acusados de sedição ou desobediência por sermos fiéis à nossa religião, então devemos escolher como escolheu São Sinforiano, e obedecer a Deus antes que aos homens.',
+    },
+  },
+  '08-23': {
+    name: { 'en-US': 'St. Philip Benizi', 'pt-BR': 'São Filipe Benício' },
+    reflection: {
+      'en-US':
+        'Endeavor so to act as you would wish to have acted when you stand before your Judge. This is the rule of the Saints, and the only safe rule for all.',
+      'pt-BR':
+        'Esforça-te por agir como desejarias ter agido quando estiveres diante do teu Juiz. Esta é a regra dos Santos, e a única regra segura para todos.',
+    },
+  },
+  '08-24': {
+    name: { 'en-US': 'St. Bartholomew, Apostle', 'pt-BR': 'São Bartolomeu, Apóstolo' },
+    reflection: {
+      'en-US':
+        'The characteristic virtue of the apostles was zeal for the divine glory, the first property of the love of God. A soldier is always ready to defend the honor of his prince, and a son that of his father; and can a Christian say he loves God who is indifferent to His honor?',
+      'pt-BR':
+        'A virtude característica dos apóstolos era o zelo pela glória divina, a primeira propriedade do amor de Deus. Um soldado está sempre pronto a defender a honra de seu príncipe, e um filho a de seu pai; e poderá um cristão dizer que ama a Deus quando é indiferente à sua honra?',
+    },
+  },
+  '08-25': {
+    name: { 'en-US': 'St. Louis, King', 'pt-BR': 'São Luís, Rei' },
+    reflection: {
+      'en-US':
+        'If we cannot imitate St. Louis in dying for the honor of God, we can at least resemble him in resenting the blasphemies offered against God by the infidel, the heretic, and the scoffer.',
+      'pt-BR':
+        'Se não podemos imitar São Luís em morrer pela honra de Deus, podemos ao menos assemelhar-nos a ele em ressentir-nos das blasfêmias proferidas contra Deus pelo infiel, pelo herege e pelo escarnecedor.',
+    },
+  },
+  '08-26': {
+    name: { 'en-US': 'St. Zephyrinus, Pope and Martyr', 'pt-BR': 'São Zeferino, Papa e Mártir' },
+    reflection: {
+      'en-US':
+        'God has always raised up holy pastors zealous to maintain the faith of His Church inviolable, and to watch over the purity of its morals and the sanctity of its discipline. We enjoy the greatest advantages of the divine grace through their labors, and we owe to God a tribute of perpetual thanksgiving and immortal praise for all those mercies which He has afforded His Church on earth.',
+      'pt-BR':
+        'Deus sempre suscitou santos pastores zelosos por manter inviolável a fé de sua Igreja, e por velar sobre a pureza de seus costumes e a santidade de sua disciplina. Gozamos das maiores vantagens da graça divina por meio de seus trabalhos, e devemos a Deus um tributo de perpétua ação de graças e de imortal louvor por todas aquelas misericórdias que Ele concedeu à sua Igreja na terra.',
+    },
+  },
+  '08-27': {
+    name: { 'en-US': 'St. Joseph Calasanctius', 'pt-BR': 'São José de Calasanz' },
+    reflection: {
+      'en-US':
+        '"My children," said the Curé of Ars, "I often think that most of the Christians who are lost are lost for want of instruction; they do not know their religion well."',
+      'pt-BR':
+        '"Meus filhos", dizia o Cura d\'Ars, "penso muitas vezes que a maior parte dos cristãos que se perdem, perdem-se por falta de instrução; não conhecem bem a sua religião."',
+    },
+  },
+  '08-28': {
+    name: { 'en-US': 'St. Augustine of Hippo', 'pt-BR': 'Santo Agostinho de Hipona' },
+    reflection: {
+      'en-US':
+        'Read the lives of the Saints, and you will find that you are gradually creating a society about you to which in some measure you will be forced to raise the standard of your daily life.',
+      'pt-BR':
+        'Lede as vidas dos Santos, e vereis que ides gradualmente criando em torno de vós uma sociedade à qual, em certa medida, sereis forçados a elevar o padrão de vossa vida diária.',
+    },
+  },
+  '08-29': {
+    name: {
+      'en-US': 'The Beheading of St. John the Baptist',
+      'pt-BR': 'A Degolação de São João Batista',
+    },
+    reflection: {
+      'en-US':
+        'All the high graces with which St. John was favored sprang from his humility; in this all his other virtues were founded. If we desire to form ourselves upon so great a model, we must, above all things, labor to lay the same deep foundation.',
+      'pt-BR':
+        'Todas as elevadas graças com que São João foi favorecido brotaram de sua humildade; nesta se fundavam todas as suas demais virtudes. Se desejamos formar-nos sobre tão grande modelo, devemos, acima de tudo, esforçar-nos por lançar o mesmo profundo fundamento.',
+    },
+  },
+  '08-30': {
+    name: {
+      'en-US': 'St. Rose of Lima · St. Fiaker, Anchorite',
+      'pt-BR': 'Santa Rosa de Lima · São Fiacro, Anacoreta',
+    },
+    reflection: {
+      'en-US':
+        'Rose, pure as driven snow, was filled with deepest contrition and humility, and did constant and terrible penance. Our sins are continual, our repentance passing, our contrition slight, our penance nothing. How will it fare with us?',
+      'pt-BR':
+        'Rosa, pura como a neve recém-caída, estava cheia da mais profunda contrição e humildade, e fazia constante e terrível penitência. Nossos pecados são contínuos, nosso arrependimento passageiro, nossa contrição leve, nossa penitência nenhuma. Como será de nós?',
+    },
+  },
+  '08-31': {
+    name: { 'en-US': 'St. Raymund Nonnatus', 'pt-BR': 'São Raimundo Nonato' },
+    reflection: {
+      'en-US':
+        'This Saint gave not only his substance but his liberty, and even exposed himself to the most cruel torments and death, for the redemption of captives and the salvation of souls. But alas! do not we, merely to gratify our prodigality, vanity, or avarice, refuse to give the superfluous part of our possessions to the poor, who for want of it are perishing with cold and hunger? Let us remember that "He that giveth to the poor shall not want."',
+      'pt-BR':
+        'Este Santo deu não somente seus bens, mas a sua liberdade, e até se expôs aos mais cruéis tormentos e à morte, pela redenção dos cativos e pela salvação das almas. Mas, ai! não recusamos nós, apenas para satisfazer nossa prodigalidade, vaidade ou avareza, dar a parte supérflua de nossas posses aos pobres, que por falta dela perecem de frio e de fome? Lembremo-nos de que "Aquele que dá ao pobre não passará necessidade."',
+    },
+  },
+  '09-01': {
+    name: { 'en-US': 'St. Giles, Abbot', 'pt-BR': 'Santo Egídio, Abade' },
+    reflection: {
+      'en-US':
+        'He who accompanies the exercises of contemplation and arduous penance with zealous and undaunted endeavors to conduct others to the same glorious term with himself, shall be truly great in the kingdom of heaven.',
+      'pt-BR':
+        'Aquele que acompanha os exercícios de contemplação e árdua penitência com zelosos e destemidos esforços por conduzir os outros ao mesmo glorioso termo a que ele próprio chega, será verdadeiramente grande no reino dos céus.',
+    },
+  },
+  '09-02': {
+    name: { 'en-US': 'St. Stephen, King', 'pt-BR': 'Santo Estêvão, Rei' },
+    reflection: {
+      'en-US':
+        '"Our duty," says Father Newman, "is to follow the Vicar of Christ whither he goeth, and never to desert him, however we may be tried; but to defend him at all hazards and against all corners, as a son would a father, and as a wife a husband, knowing that his cause is the cause of God."',
+      'pt-BR':
+        '"Nosso dever", diz o Padre Newman, "é seguir o Vigário de Cristo para onde quer que ele vá, e nunca abandoná-lo, por mais que sejamos provados; mas defendê-lo a todo custo e contra todos os adversários, como um filho a um pai, e como uma esposa a um marido, sabendo que a sua causa é a causa de Deus."',
+    },
+  },
+  '09-03': {
+    name: { 'en-US': 'St. Seraphia, Virgin and Martyr', 'pt-BR': 'Santa Seráfia, Virgem e Mártir' },
+    reflection: {
+      'en-US':
+        'Christian courage bears relation to our faith. "If we continue in the faith, grounded, and settled, and immovable," all things will be found possible to us.',
+      'pt-BR':
+        'A coragem cristã guarda relação com a nossa fé. "Se permanecermos na fé, fundamentados, firmes e inabaláveis", todas as coisas nos serão possíveis.',
+    },
+  },
+  '09-04': {
+    name: { 'en-US': 'St. Rosalia, Virgin', 'pt-BR': 'Santa Rosália, Virgem' },
+    reflection: {
+      'en-US':
+        "Rose lived but seventeen years, saved the Church's cause, and died a Saint. We have lived, perhaps, much longer, and yet with what result? Every minute something can be done for God. Let us be up and doing.",
+      'pt-BR':
+        'Rosa viveu apenas dezessete anos, salvou a causa da Igreja, e morreu Santa. Nós temos vivido, talvez, muito mais tempo, e contudo com que resultado? A cada minuto algo pode ser feito por Deus. Levantemo-nos e ponhamo-nos a fazer.',
+    },
+  },
+  '09-05': {
+    name: { 'en-US': 'St. Laurence Justinian', 'pt-BR': 'São Lourenço Justiniano' },
+    reflection: {
+      'en-US':
+        'Ask St. Laurence to vouchsafe you such a sense of the sufficiency of God that you too may fly to Him and be at rest.',
+      'pt-BR':
+        'Pedi a São Lourenço que se digne conceder-vos tal senso da suficiência de Deus que também vós voeis a Ele e nele encontreis repouso.',
+    },
+  },
+  '09-06': {
+    name: { 'en-US': 'St. Eleutherius, Abbot', 'pt-BR': 'Santo Eleutério, Abade' },
+    reflection: {
+      'en-US':
+        '"Appear not to men to fast, but to thy Father Who is in heaven, and thy Father, Who seeth in secret, He will repay thee."',
+      'pt-BR':
+        '"Não pareças aos homens que jejuas, mas a teu Pai que está no céu, e teu Pai, que vê em segredo, te recompensará."',
+    },
+  },
+  '09-07': {
+    name: { 'en-US': 'St. Cloud, Confessor', 'pt-BR': 'São Clodoaldo, Confessor' },
+    reflection: {
+      'en-US':
+        'Let us remember that "the just shall live for evermore; they shall receive a kingdom of glory, and a crown of beauty at the hand of the Lord."',
+      'pt-BR':
+        'Lembremo-nos de que "os justos viverão para sempre; receberão um reino de glória e uma coroa de beleza da mão do Senhor."',
+    },
+  },
+  '09-08': {
+    name: {
+      'en-US':
+        'The Nativity of the Blessed Virgin · The Festival, on the Sunday Within the Octave of Her Nativity, of The Holy Name of Mary',
+      'pt-BR':
+        'A Natividade da Santíssima Virgem · A Festa, no Domingo Dentro da Oitava de Sua Natividade, do Santíssimo Nome de Maria',
+    },
+  },
+  '09-09': {
+    name: {
+      'en-US': 'St. Omer, Bishop · Saint Peter Claver',
+      'pt-BR': 'Santo Omer, Bispo · São Pedro Claver',
+    },
+    reflection: {
+      'en-US':
+        'When you see any one standing in need of your assistance, either for body or soul, do not ask yourself why some one else did not help him, but think to yourself that you have found a treasure.',
+      'pt-BR':
+        'Quando vires alguém necessitado de teu auxílio, seja para o corpo ou para a alma, não te perguntes por que algum outro não o socorreu, mas pensa contigo mesmo que encontraste um tesouro.',
+    },
+  },
+  '09-10': {
+    name: { 'en-US': 'St. Nicholas of Tolentino', 'pt-BR': 'São Nicolau de Tolentino' },
+    reflection: {
+      'en-US':
+        'Would you die the death of the just? there is only one way to secure the fulfilment of your wish. Live the life of the just. For it is impossible that one who has been faithful to God in life should make a bad or an unhappy end.',
+      'pt-BR':
+        'Desejarias morrer a morte dos justos? há somente um caminho para assegurar o cumprimento de teu desejo. Vive a vida dos justos. Pois é impossível que aquele que foi fiel a Deus em vida tenha um mau ou infeliz fim.',
+    },
+  },
+  '09-11': {
+    name: { 'en-US': 'St. Paphnutius, Bishop', 'pt-BR': 'São Pafnúcio, Bispo' },
+    reflection: {
+      'en-US':
+        'If to fight for our country be glorious, "it is likewise great glory to follow the Lord," saith the Wise Man.',
+      'pt-BR':
+        'Se combater por nossa pátria é glorioso, "é igualmente grande glória seguir o Senhor," diz o Sábio.',
+    },
+  },
+  '09-12': {
+    name: { 'en-US': 'St. Guy of Anderlecht', 'pt-BR': 'São Guido de Anderlecht' },
+    reflection: {
+      'en-US':
+        'Jesus was only nine months in the womb of Mary, three hours on the cross, three days in the sepulchre, but He is always in the tabernacle. Does our reverence before Him bear witness to this most blessed truth?',
+      'pt-BR':
+        'Jesus esteve apenas nove meses no ventre de Maria, três horas na cruz, três dias no sepulcro, mas está sempre no tabernáculo. Dá a nossa reverência diante Dele testemunho desta bem-aventuradíssima verdade?',
+    },
+  },
+  '09-13': {
+    name: {
+      'en-US': 'St. Eulogius, Patriarch of Alexandria',
+      'pt-BR': 'Santo Eulógio, Patriarca de Alexandria',
+    },
+    reflection: {
+      'en-US':
+        'We admire the great actions and the glorious triumph of the Saints; yet it is not so much in these that their sanctity consisted, as in the constant, habitual heroic disposition of their souls. There is no one who does not sometimes do good actions; but he can never be called virtuous who does well only by humor, or by fits and starts, not by steady habits.',
+      'pt-BR':
+        'Admiramos as grandes ações e o glorioso triunfo dos Santos; contudo não foi tanto nestes que consistiu sua santidade, quanto na constante, habitual e heroica disposição de suas almas. Não há quem não pratique, por vezes, boas ações; mas nunca se poderá chamar virtuoso aquele que age bem apenas por humor, ou aos arrancos, e não por hábitos firmes.',
+    },
+  },
+  '09-14': {
+    name: {
+      'en-US': 'The Exaltation of the Holy Cross of Our Lord Jesus Christ',
+      'pt-BR': 'A Exaltação da Santa Cruz de Nosso Senhor Jesus Cristo',
+    },
+    reflection: {
+      'en-US':
+        'Herein is found the accomplishment of the Saviour\'s word: "If I be lifted up from the earth, I will draw all things to Myself."',
+      'pt-BR':
+        'Aqui se encontra o cumprimento da palavra do Salvador: "Se eu for levantado da terra, atrairei todas as coisas a Mim."',
+    },
+  },
+  '09-15': {
+    name: { 'en-US': 'St. Catherine of Genoa', 'pt-BR': 'Santa Catarina de Gênova' },
+    reflection: {
+      'en-US':
+        'The constant thought of purgatory will help us not only to escape its dreadful pains, but also to avoid the least imperfection which hinders our approach to God.',
+      'pt-BR':
+        'O constante pensamento no purgatório nos ajudará não somente a escapar de suas terríveis penas, mas também a evitar a menor imperfeição que estorve a nossa aproximação de Deus.',
+    },
+  },
+  '09-16': {
+    name: { 'en-US': 'St. Cyprian, Bishop, Martyr', 'pt-BR': 'São Cipriano, Bispo, Mártir' },
+    reflection: {
+      'en-US':
+        'The duty of almsgiving is declared both by nature and revelation: by nature, because it flows from the principle imprinted within us of doing to others as we would they should do to us; by revelation, in many special commands of Scripture, and in the precept of divine charity which binds us to love God for His own sake, and our neighbor for the sake of God.',
+      'pt-BR':
+        'O dever da esmola é declarado tanto pela natureza quanto pela revelação: pela natureza, porque flui do princípio impresso em nós de fazer aos outros como quereríamos que nos fizessem; pela revelação, em muitos mandamentos especiais da Escritura, e no preceito da caridade divina que nos obriga a amar a Deus por Ele mesmo, e ao próximo por amor de Deus.',
+    },
+  },
+  '09-17': {
+    name: { 'en-US': 'St. Lambert, Bishop, Martyr', 'pt-BR': 'São Lamberto, Bispo, Mártir' },
+    reflection: {
+      'en-US':
+        'How noble and heroic is this virtue of fortitude! how necessary for every Christian, especially for a pastor of souls, that neither worldly views nor fears may ever in the least warp his integrity or blind his judgment!',
+      'pt-BR':
+        'Quão nobre e heroica é esta virtude da fortaleza! Quão necessária para todo cristão, especialmente para um pastor de almas, a fim de que nem as vistas mundanas nem os temores jamais desviem em coisa alguma a sua integridade ou cegem o seu juízo!',
+    },
+  },
+  '09-18': {
+    name: { 'en-US': 'St. Thomas of Villanova', 'pt-BR': 'São Tomás de Vilanova' },
+    reflection: {
+      'en-US':
+        '"Answer me, O sinner!" St. Thomas would say, "what can you purchase with your money better or more necessary than the redemption of your sins?"',
+      'pt-BR':
+        '"Responde-me, ó pecador!", costumava dizer São Tomás, "que podes comprar com o teu dinheiro melhor ou mais necessário do que a redenção dos teus pecados?"',
+    },
+  },
+  '09-19': {
+    name: { 'en-US': 'St. Januarius, Martyr', 'pt-BR': 'São Januário, Mártir' },
+    reflection: {
+      'en-US':
+        'Thank God Who has given you superabundant motives for your faith; and pray for the spirit of the first Christians, the spirit which exults and rejoices in belief.',
+      'pt-BR':
+        'Agradece a Deus, que te concedeu motivos superabundantes para a tua fé; e roga pelo espírito dos primeiros cristãos, o espírito que exulta e se rejubila na crença.',
+    },
+  },
+  '09-20': {
+    name: {
+      'en-US': 'Sts. Eustachius and Companions, Martyrs',
+      'pt-BR': 'Santo Eustáquio e Companheiros, Mártires',
+    },
+    reflection: {
+      'en-US':
+        'It is not enough to encounter dangers with resolution; we must with equal courage and constancy vanquish pleasure and the softer passions, or we possess not the virtue of true fortitude.',
+      'pt-BR':
+        'Não basta enfrentar os perigos com resolução; devemos, com igual coragem e constância, vencer o prazer e as paixões mais brandas, ou não possuímos a virtude da verdadeira fortaleza.',
+    },
+  },
+  '09-21': {
+    name: { 'en-US': 'St. Matthew, Apostle', 'pt-BR': 'São Mateus, Apóstolo' },
+    reflection: {
+      'en-US':
+        'Obey all inspirations of Our Lord as promptly as St. Matthew, who, at a single word, "laid down," says St. Bridget, "the heavy burden of the world to put on the light and sweet yoke of Christ."',
+      'pt-BR':
+        'Obedece a todas as inspirações de Nosso Senhor tão prontamente quanto São Mateus, que, a uma só palavra, "depôs", diz Santa Brígida, "o pesado fardo do mundo para tomar o leve e suave jugo de Cristo."',
+    },
+  },
+  '09-22': {
+    name: { 'en-US': 'The Theban Legion', 'pt-BR': 'A Legião Tebana' },
+    reflection: {
+      'en-US':
+        'Thank God for every slight and injury you have to bear. An injury borne in meekness and silence is a true victory. It is the proof that we are good soldiers of Jesus Christ, disciples of that heavenly wisdom which is first pure, then peaceable.',
+      'pt-BR':
+        'Agradece a Deus por cada desprezo e injúria que tens de suportar. Uma injúria suportada em mansidão e silêncio é uma verdadeira vitória. É a prova de que somos bons soldados de Jesus Cristo, discípulos daquela sabedoria celeste que é primeiro pura, depois pacífica.',
+    },
+  },
+  '09-23': {
+    name: { 'en-US': 'St. Thecla, Virgin, Martyr', 'pt-BR': 'Santa Tecla, Virgem, Mártir' },
+    reflection: {
+      'en-US':
+        'It is purity in soul and body which will make you strong in pain, in temptation, and in the hour of death. Imitate the purity of this glorious virgin, and take her for your special patroness in your last agony.',
+      'pt-BR':
+        'É a pureza na alma e no corpo que te fará forte na dor, na tentação e na hora da morte. Imita a pureza desta gloriosa virgem, e toma-a por tua padroeira especial na tua última agonia.',
+    },
+  },
+  '09-24': {
+    name: {
+      'en-US': 'The Blessed Virgin Mary of Mercy',
+      'pt-BR': 'A Santíssima Virgem Maria da Mercê',
+    },
+    reflection: {
+      'en-US':
+        'St. Peter Nolasco and his knights were laymen, not priests, and yet they considered the salvation of their neighbor intrusted to them. We can each of us by counsel, by prayer, but above all by holy example, assist the salvation of our brethren, and thus secure our own.',
+      'pt-BR':
+        'São Pedro Nolasco e seus cavaleiros eram leigos, não sacerdotes, e contudo consideravam-se incumbidos da salvação do próximo. Cada um de nós pode, pelo conselho, pela oração, mas sobretudo pelo santo exemplo, auxiliar a salvação de nossos irmãos, e assim assegurar a nossa própria.',
+    },
+  },
+  '09-25': {
+    name: {
+      'en-US': 'St. Firmin, Bishop, Martyr. St. Finbarr, Bishop',
+      'pt-BR': 'São Firmino, Bispo, Mártir. São Finbarr, Bispo',
+    },
+  },
+  '09-26': {
+    name: {
+      'en-US': 'Sts. Cyprian and Justina, Martyrs',
+      'pt-BR': 'São Cipriano e Santa Justina, Mártires',
+    },
+    reflection: {
+      'en-US':
+        'If the errors and disorders of St. Cyprian show the degeneracy of human nature corrupted by sin and enslaved to vice, his conversion displays the power of grace and virtue to repair it. Let us beg of God to send us grace to resist temptation, and to do His holy will in all things.',
+      'pt-BR':
+        'Se os erros e as desordens de São Cipriano mostram a degeneração da natureza humana corrompida pelo pecado e escravizada ao vício, a sua conversão exibe o poder da graça e da virtude para repará-la. Roguemos a Deus que nos envie graça para resistir à tentação, e para fazer a Sua santa vontade em todas as coisas.',
+    },
+  },
+  '09-27': {
+    name: {
+      'en-US': 'Sts. Cosmas and Damian, Martyrs',
+      'pt-BR': 'São Cosme e São Damião, Mártires',
+    },
+    reflection: {
+      'en-US':
+        'We may sanctify our labor or industry, if actuated by the motive of charity toward others, even whilst we fulfil the obligation we owe to ourselves and our families of procuring an honest and necessary subsistence, which of itself is no less noble a virtue, if founded in motives equally pure and perfect.',
+      'pt-BR':
+        'Podemos santificar o nosso trabalho ou a nossa indústria, se forem movidos pelo motivo da caridade para com os outros, mesmo enquanto cumprimos a obrigação que devemos a nós mesmos e às nossas famílias de prover um sustento honesto e necessário, o que por si só não é virtude menos nobre, se fundado em motivos igualmente puros e perfeitos.',
+    },
+  },
+  '09-28': {
+    name: { 'en-US': 'St. Wenceslas, Martyr', 'pt-BR': 'São Venceslau, Mártir' },
+    reflection: {
+      'en-US':
+        'St. Wenceslas teaches us that the safest place to meet the trials of life, or to prepare for the stroke of death, is before Jesus in the Blessed Sacrament.',
+      'pt-BR':
+        'São Venceslau nos ensina que o lugar mais seguro para enfrentar as provações da vida, ou para preparar-se para o golpe da morte, é diante de Jesus no Santíssimo Sacramento.',
+    },
+  },
+  '09-29': {
+    name: { 'en-US': 'St. Michael, Archangel', 'pt-BR': 'São Miguel, Arcanjo' },
+    reflection: {
+      'en-US':
+        '"Whenever," says St. Bernard, "any grievous temptation or vehement sorrow oppresses thee, invoke thy guardian, thy leader; cry out to him, and say, \'Lord, save us, lest we perish!\'"',
+      'pt-BR':
+        '"Sempre que", diz São Bernardo, "qualquer grave tentação ou veemente tristeza te oprimir, invoca teu guardião, teu condutor; clama a ele e dize: \'Senhor, salva-nos, para que não pereçamos!\'"',
+    },
+  },
+  '09-30': {
+    name: { 'en-US': 'St. Jerome, Doctor', 'pt-BR': 'São Jerônimo, Doutor' },
+    reflection: {
+      'en-US':
+        '"To know," says St. Basil, "how to submit thyself with thy whole soul, is to know how to imitate Christ."',
+      'pt-BR':
+        '"Saber", diz São Basílio, "como submeter-te com toda a tua alma, é saber como imitar Cristo."',
+    },
+  },
+  '10-01': {
+    name: { 'en-US': 'St. Remigius, Bishop', 'pt-BR': 'São Remígio, Bispo' },
+    reflection: {
+      'en-US':
+        "Few men have had such natural advantages and such gifts of grace as St. Remi, and few have done so great a work. Learn from him to bear the world's praise as well as its scorn with a lowly and chastened heart.",
+      'pt-BR':
+        'Poucos homens tiveram tais vantagens naturais e tais dons de graça como São Remi, e poucos realizaram obra tão grande. Aprende com ele a suportar tanto o louvor do mundo quanto o seu escárnio com um coração humilde e mortificado.',
+    },
+  },
+  '10-02': {
+    name: { 'en-US': 'The Holy Guardian Angels', 'pt-BR': 'Os Santos Anjos da Guarda' },
+    reflection: {
+      'en-US':
+        'Ah! let us not give occasion, in the language of Holy Scripture, to the angels of peace to weep bitterly.',
+      'pt-BR':
+        'Ah! não demos ocasião, na linguagem da Sagrada Escritura, a que os anjos da paz chorem amargamente.',
+    },
+  },
+  '10-03': {
+    name: { 'en-US': 'St. Gerard, Abbot', 'pt-BR': 'São Gerardo, Abade' },
+    reflection: {
+      'en-US':
+        'Though we are in the world, let us strive to separate ourselves from it and consecrate ourselves to God, remembering that "the world passeth away, but he that doth the will of God abideth forever."',
+      'pt-BR':
+        'Embora estejamos no mundo, esforcemo-nos por separar-nos dele e consagrar-nos a Deus, lembrando que "o mundo passa, mas aquele que faz a vontade de Deus permanece para sempre."',
+    },
+  },
+  '10-04': {
+    name: { 'en-US': 'St. Francis of Assisi', 'pt-BR': 'São Francisco de Assis' },
+    reflection: {
+      'en-US':
+        '"My God and my all," St. Francis’ constant prayer, explains both his poverty and his wealth.',
+      'pt-BR':
+        '"Meu Deus e meu tudo", a constante oração de São Francisco, explica tanto a sua pobreza quanto a sua riqueza.',
+    },
+  },
+  '10-05': {
+    name: { 'en-US': 'St. Placid, Martyr', 'pt-BR': 'São Plácido, Mártir' },
+    reflection: {
+      'en-US':
+        'Adversity is the touchstone of the soul, because it discovers the character of the virtue which it possesses. One act of thanksgiving when matters go wrong with us is worth a thousand thanks when things are agreeable to our inclinations.',
+      'pt-BR':
+        'A adversidade é a pedra de toque da alma, porque revela o caráter da virtude que ela possui. Um ato de ação de graças quando as coisas nos correm mal vale mais que mil agradecimentos quando as coisas estão conforme as nossas inclinações.',
+    },
+  },
+  '10-06': {
+    name: { 'en-US': 'St. Bruno', 'pt-BR': 'São Bruno' },
+    reflection: {
+      'en-US':
+        '"O everlasting kingdom," said St. Augustine; "kingdom of endless ages, whereon rests the untroubled light and the peace of God which passeth all understanding, where the souls of the Saints are in rest, and everlasting joy is on their heads, and sorrow and sighing have fled away! When shall I come and appear before God?"',
+      'pt-BR':
+        '"Ó reino eterno", disse Santo Agostinho; "reino de idades sem fim, sobre o qual repousa a luz imperturbável e a paz de Deus que excede todo entendimento, onde as almas dos Santos estão em descanso, e a alegria eterna está sobre suas cabeças, e a tristeza e o gemido fugiram para longe! Quando virei e aparecerei diante de Deus?"',
+    },
+  },
+  '10-07': {
+    name: { 'en-US': 'St. Mark, Pope', 'pt-BR': 'São Marcos, Papa' },
+    reflection: {
+      'en-US':
+        'A Christian ought to be afraid of no enemy more than himself, whom he carries always about with him, and from whom he is not able to flee. He should therefore never cease to cry out to God, "Unless Thou, O Lord, art my light and support, I watch in vain."',
+      'pt-BR':
+        'Um cristão não deve temer nenhum inimigo mais do que a si mesmo, a quem carrega sempre consigo, e de quem não é capaz de fugir. Por isso, jamais deveria cessar de clamar a Deus: "Se Tu, ó Senhor, não és a minha luz e o meu sustentáculo, em vão velo."',
+    },
+  },
+  '10-08': {
+    name: { 'en-US': 'St. Bridget of Sweden', 'pt-BR': 'Santa Brígida da Suécia' },
+    reflection: {
+      'en-US':
+        '"Is confession a matter of much time or expense?" asks St. John Chrysostom. "Is it a difficult and painful remedy? Without cost or hurt, the medicine is ever ready to restore you to perfect health."',
+      'pt-BR':
+        '"Acaso é a confissão uma questão de muito tempo ou despesa?", pergunta São João Crisóstomo. "É um remédio difícil e penoso? Sem custo nem dano, o medicamento está sempre pronto para te restituir à perfeita saúde."',
+    },
+  },
+  '10-09': {
+    name: {
+      'en-US': 'St. Dionysius and his Companions, Martyrs. St. Louis Bertrand',
+      'pt-BR': 'São Dionísio e seus Companheiros, Mártires. São Luís Bertrando',
+    },
+    reflection: {
+      'en-US':
+        'The Saints fasted, toiled, and wept, not only for love of God, but for fear of damnation. How shall we, with our self-indulgent lives and unexamined consciences, face the judgment-seat of Christ?',
+      'pt-BR':
+        'Os Santos jejuaram, labutaram e choraram, não apenas por amor de Deus, mas por temor da condenação. Como haveremos nós, com nossas vidas de autoindulgência e nossas consciências não examinadas, de enfrentar o tribunal de Cristo?',
+    },
+  },
+  '10-10': {
+    name: { 'en-US': 'St. Francis Borgia', 'pt-BR': 'São Francisco de Borja' },
+    reflection: {
+      'en-US':
+        'St. Francis Borgia learnt the worthlessness of earthly greatness at the funeral of Queen Isabella. Do the deaths of friends teach us aught about ourselves?',
+      'pt-BR':
+        'São Francisco de Borja aprendeu a inutilidade da grandeza terrena no funeral da Rainha Isabel. Acaso as mortes dos amigos nos ensinam algo acerca de nós mesmos?',
+    },
+  },
+  '10-11': {
+    name: { 'en-US': 'St. Tarachus and his Companions', 'pt-BR': 'São Taraco e seus Companheiros' },
+    reflection: {
+      'en-US':
+        'Such is true Christian devotion. "Neither death nor life shall be able to separate us from the love that is in Christ Jesus."',
+      'pt-BR':
+        'Tal é a verdadeira devoção cristã. "Nem a morte nem a vida poderão separar-nos do amor que está em Cristo Jesus."',
+    },
+  },
+  '10-12': {
+    name: { 'en-US': 'St. Wilfrid, Bishop', 'pt-BR': 'São Wilfrido, Bispo' },
+    reflection: {
+      'en-US':
+        'To look towards Rome is an instinct planted in us for the preservation of the Faith. Trust in the Vicar of Christ necessarily results from the reign of His love in our hearts.',
+      'pt-BR':
+        'Olhar para Roma é um instinto plantado em nós para a preservação da Fé. A confiança no Vigário de Cristo resulta necessariamente do reinado de Seu amor em nossos corações.',
+    },
+  },
+  '10-13': {
+    name: { 'en-US': 'St. Edward the Confessor', 'pt-BR': 'Santo Eduardo, o Confessor' },
+    reflection: {
+      'en-US':
+        "David longed to build a temple for God's service. Solomon reckoned it his glory to accomplish the work. But we, who have God made flesh dwelling in our tabernacles, ought to think no time, no zeal, no treasures too much to devote to the splendor and beauty of a Christian church.",
+      'pt-BR':
+        'Davi ansiava por edificar um templo para o serviço de Deus. Salomão tinha por glória sua realizar a obra. Mas nós, que temos Deus feito carne habitando em nossos tabernáculos, não devemos julgar tempo algum, zelo algum, tesouro algum demasiado para consagrar ao esplendor e à beleza de uma igreja cristã.',
+    },
+  },
+  '10-14': {
+    name: { 'en-US': 'St. Callistus, Pope, Martyr', 'pt-BR': 'São Calisto, Papa, Mártir' },
+    reflection: {
+      'en-US':
+        'In the body of a Christian we see that which has been the temple of the Holy Ghost, which even now is precious in the eyes of God, Who will watch over it, and one day raise it up in glory to shine forever in His kingdom. Let our actions bear witness to our belief in these truths.',
+      'pt-BR':
+        'No corpo de um cristão vemos aquilo que foi o templo do Espírito Santo, que ainda agora é precioso aos olhos de Deus, que velará sobre ele, e que um dia o ressuscitará em glória para resplandecer para sempre em Seu reino. Que nossas ações dêem testemunho de nossa crença nestas verdades.',
+    },
+  },
+  '10-15': {
+    name: { 'en-US': 'St. Teresa', 'pt-BR': 'Santa Teresa' },
+    reflection: {
+      'en-US':
+        '"After all I die a child of the Church." These were the Saint\'s last words. They teach us the lesson of her life—to trust in humble, childlike obedience to our spiritual guides as the surest means of salvation.',
+      'pt-BR':
+        '"Afinal, morro filha da Igreja." Estas foram as últimas palavras da Santa. Ensinam-nos a lição de sua vida — confiar na humilde e infantil obediência a nossos guias espirituais como o mais seguro meio de salvação.',
+    },
+  },
+  '10-16': {
+    name: { 'en-US': 'St. Gall, Abbot', 'pt-BR': 'São Galo, Abade' },
+    reflection: {
+      'en-US':
+        '"If any one would be My disciple," says Our Saviour, "let him deny himself." The denial of self is, then, the royal road to perfection.',
+      'pt-BR':
+        '"Se alguém quiser ser Meu discípulo", diz Nosso Salvador, "negue-se a si mesmo." A negação de si mesmo é, pois, o caminho real para a perfeição.',
+    },
+  },
+  '10-17': {
+    name: {
+      'en-US': 'St. Hedwige. Saint Margaret Mary Alacoque',
+      'pt-BR': 'Santa Edviges. Santa Margarida Maria Alacoque',
+    },
+    reflection: {
+      'en-US':
+        'Love for the Sacred Heart especially honors the Incarnation, and makes the soul grow rapidly in humility, generosity, patience, and union with its Beloved.',
+      'pt-BR':
+        'O amor pelo Sagrado Coração honra de modo especial a Encarnação, e faz a alma crescer rapidamente em humildade, generosidade, paciência e união com o seu Amado.',
+    },
+  },
+  '10-18': {
+    name: { 'en-US': 'St. Luke', 'pt-BR': 'São Lucas' },
+    reflection: {
+      'en-US': 'Christ has given all He had for thee; do thou give all thou hast for Him.',
+      'pt-BR': 'Cristo deu tudo o que tinha por ti; dá tu tudo o que tens por Ele.',
+    },
+  },
+  '10-19': {
+    name: { 'en-US': 'St. Peter of Alcantara', 'pt-BR': 'São Pedro de Alcântara' },
+    reflection: {
+      'en-US':
+        'If men do not go about barefoot now, nor undergo sharp penances, as St. Peter did, there are many ways of trampling on the world; and Our Lord teaches them when He finds the necessary courage.',
+      'pt-BR':
+        'Se os homens hoje não andam descalços, nem se submetem a penitências agudas, como São Pedro fazia, há muitas maneiras de pisar o mundo; e Nosso Senhor as ensina quando encontra a coragem necessária.',
+    },
+  },
+  '10-20': {
+    name: { 'en-US': 'St. John Cantius', 'pt-BR': 'São João Câncio' },
+    reflection: {
+      'en-US':
+        'He who orders all his doings according to the will of God may often be spoken of by the world as simple and stupid; but in the end he wins the esteem and confidence of the world itself, and the approval and peace of God.',
+      'pt-BR':
+        'Aquele que ordena todos os seus atos segundo a vontade de Deus pode ser muitas vezes tachado pelo mundo de simples e tolo; mas no fim conquista a estima e a confiança do próprio mundo, e a aprovação e a paz de Deus.',
+    },
+  },
+  '10-21': {
+    name: { 'en-US': 'St. Ursula, Virgin and Martyr', 'pt-BR': 'Santa Úrsula, Virgem e Mártir' },
+    reflection: {
+      'en-US':
+        'In the estimation of the wise man, "the guarding of virtue" is the most important part of the education of youth.',
+      'pt-BR':
+        'Na estimação do sábio, "a guarda da virtude" é a parte mais importante da educação da juventude.',
+    },
+  },
+  '10-22': {
+    name: {
+      'en-US': 'St. Mello, Bishop. St. Hilarion, Abbot',
+      'pt-BR': 'São Melônio, Bispo. Santo Hilarião, Abade',
+    },
+  },
+  '10-23': {
+    name: { 'en-US': 'St. Theodoret, Martyr', 'pt-BR': 'São Teodoreto, Mártir' },
+    reflection: {
+      'en-US':
+        'Those who do not go down to hell in spirit are very likely to go there in reality. Take care to meditate upon the four last things, and to live in holy fear. You will learn to love God better by thinking how He punishes those who do not love Him.',
+      'pt-BR':
+        'Aqueles que não descem ao inferno em espírito são muito propensos a ir para lá na realidade. Cuida de meditar sobre as quatro últimas coisas e de viver no santo temor. Aprenderás a amar a Deus melhor pensando em como Ele castiga aqueles que não O amam.',
+    },
+  },
+  '10-24': {
+    name: { 'en-US': 'St. Magloire, Bishop', 'pt-BR': 'São Maglório, Bispo' },
+    reflection: {
+      'en-US':
+        '"Be mindful of them that have rule over you, who have spoken to you the word of God, whose faith follow, considering the end."',
+      'pt-BR':
+        '"Lembrai-vos dos vossos guias, que vos anunciaram a palavra de Deus; e, considerando o fim da sua vida, imitai-lhes a fé."',
+    },
+  },
+  '10-25': {
+    name: {
+      'en-US': 'Sts. Crispin and Crispinian, Martyrs',
+      'pt-BR': 'São Crispim e São Crispiniano, Mártires',
+    },
+    reflection: {
+      'en-US':
+        'Of how many may it be said that "they labor in vain," since God is not the end and purpose that inspires the labor?',
+      'pt-BR':
+        'De quantos se pode dizer que "trabalham em vão", visto que Deus não é o fim e o propósito que inspira o trabalho?',
+    },
+  },
+  '10-26': {
+    name: { 'en-US': 'St. Evaristus, Pope and Martyr', 'pt-BR': 'Santo Evaristo, Papa e Mártir' },
+    reflection: {
+      'en-US':
+        'The disciples of the apostles, by assiduous meditation on heavenly things, were so swallowed up in the life to come, that they seemed no longer inhabitants of this world. If Christians esteem and set their hearts on earthly goods, and lose sight of eternity in the course of their actions, they are no longer animated by the spirit of the primitive Saints, and are become children of this world, slaves to its vanities, and to their own irregular passions. If we do not correct this disorder of our hearts, and conform our interior to the spirit of Christ, we cannot be entitled to His promises.',
+      'pt-BR':
+        'Os discípulos dos apóstolos, pela assídua meditação nas coisas celestiais, estavam tão absortos na vida futura que pareciam já não ser habitantes deste mundo. Se os cristãos estimam e põem seu coração nos bens terrenos, e perdem de vista a eternidade no curso de suas ações, já não são animados pelo espírito dos Santos primitivos, e tornaram-se filhos deste mundo, escravos de suas vaidades e de suas próprias paixões desregradas. Se não corrigirmos esta desordem de nossos corações, e não conformarmos o nosso interior ao espírito de Cristo, não poderemos ter direito às Suas promessas.',
+    },
+  },
+  '10-27': {
+    name: { 'en-US': 'St. Frumentius, Bishop', 'pt-BR': 'São Frumêncio, Bispo' },
+    reflection: {
+      'en-US':
+        '"The soul that journeys in the light and the truths of the Faith is safe against all error."',
+      'pt-BR': '"A alma que caminha na luz e nas verdades da Fé está a salvo de todo erro."',
+    },
+  },
+  '10-28': {
+    name: { 'en-US': 'Sts. Simon and Jude', 'pt-BR': 'São Simão e São Judas' },
+    reflection: {
+      'en-US':
+        "Zeal is an ardent love which makes a man fearless in defence of God's honor, and earnest at all costs to make known the truth. If we would be children of the Saints, we must be zealous for the Faith.",
+      'pt-BR':
+        'O zelo é um amor ardente que torna o homem destemido na defesa da honra de Deus, e empenhado a todo custo em dar a conhecer a verdade. Se quisermos ser filhos dos Santos, devemos ser zelosos pela Fé.',
+    },
+  },
+  '10-29': {
+    name: { 'en-US': 'St. Narcissus, Bishop', 'pt-BR': 'São Narciso, Bispo' },
+    reflection: {
+      'en-US':
+        'God never fails those who trust in Him; He guides them through darkness and through trials secretly and surely to their end, and in the evening time there is light.',
+      'pt-BR':
+        "Deus nunca falha àqueles que n'Ele confiam; Ele os guia através das trevas e das provações, secreta e seguramente, ao seu fim, e na hora da tarde haverá luz.",
+    },
+  },
+  '10-30': {
+    name: {
+      'en-US': 'St. Marcellus, the Centurion, Martyr',
+      'pt-BR': 'São Marcelo, o Centurião, Mártir',
+    },
+    reflection: {
+      'en-US':
+        '"We are ready to die rather than to transgress the laws of God!" exclaimed one of the Machabees. This sentiment should ever be that of a Christian in presence of temptation.',
+      'pt-BR':
+        '"Estamos prontos a morrer antes que transgredir as leis de Deus!" exclamou um dos Macabeus. Este sentimento deve ser sempre o de um cristão em presença da tentação.',
+    },
+  },
+  '10-31': {
+    name: { 'en-US': 'St. Quintin, Martyr', 'pt-BR': 'São Quintino, Mártir' },
+    reflection: {
+      'en-US':
+        'Let us bear in mind that the ills of this life are not worthy to be compared to the glory "God has reserved for those who love Him."',
+      'pt-BR':
+        'Tenhamos em mente que os males desta vida não são dignos de ser comparados com a glória que "Deus reservou para aqueles que O amam".',
+    },
+  },
+  '11-01': {
+    name: { 'en-US': 'All-Saints', 'pt-BR': 'Todos os Santos' },
+    reflection: {
+      'en-US':
+        'Let us have a solicitude to render ourselves worthy of "that chaste generation, so beautiful amid the glory where it dwells."',
+      'pt-BR':
+        'Tenhamos a solicitude de tornar-nos dignos "daquela casta geração, tão bela em meio à glória onde habita".',
+    },
+  },
+  '11-02': {
+    name: {
+      'en-US': 'All-Souls · St. Malachi, Bishop',
+      'pt-BR': 'Todos os Fiéis Defuntos · São Malaquias, Bispo',
+    },
+    reflection: {
+      'en-US':
+        'Our Lord said to St. Gertrude, "God accepts every soul you set free, as if you had redeemed him from captivity, and will reward you in a fitting time for the benefit you have conferred."',
+      'pt-BR':
+        'Nosso Senhor disse a Santa Gertrudes: "Deus aceita cada alma que libertas, como se a tivesses resgatado do cativeiro, e te recompensará no tempo devido pelo benefício que conferiste."',
+    },
+  },
+  '11-03': {
+    name: { 'en-US': 'St. Hubert, Bishop', 'pt-BR': 'Santo Huberto, Bispo' },
+    reflection: {
+      'en-US':
+        'What the Wise Man has said of Wisdom may be applied to Grace: "That it ordereth the means with gentleness, and attaineth its end with power."',
+      'pt-BR':
+        'O que o Sábio disse da Sabedoria pode aplicar-se à Graça: "Que dispõe os meios com brandura, e alcança seu fim com poder."',
+    },
+  },
+  '11-04': {
+    name: { 'en-US': 'St. Charles Borromeo', 'pt-BR': 'São Carlos Borromeu' },
+    reflection: {
+      'en-US':
+        'Daily resolutions to fulfil, at all cost, every duty demanded by God, is the lesson taught by St. Charles; and a lesson we must learn if we would overcome our corrupt nature and reform our lives.',
+      'pt-BR':
+        'Resoluções diárias de cumprir, a todo custo, todo dever exigido por Deus, é a lição ensinada por São Carlos; e uma lição que devemos aprender se quisermos vencer nossa natureza corrompida e reformar nossas vidas.',
+    },
+  },
+  '11-05': {
+    name: { 'en-US': 'St. Bertille, Abbess', 'pt-BR': 'Santa Bertila, Abadessa' },
+    reflection: {
+      'en-US':
+        'It is written that the Saints raise themselves heavenward, going from virtue to virtue, as by steps.',
+      'pt-BR':
+        'Está escrito que os Santos se elevam rumo ao céu, indo de virtude em virtude, como por degraus.',
+    },
+  },
+  '11-06': {
+    name: { 'en-US': 'St. Leonard', 'pt-BR': 'São Leonardo' },
+    reflection: {
+      'en-US':
+        '"The wicked shall be taken with his own iniquities, and shall be held by the cords of his own sin."',
+      'pt-BR':
+        '"O ímpio será apanhado por suas próprias iniquidades, e será preso pelas cordas de seu próprio pecado."',
+    },
+  },
+  '11-07': {
+    name: { 'en-US': 'St. Willibrord', 'pt-BR': 'São Vilibrordo' },
+    reflection: {
+      'en-US':
+        'True zeal has its root in the love of God. It can never be idle; it must labor, toil, be doing great things. It glows as fire; it is, like fire, insatiable. See if this spirit be in you!',
+      'pt-BR':
+        'O verdadeiro zelo tem sua raiz no amor de Deus. Nunca pode ficar ocioso; deve trabalhar, labutar, realizar grandes coisas. Arde como o fogo; é, como o fogo, insaciável. Vê se este espírito está em ti!',
+    },
+  },
+  '11-08': {
+    name: { 'en-US': 'The Feast of the Holy Relics', 'pt-BR': 'A Festa das Santas Relíquias' },
+  },
+  '11-09': {
+    name: { 'en-US': 'St. Theodore Tyro, Martyr', 'pt-BR': 'São Teodoro Tiro, Mártir' },
+    reflection: {
+      'en-US':
+        "We are enlisted in the same service as the holy martyrs, and we too must have courage and constancy if we would be perfect soldiers of Jesus Christ. Let us take our part with them in confessing the faith of Christ and despising the world, that we may have our part with them in Christ's kingdom.",
+      'pt-BR':
+        'Estamos alistados no mesmo serviço que os santos mártires, e também nós devemos ter coragem e constância se quisermos ser perfeitos soldados de Jesus Cristo. Tomemos parte com eles em confessar a fé de Cristo e desprezar o mundo, para que tenhamos parte com eles no reino de Cristo.',
+    },
+  },
+  '11-10': {
+    name: { 'en-US': '10: St. Andrew Avellino', 'pt-BR': 'Santo André Avelino' },
+    reflection: {
+      'en-US':
+        'St. Andrew, who suffered so terrible an agony, is the special patron against sudden death. Ask him to be with you in your last hour, and to bring Jesus and Mary to your aid.',
+      'pt-BR':
+        'Santo André, que padeceu agonia tão terrível, é o padroeiro especial contra a morte súbita. Pedi-lhe que esteja convosco em vossa última hora, e que traga Jesus e Maria em vosso auxílio.',
+    },
+  },
+  '11-11': {
+    name: { 'en-US': 'St. Martin of Tours', 'pt-BR': 'São Martinho de Tours' },
+    reflection: {
+      'en-US':
+        'It was for Christ crucified that St. Martin worked. Are you working for the same Lord?',
+      'pt-BR':
+        'Foi por Cristo crucificado que São Martinho trabalhou. Trabalhas tu pelo mesmo Senhor?',
+    },
+  },
+  '11-12': {
+    name: { 'en-US': 'St. Martin, Pope', 'pt-BR': 'São Martinho, Papa' },
+    reflection: {
+      'en-US':
+        'There have been times in the history of Christianity when its truths have seemed on the verge of extinction. But there is one Church whose testimony has never failed: it is the Church of St. Peter, the Apostolic and Roman See. Put your whole trust in her teaching!',
+      'pt-BR':
+        'Houve tempos na história do cristianismo em que suas verdades pareceram à beira da extinção. Mas há uma Igreja cujo testemunho jamais falhou: é a Igreja de São Pedro, a Sé Apostólica e Romana. Depositai toda a vossa confiança em seu ensino!',
+    },
+  },
+  '11-13': {
+    name: { 'en-US': 'St. Stanislas Kostka', 'pt-BR': 'São Estanislau Kostka' },
+    reflection: {
+      'en-US':
+        'St. Stanislas teaches us in every trial of life, and above all in the hour of death, to have recourse to our patron Saint, and to trust without fear to his aid.',
+      'pt-BR':
+        'São Estanislau ensina-nos, em toda provação da vida, e acima de tudo na hora da morte, a recorrer ao nosso Santo padroeiro, e a confiar sem temor em seu auxílio.',
+    },
+  },
+  '11-14': {
+    name: {
+      'en-US': "St. Didacus · St. Laurence O'Toole, Archbishop of Dublin",
+      'pt-BR': "São Dídaco · São Lourenço O'Toole, Arcebispo de Dublin",
+    },
+    reflection: {
+      'en-US':
+        'If God be in your heart, He will be also on your lips; for Christ has said, "From the abundance of the heart the mouth speaketh."',
+      'pt-BR':
+        'Se Deus estiver em teu coração, estará também em teus lábios; pois Cristo disse: "Da abundância do coração fala a boca."',
+    },
+  },
+  '11-15': {
+    name: { 'en-US': 'St. Gertrude, Abbess', 'pt-BR': 'Santa Gertrudes, Abadessa' },
+    reflection: {
+      'en-US':
+        'No preparation for death can be better than to offer and resign ourselves anew to the Divine Will—humbly, lovingly, with unbounded confidence in the infinite mercy and goodness of God.',
+      'pt-BR':
+        'Nenhuma preparação para a morte pode ser melhor do que oferecer-nos e entregar-nos de novo à Vontade Divina — humildemente, amorosamente, com ilimitada confiança na infinita misericórdia e bondade de Deus.',
+    },
+  },
+  '11-16': {
+    name: { 'en-US': 'St. Edmund of Canterbury', 'pt-BR': 'Santo Edmundo de Cantuária' },
+    reflection: {
+      'en-US':
+        'The Saints were tempted even more than ourselves; but they stood where we fall, because they trusted to Mary, and not to themselves.',
+      'pt-BR':
+        'Os Santos foram tentados ainda mais do que nós; mas mantiveram-se firmes onde nós caímos, porque confiaram em Maria, e não em si mesmos.',
+    },
+  },
+  '11-17': {
+    name: { 'en-US': 'St. Gregory Thaumaturgus', 'pt-BR': 'São Gregório Taumaturgo' },
+    reflection: {
+      'en-US':
+        'Devotion to the blessed Mother of God is the sure protection of faith in her Divine Son. Every time that we invoke her, we renew our faith in the Incarnate God; we reverse the sin and unbelief of our first parents; we take our part with her who was blessed because she believed.',
+      'pt-BR':
+        'A devoção à bendita Mãe de Deus é a segura proteção da fé em seu Filho Divino. Cada vez que a invocamos, renovamos nossa fé no Deus Encarnado; revertemos o pecado e a incredulidade de nossos primeiros pais; tomamos parte com aquela que foi bem-aventurada porque creu.',
+    },
+  },
+  '11-18': {
+    name: { 'en-US': 'St. Odo of Cluny', 'pt-BR': 'Santo Odão de Cluny' },
+    reflection: {
+      'en-US':
+        '"It needs only," says Father Newman, "for a Catholic to show devotion to any Saint, in order to receive special benefits from his intercession."',
+      'pt-BR':
+        '"Basta apenas", diz o Padre Newman, "que um católico mostre devoção a algum Santo, para receber benefícios especiais de sua intercessão."',
+    },
+  },
+  '11-19': {
+    name: { 'en-US': 'St. Elizabeth of Hungary', 'pt-BR': 'Santa Isabel da Hungria' },
+    reflection: {
+      'en-US':
+        'This young and delicate princess made herself the servant and nurse of the poor. Let her example teach us to disregard the opinions of the world and to overcome our natural repugnances, in order to serve Christ in the persons of His poor.',
+      'pt-BR':
+        'Esta jovem e delicada princesa fez-se serva e enfermeira dos pobres. Que seu exemplo nos ensine a desprezar as opiniões do mundo e a vencer nossas repugnâncias naturais, a fim de servir a Cristo nas pessoas de seus pobres.',
+    },
+  },
+  '11-20': {
+    name: { 'en-US': 'St. Felix of Valois', 'pt-BR': 'São Félix de Valois' },
+    reflection: {
+      'en-US':
+        '"Think how much," says St. John Chrysostom, "and how often thy mouth has sinned, and thou wilt devote thyself entirely to the conversion of sinners. For by this one means thou wilt blot out all thy sins, in that thy mouth will become the mouth of God."',
+      'pt-BR':
+        '"Pensa quanto", diz São João Crisóstomo, "e quão amiúde tua boca pecou, e te dedicarás inteiramente à conversão dos pecadores. Pois por este único meio apagarás todos os teus pecados, porquanto tua boca se tornará a boca de Deus."',
+    },
+  },
+  '11-21': {
+    name: {
+      'en-US': 'The Presentation of the Blessed Virgin Mary',
+      'pt-BR': 'A Apresentação da Santíssima Virgem Maria',
+    },
+    reflection: {
+      'en-US':
+        "Mary's first presentation to God was an offering most acceptable in His sight. Let our consecration of ourselves to God be made under her patronage, and assisted by her powerful intercession and the union of her merits.",
+      'pt-BR':
+        'A primeira apresentação de Maria a Deus foi uma oferta sumamente aceitável a seus olhos. Que nossa consagração de nós mesmos a Deus seja feita sob seu patrocínio, e assistida por sua poderosa intercessão e pela união de seus méritos.',
+    },
+  },
+  '11-22': {
+    name: { 'en-US': 'St. Cecilia, Virgin, Martyr', 'pt-BR': 'Santa Cecília, Virgem, Mártir' },
+    reflection: {
+      'en-US':
+        'St. Cecilia teaches us to rejoice in every sacrifice as a pledge of our love of Christ, and to welcome sufferings and death as hastening our union with Him.',
+      'pt-BR':
+        'Santa Cecília nos ensina a regozijar-nos em cada sacrifício como penhor de nosso amor a Cristo, e a acolher os sofrimentos e a morte como apressando nossa união com Ele.',
+    },
+  },
+  '11-23': {
+    name: { 'en-US': 'St. Clement of Rome', 'pt-BR': 'São Clemente de Roma' },
+    reflection: {
+      'en-US':
+        'God rewards a simple spirit of submission to the clergy, for the honor done to them is done to Him. Your virtue is unreal, your faith in danger, if you fail in this.',
+      'pt-BR':
+        'Deus recompensa um simples espírito de submissão ao clero, pois a honra prestada a eles é prestada a Ele. Tua virtude é irreal, tua fé está em perigo, se faltas neste ponto.',
+    },
+  },
+  '11-24': {
+    name: { 'en-US': 'St. John of the Cross', 'pt-BR': 'São João da Cruz' },
+    reflection: {
+      'en-US':
+        '"Live in the world," said St. John, "as if God and your soul only were in it; so shall your heart be never made captive by any earthly thing."',
+      'pt-BR':
+        '"Vive no mundo", dizia São João, "como se nele estivessem somente Deus e tua alma; assim teu coração nunca será cativado por nenhuma coisa terrena."',
+    },
+  },
+  '11-25': {
+    name: { 'en-US': 'St. Catherine of Alexandria', 'pt-BR': 'Santa Catarina de Alexandria' },
+    reflection: {
+      'en-US':
+        'The constancy displayed by the Saints in their glorious martyrdom cannot be isolated from their previous lives, but is their natural sequence. If we wish to emulate their perseverance, let us first imitate their fidelity to grace.',
+      'pt-BR':
+        'A constância demonstrada pelos Santos em seu glorioso martírio não pode ser isolada de suas vidas anteriores, mas é sua consequência natural. Se desejamos emular sua perseverança, imitemos primeiro sua fidelidade à graça.',
+    },
+  },
+  '11-26': {
+    name: {
+      'en-US': 'St. Peter of Alexandria, Bishop, Martyr',
+      'pt-BR': 'São Pedro de Alexandria, Bispo, Mártir',
+    },
+    reflection: {
+      'en-US':
+        '"How hardly shall they that have riches enter into the kingdom of God!" says Our Saviour; because they are bound to earth by the strong ties of their riches.',
+      'pt-BR':
+        '"Quão dificilmente entrarão no reino de Deus os que têm riquezas!", diz Nosso Salvador; porque estão presos à terra pelos fortes laços de suas riquezas.',
+    },
+  },
+  '11-27': {
+    name: { 'en-US': 'St. Maximus, Bishop', 'pt-BR': 'São Máximo, Bispo' },
+    reflection: {
+      'en-US':
+        '"Masters, do to your servants that which is just and equal, knowing that you also have a Master in heaven."',
+      'pt-BR':
+        '"Senhores, fazei a vossos servos o que é justo e equitativo, sabendo que também vós tendes um Senhor no céu."',
+    },
+  },
+  '11-28': {
+    name: {
+      'en-US': 'St. James of La Marca of Ancona',
+      'pt-BR': 'São Tiago de La Marca de Ancona',
+    },
+  },
+  '11-29': {
+    name: { 'en-US': 'St. Saturninus, Martyr', 'pt-BR': 'São Saturnino, Mártir' },
+    reflection: {
+      'en-US':
+        'When beset by the temptations of the devil, let us call upon the Saints, who reign with Christ. They were powerful during their lives against the devil and his angels. They are more powerful now that they have passed from the Church on earth to the Church triumphant.',
+      'pt-BR':
+        'Quando assediados pelas tentações do demônio, invoquemos os Santos, que reinam com Cristo. Eles foram poderosos durante suas vidas contra o demônio e seus anjos. São ainda mais poderosos agora que passaram da Igreja na terra para a Igreja triunfante.',
+    },
+  },
+  '11-30': {
+    name: { 'en-US': 'St. Andrew, Apostle', 'pt-BR': 'Santo André, Apóstolo' },
+    reflection: {
+      'en-US': 'If we would do good to others, we must, like St. Andrew, keep close to the cross.',
+      'pt-BR':
+        'Se quisermos fazer o bem aos outros, devemos, como Santo André, manter-nos perto da cruz.',
+    },
+  },
+  '12-01': {
+    name: { 'en-US': 'St. Eligius', 'pt-BR': 'Santo Elói' },
+    reflection: {
+      'en-US':
+        'When God called His Saints to Himself, He might, had He so pleased, have taken their bodies also; but He willed to leave them in our charge, for our help and consolation. Be careful to imitate St. Eligius in making a good use of so great a treasure.',
+      'pt-BR':
+        'Quando Deus chamou os seus Santos para Si, poderia, se assim Lhe aprouvesse, ter tomado também os seus corpos; mas quis deixá-los a nosso cuidado, para nosso auxílio e consolação. Tem cuidado de imitar Santo Elói no fazer bom uso de tão grande tesouro.',
+    },
+  },
+  '12-02': {
+    name: { 'en-US': 'St. Bibiana, Virgin, Martyr', 'pt-BR': 'Santa Bibiana, Virgem, Mártir' },
+    reflection: {
+      'en-US':
+        "Pray for a fidelity and patience like Bibiana's under all trials, that neither convenience nor any worldly advantage may ever prevail upon you to transgress your duty.",
+      'pt-BR':
+        'Ora por uma fidelidade e uma paciência como as de Bibiana sob todas as provações, para que nem a conveniência nem qualquer vantagem mundana jamais prevaleçam sobre ti a ponto de transgredires o teu dever.',
+    },
+  },
+  '12-03': {
+    name: { 'en-US': 'St. Francis Xavier', 'pt-BR': 'São Francisco Xavier' },
+    reflection: {
+      'en-US':
+        'Some are specially called to work for souls; but there is no one who cannot help much in their salvation. Holy example, earnest intercession, the offerings of our actions in their behalf—all this needs only the spirit which animated St. Francis Xavier, the desire to make some return to God.',
+      'pt-BR':
+        'Alguns são especialmente chamados a trabalhar pelas almas; mas não há ninguém que não possa auxiliar muito em sua salvação. O santo exemplo, a fervorosa intercessão, o oferecimento de nossas ações em seu favor — tudo isto necessita apenas do espírito que animava São Francisco Xavier, o desejo de fazer algum retorno a Deus.',
+    },
+  },
+  '12-04': {
+    name: { 'en-US': 'St. Barbara, Virgin, Martyr', 'pt-BR': 'Santa Bárbara, Virgem, Mártir' },
+    reflection: {
+      'en-US':
+        'Pray often against a sudden and unprovided death; and, above all, that you may be strengthened by the Holy Viaticum against the dangers of your last hour.',
+      'pt-BR':
+        'Ora frequentemente contra uma morte súbita e desprevenida; e, acima de tudo, para que sejas fortalecido pelo Santo Viático contra os perigos de tua última hora.',
+    },
+  },
+  '12-05': {
+    name: { 'en-US': 'St. Sabas, Abbot', 'pt-BR': 'São Sabas, Abade' },
+  },
+  '12-06': {
+    name: { 'en-US': 'St. Nicholas of Bari', 'pt-BR': 'São Nicolau de Bari' },
+    reflection: {
+      'en-US':
+        'Those who would enter heaven must be as little children, whose greatest glory is their innocence. Now, two things are ours to do: first, to preserve it in ourselves, or regain it by penance; secondly, to love and shield it in others.',
+      'pt-BR':
+        'Aqueles que quiserem entrar no céu devem ser como criancinhas, cuja maior glória é a sua inocência. Ora, duas coisas nos cabe fazer: primeiro, conservá-la em nós mesmos, ou recuperá-la pela penitência; segundo, amá-la e protegê-la nos outros.',
+    },
+  },
+  '12-07': {
+    name: { 'en-US': 'St. Ambrose, Bishop', 'pt-BR': 'Santo Ambrósio, Bispo' },
+    reflection: {
+      'en-US':
+        'Whence came to St. Ambrose his grandeur of mind, his clearness of insight, his intrepidity in maintaining the faith and discipline of the Church? Whence but from his contempt of the world, from his fearing God alone?',
+      'pt-BR':
+        'De onde veio a Santo Ambrósio sua grandeza de espírito, sua clareza de discernimento, sua intrepidez em manter a fé e a disciplina da Igreja? De onde, senão de seu desprezo do mundo, de seu temer a Deus somente?',
+    },
+  },
+  '12-08': {
+    name: {
+      'en-US': 'The Feast of the Immaculate Conception',
+      'pt-BR': 'A Festa da Imaculada Conceição',
+    },
+    reflection: {
+      'en-US':
+        'Let us repeat frequently these words applied by the Church to the Blessed Virgin: "Thou art all fair, O Mary, and there is not a spot in thee" (Cant. iv. 7).',
+      'pt-BR':
+        'Repitamos com frequência estas palavras aplicadas pela Igreja à Santíssima Virgem: "Tu és toda formosa, ó Maria, e não há mancha em ti" (Cânt. iv. 7).',
+    },
+  },
+  '12-09': {
+    name: { 'en-US': 'St. Leocadia, Virgin, Martyr', 'pt-BR': 'Santa Leocádia, Virgem, Mártir' },
+    reflection: {
+      'en-US':
+        'Were we not blinded by the world and the enchantment of its follies, the near prospect of eternity, the uncertainty of the hour of our death, and the repeated precepts of Christ would produce in us the same fervent dispositions which they did in the primitive Christians.',
+      'pt-BR':
+        'Se não estivéssemos cegos pelo mundo e pelo encanto de suas loucuras, a iminente perspectiva da eternidade, a incerteza da hora de nossa morte e os repetidos preceitos de Cristo produziriam em nós as mesmas fervorosas disposições que produziram nos primeiros cristãos.',
+    },
+  },
+  '12-10': {
+    name: { 'en-US': 'St. Eulalia, Virgin, Martyr', 'pt-BR': 'Santa Eulália, Virgem, Mártir' },
+    reflection: {
+      'en-US':
+        'The apostles rejoiced "that they were accounted worthy to suffer reproach for the name of Jesus." Do we bear our crosses with the same spirit?',
+      'pt-BR':
+        'Os apóstolos regozijaram-se "por terem sido considerados dignos de sofrer afronta pelo nome de Jesus." Carregamos nós as nossas cruzes com o mesmo espírito?',
+    },
+  },
+  '12-11': {
+    name: { 'en-US': 'St. Damasus, Pope', 'pt-BR': 'São Dâmaso, Papa' },
+  },
+  '12-12': {
+    name: {
+      'en-US': 'St. Valery, Abbot. St. Finian, Bishop',
+      'pt-BR': 'São Valério, Abade. São Finiano, Bispo',
+    },
+  },
+  '12-13': {
+    name: { 'en-US': 'St. Lucy, Virgin, Martyr', 'pt-BR': 'Santa Luzia, Virgem, Mártir' },
+    reflection: {
+      'en-US':
+        "The Saints had to bear sufferings and temptations greater far than yours. How did they overcome them? By the love of Christ. Nourish this pure love by meditating on the mysteries of Christ's life; and, above all, by devotion to the Holy Eucharist, which is the antidote against sin and the pledge of eternal life.",
+      'pt-BR':
+        'Os Santos tiveram de suportar sofrimentos e tentações muito maiores que os teus. Como os venceram? Pelo amor de Cristo. Nutre este amor puro meditando nos mistérios da vida de Cristo; e, sobretudo, pela devoção à Santíssima Eucaristia, que é o antídoto contra o pecado e o penhor da vida eterna.',
+    },
+  },
+  '12-14': {
+    name: {
+      'en-US': 'St. Nicasius, Archbishop, and his Companions, Martyrs',
+      'pt-BR': 'São Nicásio, Arcebispo, e seus Companheiros, Mártires',
+    },
+    reflection: {
+      'en-US':
+        'Bear patiently and sweetly bodily sufferings, and prepare for the day of trial by the courageous endurance of the daily crosses incident to your state.',
+      'pt-BR':
+        'Suporta com paciência e doçura os sofrimentos corporais, e prepara-te para o dia da provação pela corajosa resistência às cruzes diárias inerentes ao teu estado.',
+    },
+  },
+  '12-15': {
+    name: { 'en-US': 'St. Mesmin', 'pt-BR': 'São Mesmin' },
+    reflection: {
+      'en-US':
+        'Few are called to serve God by great actions, but all are bound to strive after perfection in the ordinary actions of their daily life.',
+      'pt-BR':
+        'Poucos são chamados a servir a Deus por grandes ações, mas todos estão obrigados a buscar a perfeição nas ações ordinárias de sua vida cotidiana.',
+    },
+  },
+  '12-16': {
+    name: { 'en-US': 'St. Eusebius, Bishop', 'pt-BR': 'Santo Eusébio, Bispo' },
+    reflection: {
+      'en-US':
+        'The routine of every-day, commonplace duties is no hindrance to a free intimacy with God. He will disclose His hidden ways to you in proportion as you follow your vocation faithfully, whether in the world or the cloister.',
+      'pt-BR':
+        'A rotina dos deveres diários, comuns e ordinários, não é obstáculo a uma livre intimidade com Deus. Ele te revelará Seus caminhos ocultos na medida em que seguires fielmente a tua vocação, seja no mundo, seja no claustro.',
+    },
+  },
+  '12-17': {
+    name: { 'en-US': 'St. Olympias, Widow', 'pt-BR': 'Santa Olímpia, Viúva' },
+    reflection: {
+      'en-US':
+        '"Lay not up to yourselves treasures on earth, but in heaven, where neither rust nor moth doth consume."',
+      'pt-BR':
+        '"Não ajunteis para vós tesouros na terra, mas no céu, onde nem a ferrugem nem a traça os consomem."',
+    },
+  },
+  '12-18': {
+    name: { 'en-US': 'St. Gatian, Bishop', 'pt-BR': 'São Gaciano, Bispo' },
+    reflection: {
+      'en-US':
+        'God does not ask great sacrifices from all; but in His goodness He gives us all some things to renounce or to suffer for Him, and it is by our loving submission to His will that we show ourselves to be Christians.',
+      'pt-BR':
+        'Deus não pede de todos grandes sacrifícios; mas em Sua bondade dá a todos nós algumas coisas a renunciar ou a sofrer por Ele, e é por nossa amorosa submissão à Sua vontade que nos mostramos cristãos.',
+    },
+  },
+  '12-19': {
+    name: { 'en-US': 'St. Nemesion, Martyr', 'pt-BR': 'São Nemésio, Mártir' },
+    reflection: {
+      'en-US':
+        'Can we call to mind the fervor of the Saints in laboring and suffering cheerfully for God, and not feel a holy ardor glow in our own breasts, and our souls strongly affected with their heroic sentiments of virtue?',
+      'pt-BR':
+        'Poderemos recordar o fervor dos Santos em trabalhar e sofrer alegremente por Deus, e não sentir um santo ardor abrasar nossos próprios peitos, e nossas almas fortemente comovidas por seus heroicos sentimentos de virtude?',
+    },
+  },
+  '12-20': {
+    name: { 'en-US': 'St. Philogonius, Bishop', 'pt-BR': 'São Filogônio, Bispo' },
+    reflection: {
+      'en-US':
+        "St. Philogonius had so perfectly renounced the world, and crucified its inordinate desires in his heart, that he received in this life the earnest of Christ's Spirit, was admitted to the sacred council of the heavenly King, and had free access to the Almighty. A soul must here learn the heavenly spirit, and be well versed in the occupations of the blessed, that hopes to reign with them hereafter.",
+      'pt-BR':
+        'São Filogônio havia renunciado tão perfeitamente ao mundo, e crucificado em seu coração os desejos desordenados deste, que recebeu nesta vida as arras do Espírito de Cristo, foi admitido ao sagrado concílio do Rei celestial e teve livre acesso ao Todo-Poderoso. Uma alma deve aprender aqui o espírito celestial, e estar bem versada nas ocupações dos bem-aventurados, se espera reinar com eles no porvir.',
+    },
+  },
+  '12-21': {
+    name: { 'en-US': 'St. Thomas, Apostle', 'pt-BR': 'São Tomé, Apóstolo' },
+    reflection: {
+      'en-US':
+        'Cast away all disquieting doubts, and learn to triumph over old weaknesses as St. Thomas did, who "by his ignorance hath instructed the ignorant, and by, his incredulity hath served for the faith of all ages."',
+      'pt-BR':
+        'Lança fora todas as dúvidas inquietantes, e aprende a triunfar sobre as antigas fraquezas como fez São Tomé, que "por sua ignorância instruiu os ignorantes, e por sua incredulidade serviu à fé de todas as eras."',
+    },
+  },
+  '12-22': {
+    name: { 'en-US': 'St. Ischyrion, Martyr', 'pt-BR': 'Santo Isquírion, Mártir' },
+    reflection: {
+      'en-US':
+        "It is not a man's condition, but virtue, that can make him truly great or truly happy. How mean soever a person's station or circumstances may be, the road to both is open to him; and there is not a servant or slave who ought not to be enkindled with a laudable ambition of arriving at this greatness, which will set him on the same level with the rich and the most powerful.",
+      'pt-BR':
+        'Não é a condição de um homem, mas a virtude, que pode torná-lo verdadeiramente grande ou verdadeiramente feliz. Por mais humilde que seja a posição ou as circunstâncias de uma pessoa, o caminho para ambas lhe está aberto; e não há servo ou escravo que não deva inflamar-se com a louvável ambição de chegar a esta grandeza, que o colocará no mesmo nível dos ricos e dos mais poderosos.',
+    },
+  },
+  '12-23': {
+    name: { 'en-US': 'St. Servulus', 'pt-BR': 'São Sérvulo' },
+    reflection: {
+      'en-US':
+        'The whole behaviour of this poor sick beggar loudly condemns those who, when blessed with good health and a plentiful fortune, neither do good works nor suffer the least cross with tolerable patience.',
+      'pt-BR':
+        'Todo o comportamento deste pobre mendigo enfermo condena fortemente aqueles que, sendo abençoados com boa saúde e fortuna abundante, nem praticam boas obras nem suportam a menor cruz com tolerável paciência.',
+    },
+  },
+  '12-24': {
+    name: {
+      'en-US': 'St. Delphinus, Bishop. Sts. Thrasilla and Emiliana, Virgins',
+      'pt-BR': 'São Delfino, Bispo. Santas Trasila e Emiliana, Virgens',
+    },
+    reflection: {
+      'en-US':
+        'We may often think the austerities of the Saints are beyond our strength; let us, then, imitate the guard they kept over their tongue. This is within the reach of all.',
+      'pt-BR':
+        'Podemos muitas vezes pensar que as austeridades dos Santos estão além de nossas forças; imitemos, então, a guarda que mantinham sobre a sua língua. Isto está ao alcance de todos.',
+    },
+  },
+  '12-25': {
+    name: {
+      'en-US': 'The Nativity of Christ, or Christmas Day',
+      'pt-BR': 'A Natividade de Cristo, ou Dia de Natal',
+    },
+    reflection: {
+      'en-US':
+        'Our Saviour sanctified our flesh by taking it on Himself, and with His last breath He commended us to the care of His Virgin Mother. Day by day He still feeds us at the altar with the food of incorruption—His body and His blood.',
+      'pt-BR':
+        'Nosso Salvador santificou a nossa carne ao tomá-la sobre Si, e com Seu último alento confiou-nos aos cuidados de Sua Virgem Mãe. Dia após dia, Ele ainda nos alimenta no altar com o alimento da incorrupção — Seu corpo e Seu sangue.',
+    },
+  },
+  '12-26': {
+    name: { 'en-US': 'St. Stephen, First Martyr', 'pt-BR': 'Santo Estêvão, Primeiro Mártir' },
+    reflection: {
+      'en-US':
+        'If ever you are tempted to resentment, pray from your heart for him who has offended you.',
+      'pt-BR':
+        'Se alguma vez fores tentado ao ressentimento, reza de coração por aquele que te ofendeu.',
+    },
+  },
+  '12-27': {
+    name: { 'en-US': 'St. John, Evangelist', 'pt-BR': 'São João, Evangelista' },
+    reflection: {
+      'en-US':
+        'St. John is a living example of Our Lord\'s saying, "Blessed are the clean of heart, for they shall see God."',
+      'pt-BR':
+        'São João é um exemplo vivo da palavra de Nosso Senhor: "Bem-aventurados os puros de coração, porque verão a Deus."',
+    },
+  },
+  '12-28': {
+    name: { 'en-US': 'The Holy Innocents', 'pt-BR': 'Os Santos Inocentes' },
+    reflection: {
+      'en-US':
+        'How few perhaps of these children, if they had lived, would have escaped the dangers of the world! What snares, what sins, what miseries were they preserved from! So we often lament as misfortunes many accidents which in the designs of Heaven are the greatest mercies.',
+      'pt-BR':
+        'Quão poucas, talvez, destas crianças, se tivessem vivido, teriam escapado dos perigos do mundo! De que laços, de que pecados, de que misérias foram preservadas! Assim, muitas vezes lamentamos como infortúnios muitos acontecimentos que, nos desígnios do Céu, são as maiores misericórdias.',
+    },
+  },
+  '12-29': {
+    name: { 'en-US': 'St. Thomas of Canterbury', 'pt-BR': 'São Tomás de Cantuária' },
+    reflection: {
+      'en-US':
+        '"Learn from St. Thomas," says Father Faber, "to fight the good fight even to the shedding of blood, or, to what men find harder, the shedding of their good name by pouring it out to waste on the earth."',
+      'pt-BR':
+        '"Aprende com São Tomás," diz o Padre Faber, "a combater o bom combate até ao derramamento do sangue, ou, ao que os homens acham mais difícil, ao derramamento do seu bom nome, vertendo-o em desperdício sobre a terra."',
+    },
+  },
+  '12-30': {
+    name: {
+      'en-US': 'St. Sabinus, Bishop, and his Companions, Martyrs',
+      'pt-BR': 'São Sabino, Bispo, e seus Companheiros, Mártires',
+    },
+    reflection: {
+      'en-US':
+        'How powerfully do the martyrs cry out to us by their example, exhorting us to despise a false and wicked world!',
+      'pt-BR':
+        'Quão poderosamente clamam a nós os mártires pelo seu exemplo, exortando-nos a desprezar um mundo falso e perverso!',
+    },
+  },
+  '12-31': {
+    name: { 'en-US': 'St. Sylvester, Pope', 'pt-BR': 'São Silvestre, Papa' },
+  },
 }

--- a/apps/app/src/features/saints/index.ts
+++ b/apps/app/src/features/saints/index.ts
@@ -1,4 +1,4 @@
 export { SaintCard, SaintCardGrid, SaintCardViewer } from './components'
-export { saintOfDayNames } from './data/saintOfDayNames'
+export { type SaintOfDayEntry, saintOfDay } from './data/saintOfDayNames'
 export { type Saint, saints } from './data/saints'
 export { useSaintOfDayReading } from './useSaintOfDayReading'

--- a/apps/app/src/features/saints/useSaintOfDayReading.ts
+++ b/apps/app/src/features/saints/useSaintOfDayReading.ts
@@ -1,5 +1,6 @@
 import { useToday } from '@/hooks/useToday'
-import { saintOfDayNames } from './data/saintOfDayNames'
+import { localizeContent } from '@/lib/i18n'
+import { saintOfDay } from './data/saintOfDayNames'
 
 /**
  * Today's primary saint as titled in Pictorial Lives of the Saints, looked up
@@ -7,9 +8,13 @@ import { saintOfDayNames } from './data/saintOfDayNames'
  * `saint-of-the-day` practice (the full life + reflection from the book).
  * Returns undefined only if today's date somehow has no mapped entry.
  */
-export function useSaintOfDayReading(): { name: string } | undefined {
+export function useSaintOfDayReading(): { name: string; reflection?: string } | undefined {
   const today = useToday()
   const key = `${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
-  const name = saintOfDayNames[key]
-  return name ? { name } : undefined
+  const entry = saintOfDay[key]
+  if (!entry) return undefined
+  return {
+    name: localizeContent(entry.name),
+    reflection: entry.reflection ? localizeContent(entry.reflection) : undefined,
+  }
 }

--- a/content/practices/saint-of-the-day/flow.json
+++ b/content/practices/saint-of-the-day/flow.json
@@ -376,7 +376,8 @@
         {
           "id": "01-01",
           "label": {
-            "en-US": "The Circumcision of our Lord"
+            "en-US": "The Circumcision of our Lord",
+            "pt-BR": "A Circuncisão de Nosso Senhor"
           },
           "sections": [
             {
@@ -390,30 +391,56 @@
         {
           "id": "01-02",
           "label": {
-            "en-US": "St. Fulgentius, Bishop · St. Macarius of Alexandria"
+            "en-US": "St. Fulgentius, Bishop · St. Macarius of Alexandria",
+            "pt-BR": "São Fulgêncio, Bispo · São Macário de Alexandria"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "jan-02-fulgentius",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "jan-02-macarius-of-alexandria",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "fulgentius",
+                  "label": {
+                    "en-US": "St. Fulgentius, Bishop",
+                    "pt-BR": "São Fulgêncio, Bispo"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "jan-02-fulgentius",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "macarius-of-alexandria",
+                  "label": {
+                    "en-US": "St. Macarius of Alexandria",
+                    "pt-BR": "São Macário de Alexandria"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "jan-02-macarius-of-alexandria",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "01-03",
           "label": {
-            "en-US": "St. Genevieve, Virgin"
+            "en-US": "St. Genevieve, Virgin",
+            "pt-BR": "Santa Genoveva, Virgem"
           },
           "sections": [
             {
@@ -427,30 +454,56 @@
         {
           "id": "01-04",
           "label": {
-            "en-US": "St. Titus, Bishop · St. Gregory, Bishop"
+            "en-US": "St. Titus, Bishop · St. Gregory, Bishop",
+            "pt-BR": "São Tito, Bispo · São Gregório, Bispo"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "jan-04-titus",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "jan-04-gregory",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "titus",
+                  "label": {
+                    "en-US": "St. Titus, Bishop",
+                    "pt-BR": "São Tito, Bispo"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "jan-04-titus",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "gregory",
+                  "label": {
+                    "en-US": "St. Gregory, Bishop",
+                    "pt-BR": "São Gregório, Bispo"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "jan-04-gregory",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "01-05",
           "label": {
-            "en-US": "St. Simeon Stylites"
+            "en-US": "St. Simeon Stylites",
+            "pt-BR": "São Simeão Estilita"
           },
           "sections": [
             {
@@ -464,7 +517,8 @@
         {
           "id": "01-06",
           "label": {
-            "en-US": "The Epiphany of Our Lord"
+            "en-US": "The Epiphany of Our Lord",
+            "pt-BR": "A Epifania de Nosso Senhor"
           },
           "sections": [
             {
@@ -478,7 +532,8 @@
         {
           "id": "01-07",
           "label": {
-            "en-US": "St. Lucian, Martyr"
+            "en-US": "St. Lucian, Martyr",
+            "pt-BR": "São Luciano, Mártir"
           },
           "sections": [
             {
@@ -492,7 +547,8 @@
         {
           "id": "01-08",
           "label": {
-            "en-US": "St. Apollinaris, the Apologist, Bishop"
+            "en-US": "St. Apollinaris, the Apologist, Bishop",
+            "pt-BR": "Santo Apolinário, o Apologista, Bispo"
           },
           "sections": [
             {
@@ -506,7 +562,8 @@
         {
           "id": "01-09",
           "label": {
-            "en-US": "Ss. Julian and Basilissa, Martyrs"
+            "en-US": "Ss. Julian and Basilissa, Martyrs",
+            "pt-BR": "São Julião e Santa Basilissa, Mártires"
           },
           "sections": [
             {
@@ -520,7 +577,8 @@
         {
           "id": "01-10",
           "label": {
-            "en-US": "St. William, Archbishop"
+            "en-US": "St. William, Archbishop",
+            "pt-BR": "São Guilherme, Arcebispo"
           },
           "sections": [
             {
@@ -534,7 +592,8 @@
         {
           "id": "01-11",
           "label": {
-            "en-US": "St. Theodosius, The Cenobiarch"
+            "en-US": "St. Theodosius, The Cenobiarch",
+            "pt-BR": "São Teodósio, o Cenobiarca"
           },
           "sections": [
             {
@@ -548,7 +607,8 @@
         {
           "id": "01-12",
           "label": {
-            "en-US": "St. Aelred, Abbot"
+            "en-US": "St. Aelred, Abbot",
+            "pt-BR": "Santo Elredo, Abade"
           },
           "sections": [
             {
@@ -562,7 +622,8 @@
         {
           "id": "01-13",
           "label": {
-            "en-US": "St. Veronica of Milan"
+            "en-US": "St. Veronica of Milan",
+            "pt-BR": "Santa Verônica de Milão"
           },
           "sections": [
             {
@@ -576,7 +637,8 @@
         {
           "id": "01-14",
           "label": {
-            "en-US": "St. Hilary of Poitiers"
+            "en-US": "St. Hilary of Poitiers",
+            "pt-BR": "Santo Hilário de Poitiers"
           },
           "sections": [
             {
@@ -590,7 +652,8 @@
         {
           "id": "01-15",
           "label": {
-            "en-US": "St. Paul, the First Hermit"
+            "en-US": "St. Paul, the First Hermit",
+            "pt-BR": "São Paulo, o Primeiro Eremita"
           },
           "sections": [
             {
@@ -604,7 +667,8 @@
         {
           "id": "01-16",
           "label": {
-            "en-US": "St. Honoratus, Archbishop"
+            "en-US": "St. Honoratus, Archbishop",
+            "pt-BR": "Santo Honorato, Arcebispo"
           },
           "sections": [
             {
@@ -618,7 +682,8 @@
         {
           "id": "01-17",
           "label": {
-            "en-US": "St. Antony, Patriarch of Monks"
+            "en-US": "St. Antony, Patriarch of Monks",
+            "pt-BR": "Santo Antão, Patriarca dos Monges"
           },
           "sections": [
             {
@@ -632,7 +697,8 @@
         {
           "id": "01-18",
           "label": {
-            "en-US": "St. Peter's Chair at Rome"
+            "en-US": "St. Peter's Chair at Rome",
+            "pt-BR": "A Cátedra de São Pedro em Roma"
           },
           "sections": [
             {
@@ -646,7 +712,8 @@
         {
           "id": "01-19",
           "label": {
-            "en-US": "St. Canutus, King, Martyr"
+            "en-US": "St. Canutus, King, Martyr",
+            "pt-BR": "São Canuto, Rei, Mártir"
           },
           "sections": [
             {
@@ -660,7 +727,8 @@
         {
           "id": "01-20",
           "label": {
-            "en-US": "St. Sebastian, Martyr"
+            "en-US": "St. Sebastian, Martyr",
+            "pt-BR": "São Sebastião, Mártir"
           },
           "sections": [
             {
@@ -674,7 +742,8 @@
         {
           "id": "01-21",
           "label": {
-            "en-US": "St. Agnes, Virgin, Martyr"
+            "en-US": "St. Agnes, Virgin, Martyr",
+            "pt-BR": "Santa Inês, Virgem, Mártir"
           },
           "sections": [
             {
@@ -688,7 +757,8 @@
         {
           "id": "01-22",
           "label": {
-            "en-US": "St. Vincent, Martyr"
+            "en-US": "St. Vincent, Martyr",
+            "pt-BR": "São Vicente, Mártir"
           },
           "sections": [
             {
@@ -702,7 +772,8 @@
         {
           "id": "01-23",
           "label": {
-            "en-US": "St. Raymund of Pennafort"
+            "en-US": "St. Raymund of Pennafort",
+            "pt-BR": "São Raimundo de Penafort"
           },
           "sections": [
             {
@@ -716,7 +787,8 @@
         {
           "id": "01-24",
           "label": {
-            "en-US": "St. Timothy, Bishop, Martyr"
+            "en-US": "St. Timothy, Bishop, Martyr",
+            "pt-BR": "São Timóteo, Bispo, Mártir"
           },
           "sections": [
             {
@@ -730,7 +802,8 @@
         {
           "id": "01-25",
           "label": {
-            "en-US": "The Conversion of St. Paul"
+            "en-US": "The Conversion of St. Paul",
+            "pt-BR": "A Conversão de São Paulo"
           },
           "sections": [
             {
@@ -744,7 +817,8 @@
         {
           "id": "01-26",
           "label": {
-            "en-US": "St. Polycarp, Bishop, Martyr"
+            "en-US": "St. Polycarp, Bishop, Martyr",
+            "pt-BR": "São Policarpo, Bispo, Mártir"
           },
           "sections": [
             {
@@ -758,7 +832,8 @@
         {
           "id": "01-27",
           "label": {
-            "en-US": "St. John Chrysostom"
+            "en-US": "St. John Chrysostom",
+            "pt-BR": "São João Crisóstomo"
           },
           "sections": [
             {
@@ -772,7 +847,8 @@
         {
           "id": "01-28",
           "label": {
-            "en-US": "St. Cyril of Alexandria"
+            "en-US": "St. Cyril of Alexandria",
+            "pt-BR": "São Cirilo de Alexandria"
           },
           "sections": [
             {
@@ -786,7 +862,8 @@
         {
           "id": "01-29",
           "label": {
-            "en-US": "St. Francis of Sales"
+            "en-US": "St. Francis of Sales",
+            "pt-BR": "São Francisco de Sales"
           },
           "sections": [
             {
@@ -800,7 +877,8 @@
         {
           "id": "01-30",
           "label": {
-            "en-US": "St. Bathildes, Queen"
+            "en-US": "St. Bathildes, Queen",
+            "pt-BR": "Santa Batildes, Rainha"
           },
           "sections": [
             {
@@ -814,7 +892,8 @@
         {
           "id": "01-31",
           "label": {
-            "en-US": "St. Marcella, Widow"
+            "en-US": "St. Marcella, Widow",
+            "pt-BR": "Santa Marcela, Viúva"
           },
           "sections": [
             {
@@ -828,30 +907,56 @@
         {
           "id": "02-01",
           "label": {
-            "en-US": "St. Bridgid, Abbess, and Patroness of Ireland · St. Ignatius, Bishop, Martyr"
+            "en-US": "St. Bridgid, Abbess, and Patroness of Ireland · St. Ignatius, Bishop, Martyr",
+            "pt-BR": "Santa Brígida, Abadessa e Padroeira da Irlanda · Santo Inácio, Bispo, Mártir"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "feb-01-bridgid",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "feb-01-ignatius",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "bridgid",
+                  "label": {
+                    "en-US": "St. Bridgid, Abbess, and Patroness of Ireland",
+                    "pt-BR": "Santa Brígida, Abadessa e Padroeira da Irlanda"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "feb-01-bridgid",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "ignatius",
+                  "label": {
+                    "en-US": "St. Ignatius, Bishop, Martyr",
+                    "pt-BR": "Santo Inácio, Bispo, Mártir"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "feb-01-ignatius",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "02-02",
           "label": {
-            "en-US": "The Purification, Commonly Called Candlemas-Day"
+            "en-US": "The Purification, Commonly Called Candlemas-Day",
+            "pt-BR": "A Purificação, Comumente Chamada Dia de Candelária"
           },
           "sections": [
             {
@@ -865,7 +970,8 @@
         {
           "id": "02-03",
           "label": {
-            "en-US": "St. Blase, Bishop and Martyr"
+            "en-US": "St. Blase, Bishop and Martyr",
+            "pt-BR": "São Brás, Bispo e Mártir"
           },
           "sections": [
             {
@@ -879,7 +985,8 @@
         {
           "id": "02-04",
           "label": {
-            "en-US": "St. Jane of Valois"
+            "en-US": "St. Jane of Valois",
+            "pt-BR": "Santa Joana de Valois"
           },
           "sections": [
             {
@@ -893,30 +1000,56 @@
         {
           "id": "02-05",
           "label": {
-            "en-US": "St. Agatha, Virgin, Martyr · The Martyrs of Japan"
+            "en-US": "St. Agatha, Virgin, Martyr · The Martyrs of Japan",
+            "pt-BR": "Santa Ágata, Virgem, Mártir · Os Mártires do Japão"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "feb-05-agatha",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "feb-05-the-martyrs-of-japan",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "agatha",
+                  "label": {
+                    "en-US": "St. Agatha, Virgin, Martyr",
+                    "pt-BR": "Santa Ágata, Virgem, Mártir"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "feb-05-agatha",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "the-martyrs-of-japan",
+                  "label": {
+                    "en-US": "The Martyrs of Japan",
+                    "pt-BR": "Os Mártires do Japão"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "feb-05-the-martyrs-of-japan",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "02-06",
           "label": {
-            "en-US": "St. Dorothy, Virgin, Martyr"
+            "en-US": "St. Dorothy, Virgin, Martyr",
+            "pt-BR": "Santa Doroteia, Virgem, Mártir"
           },
           "sections": [
             {
@@ -930,7 +1063,8 @@
         {
           "id": "02-07",
           "label": {
-            "en-US": "St. Romuald, Abbot"
+            "en-US": "St. Romuald, Abbot",
+            "pt-BR": "São Romualdo, Abade"
           },
           "sections": [
             {
@@ -944,7 +1078,8 @@
         {
           "id": "02-08",
           "label": {
-            "en-US": "St. John of Matha"
+            "en-US": "St. John of Matha",
+            "pt-BR": "São João de Matha"
           },
           "sections": [
             {
@@ -958,7 +1093,8 @@
         {
           "id": "02-09",
           "label": {
-            "en-US": "St. Apollonia and the Martyrs of Alexandria"
+            "en-US": "St. Apollonia and the Martyrs of Alexandria",
+            "pt-BR": "Santa Apolônia e os Mártires de Alexandria"
           },
           "sections": [
             {
@@ -972,7 +1108,8 @@
         {
           "id": "02-10",
           "label": {
-            "en-US": "St. Scholastica, Abbess"
+            "en-US": "St. Scholastica, Abbess",
+            "pt-BR": "Santa Escolástica, Abadessa"
           },
           "sections": [
             {
@@ -986,7 +1123,8 @@
         {
           "id": "02-11",
           "label": {
-            "en-US": "St. Severinus, Abbot of Agaunum"
+            "en-US": "St. Severinus, Abbot of Agaunum",
+            "pt-BR": "São Severino, Abade de Agauno"
           },
           "sections": [
             {
@@ -1000,7 +1138,8 @@
         {
           "id": "02-12",
           "label": {
-            "en-US": "St. Benedict of Anian"
+            "en-US": "St. Benedict of Anian",
+            "pt-BR": "São Bento de Aniane"
           },
           "sections": [
             {
@@ -1014,7 +1153,8 @@
         {
           "id": "02-13",
           "label": {
-            "en-US": "St. Catherine of Ricci"
+            "en-US": "St. Catherine of Ricci",
+            "pt-BR": "Santa Catarina de Ricci"
           },
           "sections": [
             {
@@ -1028,7 +1168,8 @@
         {
           "id": "02-14",
           "label": {
-            "en-US": "St. Valentine, Priest and Martyr"
+            "en-US": "St. Valentine, Priest and Martyr",
+            "pt-BR": "São Valentim, Sacerdote e Mártir"
           },
           "sections": [
             {
@@ -1042,7 +1183,8 @@
         {
           "id": "02-15",
           "label": {
-            "en-US": "Sts. Faustinus and Jovita, Martyrs"
+            "en-US": "Sts. Faustinus and Jovita, Martyrs",
+            "pt-BR": "São Faustino e São Jovita, Mártires"
           },
           "sections": [
             {
@@ -1056,30 +1198,56 @@
         {
           "id": "02-16",
           "label": {
-            "en-US": "Blessed John de Britto, Martyr · St. Onesimus, Disciple of St. Paul"
+            "en-US": "Blessed John de Britto, Martyr · St. Onesimus, Disciple of St. Paul",
+            "pt-BR": "Beato João de Brito, Mártir · Santo Onésimo, Discípulo de São Paulo"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "feb-16-blessed-john-de-britto",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "feb-16-onesimus-disciple-of-st-paul",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "blessed-john-de-britto",
+                  "label": {
+                    "en-US": "Blessed John de Britto, Martyr",
+                    "pt-BR": "Beato João de Brito, Mártir"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "feb-16-blessed-john-de-britto",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "onesimus-disciple-of-st-paul",
+                  "label": {
+                    "en-US": "St. Onesimus, Disciple of St. Paul",
+                    "pt-BR": "Santo Onésimo, Discípulo de São Paulo"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "feb-16-onesimus-disciple-of-st-paul",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "02-17",
           "label": {
-            "en-US": "St. Flavian, Bishop, Martyr"
+            "en-US": "St. Flavian, Bishop, Martyr",
+            "pt-BR": "São Flaviano, Bispo, Mártir"
           },
           "sections": [
             {
@@ -1093,7 +1261,8 @@
         {
           "id": "02-18",
           "label": {
-            "en-US": "St. Simeon, Bishop, Martyr"
+            "en-US": "St. Simeon, Bishop, Martyr",
+            "pt-BR": "São Simeão, Bispo, Mártir"
           },
           "sections": [
             {
@@ -1107,7 +1276,8 @@
         {
           "id": "02-19",
           "label": {
-            "en-US": "St. Barbatus, Bishop"
+            "en-US": "St. Barbatus, Bishop",
+            "pt-BR": "São Barbato, Bispo"
           },
           "sections": [
             {
@@ -1121,7 +1291,8 @@
         {
           "id": "02-20",
           "label": {
-            "en-US": "St. Eucherius, Bishop"
+            "en-US": "St. Eucherius, Bishop",
+            "pt-BR": "Santo Euquério, Bispo"
           },
           "sections": [
             {
@@ -1135,7 +1306,8 @@
         {
           "id": "02-21",
           "label": {
-            "en-US": "St. Severianus, Martyr, Bishop"
+            "en-US": "St. Severianus, Martyr, Bishop",
+            "pt-BR": "São Severiano, Mártir, Bispo"
           },
           "sections": [
             {
@@ -1149,7 +1321,8 @@
         {
           "id": "02-22",
           "label": {
-            "en-US": "St. Peter's Chair at Antioch"
+            "en-US": "St. Peter's Chair at Antioch",
+            "pt-BR": "A Cátedra de São Pedro em Antioquia"
           },
           "sections": [
             {
@@ -1163,30 +1336,56 @@
         {
           "id": "02-23",
           "label": {
-            "en-US": "St. Peter Damian · St. Serenus, a Gardener, Martyr"
+            "en-US": "St. Peter Damian · St. Serenus, a Gardener, Martyr",
+            "pt-BR": "São Pedro Damião · São Sereno, um Jardineiro, Mártir"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "feb-23-peter-damian",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "feb-23-serenus-a-gardener",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "peter-damian",
+                  "label": {
+                    "en-US": "St. Peter Damian",
+                    "pt-BR": "São Pedro Damião"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "feb-23-peter-damian",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "serenus-a-gardener",
+                  "label": {
+                    "en-US": "St. Serenus, a Gardener, Martyr",
+                    "pt-BR": "São Sereno, um Jardineiro, Mártir"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "feb-23-serenus-a-gardener",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "02-24",
           "label": {
-            "en-US": "St. Matthias, Apostle"
+            "en-US": "St. Matthias, Apostle",
+            "pt-BR": "São Matias, Apóstolo"
           },
           "sections": [
             {
@@ -1200,7 +1399,8 @@
         {
           "id": "02-25",
           "label": {
-            "en-US": "St. Tarasius"
+            "en-US": "St. Tarasius",
+            "pt-BR": "São Tarásio"
           },
           "sections": [
             {
@@ -1214,7 +1414,8 @@
         {
           "id": "02-26",
           "label": {
-            "en-US": "St. Porphyry, Bishop"
+            "en-US": "St. Porphyry, Bishop",
+            "pt-BR": "São Porfírio, Bispo"
           },
           "sections": [
             {
@@ -1228,7 +1429,8 @@
         {
           "id": "02-27",
           "label": {
-            "en-US": "St. Leander, Bishop"
+            "en-US": "St. Leander, Bishop",
+            "pt-BR": "São Leandro, Bispo"
           },
           "sections": [
             {
@@ -1242,7 +1444,8 @@
         {
           "id": "02-28",
           "label": {
-            "en-US": "Sts. Romanus and Lupicinus, Abbots"
+            "en-US": "Sts. Romanus and Lupicinus, Abbots",
+            "pt-BR": "São Romano e São Lupicino, Abades"
           },
           "sections": [
             {
@@ -1256,7 +1459,8 @@
         {
           "id": "02-29",
           "label": {
-            "en-US": "St. Oswald, Bishop"
+            "en-US": "St. Oswald, Bishop",
+            "pt-BR": "Santo Osvaldo, Bispo"
           },
           "sections": [
             {
@@ -1270,30 +1474,56 @@
         {
           "id": "03-01",
           "label": {
-            "en-US": "St. David, Bishop · St. Albinus, Bishop"
+            "en-US": "St. David, Bishop · St. Albinus, Bishop",
+            "pt-BR": "São David, Bispo · Santo Albino, Bispo"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "mar-01-david",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "mar-01-albinus",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "david",
+                  "label": {
+                    "en-US": "St. David, Bishop",
+                    "pt-BR": "São David, Bispo"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "mar-01-david",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "albinus",
+                  "label": {
+                    "en-US": "St. Albinus, Bishop",
+                    "pt-BR": "Santo Albino, Bispo"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "mar-01-albinus",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "03-02",
           "label": {
-            "en-US": "St. Simplicius, Pope"
+            "en-US": "St. Simplicius, Pope",
+            "pt-BR": "São Simplício, Papa"
           },
           "sections": [
             {
@@ -1307,7 +1537,8 @@
         {
           "id": "03-03",
           "label": {
-            "en-US": "St. Cunegundes, Empress"
+            "en-US": "St. Cunegundes, Empress",
+            "pt-BR": "Santa Cunegundes, Imperatriz"
           },
           "sections": [
             {
@@ -1321,7 +1552,8 @@
         {
           "id": "03-04",
           "label": {
-            "en-US": "St. Casimir, King"
+            "en-US": "St. Casimir, King",
+            "pt-BR": "São Casimiro, Rei"
           },
           "sections": [
             {
@@ -1335,7 +1567,8 @@
         {
           "id": "03-05",
           "label": {
-            "en-US": "Sts. Adrian and Eubulus, Martyrs"
+            "en-US": "Sts. Adrian and Eubulus, Martyrs",
+            "pt-BR": "Santo Adrião e Santo Êubulo, Mártires"
           },
           "sections": [
             {
@@ -1349,7 +1582,8 @@
         {
           "id": "03-06",
           "label": {
-            "en-US": "St. Colette, Virgin"
+            "en-US": "St. Colette, Virgin",
+            "pt-BR": "Santa Coleta, Virgem"
           },
           "sections": [
             {
@@ -1363,7 +1597,8 @@
         {
           "id": "03-07",
           "label": {
-            "en-US": "St. Thomas Aquinas"
+            "en-US": "St. Thomas Aquinas",
+            "pt-BR": "São Tomás de Aquino"
           },
           "sections": [
             {
@@ -1377,7 +1612,8 @@
         {
           "id": "03-08",
           "label": {
-            "en-US": "St. John of God"
+            "en-US": "St. John of God",
+            "pt-BR": "São João de Deus"
           },
           "sections": [
             {
@@ -1391,7 +1627,8 @@
         {
           "id": "03-09",
           "label": {
-            "en-US": "St. Frances of Rome"
+            "en-US": "St. Frances of Rome",
+            "pt-BR": "Santa Francisca Romana"
           },
           "sections": [
             {
@@ -1405,7 +1642,8 @@
         {
           "id": "03-10",
           "label": {
-            "en-US": "The Forty Martyrs of Sebaste"
+            "en-US": "The Forty Martyrs of Sebaste",
+            "pt-BR": "Os Quarenta Mártires de Sebaste"
           },
           "sections": [
             {
@@ -1419,7 +1657,8 @@
         {
           "id": "03-11",
           "label": {
-            "en-US": "St. Eulogius, Martyr"
+            "en-US": "St. Eulogius, Martyr",
+            "pt-BR": "Santo Eulógio, Mártir"
           },
           "sections": [
             {
@@ -1433,7 +1672,8 @@
         {
           "id": "03-12",
           "label": {
-            "en-US": "St. Gregory the Great"
+            "en-US": "St. Gregory the Great",
+            "pt-BR": "São Gregório Magno"
           },
           "sections": [
             {
@@ -1447,7 +1687,8 @@
         {
           "id": "03-13",
           "label": {
-            "en-US": "St. Euphrasia, Virgin"
+            "en-US": "St. Euphrasia, Virgin",
+            "pt-BR": "Santa Eufrásia, Virgem"
           },
           "sections": [
             {
@@ -1461,7 +1702,8 @@
         {
           "id": "03-14",
           "label": {
-            "en-US": "St. Maud. Queen"
+            "en-US": "St. Maud. Queen",
+            "pt-BR": "Santa Maud, Rainha"
           },
           "sections": [
             {
@@ -1475,7 +1717,8 @@
         {
           "id": "03-15",
           "label": {
-            "en-US": "St. Zachary, Pope"
+            "en-US": "St. Zachary, Pope",
+            "pt-BR": "São Zacarias, Papa"
           },
           "sections": [
             {
@@ -1489,7 +1732,8 @@
         {
           "id": "03-16",
           "label": {
-            "en-US": "Sts. Abraham and Mary"
+            "en-US": "Sts. Abraham and Mary",
+            "pt-BR": "Santo Abraão e Santa Maria"
           },
           "sections": [
             {
@@ -1503,7 +1747,8 @@
         {
           "id": "03-17",
           "label": {
-            "en-US": "St. Patrick, Bishop, Apostle of Ireland"
+            "en-US": "St. Patrick, Bishop, Apostle of Ireland",
+            "pt-BR": "São Patrício, Bispo, Apóstolo da Irlanda"
           },
           "sections": [
             {
@@ -1517,7 +1762,8 @@
         {
           "id": "03-18",
           "label": {
-            "en-US": "St. Cyril of Jerusalem"
+            "en-US": "St. Cyril of Jerusalem",
+            "pt-BR": "São Cirilo de Jerusalém"
           },
           "sections": [
             {
@@ -1531,7 +1777,8 @@
         {
           "id": "03-19",
           "label": {
-            "en-US": "St. Joseph, Spouse of the Blessed Virgin and Patron of the Universal Church"
+            "en-US": "St. Joseph, Spouse of the Blessed Virgin and Patron of the Universal Church",
+            "pt-BR": "São José, Esposo da Santíssima Virgem e Patrono da Igreja Universal"
           },
           "sections": [
             {
@@ -1545,7 +1792,8 @@
         {
           "id": "03-20",
           "label": {
-            "en-US": "St. Wulfran, Archbishop"
+            "en-US": "St. Wulfran, Archbishop",
+            "pt-BR": "São Wulfrano, Arcebispo"
           },
           "sections": [
             {
@@ -1559,7 +1807,8 @@
         {
           "id": "03-21",
           "label": {
-            "en-US": "St. Benedict, Abbot"
+            "en-US": "St. Benedict, Abbot",
+            "pt-BR": "São Bento, Abade"
           },
           "sections": [
             {
@@ -1573,7 +1822,8 @@
         {
           "id": "03-22",
           "label": {
-            "en-US": "St. Catharine of Sweden, Virgin"
+            "en-US": "St. Catharine of Sweden, Virgin",
+            "pt-BR": "Santa Catarina da Suécia, Virgem"
           },
           "sections": [
             {
@@ -1587,7 +1837,8 @@
         {
           "id": "03-23",
           "label": {
-            "en-US": "Sts. Victorian and Others, Martyrs"
+            "en-US": "Sts. Victorian and Others, Martyrs",
+            "pt-BR": "Santos Vitoriano e Outros, Mártires"
           },
           "sections": [
             {
@@ -1601,7 +1852,8 @@
         {
           "id": "03-24",
           "label": {
-            "en-US": "St. Simon, Infant Martyr"
+            "en-US": "St. Simon, Infant Martyr",
+            "pt-BR": "São Simão, Mártir Infante"
           },
           "sections": [
             {
@@ -1615,7 +1867,8 @@
         {
           "id": "03-25",
           "label": {
-            "en-US": "The Annunciation of the Blessed Virgin Mary"
+            "en-US": "The Annunciation of the Blessed Virgin Mary",
+            "pt-BR": "A Anunciação da Santíssima Virgem Maria"
           },
           "sections": [
             {
@@ -1629,7 +1882,8 @@
         {
           "id": "03-26",
           "label": {
-            "en-US": "St. Ludger, Bishop"
+            "en-US": "St. Ludger, Bishop",
+            "pt-BR": "São Ludgero, Bispo"
           },
           "sections": [
             {
@@ -1643,7 +1897,8 @@
         {
           "id": "03-27",
           "label": {
-            "en-US": "St. John of Egypt"
+            "en-US": "St. John of Egypt",
+            "pt-BR": "São João do Egito"
           },
           "sections": [
             {
@@ -1657,7 +1912,8 @@
         {
           "id": "03-28",
           "label": {
-            "en-US": "St. Gontran, King"
+            "en-US": "St. Gontran, King",
+            "pt-BR": "São Gontrão, Rei"
           },
           "sections": [
             {
@@ -1671,7 +1927,8 @@
         {
           "id": "03-29",
           "label": {
-            "en-US": "Sts. Jonas, Barachisius, and their Companions, Martyrs"
+            "en-US": "Sts. Jonas, Barachisius, and their Companions, Martyrs",
+            "pt-BR": "São Jonas, São Baraquísio e seus Companheiros, Mártires"
           },
           "sections": [
             {
@@ -1685,7 +1942,8 @@
         {
           "id": "03-30",
           "label": {
-            "en-US": "St. John Climacus"
+            "en-US": "St. John Climacus",
+            "pt-BR": "São João Clímaco"
           },
           "sections": [
             {
@@ -1699,7 +1957,8 @@
         {
           "id": "03-31",
           "label": {
-            "en-US": "St. Benjamin, Deacon, Martyr"
+            "en-US": "St. Benjamin, Deacon, Martyr",
+            "pt-BR": "São Benjamim, Diácono, Mártir"
           },
           "sections": [
             {
@@ -1713,7 +1972,8 @@
         {
           "id": "04-01",
           "label": {
-            "en-US": "St. Hugh, Bishop"
+            "en-US": "St. Hugh, Bishop",
+            "pt-BR": "Santo Hugo, Bispo"
           },
           "sections": [
             {
@@ -1727,7 +1987,8 @@
         {
           "id": "04-02",
           "label": {
-            "en-US": "St. Francis of Paula"
+            "en-US": "St. Francis of Paula",
+            "pt-BR": "São Francisco de Paula"
           },
           "sections": [
             {
@@ -1741,7 +2002,8 @@
         {
           "id": "04-03",
           "label": {
-            "en-US": "St. Richard of Chichester"
+            "en-US": "St. Richard of Chichester",
+            "pt-BR": "São Ricardo de Chichester"
           },
           "sections": [
             {
@@ -1755,7 +2017,8 @@
         {
           "id": "04-04",
           "label": {
-            "en-US": "St. Isidore, Archbishop"
+            "en-US": "St. Isidore, Archbishop",
+            "pt-BR": "Santo Isidoro, Arcebispo"
           },
           "sections": [
             {
@@ -1769,7 +2032,8 @@
         {
           "id": "04-05",
           "label": {
-            "en-US": "St. Vincent Ferrer"
+            "en-US": "St. Vincent Ferrer",
+            "pt-BR": "São Vicente Ferrer"
           },
           "sections": [
             {
@@ -1783,7 +2047,8 @@
         {
           "id": "04-06",
           "label": {
-            "en-US": "St. Celestine, Pope"
+            "en-US": "St. Celestine, Pope",
+            "pt-BR": "São Celestino, Papa"
           },
           "sections": [
             {
@@ -1797,30 +2062,56 @@
         {
           "id": "04-07",
           "label": {
-            "en-US": "St. Hegesippus, a Primitive Father · Blessed Herman Joseph of Steinfeld"
+            "en-US": "St. Hegesippus, a Primitive Father · Blessed Herman Joseph of Steinfeld",
+            "pt-BR": "São Hegésipo, um Padre Primitivo · Beato Hermano José de Steinfeld"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "apr-07-hegesippus-a-primitive-father",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "apr-07-blessed-herman-joseph-of-steinfeld",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "hegesippus-a-primitive-father",
+                  "label": {
+                    "en-US": "St. Hegesippus, a Primitive Father",
+                    "pt-BR": "São Hegésipo, um Padre Primitivo"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "apr-07-hegesippus-a-primitive-father",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "blessed-herman-joseph-of-steinfeld",
+                  "label": {
+                    "en-US": "Blessed Herman Joseph of Steinfeld",
+                    "pt-BR": "Beato Hermano José de Steinfeld"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "apr-07-blessed-herman-joseph-of-steinfeld",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "04-08",
           "label": {
-            "en-US": "St. Perpetuus, Bishop"
+            "en-US": "St. Perpetuus, Bishop",
+            "pt-BR": "São Perpétuo, Bispo"
           },
           "sections": [
             {
@@ -1834,30 +2125,56 @@
         {
           "id": "04-09",
           "label": {
-            "en-US": "St. Mary of Egypt · St. John the Almoner"
+            "en-US": "St. Mary of Egypt · St. John the Almoner",
+            "pt-BR": "Santa Maria Egipcíaca · São João, o Esmoler"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "apr-09-mary-of-egypt",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "apr-09-john-the-almoner",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "mary-of-egypt",
+                  "label": {
+                    "en-US": "St. Mary of Egypt",
+                    "pt-BR": "Santa Maria Egipcíaca"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "apr-09-mary-of-egypt",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "john-the-almoner",
+                  "label": {
+                    "en-US": "St. John the Almoner",
+                    "pt-BR": "São João, o Esmoler"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "apr-09-john-the-almoner",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "04-10",
           "label": {
-            "en-US": "St. Bademus, Martyr"
+            "en-US": "St. Bademus, Martyr",
+            "pt-BR": "São Bademo, Mártir"
           },
           "sections": [
             {
@@ -1871,7 +2188,8 @@
         {
           "id": "04-11",
           "label": {
-            "en-US": "St. Leo the Great"
+            "en-US": "St. Leo the Great",
+            "pt-BR": "São Leão Magno"
           },
           "sections": [
             {
@@ -1885,7 +2203,8 @@
         {
           "id": "04-12",
           "label": {
-            "en-US": "St. Julius, Pope"
+            "en-US": "St. Julius, Pope",
+            "pt-BR": "São Júlio, Papa"
           },
           "sections": [
             {
@@ -1899,7 +2218,8 @@
         {
           "id": "04-13",
           "label": {
-            "en-US": "St. Hermenegild, Martyr"
+            "en-US": "St. Hermenegild, Martyr",
+            "pt-BR": "São Hermenegildo, Mártir"
           },
           "sections": [
             {
@@ -1913,7 +2233,8 @@
         {
           "id": "04-14",
           "label": {
-            "en-US": "St. Benezet, or Little Bennet"
+            "en-US": "St. Benezet, or Little Bennet",
+            "pt-BR": "São Benezet, ou o Pequeno Bennet"
           },
           "sections": [
             {
@@ -1927,7 +2248,8 @@
         {
           "id": "04-15",
           "label": {
-            "en-US": "St. Paternus, Bishop"
+            "en-US": "St. Paternus, Bishop",
+            "pt-BR": "São Paterno, Bispo"
           },
           "sections": [
             {
@@ -1941,7 +2263,8 @@
         {
           "id": "04-16",
           "label": {
-            "en-US": "Eighteen Martyrs of Saragossa, and St. Encratis, or Engratia, Virgin, Martyr"
+            "en-US": "Eighteen Martyrs of Saragossa, and St. Encratis, or Engratia, Virgin, Martyr",
+            "pt-BR": "Dezoito Mártires de Saragoça, e Santa Êncratis, ou Engrácia, Virgem, Mártir"
           },
           "sections": [
             {
@@ -1955,7 +2278,8 @@
         {
           "id": "04-17",
           "label": {
-            "en-US": "St. Anicetus, Pope, Martyr"
+            "en-US": "St. Anicetus, Pope, Martyr",
+            "pt-BR": "Santo Aniceto, Papa, Mártir"
           },
           "sections": [
             {
@@ -1969,7 +2293,8 @@
         {
           "id": "04-18",
           "label": {
-            "en-US": "St. Apollonius, Martyr"
+            "en-US": "St. Apollonius, Martyr",
+            "pt-BR": "Santo Apolônio, Mártir"
           },
           "sections": [
             {
@@ -1983,7 +2308,8 @@
         {
           "id": "04-19",
           "label": {
-            "en-US": "St. Elphege, Archbishop"
+            "en-US": "St. Elphege, Archbishop",
+            "pt-BR": "Santo Elfego, Arcebispo"
           },
           "sections": [
             {
@@ -1997,7 +2323,8 @@
         {
           "id": "04-20",
           "label": {
-            "en-US": "St. Marcellinus, Bishop"
+            "en-US": "St. Marcellinus, Bishop",
+            "pt-BR": "São Marcelino, Bispo"
           },
           "sections": [
             {
@@ -2011,7 +2338,8 @@
         {
           "id": "04-21",
           "label": {
-            "en-US": "St. Anselm, Archbishop"
+            "en-US": "St. Anselm, Archbishop",
+            "pt-BR": "Santo Anselmo, Arcebispo"
           },
           "sections": [
             {
@@ -2025,30 +2353,56 @@
         {
           "id": "04-22",
           "label": {
-            "en-US": "St. Soter, Pope, Martyr · St. Leonides, Martyr"
+            "en-US": "St. Soter, Pope, Martyr · St. Leonides, Martyr",
+            "pt-BR": "São Sótero, Papa, Mártir · São Leônides, Mártir"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "apr-22-soter",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "apr-22-leonides",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "soter",
+                  "label": {
+                    "en-US": "St. Soter, Pope, Martyr",
+                    "pt-BR": "São Sótero, Papa, Mártir"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "apr-22-soter",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "leonides",
+                  "label": {
+                    "en-US": "St. Leonides, Martyr",
+                    "pt-BR": "São Leônides, Mártir"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "apr-22-leonides",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "04-23",
           "label": {
-            "en-US": "St. George, Martyr"
+            "en-US": "St. George, Martyr",
+            "pt-BR": "São Jorge, Mártir"
           },
           "sections": [
             {
@@ -2062,7 +2416,8 @@
         {
           "id": "04-24",
           "label": {
-            "en-US": "St. Fidelis of Sigmaringen"
+            "en-US": "St. Fidelis of Sigmaringen",
+            "pt-BR": "São Fidélis de Sigmaringen"
           },
           "sections": [
             {
@@ -2076,7 +2431,8 @@
         {
           "id": "04-25",
           "label": {
-            "en-US": "St. Mark, Evangelist"
+            "en-US": "St. Mark, Evangelist",
+            "pt-BR": "São Marcos, Evangelista"
           },
           "sections": [
             {
@@ -2090,7 +2446,8 @@
         {
           "id": "04-26",
           "label": {
-            "en-US": "Sts. Cletus and Marcellinus, Popes, Martyrs"
+            "en-US": "Sts. Cletus and Marcellinus, Popes, Martyrs",
+            "pt-BR": "São Cleto e São Marcelino, Papas, Mártires"
           },
           "sections": [
             {
@@ -2104,7 +2461,8 @@
         {
           "id": "04-27",
           "label": {
-            "en-US": "St. Zita, Virgin"
+            "en-US": "St. Zita, Virgin",
+            "pt-BR": "Santa Zita, Virgem"
           },
           "sections": [
             {
@@ -2118,53 +2476,104 @@
         {
           "id": "04-28",
           "label": {
-            "en-US": "St. Paul of the Cross · St. Vitalis, Martyr"
+            "en-US": "St. Paul of the Cross · St. Vitalis, Martyr",
+            "pt-BR": "São Paulo da Cruz · São Vital, Mártir"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "apr-28-paul-of-the-cross",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "apr-28-vitalis",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "paul-of-the-cross",
+                  "label": {
+                    "en-US": "St. Paul of the Cross",
+                    "pt-BR": "São Paulo da Cruz"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "apr-28-paul-of-the-cross",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "vitalis",
+                  "label": {
+                    "en-US": "St. Vitalis, Martyr",
+                    "pt-BR": "São Vital, Mártir"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "apr-28-vitalis",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "04-29",
           "label": {
-            "en-US": "St. Peter, Martyr · St. Hugh, Abbot of Cluny"
+            "en-US": "St. Peter, Martyr · St. Hugh, Abbot of Cluny",
+            "pt-BR": "São Pedro, Mártir · Santo Hugo, Abade de Cluny"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "apr-29-peter",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "apr-29-hugh",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "peter",
+                  "label": {
+                    "en-US": "St. Peter, Martyr",
+                    "pt-BR": "São Pedro, Mártir"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "apr-29-peter",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "hugh",
+                  "label": {
+                    "en-US": "St. Hugh, Abbot of Cluny",
+                    "pt-BR": "Santo Hugo, Abade de Cluny"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "apr-29-hugh",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "04-30",
           "label": {
-            "en-US": "St. Catherine of Siena"
+            "en-US": "St. Catherine of Siena",
+            "pt-BR": "Santa Catarina de Sena"
           },
           "sections": [
             {
@@ -2178,7 +2587,8 @@
         {
           "id": "05-01",
           "label": {
-            "en-US": "Sts. Philip and James, Apostles"
+            "en-US": "Sts. Philip and James, Apostles",
+            "pt-BR": "São Filipe e São Tiago, Apóstolos"
           },
           "sections": [
             {
@@ -2192,7 +2602,8 @@
         {
           "id": "05-02",
           "label": {
-            "en-US": "St. Athanasius, Bishop"
+            "en-US": "St. Athanasius, Bishop",
+            "pt-BR": "Santo Atanásio, Bispo"
           },
           "sections": [
             {
@@ -2206,7 +2617,8 @@
         {
           "id": "05-03",
           "label": {
-            "en-US": "The Discovery of the Holy Cross"
+            "en-US": "The Discovery of the Holy Cross",
+            "pt-BR": "A Descoberta da Santa Cruz"
           },
           "sections": [
             {
@@ -2220,7 +2632,8 @@
         {
           "id": "05-04",
           "label": {
-            "en-US": "St. Monica"
+            "en-US": "St. Monica",
+            "pt-BR": "Santa Mônica"
           },
           "sections": [
             {
@@ -2234,7 +2647,8 @@
         {
           "id": "05-05",
           "label": {
-            "en-US": "St. Pius V"
+            "en-US": "St. Pius V",
+            "pt-BR": "São Pio V"
           },
           "sections": [
             {
@@ -2248,7 +2662,8 @@
         {
           "id": "05-06",
           "label": {
-            "en-US": "St. John Before the Latin Gate"
+            "en-US": "St. John Before the Latin Gate",
+            "pt-BR": "São João ante a Porta Latina"
           },
           "sections": [
             {
@@ -2262,7 +2677,8 @@
         {
           "id": "05-07",
           "label": {
-            "en-US": "St. Stanislas, Bishop, Martyr"
+            "en-US": "St. Stanislas, Bishop, Martyr",
+            "pt-BR": "São Estanislau, Bispo, Mártir"
           },
           "sections": [
             {
@@ -2276,7 +2692,8 @@
         {
           "id": "05-08",
           "label": {
-            "en-US": "The Apparition of St. Michael the Archangel"
+            "en-US": "The Apparition of St. Michael the Archangel",
+            "pt-BR": "A Aparição de São Miguel Arcanjo"
           },
           "sections": [
             {
@@ -2290,7 +2707,8 @@
         {
           "id": "05-09",
           "label": {
-            "en-US": "St. Gregory Nazianzen"
+            "en-US": "St. Gregory Nazianzen",
+            "pt-BR": "São Gregório Nazianzeno"
           },
           "sections": [
             {
@@ -2304,7 +2722,8 @@
         {
           "id": "05-10",
           "label": {
-            "en-US": "St. Antoninus, Bishop"
+            "en-US": "St. Antoninus, Bishop",
+            "pt-BR": "Santo Antonino, Bispo"
           },
           "sections": [
             {
@@ -2318,7 +2737,8 @@
         {
           "id": "05-11",
           "label": {
-            "en-US": "St. Mammertus, Archbishop"
+            "en-US": "St. Mammertus, Archbishop",
+            "pt-BR": "São Mamerto, Arcebispo"
           },
           "sections": [
             {
@@ -2332,7 +2752,8 @@
         {
           "id": "05-12",
           "label": {
-            "en-US": "St. Epiphanius, Archbishop"
+            "en-US": "St. Epiphanius, Archbishop",
+            "pt-BR": "Santo Epifânio, Arcebispo"
           },
           "sections": [
             {
@@ -2346,7 +2767,8 @@
         {
           "id": "05-13",
           "label": {
-            "en-US": "St. John the Silent"
+            "en-US": "St. John the Silent",
+            "pt-BR": "São João, o Silencioso"
           },
           "sections": [
             {
@@ -2360,7 +2782,8 @@
         {
           "id": "05-14",
           "label": {
-            "en-US": "St. Pachomius, Abbot"
+            "en-US": "St. Pachomius, Abbot",
+            "pt-BR": "São Pacômio, Abade"
           },
           "sections": [
             {
@@ -2374,7 +2797,8 @@
         {
           "id": "05-15",
           "label": {
-            "en-US": "Sts. Peter and Dionysia"
+            "en-US": "Sts. Peter and Dionysia",
+            "pt-BR": "São Pedro e Santa Dionísia"
           },
           "sections": [
             {
@@ -2388,7 +2812,8 @@
         {
           "id": "05-16",
           "label": {
-            "en-US": "St. John Nepomucen"
+            "en-US": "St. John Nepomucen",
+            "pt-BR": "São João Nepomuceno"
           },
           "sections": [
             {
@@ -2402,7 +2827,8 @@
         {
           "id": "05-17",
           "label": {
-            "en-US": "St. Paschal Baylon"
+            "en-US": "St. Paschal Baylon",
+            "pt-BR": "São Pascoal Baylon"
           },
           "sections": [
             {
@@ -2416,7 +2842,8 @@
         {
           "id": "05-18",
           "label": {
-            "en-US": "St. Venantius, Martyr"
+            "en-US": "St. Venantius, Martyr",
+            "pt-BR": "São Venâncio, Mártir"
           },
           "sections": [
             {
@@ -2430,7 +2857,8 @@
         {
           "id": "05-19",
           "label": {
-            "en-US": "St. Peter Celestine"
+            "en-US": "St. Peter Celestine",
+            "pt-BR": "São Pedro Celestino"
           },
           "sections": [
             {
@@ -2444,7 +2872,8 @@
         {
           "id": "05-20",
           "label": {
-            "en-US": "St. Bernardine of Siena"
+            "en-US": "St. Bernardine of Siena",
+            "pt-BR": "São Bernardino de Siena"
           },
           "sections": [
             {
@@ -2458,7 +2887,8 @@
         {
           "id": "05-21",
           "label": {
-            "en-US": "St. Hospitius, Recluse"
+            "en-US": "St. Hospitius, Recluse",
+            "pt-BR": "Santo Hospício, Recluso"
           },
           "sections": [
             {
@@ -2472,7 +2902,8 @@
         {
           "id": "05-22",
           "label": {
-            "en-US": "St. Yvo, Confessor"
+            "en-US": "St. Yvo, Confessor",
+            "pt-BR": "Santo Ivo, Confessor"
           },
           "sections": [
             {
@@ -2486,7 +2917,8 @@
         {
           "id": "05-23",
           "label": {
-            "en-US": "St. Julia, Virgin, Martyr"
+            "en-US": "St. Julia, Virgin, Martyr",
+            "pt-BR": "Santa Júlia, Virgem, Mártir"
           },
           "sections": [
             {
@@ -2500,7 +2932,8 @@
         {
           "id": "05-24",
           "label": {
-            "en-US": "Sts. Donatian and Rogatian, Martyrs"
+            "en-US": "Sts. Donatian and Rogatian, Martyrs",
+            "pt-BR": "São Donaciano e São Rogaciano, Mártires"
           },
           "sections": [
             {
@@ -2514,7 +2947,8 @@
         {
           "id": "05-25",
           "label": {
-            "en-US": "St. Gregory VII"
+            "en-US": "St. Gregory VII",
+            "pt-BR": "São Gregório VII"
           },
           "sections": [
             {
@@ -2528,53 +2962,104 @@
         {
           "id": "05-26",
           "label": {
-            "en-US": "St. Philip Neri · St. Augustine, Apostle of England"
+            "en-US": "St. Philip Neri · St. Augustine, Apostle of England",
+            "pt-BR": "São Filipe Neri · Santo Agostinho, Apóstolo da Inglaterra"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "may-26-philip-neri",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "may-26-augustine",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "philip-neri",
+                  "label": {
+                    "en-US": "St. Philip Neri",
+                    "pt-BR": "São Filipe Neri"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "may-26-philip-neri",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "augustine",
+                  "label": {
+                    "en-US": "St. Augustine, Apostle of England",
+                    "pt-BR": "Santo Agostinho, Apóstolo da Inglaterra"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "may-26-augustine",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "05-27",
           "label": {
-            "en-US": "St. Mary Magdalen of Pazzi · Venerable Bede"
+            "en-US": "St. Mary Magdalen of Pazzi · Venerable Bede",
+            "pt-BR": "Santa Maria Madalena de Pazzi · Venerável Beda"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "may-27-mary-magdalen-of-pazzi",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "may-27-venerable-bede",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "mary-magdalen-of-pazzi",
+                  "label": {
+                    "en-US": "St. Mary Magdalen of Pazzi",
+                    "pt-BR": "Santa Maria Madalena de Pazzi"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "may-27-mary-magdalen-of-pazzi",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "venerable-bede",
+                  "label": {
+                    "en-US": "Venerable Bede",
+                    "pt-BR": "Venerável Beda"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "may-27-venerable-bede",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "05-28",
           "label": {
-            "en-US": "St. Germanus, Bishop"
+            "en-US": "St. Germanus, Bishop",
+            "pt-BR": "São Germano, Bispo"
           },
           "sections": [
             {
@@ -2588,7 +3073,8 @@
         {
           "id": "05-29",
           "label": {
-            "en-US": "St. Cyril, Martyr"
+            "en-US": "St. Cyril, Martyr",
+            "pt-BR": "São Cirilo, Mártir"
           },
           "sections": [
             {
@@ -2602,7 +3088,8 @@
         {
           "id": "05-30",
           "label": {
-            "en-US": "St. Felix I., Pope and Martyr"
+            "en-US": "St. Felix I., Pope and Martyr",
+            "pt-BR": "São Félix I, Papa e Mártir"
           },
           "sections": [
             {
@@ -2616,7 +3103,8 @@
         {
           "id": "05-31",
           "label": {
-            "en-US": "St. Petronilla, Virgin"
+            "en-US": "St. Petronilla, Virgin",
+            "pt-BR": "Santa Petronilha, Virgem"
           },
           "sections": [
             {
@@ -2630,30 +3118,56 @@
         {
           "id": "06-01",
           "label": {
-            "en-US": "St. Justin, Martyr · St. Pamphilus, Martyr"
+            "en-US": "St. Justin, Martyr · St. Pamphilus, Martyr",
+            "pt-BR": "São Justino, Mártir · São Pânfilo, Mártir"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "jun-01-justin",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "jun-01-pamphilus",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "justin",
+                  "label": {
+                    "en-US": "St. Justin, Martyr",
+                    "pt-BR": "São Justino, Mártir"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "jun-01-justin",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "pamphilus",
+                  "label": {
+                    "en-US": "St. Pamphilus, Martyr",
+                    "pt-BR": "São Pânfilo, Mártir"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "jun-01-pamphilus",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "06-02",
           "label": {
-            "en-US": "Sts. Pothinus, Bishop, Sanctus, Attalus, Blandina, and the other Martyrs of Lyon"
+            "en-US": "Sts. Pothinus, Bishop, Sanctus, Attalus, Blandina, and the other Martyrs of Lyons",
+            "pt-BR": "São Potino, Bispo, Sanctus, Atalo, Blandina e os demais Mártires de Lião"
           },
           "sections": [
             {
@@ -2667,7 +3181,8 @@
         {
           "id": "06-03",
           "label": {
-            "en-US": "St. Clotilda, Queen"
+            "en-US": "St. Clotilda, Queen",
+            "pt-BR": "Santa Clotilde, Rainha"
           },
           "sections": [
             {
@@ -2681,7 +3196,8 @@
         {
           "id": "06-04",
           "label": {
-            "en-US": "St. Francis Caracciolo"
+            "en-US": "St. Francis Caracciolo",
+            "pt-BR": "São Francisco Caracciolo"
           },
           "sections": [
             {
@@ -2695,7 +3211,8 @@
         {
           "id": "06-05",
           "label": {
-            "en-US": "St. Boniface, Bishop, Martyr"
+            "en-US": "St. Boniface, Bishop, Martyr",
+            "pt-BR": "São Bonifácio, Bispo, Mártir"
           },
           "sections": [
             {
@@ -2709,7 +3226,8 @@
         {
           "id": "06-06",
           "label": {
-            "en-US": "St. Norbert, Bishop"
+            "en-US": "St. Norbert, Bishop",
+            "pt-BR": "São Norberto, Bispo"
           },
           "sections": [
             {
@@ -2723,30 +3241,56 @@
         {
           "id": "06-07",
           "label": {
-            "en-US": "St. Robert of Newminster · St. Claude, Archbishop"
+            "en-US": "St. Robert of Newminster · St. Claude, Archbishop",
+            "pt-BR": "São Roberto de Newminster · São Cláudio, Arcebispo"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "jun-07-robert-of-newminster",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "jun-07-claude",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "robert-of-newminster",
+                  "label": {
+                    "en-US": "St. Robert of Newminster",
+                    "pt-BR": "São Roberto de Newminster"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "jun-07-robert-of-newminster",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "claude",
+                  "label": {
+                    "en-US": "St. Claude, Archbishop",
+                    "pt-BR": "São Cláudio, Arcebispo"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "jun-07-claude",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "06-08",
           "label": {
-            "en-US": "St. Medard, Bishop"
+            "en-US": "St. Medard, Bishop",
+            "pt-BR": "São Medardo, Bispo"
           },
           "sections": [
             {
@@ -2760,30 +3304,56 @@
         {
           "id": "06-09",
           "label": {
-            "en-US": "Sts. Primus and Felicianus, Martyrs · St. Columba, or Columkille, Abbot"
+            "en-US": "Sts. Primus and Felicianus, Martyrs · St. Columba, or Columkille, Abbot",
+            "pt-BR": "São Primo e São Feliciano, Mártires · São Columba, ou Columkille, Abade"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "jun-09-sts-primus-and-felicianus",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "jun-09-columba-or-columkille",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "sts-primus-and-felicianus",
+                  "label": {
+                    "en-US": "Sts. Primus and Felicianus, Martyrs",
+                    "pt-BR": "São Primo e São Feliciano, Mártires"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "jun-09-sts-primus-and-felicianus",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "columba-or-columkille",
+                  "label": {
+                    "en-US": "St. Columba, or Columkille, Abbot",
+                    "pt-BR": "São Columba, ou Columkille, Abade"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "jun-09-columba-or-columkille",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "06-10",
           "label": {
-            "en-US": "St. Margaret of Scotland"
+            "en-US": "St. Margaret of Scotland",
+            "pt-BR": "Santa Margarida da Escócia"
           },
           "sections": [
             {
@@ -2797,7 +3367,8 @@
         {
           "id": "06-11",
           "label": {
-            "en-US": "St. Barnabas, Apostle"
+            "en-US": "St. Barnabas, Apostle",
+            "pt-BR": "São Barnabé, Apóstolo"
           },
           "sections": [
             {
@@ -2811,7 +3382,8 @@
         {
           "id": "06-12",
           "label": {
-            "en-US": "St. John of St. Fagondez"
+            "en-US": "St. John of St. Fagondez",
+            "pt-BR": "São João de São Fagondez"
           },
           "sections": [
             {
@@ -2825,7 +3397,8 @@
         {
           "id": "06-13",
           "label": {
-            "en-US": "St. Antony of Padua"
+            "en-US": "St. Antony of Padua",
+            "pt-BR": "Santo Antônio de Pádua"
           },
           "sections": [
             {
@@ -2839,7 +3412,8 @@
         {
           "id": "06-14",
           "label": {
-            "en-US": "St. Basil the Great"
+            "en-US": "St. Basil the Great",
+            "pt-BR": "São Basílio Magno"
           },
           "sections": [
             {
@@ -2853,7 +3427,8 @@
         {
           "id": "06-15",
           "label": {
-            "en-US": "Sts. Vitus, Crescentia, and Modestus, Martyrs"
+            "en-US": "Sts. Vitus, Crescentia, and Modestus, Martyrs",
+            "pt-BR": "São Vito, Santa Crescência e São Modesto, Mártires"
           },
           "sections": [
             {
@@ -2867,7 +3442,8 @@
         {
           "id": "06-16",
           "label": {
-            "en-US": "St. John Francis Regis"
+            "en-US": "St. John Francis Regis",
+            "pt-BR": "São João Francisco Regis"
           },
           "sections": [
             {
@@ -2881,7 +3457,8 @@
         {
           "id": "06-17",
           "label": {
-            "en-US": "St. Avitus, Abbot"
+            "en-US": "St. Avitus, Abbot",
+            "pt-BR": "Santo Ávito, Abade"
           },
           "sections": [
             {
@@ -2895,7 +3472,8 @@
         {
           "id": "06-18",
           "label": {
-            "en-US": "Sts. Marcus and Marcellianus, Martyrs"
+            "en-US": "Sts. Marcus and Marcellianus, Martyrs",
+            "pt-BR": "São Marco e São Marceliano, Mártires"
           },
           "sections": [
             {
@@ -2909,7 +3487,8 @@
         {
           "id": "06-19",
           "label": {
-            "en-US": "St. Juliana Falconieri"
+            "en-US": "St. Juliana Falconieri",
+            "pt-BR": "Santa Juliana Falconieri"
           },
           "sections": [
             {
@@ -2923,7 +3502,8 @@
         {
           "id": "06-20",
           "label": {
-            "en-US": "St. Silverius, Pope and Martyr"
+            "en-US": "St. Silverius, Pope and Martyr",
+            "pt-BR": "São Silvério, Papa e Mártir"
           },
           "sections": [
             {
@@ -2937,7 +3517,8 @@
         {
           "id": "06-21",
           "label": {
-            "en-US": "St. Aloysius Gonzaga"
+            "en-US": "St. Aloysius Gonzaga",
+            "pt-BR": "São Luís Gonzaga"
           },
           "sections": [
             {
@@ -2951,7 +3532,8 @@
         {
           "id": "06-22",
           "label": {
-            "en-US": "St. Paulinus of Nola"
+            "en-US": "St. Paulinus of Nola",
+            "pt-BR": "São Paulino de Nola"
           },
           "sections": [
             {
@@ -2965,7 +3547,8 @@
         {
           "id": "06-23",
           "label": {
-            "en-US": "St. Etheldreda, Abbess"
+            "en-US": "St. Etheldreda, Abbess",
+            "pt-BR": "Santa Eteldreda, Abadessa"
           },
           "sections": [
             {
@@ -2979,7 +3562,8 @@
         {
           "id": "06-24",
           "label": {
-            "en-US": "St. John the Baptist"
+            "en-US": "St. John the Baptist",
+            "pt-BR": "São João Batista"
           },
           "sections": [
             {
@@ -2993,7 +3577,8 @@
         {
           "id": "06-25",
           "label": {
-            "en-US": "St. Prosper of Aquitaine. St William of Monte-Vergine"
+            "en-US": "St. Prosper of Aquitaine. St William of Monte-Vergine",
+            "pt-BR": "São Próspero da Aquitânia. São Guilherme de Monte-Vergine"
           },
           "sections": [
             {
@@ -3007,7 +3592,8 @@
         {
           "id": "06-26",
           "label": {
-            "en-US": "Sts. John and Paul, Martyrs"
+            "en-US": "Sts. John and Paul, Martyrs",
+            "pt-BR": "São João e São Paulo, Mártires"
           },
           "sections": [
             {
@@ -3021,7 +3607,8 @@
         {
           "id": "06-27",
           "label": {
-            "en-US": "St. Ladislas, King"
+            "en-US": "St. Ladislas, King",
+            "pt-BR": "São Ladislau, Rei"
           },
           "sections": [
             {
@@ -3035,7 +3622,8 @@
         {
           "id": "06-28",
           "label": {
-            "en-US": "St. Irenæus, Bishop, Martyr"
+            "en-US": "St. Irenæus, Bishop, Martyr",
+            "pt-BR": "Santo Irineu, Bispo, Mártir"
           },
           "sections": [
             {
@@ -3049,7 +3637,8 @@
         {
           "id": "06-29",
           "label": {
-            "en-US": "St. Peter, Apostle"
+            "en-US": "St. Peter, Apostle",
+            "pt-BR": "São Pedro, Apóstolo"
           },
           "sections": [
             {
@@ -3063,7 +3652,8 @@
         {
           "id": "06-30",
           "label": {
-            "en-US": "St. Paul"
+            "en-US": "St. Paul",
+            "pt-BR": "São Paulo"
           },
           "sections": [
             {
@@ -3077,7 +3667,8 @@
         {
           "id": "07-01",
           "label": {
-            "en-US": "St. Gal, Bishop"
+            "en-US": "St. Gal, Bishop",
+            "pt-BR": "São Galo, Bispo"
           },
           "sections": [
             {
@@ -3091,7 +3682,8 @@
         {
           "id": "07-02",
           "label": {
-            "en-US": "The Visitation of the Blessed Virgin"
+            "en-US": "The Visitation of the Blessed Virgin",
+            "pt-BR": "A Visitação da Santíssima Virgem"
           },
           "sections": [
             {
@@ -3105,7 +3697,8 @@
         {
           "id": "07-03",
           "label": {
-            "en-US": "St. Heliodorus, Bishop"
+            "en-US": "St. Heliodorus, Bishop",
+            "pt-BR": "Santo Heliodoro, Bispo"
           },
           "sections": [
             {
@@ -3119,7 +3712,8 @@
         {
           "id": "07-04",
           "label": {
-            "en-US": "St. Bertha, Widow, Abbess"
+            "en-US": "St. Bertha, Widow, Abbess",
+            "pt-BR": "Santa Berta, Viúva, Abadessa"
           },
           "sections": [
             {
@@ -3133,7 +3727,8 @@
         {
           "id": "07-05",
           "label": {
-            "en-US": "St. Peter of Luxemburg"
+            "en-US": "St. Peter of Luxemburg",
+            "pt-BR": "São Pedro de Luxemburgo"
           },
           "sections": [
             {
@@ -3147,30 +3742,56 @@
         {
           "id": "07-06",
           "label": {
-            "en-US": "St. Goar, Priest · St. Palladius, Bishop, Apostle of the Scots"
+            "en-US": "St. Goar, Priest · St. Palladius, Bishop, Apostle of the Scots",
+            "pt-BR": "São Goar, Sacerdote · São Paládio, Bispo, Apóstolo dos Escotos"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "jul-06-goar",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "jul-06-palladius",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "goar",
+                  "label": {
+                    "en-US": "St. Goar, Priest",
+                    "pt-BR": "São Goar, Sacerdote"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "jul-06-goar",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "palladius",
+                  "label": {
+                    "en-US": "St. Palladius, Bishop, Apostle of the Scots",
+                    "pt-BR": "São Paládio, Bispo, Apóstolo dos Escotos"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "jul-06-palladius",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "07-07",
           "label": {
-            "en-US": "St. Pantænus, Father of the Church"
+            "en-US": "St. Pantænus, Father of the Church",
+            "pt-BR": "São Panteno, Padre da Igreja"
           },
           "sections": [
             {
@@ -3184,7 +3805,8 @@
         {
           "id": "07-08",
           "label": {
-            "en-US": "St. Elizabeth of Portugal"
+            "en-US": "St. Elizabeth of Portugal",
+            "pt-BR": "Santa Isabel de Portugal"
           },
           "sections": [
             {
@@ -3198,7 +3820,8 @@
         {
           "id": "07-09",
           "label": {
-            "en-US": "St. Ephrem, Deacon"
+            "en-US": "St. Ephrem, Deacon",
+            "pt-BR": "Santo Efrém, Diácono"
           },
           "sections": [
             {
@@ -3212,7 +3835,8 @@
         {
           "id": "07-10",
           "label": {
-            "en-US": "The Seven Brothers, Martyrs, and St. Felicitas, their Mother"
+            "en-US": "The Seven Brothers, Martyrs, and St. Felicitas, their Mother",
+            "pt-BR": "Os Sete Irmãos, Mártires, e Santa Felicidade, sua Mãe"
           },
           "sections": [
             {
@@ -3226,7 +3850,8 @@
         {
           "id": "07-11",
           "label": {
-            "en-US": "St. James, Bishop"
+            "en-US": "St. James, Bishop",
+            "pt-BR": "São Tiago, Bispo"
           },
           "sections": [
             {
@@ -3240,7 +3865,8 @@
         {
           "id": "07-12",
           "label": {
-            "en-US": "St. John Gualbert"
+            "en-US": "St. John Gualbert",
+            "pt-BR": "São João Gualberto"
           },
           "sections": [
             {
@@ -3254,7 +3880,8 @@
         {
           "id": "07-13",
           "label": {
-            "en-US": "St. Eugenius, Bishop"
+            "en-US": "St. Eugenius, Bishop",
+            "pt-BR": "São Eugênio, Bispo"
           },
           "sections": [
             {
@@ -3268,7 +3895,8 @@
         {
           "id": "07-14",
           "label": {
-            "en-US": "St. Bonaventure"
+            "en-US": "St. Bonaventure",
+            "pt-BR": "São Boaventura"
           },
           "sections": [
             {
@@ -3282,7 +3910,8 @@
         {
           "id": "07-15",
           "label": {
-            "en-US": "St. Henry, Emperor"
+            "en-US": "St. Henry, Emperor",
+            "pt-BR": "Santo Henrique, Imperador"
           },
           "sections": [
             {
@@ -3296,7 +3925,8 @@
         {
           "id": "07-16",
           "label": {
-            "en-US": "St. Simon Stock"
+            "en-US": "St. Simon Stock",
+            "pt-BR": "São Simão Stock"
           },
           "sections": [
             {
@@ -3310,7 +3940,8 @@
         {
           "id": "07-17",
           "label": {
-            "en-US": "St. Alexius"
+            "en-US": "St. Alexius",
+            "pt-BR": "Santo Aleixo"
           },
           "sections": [
             {
@@ -3324,7 +3955,8 @@
         {
           "id": "07-18",
           "label": {
-            "en-US": "St. Camillus Of Lellis"
+            "en-US": "St. Camillus Of Lellis",
+            "pt-BR": "São Camilo de Lélis"
           },
           "sections": [
             {
@@ -3338,7 +3970,8 @@
         {
           "id": "07-19",
           "label": {
-            "en-US": "St. Vincent of Paul"
+            "en-US": "St. Vincent of Paul",
+            "pt-BR": "São Vicente de Paulo"
           },
           "sections": [
             {
@@ -3352,30 +3985,56 @@
         {
           "id": "07-20",
           "label": {
-            "en-US": "St. Margaret, Virgin and Martyr · St. Jerome Emiliani"
+            "en-US": "St. Margaret, Virgin and Martyr · St. Jerome Emiliani",
+            "pt-BR": "Santa Margarida, Virgem e Mártir · São Jerônimo Emiliani"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "jul-20-margaret",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "jul-20-jerome-emiliani",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "margaret",
+                  "label": {
+                    "en-US": "St. Margaret, Virgin and Martyr",
+                    "pt-BR": "Santa Margarida, Virgem e Mártir"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "jul-20-margaret",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "jerome-emiliani",
+                  "label": {
+                    "en-US": "St. Jerome Emiliani",
+                    "pt-BR": "São Jerônimo Emiliani"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "jul-20-jerome-emiliani",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "07-21",
           "label": {
-            "en-US": "St. Victor, Martyr"
+            "en-US": "St. Victor, Martyr",
+            "pt-BR": "São Vítor, Mártir"
           },
           "sections": [
             {
@@ -3389,7 +4048,8 @@
         {
           "id": "07-22",
           "label": {
-            "en-US": "St. Mary Magdalen"
+            "en-US": "St. Mary Magdalen",
+            "pt-BR": "Santa Maria Madalena"
           },
           "sections": [
             {
@@ -3403,7 +4063,8 @@
         {
           "id": "07-23",
           "label": {
-            "en-US": "St. Apollinaris, Bishop and Martyr"
+            "en-US": "St. Apollinaris, Bishop and Martyr",
+            "pt-BR": "Santo Apolinário, Bispo e Mártir"
           },
           "sections": [
             {
@@ -3417,7 +4078,8 @@
         {
           "id": "07-24",
           "label": {
-            "en-US": "St. Christina, Virgin and Martyr"
+            "en-US": "St. Christina, Virgin and Martyr",
+            "pt-BR": "Santa Cristina, Virgem e Mártir"
           },
           "sections": [
             {
@@ -3431,7 +4093,8 @@
         {
           "id": "07-25",
           "label": {
-            "en-US": "St. James, Apostle"
+            "en-US": "St. James, Apostle",
+            "pt-BR": "São Tiago, Apóstolo"
           },
           "sections": [
             {
@@ -3445,7 +4108,8 @@
         {
           "id": "07-26",
           "label": {
-            "en-US": "St. Anne"
+            "en-US": "St. Anne",
+            "pt-BR": "Santa Ana"
           },
           "sections": [
             {
@@ -3459,7 +4123,8 @@
         {
           "id": "07-27",
           "label": {
-            "en-US": "St. Pantaleon, Martyr"
+            "en-US": "St. Pantaleon, Martyr",
+            "pt-BR": "São Pantaleão, Mártir"
           },
           "sections": [
             {
@@ -3473,7 +4138,8 @@
         {
           "id": "07-28",
           "label": {
-            "en-US": "Sts. Nazarius and Celsus, Martyrs"
+            "en-US": "Sts. Nazarius and Celsus, Martyrs",
+            "pt-BR": "São Nazário e São Celso, Mártires"
           },
           "sections": [
             {
@@ -3487,7 +4153,8 @@
         {
           "id": "07-29",
           "label": {
-            "en-US": "St. Martha, Virgin"
+            "en-US": "St. Martha, Virgin",
+            "pt-BR": "Santa Marta, Virgem"
           },
           "sections": [
             {
@@ -3501,7 +4168,8 @@
         {
           "id": "07-30",
           "label": {
-            "en-US": "St. Germanus, Bishop"
+            "en-US": "St. Germanus, Bishop",
+            "pt-BR": "São Germano, Bispo"
           },
           "sections": [
             {
@@ -3515,7 +4183,8 @@
         {
           "id": "07-31",
           "label": {
-            "en-US": "St. Ignatius of Loyola"
+            "en-US": "St. Ignatius of Loyola",
+            "pt-BR": "Santo Inácio de Loiola"
           },
           "sections": [
             {
@@ -3529,7 +4198,8 @@
         {
           "id": "08-01",
           "label": {
-            "en-US": "St. Peter's Chains"
+            "en-US": "St. Peter's Chains",
+            "pt-BR": "As Cadeias de São Pedro"
           },
           "sections": [
             {
@@ -3543,30 +4213,56 @@
         {
           "id": "08-02",
           "label": {
-            "en-US": "St. Stephen, Pope and Martyr · St. Alphonsus Liguori"
+            "en-US": "St. Stephen, Pope and Martyr · St. Alphonsus Liguori",
+            "pt-BR": "São Estêvão, Papa e Mártir · Santo Afonso de Ligório"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "aug-02-stephen",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "aug-02-alphonsus-liguori",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "stephen",
+                  "label": {
+                    "en-US": "St. Stephen, Pope and Martyr",
+                    "pt-BR": "São Estêvão, Papa e Mártir"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "aug-02-stephen",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "alphonsus-liguori",
+                  "label": {
+                    "en-US": "St. Alphonsus Liguori",
+                    "pt-BR": "Santo Afonso de Ligório"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "aug-02-alphonsus-liguori",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "08-03",
           "label": {
-            "en-US": "The Finding of St. Stephen's Relics"
+            "en-US": "The Finding of St. Stephen's Relics",
+            "pt-BR": "O Achado das Relíquias de Santo Estêvão"
           },
           "sections": [
             {
@@ -3580,7 +4276,8 @@
         {
           "id": "08-04",
           "label": {
-            "en-US": "St. Dominic"
+            "en-US": "St. Dominic",
+            "pt-BR": "São Domingos"
           },
           "sections": [
             {
@@ -3594,7 +4291,8 @@
         {
           "id": "08-05",
           "label": {
-            "en-US": "The Dedication of St. Mary ad Nives"
+            "en-US": "The Dedication of St. Mary ad Nives",
+            "pt-BR": "A Dedicação de Santa Maria ad Nives"
           },
           "sections": [
             {
@@ -3608,7 +4306,8 @@
         {
           "id": "08-06",
           "label": {
-            "en-US": "The Transfiguration of Our Lord"
+            "en-US": "The Transfiguration of Our Lord",
+            "pt-BR": "A Transfiguração de Nosso Senhor"
           },
           "sections": [
             {
@@ -3622,7 +4321,8 @@
         {
           "id": "08-07",
           "label": {
-            "en-US": "St. Cajetan"
+            "en-US": "St. Cajetan",
+            "pt-BR": "São Caetano"
           },
           "sections": [
             {
@@ -3636,30 +4336,56 @@
         {
           "id": "08-08",
           "label": {
-            "en-US": "St. Cyriacus and His Companions, Martyrs · Blessed Peter Favre"
+            "en-US": "St. Cyriacus and His Companions, Martyrs · Blessed Peter Favre",
+            "pt-BR": "São Ciríaco e Seus Companheiros, Mártires · Beato Pedro Favre"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "aug-08-cyriacus-and-his-companions",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "aug-08-blessed-peter-favre",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "cyriacus-and-his-companions",
+                  "label": {
+                    "en-US": "St. Cyriacus and His Companions, Martyrs",
+                    "pt-BR": "São Ciríaco e Seus Companheiros, Mártires"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "aug-08-cyriacus-and-his-companions",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "blessed-peter-favre",
+                  "label": {
+                    "en-US": "Blessed Peter Favre",
+                    "pt-BR": "Beato Pedro Favre"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "aug-08-blessed-peter-favre",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "08-09",
           "label": {
-            "en-US": "St. Romanus, Martyr"
+            "en-US": "St. Romanus, Martyr",
+            "pt-BR": "São Romano, Mártir"
           },
           "sections": [
             {
@@ -3673,7 +4399,8 @@
         {
           "id": "08-10",
           "label": {
-            "en-US": "St. Laurence, Martyr"
+            "en-US": "St. Laurence, Martyr",
+            "pt-BR": "São Lourenço, Mártir"
           },
           "sections": [
             {
@@ -3687,7 +4414,8 @@
         {
           "id": "08-11",
           "label": {
-            "en-US": "Sts. Tiburtius and Susanna, Martyrs"
+            "en-US": "Sts. Tiburtius and Susanna, Martyrs",
+            "pt-BR": "São Tibúrcio e Santa Susana, Mártires"
           },
           "sections": [
             {
@@ -3701,7 +4429,8 @@
         {
           "id": "08-12",
           "label": {
-            "en-US": "St. Clare, Abbess"
+            "en-US": "St. Clare, Abbess",
+            "pt-BR": "Santa Clara, Abadessa"
           },
           "sections": [
             {
@@ -3715,7 +4444,8 @@
         {
           "id": "08-13",
           "label": {
-            "en-US": "St. Radegundes, Queen"
+            "en-US": "St. Radegundes, Queen",
+            "pt-BR": "Santa Radegundes, Rainha"
           },
           "sections": [
             {
@@ -3729,7 +4459,8 @@
         {
           "id": "08-14",
           "label": {
-            "en-US": "St. Eusebius, Priest"
+            "en-US": "St. Eusebius, Priest",
+            "pt-BR": "Santo Eusébio, Sacerdote"
           },
           "sections": [
             {
@@ -3743,7 +4474,8 @@
         {
           "id": "08-15",
           "label": {
-            "en-US": "The Assumption of the Blessed Virgin Mary"
+            "en-US": "The Assumption of the Blessed Virgin Mary",
+            "pt-BR": "A Assunção da Santíssima Virgem Maria"
           },
           "sections": [
             {
@@ -3757,7 +4489,8 @@
         {
           "id": "08-16",
           "label": {
-            "en-US": "St. Hyacinth"
+            "en-US": "St. Hyacinth",
+            "pt-BR": "São Jacinto"
           },
           "sections": [
             {
@@ -3771,7 +4504,8 @@
         {
           "id": "08-17",
           "label": {
-            "en-US": "St. Liberatus, Abbot, and Six Monks, Martyrs"
+            "en-US": "St. Liberatus, Abbot, and Six Monks, Martyrs",
+            "pt-BR": "São Liberato, Abade, e Seis Monges, Mártires"
           },
           "sections": [
             {
@@ -3785,7 +4519,8 @@
         {
           "id": "08-18",
           "label": {
-            "en-US": "St. Helena, Empress; St. Agapetus, Martyr"
+            "en-US": "St. Helena, Empress; St. Agapetus, Martyr",
+            "pt-BR": "Santa Helena, Imperatriz; Santo Agapito, Mártir"
           },
           "sections": [
             {
@@ -3799,7 +4534,8 @@
         {
           "id": "08-19",
           "label": {
-            "en-US": "St. Louis, Bishop"
+            "en-US": "St. Louis, Bishop",
+            "pt-BR": "São Luís, Bispo"
           },
           "sections": [
             {
@@ -3813,7 +4549,8 @@
         {
           "id": "08-20",
           "label": {
-            "en-US": "St. Bernard"
+            "en-US": "St. Bernard",
+            "pt-BR": "São Bernardo"
           },
           "sections": [
             {
@@ -3827,7 +4564,8 @@
         {
           "id": "08-21",
           "label": {
-            "en-US": "St. Jane Frances de Chantal"
+            "en-US": "St. Jane Frances de Chantal",
+            "pt-BR": "Santa Joana Francisca de Chantal"
           },
           "sections": [
             {
@@ -3841,7 +4579,8 @@
         {
           "id": "08-22",
           "label": {
-            "en-US": "St. Symphorian, Martyr"
+            "en-US": "St. Symphorian, Martyr",
+            "pt-BR": "São Sinforiano, Mártir"
           },
           "sections": [
             {
@@ -3855,7 +4594,8 @@
         {
           "id": "08-23",
           "label": {
-            "en-US": "St. Philip Benizi"
+            "en-US": "St. Philip Benizi",
+            "pt-BR": "São Filipe Benício"
           },
           "sections": [
             {
@@ -3869,7 +4609,8 @@
         {
           "id": "08-24",
           "label": {
-            "en-US": "St. Bartholomew, Apostle"
+            "en-US": "St. Bartholomew, Apostle",
+            "pt-BR": "São Bartolomeu, Apóstolo"
           },
           "sections": [
             {
@@ -3883,7 +4624,8 @@
         {
           "id": "08-25",
           "label": {
-            "en-US": "St. Louis, King"
+            "en-US": "St. Louis, King",
+            "pt-BR": "São Luís, Rei"
           },
           "sections": [
             {
@@ -3897,7 +4639,8 @@
         {
           "id": "08-26",
           "label": {
-            "en-US": "St. Zephyrinus, Pope and Martyr"
+            "en-US": "St. Zephyrinus, Pope and Martyr",
+            "pt-BR": "São Zeferino, Papa e Mártir"
           },
           "sections": [
             {
@@ -3911,7 +4654,8 @@
         {
           "id": "08-27",
           "label": {
-            "en-US": "St. Joseph Calasanctius"
+            "en-US": "St. Joseph Calasanctius",
+            "pt-BR": "São José de Calasanz"
           },
           "sections": [
             {
@@ -3925,7 +4669,8 @@
         {
           "id": "08-28",
           "label": {
-            "en-US": "St. Augustine of Hippo"
+            "en-US": "St. Augustine of Hippo",
+            "pt-BR": "Santo Agostinho de Hipona"
           },
           "sections": [
             {
@@ -3939,7 +4684,8 @@
         {
           "id": "08-29",
           "label": {
-            "en-US": "The Beheading of St. John the Baptist"
+            "en-US": "The Beheading of St. John the Baptist",
+            "pt-BR": "A Degolação de São João Batista"
           },
           "sections": [
             {
@@ -3953,30 +4699,56 @@
         {
           "id": "08-30",
           "label": {
-            "en-US": "St. Rose of Lima · St. Fiaker, Anchorite"
+            "en-US": "St. Rose of Lima · St. Fiaker, Anchorite",
+            "pt-BR": "Santa Rosa de Lima · São Fiacro, Anacoreta"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "aug-30-rose-of-lima",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "aug-30-fiaker-anchorite",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "rose-of-lima",
+                  "label": {
+                    "en-US": "St. Rose of Lima",
+                    "pt-BR": "Santa Rosa de Lima"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "aug-30-rose-of-lima",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "fiaker-anchorite",
+                  "label": {
+                    "en-US": "St. Fiaker, Anchorite",
+                    "pt-BR": "São Fiacro, Anacoreta"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "aug-30-fiaker-anchorite",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "08-31",
           "label": {
-            "en-US": "St. Raymund Nonnatus"
+            "en-US": "St. Raymund Nonnatus",
+            "pt-BR": "São Raimundo Nonato"
           },
           "sections": [
             {
@@ -3990,7 +4762,8 @@
         {
           "id": "09-01",
           "label": {
-            "en-US": "St. Giles, Abbot"
+            "en-US": "St. Giles, Abbot",
+            "pt-BR": "Santo Egídio, Abade"
           },
           "sections": [
             {
@@ -4004,7 +4777,8 @@
         {
           "id": "09-02",
           "label": {
-            "en-US": "St. Stephen, King"
+            "en-US": "St. Stephen, King",
+            "pt-BR": "Santo Estêvão, Rei"
           },
           "sections": [
             {
@@ -4018,7 +4792,8 @@
         {
           "id": "09-03",
           "label": {
-            "en-US": "St. Seraphia, Virgin and Martyr"
+            "en-US": "St. Seraphia, Virgin and Martyr",
+            "pt-BR": "Santa Seráfia, Virgem e Mártir"
           },
           "sections": [
             {
@@ -4032,7 +4807,8 @@
         {
           "id": "09-04",
           "label": {
-            "en-US": "St. Rosalia, Virgin"
+            "en-US": "St. Rosalia, Virgin",
+            "pt-BR": "Santa Rosália, Virgem"
           },
           "sections": [
             {
@@ -4046,7 +4822,8 @@
         {
           "id": "09-05",
           "label": {
-            "en-US": "St. Laurence Justinian"
+            "en-US": "St. Laurence Justinian",
+            "pt-BR": "São Lourenço Justiniano"
           },
           "sections": [
             {
@@ -4060,7 +4837,8 @@
         {
           "id": "09-06",
           "label": {
-            "en-US": "St. Eleutherius, Abbot"
+            "en-US": "St. Eleutherius, Abbot",
+            "pt-BR": "Santo Eleutério, Abade"
           },
           "sections": [
             {
@@ -4074,7 +4852,8 @@
         {
           "id": "09-07",
           "label": {
-            "en-US": "St. Cloud, Confessor"
+            "en-US": "St. Cloud, Confessor",
+            "pt-BR": "São Clodoaldo, Confessor"
           },
           "sections": [
             {
@@ -4088,53 +4867,104 @@
         {
           "id": "09-08",
           "label": {
-            "en-US": "The Nativity of the Blessed Virgin · The Festival, on the Sunday Within the Octa"
+            "en-US": "The Nativity of the Blessed Virgin · The Festival, on the Sunday Within the Octave of Her Nativity, of The Holy Name of Mary",
+            "pt-BR": "A Natividade da Santíssima Virgem · A Festa, no Domingo Dentro da Oitava de Sua Natividade, do Santíssimo Nome de Maria"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "sep-08-the-nativity-of-the-blessed",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "sep-08-the-festival-on-the-sunday-within-the-octave-of-her-nativity-of-the-holy-name-of-mary",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "the-nativity-of-the-blessed",
+                  "label": {
+                    "en-US": "The Nativity of the Blessed Virgin",
+                    "pt-BR": "A Natividade da Santíssima Virgem"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "sep-08-the-nativity-of-the-blessed",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "the-festival-on-the-sunday-within-the-octave-of-her-nativity-of-the-holy-name-of-mary",
+                  "label": {
+                    "en-US": "The Festival, on the Sunday Within the Octave of Her Nativity, of The Holy Name of Mary",
+                    "pt-BR": "A Festa, no Domingo Dentro da Oitava de Sua Natividade, do Santíssimo Nome de Maria"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "sep-08-the-festival-on-the-sunday-within-the-octave-of-her-nativity-of-the-holy-name-of-mary",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "09-09",
           "label": {
-            "en-US": "St. Omer, Bishop · Saint Peter Claver"
+            "en-US": "St. Omer, Bishop · Saint Peter Claver",
+            "pt-BR": "Santo Omer, Bispo · São Pedro Claver"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "sep-09-omer",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "sep-09-saint-peter-claver",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "omer",
+                  "label": {
+                    "en-US": "St. Omer, Bishop",
+                    "pt-BR": "Santo Omer, Bispo"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "sep-09-omer",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "saint-peter-claver",
+                  "label": {
+                    "en-US": "Saint Peter Claver",
+                    "pt-BR": "São Pedro Claver"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "sep-09-saint-peter-claver",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "09-10",
           "label": {
-            "en-US": "St. Nicholas of Tolentino"
+            "en-US": "St. Nicholas of Tolentino",
+            "pt-BR": "São Nicolau de Tolentino"
           },
           "sections": [
             {
@@ -4148,7 +4978,8 @@
         {
           "id": "09-11",
           "label": {
-            "en-US": "St. Paphnutius, Bishop"
+            "en-US": "St. Paphnutius, Bishop",
+            "pt-BR": "São Pafnúcio, Bispo"
           },
           "sections": [
             {
@@ -4162,7 +4993,8 @@
         {
           "id": "09-12",
           "label": {
-            "en-US": "St. Guy of Anderlecht"
+            "en-US": "St. Guy of Anderlecht",
+            "pt-BR": "São Guido de Anderlecht"
           },
           "sections": [
             {
@@ -4176,7 +5008,8 @@
         {
           "id": "09-13",
           "label": {
-            "en-US": "St. Eulogius, Patriarch of Alexandria"
+            "en-US": "St. Eulogius, Patriarch of Alexandria",
+            "pt-BR": "Santo Eulógio, Patriarca de Alexandria"
           },
           "sections": [
             {
@@ -4190,7 +5023,8 @@
         {
           "id": "09-14",
           "label": {
-            "en-US": "The Exaltation of the Holy Cross of Our Lord Jesus Christ"
+            "en-US": "The Exaltation of the Holy Cross of Our Lord Jesus Christ",
+            "pt-BR": "A Exaltação da Santa Cruz de Nosso Senhor Jesus Cristo"
           },
           "sections": [
             {
@@ -4204,7 +5038,8 @@
         {
           "id": "09-15",
           "label": {
-            "en-US": "St. Catherine of Genoa"
+            "en-US": "St. Catherine of Genoa",
+            "pt-BR": "Santa Catarina de Gênova"
           },
           "sections": [
             {
@@ -4218,7 +5053,8 @@
         {
           "id": "09-16",
           "label": {
-            "en-US": "St. Cyprian, Bishop, Martyr"
+            "en-US": "St. Cyprian, Bishop, Martyr",
+            "pt-BR": "São Cipriano, Bispo, Mártir"
           },
           "sections": [
             {
@@ -4232,7 +5068,8 @@
         {
           "id": "09-17",
           "label": {
-            "en-US": "St. Lambert, Bishop, Martyr"
+            "en-US": "St. Lambert, Bishop, Martyr",
+            "pt-BR": "São Lamberto, Bispo, Mártir"
           },
           "sections": [
             {
@@ -4246,7 +5083,8 @@
         {
           "id": "09-18",
           "label": {
-            "en-US": "St. Thomas of Villanova"
+            "en-US": "St. Thomas of Villanova",
+            "pt-BR": "São Tomás de Vilanova"
           },
           "sections": [
             {
@@ -4260,7 +5098,8 @@
         {
           "id": "09-19",
           "label": {
-            "en-US": "St. Januarius, Martyr"
+            "en-US": "St. Januarius, Martyr",
+            "pt-BR": "São Januário, Mártir"
           },
           "sections": [
             {
@@ -4274,7 +5113,8 @@
         {
           "id": "09-20",
           "label": {
-            "en-US": "Sts. Eustachius and Companions, Martyrs"
+            "en-US": "Sts. Eustachius and Companions, Martyrs",
+            "pt-BR": "Santo Eustáquio e Companheiros, Mártires"
           },
           "sections": [
             {
@@ -4288,7 +5128,8 @@
         {
           "id": "09-21",
           "label": {
-            "en-US": "St. Matthew, Apostle"
+            "en-US": "St. Matthew, Apostle",
+            "pt-BR": "São Mateus, Apóstolo"
           },
           "sections": [
             {
@@ -4302,7 +5143,8 @@
         {
           "id": "09-22",
           "label": {
-            "en-US": "The Theban Legion"
+            "en-US": "The Theban Legion",
+            "pt-BR": "A Legião Tebana"
           },
           "sections": [
             {
@@ -4316,7 +5158,8 @@
         {
           "id": "09-23",
           "label": {
-            "en-US": "St. Thecla, Virgin, Martyr"
+            "en-US": "St. Thecla, Virgin, Martyr",
+            "pt-BR": "Santa Tecla, Virgem, Mártir"
           },
           "sections": [
             {
@@ -4330,7 +5173,8 @@
         {
           "id": "09-24",
           "label": {
-            "en-US": "The Blessed Virgin Mary of Mercy"
+            "en-US": "The Blessed Virgin Mary of Mercy",
+            "pt-BR": "A Santíssima Virgem Maria da Mercê"
           },
           "sections": [
             {
@@ -4344,7 +5188,8 @@
         {
           "id": "09-25",
           "label": {
-            "en-US": "St. Firmin, Bishop, Martyr. St. Finbarr, Bishop"
+            "en-US": "St. Firmin, Bishop, Martyr. St. Finbarr, Bishop",
+            "pt-BR": "São Firmino, Bispo, Mártir. São Finbarr, Bispo"
           },
           "sections": [
             {
@@ -4358,7 +5203,8 @@
         {
           "id": "09-26",
           "label": {
-            "en-US": "Sts. Cyprian and Justina, Martyrs"
+            "en-US": "Sts. Cyprian and Justina, Martyrs",
+            "pt-BR": "São Cipriano e Santa Justina, Mártires"
           },
           "sections": [
             {
@@ -4372,7 +5218,8 @@
         {
           "id": "09-27",
           "label": {
-            "en-US": "Sts. Cosmas and Damian, Martyrs"
+            "en-US": "Sts. Cosmas and Damian, Martyrs",
+            "pt-BR": "São Cosme e São Damião, Mártires"
           },
           "sections": [
             {
@@ -4386,7 +5233,8 @@
         {
           "id": "09-28",
           "label": {
-            "en-US": "St. Wenceslas, Martyr"
+            "en-US": "St. Wenceslas, Martyr",
+            "pt-BR": "São Venceslau, Mártir"
           },
           "sections": [
             {
@@ -4400,7 +5248,8 @@
         {
           "id": "09-29",
           "label": {
-            "en-US": "St. Michael, Archangel"
+            "en-US": "St. Michael, Archangel",
+            "pt-BR": "São Miguel, Arcanjo"
           },
           "sections": [
             {
@@ -4414,7 +5263,8 @@
         {
           "id": "09-30",
           "label": {
-            "en-US": "St. Jerome, Doctor"
+            "en-US": "St. Jerome, Doctor",
+            "pt-BR": "São Jerônimo, Doutor"
           },
           "sections": [
             {
@@ -4428,7 +5278,8 @@
         {
           "id": "10-01",
           "label": {
-            "en-US": "St. Remigius, Bishop"
+            "en-US": "St. Remigius, Bishop",
+            "pt-BR": "São Remígio, Bispo"
           },
           "sections": [
             {
@@ -4442,7 +5293,8 @@
         {
           "id": "10-02",
           "label": {
-            "en-US": "The Holy Guardian Angels"
+            "en-US": "The Holy Guardian Angels",
+            "pt-BR": "Os Santos Anjos da Guarda"
           },
           "sections": [
             {
@@ -4456,7 +5308,8 @@
         {
           "id": "10-03",
           "label": {
-            "en-US": "St. Gerard, Abbot"
+            "en-US": "St. Gerard, Abbot",
+            "pt-BR": "São Gerardo, Abade"
           },
           "sections": [
             {
@@ -4470,7 +5323,8 @@
         {
           "id": "10-04",
           "label": {
-            "en-US": "St. Francis of Assisi"
+            "en-US": "St. Francis of Assisi",
+            "pt-BR": "São Francisco de Assis"
           },
           "sections": [
             {
@@ -4484,7 +5338,8 @@
         {
           "id": "10-05",
           "label": {
-            "en-US": "St. Placid, Martyr"
+            "en-US": "St. Placid, Martyr",
+            "pt-BR": "São Plácido, Mártir"
           },
           "sections": [
             {
@@ -4498,7 +5353,8 @@
         {
           "id": "10-06",
           "label": {
-            "en-US": "St. Bruno"
+            "en-US": "St. Bruno",
+            "pt-BR": "São Bruno"
           },
           "sections": [
             {
@@ -4512,7 +5368,8 @@
         {
           "id": "10-07",
           "label": {
-            "en-US": "St. Mark, Pope"
+            "en-US": "St. Mark, Pope",
+            "pt-BR": "São Marcos, Papa"
           },
           "sections": [
             {
@@ -4526,7 +5383,8 @@
         {
           "id": "10-08",
           "label": {
-            "en-US": "St. Bridget of Sweden"
+            "en-US": "St. Bridget of Sweden",
+            "pt-BR": "Santa Brígida da Suécia"
           },
           "sections": [
             {
@@ -4540,7 +5398,8 @@
         {
           "id": "10-09",
           "label": {
-            "en-US": "St. Dionysius and his Companions, Martyrs. St. Louis Bertrand"
+            "en-US": "St. Dionysius and his Companions, Martyrs. St. Louis Bertrand",
+            "pt-BR": "São Dionísio e seus Companheiros, Mártires. São Luís Bertrando"
           },
           "sections": [
             {
@@ -4554,7 +5413,8 @@
         {
           "id": "10-10",
           "label": {
-            "en-US": "St. Francis Borgia"
+            "en-US": "St. Francis Borgia",
+            "pt-BR": "São Francisco de Borja"
           },
           "sections": [
             {
@@ -4568,7 +5428,8 @@
         {
           "id": "10-11",
           "label": {
-            "en-US": "St. Tarachus and his Companions"
+            "en-US": "St. Tarachus and his Companions",
+            "pt-BR": "São Taraco e seus Companheiros"
           },
           "sections": [
             {
@@ -4582,7 +5443,8 @@
         {
           "id": "10-12",
           "label": {
-            "en-US": "St. Wilfrid, Bishop"
+            "en-US": "St. Wilfrid, Bishop",
+            "pt-BR": "São Wilfrido, Bispo"
           },
           "sections": [
             {
@@ -4596,7 +5458,8 @@
         {
           "id": "10-13",
           "label": {
-            "en-US": "St. Edward the Confessor"
+            "en-US": "St. Edward the Confessor",
+            "pt-BR": "Santo Eduardo, o Confessor"
           },
           "sections": [
             {
@@ -4610,7 +5473,8 @@
         {
           "id": "10-14",
           "label": {
-            "en-US": "St. Callistus, Pope, Martyr"
+            "en-US": "St. Callistus, Pope, Martyr",
+            "pt-BR": "São Calisto, Papa, Mártir"
           },
           "sections": [
             {
@@ -4624,7 +5488,8 @@
         {
           "id": "10-15",
           "label": {
-            "en-US": "St. Teresa"
+            "en-US": "St. Teresa",
+            "pt-BR": "Santa Teresa"
           },
           "sections": [
             {
@@ -4638,7 +5503,8 @@
         {
           "id": "10-16",
           "label": {
-            "en-US": "St. Gall, Abbot"
+            "en-US": "St. Gall, Abbot",
+            "pt-BR": "São Galo, Abade"
           },
           "sections": [
             {
@@ -4652,7 +5518,8 @@
         {
           "id": "10-17",
           "label": {
-            "en-US": "St. Hedwige. Saint Margaret Mary Alacoque"
+            "en-US": "St. Hedwige. Saint Margaret Mary Alacoque",
+            "pt-BR": "Santa Edviges. Santa Margarida Maria Alacoque"
           },
           "sections": [
             {
@@ -4666,7 +5533,8 @@
         {
           "id": "10-18",
           "label": {
-            "en-US": "St. Luke"
+            "en-US": "St. Luke",
+            "pt-BR": "São Lucas"
           },
           "sections": [
             {
@@ -4680,7 +5548,8 @@
         {
           "id": "10-19",
           "label": {
-            "en-US": "St. Peter of Alcantara"
+            "en-US": "St. Peter of Alcantara",
+            "pt-BR": "São Pedro de Alcântara"
           },
           "sections": [
             {
@@ -4694,7 +5563,8 @@
         {
           "id": "10-20",
           "label": {
-            "en-US": "St. John Cantius"
+            "en-US": "St. John Cantius",
+            "pt-BR": "São João Câncio"
           },
           "sections": [
             {
@@ -4708,7 +5578,8 @@
         {
           "id": "10-21",
           "label": {
-            "en-US": "St. Ursula, Virgin and Martyr"
+            "en-US": "St. Ursula, Virgin and Martyr",
+            "pt-BR": "Santa Úrsula, Virgem e Mártir"
           },
           "sections": [
             {
@@ -4722,7 +5593,8 @@
         {
           "id": "10-22",
           "label": {
-            "en-US": "St. Mello, Bishop. St. Hilarion, Abbot"
+            "en-US": "St. Mello, Bishop. St. Hilarion, Abbot",
+            "pt-BR": "São Melônio, Bispo. Santo Hilarião, Abade"
           },
           "sections": [
             {
@@ -4736,7 +5608,8 @@
         {
           "id": "10-23",
           "label": {
-            "en-US": "St. Theodoret, Martyr"
+            "en-US": "St. Theodoret, Martyr",
+            "pt-BR": "São Teodoreto, Mártir"
           },
           "sections": [
             {
@@ -4750,7 +5623,8 @@
         {
           "id": "10-24",
           "label": {
-            "en-US": "St. Magloire, Bishop"
+            "en-US": "St. Magloire, Bishop",
+            "pt-BR": "São Maglório, Bispo"
           },
           "sections": [
             {
@@ -4764,7 +5638,8 @@
         {
           "id": "10-25",
           "label": {
-            "en-US": "Sts. Crispin and Crispinian, Martyrs"
+            "en-US": "Sts. Crispin and Crispinian, Martyrs",
+            "pt-BR": "São Crispim e São Crispiniano, Mártires"
           },
           "sections": [
             {
@@ -4778,7 +5653,8 @@
         {
           "id": "10-26",
           "label": {
-            "en-US": "St. Evaristus, Pope and Martyr"
+            "en-US": "St. Evaristus, Pope and Martyr",
+            "pt-BR": "Santo Evaristo, Papa e Mártir"
           },
           "sections": [
             {
@@ -4792,7 +5668,8 @@
         {
           "id": "10-27",
           "label": {
-            "en-US": "St. Frumentius, Bishop"
+            "en-US": "St. Frumentius, Bishop",
+            "pt-BR": "São Frumêncio, Bispo"
           },
           "sections": [
             {
@@ -4806,7 +5683,8 @@
         {
           "id": "10-28",
           "label": {
-            "en-US": "Sts. Simon and Jude"
+            "en-US": "Sts. Simon and Jude",
+            "pt-BR": "São Simão e São Judas"
           },
           "sections": [
             {
@@ -4820,7 +5698,8 @@
         {
           "id": "10-29",
           "label": {
-            "en-US": "St. Narcissus, Bishop"
+            "en-US": "St. Narcissus, Bishop",
+            "pt-BR": "São Narciso, Bispo"
           },
           "sections": [
             {
@@ -4834,7 +5713,8 @@
         {
           "id": "10-30",
           "label": {
-            "en-US": "St. Marcellus, the Centurion, Martyr"
+            "en-US": "St. Marcellus, the Centurion, Martyr",
+            "pt-BR": "São Marcelo, o Centurião, Mártir"
           },
           "sections": [
             {
@@ -4848,7 +5728,8 @@
         {
           "id": "10-31",
           "label": {
-            "en-US": "St. Quintin, Martyr"
+            "en-US": "St. Quintin, Martyr",
+            "pt-BR": "São Quintino, Mártir"
           },
           "sections": [
             {
@@ -4862,7 +5743,8 @@
         {
           "id": "11-01",
           "label": {
-            "en-US": "All-Saints"
+            "en-US": "All-Saints",
+            "pt-BR": "Todos os Santos"
           },
           "sections": [
             {
@@ -4876,30 +5758,56 @@
         {
           "id": "11-02",
           "label": {
-            "en-US": "All-Souls · St. Malachi, Bishop"
+            "en-US": "All-Souls · St. Malachi, Bishop",
+            "pt-BR": "Todos os Fiéis Defuntos · São Malaquias, Bispo"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "nov-02-all-souls",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "nov-02-malachi",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "all-souls",
+                  "label": {
+                    "en-US": "All-Souls",
+                    "pt-BR": "Todos os Fiéis Defuntos"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "nov-02-all-souls",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "malachi",
+                  "label": {
+                    "en-US": "St. Malachi, Bishop",
+                    "pt-BR": "São Malaquias, Bispo"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "nov-02-malachi",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "11-03",
           "label": {
-            "en-US": "St. Hubert, Bishop"
+            "en-US": "St. Hubert, Bishop",
+            "pt-BR": "Santo Huberto, Bispo"
           },
           "sections": [
             {
@@ -4913,7 +5821,8 @@
         {
           "id": "11-04",
           "label": {
-            "en-US": "St. Charles Borromeo"
+            "en-US": "St. Charles Borromeo",
+            "pt-BR": "São Carlos Borromeu"
           },
           "sections": [
             {
@@ -4927,7 +5836,8 @@
         {
           "id": "11-05",
           "label": {
-            "en-US": "St. Bertille, Abbess"
+            "en-US": "St. Bertille, Abbess",
+            "pt-BR": "Santa Bertila, Abadessa"
           },
           "sections": [
             {
@@ -4941,7 +5851,8 @@
         {
           "id": "11-06",
           "label": {
-            "en-US": "St. Leonard"
+            "en-US": "St. Leonard",
+            "pt-BR": "São Leonardo"
           },
           "sections": [
             {
@@ -4955,7 +5866,8 @@
         {
           "id": "11-07",
           "label": {
-            "en-US": "St. Willibrord"
+            "en-US": "St. Willibrord",
+            "pt-BR": "São Vilibrordo"
           },
           "sections": [
             {
@@ -4969,7 +5881,8 @@
         {
           "id": "11-08",
           "label": {
-            "en-US": "The Feast of the Holy Relics"
+            "en-US": "The Feast of the Holy Relics",
+            "pt-BR": "A Festa das Santas Relíquias"
           },
           "sections": [
             {
@@ -4983,7 +5896,8 @@
         {
           "id": "11-09",
           "label": {
-            "en-US": "St. Theodore Tyro, Martyr"
+            "en-US": "St. Theodore Tyro, Martyr",
+            "pt-BR": "São Teodoro Tiro, Mártir"
           },
           "sections": [
             {
@@ -4997,7 +5911,8 @@
         {
           "id": "11-10",
           "label": {
-            "en-US": "10: St. Andrew Avellino"
+            "en-US": "10: St. Andrew Avellino",
+            "pt-BR": "Santo André Avelino"
           },
           "sections": [
             {
@@ -5011,7 +5926,8 @@
         {
           "id": "11-11",
           "label": {
-            "en-US": "St. Martin of Tours"
+            "en-US": "St. Martin of Tours",
+            "pt-BR": "São Martinho de Tours"
           },
           "sections": [
             {
@@ -5025,7 +5941,8 @@
         {
           "id": "11-12",
           "label": {
-            "en-US": "St. Martin, Pope"
+            "en-US": "St. Martin, Pope",
+            "pt-BR": "São Martinho, Papa"
           },
           "sections": [
             {
@@ -5039,7 +5956,8 @@
         {
           "id": "11-13",
           "label": {
-            "en-US": "St. Stanislas Kostka"
+            "en-US": "St. Stanislas Kostka",
+            "pt-BR": "São Estanislau Kostka"
           },
           "sections": [
             {
@@ -5053,30 +5971,56 @@
         {
           "id": "11-14",
           "label": {
-            "en-US": "St. Didacus · St. Laurence O'Toole, Archbishop of Dublin"
+            "en-US": "St. Didacus · St. Laurence O'Toole, Archbishop of Dublin",
+            "pt-BR": "São Dídaco · São Lourenço O'Toole, Arcebispo de Dublin"
           },
           "sections": [
             {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "nov-14-didacus",
-              "langPolicy": "book-default"
-            },
-            {
-              "type": "divider"
-            },
-            {
-              "type": "prose",
-              "book": "pictorial-lives-of-saints",
-              "chapter": "nov-14-laurence-otoole",
-              "langPolicy": "book-default"
+              "type": "select",
+              "label": {
+                "en-US": "Saint",
+                "pt-BR": "Santo"
+              },
+              "options": [
+                {
+                  "id": "didacus",
+                  "label": {
+                    "en-US": "St. Didacus",
+                    "pt-BR": "São Dídaco"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "nov-14-didacus",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                },
+                {
+                  "id": "laurence-otoole",
+                  "label": {
+                    "en-US": "St. Laurence O'Toole, Archbishop of Dublin",
+                    "pt-BR": "São Lourenço O'Toole, Arcebispo de Dublin"
+                  },
+                  "sections": [
+                    {
+                      "type": "prose",
+                      "book": "pictorial-lives-of-saints",
+                      "chapter": "nov-14-laurence-otoole",
+                      "langPolicy": "book-default"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         },
         {
           "id": "11-15",
           "label": {
-            "en-US": "St. Gertrude, Abbess"
+            "en-US": "St. Gertrude, Abbess",
+            "pt-BR": "Santa Gertrudes, Abadessa"
           },
           "sections": [
             {
@@ -5090,7 +6034,8 @@
         {
           "id": "11-16",
           "label": {
-            "en-US": "St. Edmund of Canterbury"
+            "en-US": "St. Edmund of Canterbury",
+            "pt-BR": "Santo Edmundo de Cantuária"
           },
           "sections": [
             {
@@ -5104,7 +6049,8 @@
         {
           "id": "11-17",
           "label": {
-            "en-US": "St. Gregory Thaumaturgus"
+            "en-US": "St. Gregory Thaumaturgus",
+            "pt-BR": "São Gregório Taumaturgo"
           },
           "sections": [
             {
@@ -5118,7 +6064,8 @@
         {
           "id": "11-18",
           "label": {
-            "en-US": "St. Odo of Cluny"
+            "en-US": "St. Odo of Cluny",
+            "pt-BR": "Santo Odão de Cluny"
           },
           "sections": [
             {
@@ -5132,7 +6079,8 @@
         {
           "id": "11-19",
           "label": {
-            "en-US": "St. Elizabeth of Hungary"
+            "en-US": "St. Elizabeth of Hungary",
+            "pt-BR": "Santa Isabel da Hungria"
           },
           "sections": [
             {
@@ -5146,7 +6094,8 @@
         {
           "id": "11-20",
           "label": {
-            "en-US": "St. Felix of Valois"
+            "en-US": "St. Felix of Valois",
+            "pt-BR": "São Félix de Valois"
           },
           "sections": [
             {
@@ -5160,7 +6109,8 @@
         {
           "id": "11-21",
           "label": {
-            "en-US": "The Presentation of the Blessed Virgin Mary"
+            "en-US": "The Presentation of the Blessed Virgin Mary",
+            "pt-BR": "A Apresentação da Santíssima Virgem Maria"
           },
           "sections": [
             {
@@ -5174,7 +6124,8 @@
         {
           "id": "11-22",
           "label": {
-            "en-US": "St. Cecilia, Virgin, Martyr"
+            "en-US": "St. Cecilia, Virgin, Martyr",
+            "pt-BR": "Santa Cecília, Virgem, Mártir"
           },
           "sections": [
             {
@@ -5188,7 +6139,8 @@
         {
           "id": "11-23",
           "label": {
-            "en-US": "St. Clement of Rome"
+            "en-US": "St. Clement of Rome",
+            "pt-BR": "São Clemente de Roma"
           },
           "sections": [
             {
@@ -5202,7 +6154,8 @@
         {
           "id": "11-24",
           "label": {
-            "en-US": "St. John of the Cross"
+            "en-US": "St. John of the Cross",
+            "pt-BR": "São João da Cruz"
           },
           "sections": [
             {
@@ -5216,7 +6169,8 @@
         {
           "id": "11-25",
           "label": {
-            "en-US": "St. Catherine of Alexandria"
+            "en-US": "St. Catherine of Alexandria",
+            "pt-BR": "Santa Catarina de Alexandria"
           },
           "sections": [
             {
@@ -5230,7 +6184,8 @@
         {
           "id": "11-26",
           "label": {
-            "en-US": "St. Peter of Alexandria, Bishop, Martyr"
+            "en-US": "St. Peter of Alexandria, Bishop, Martyr",
+            "pt-BR": "São Pedro de Alexandria, Bispo, Mártir"
           },
           "sections": [
             {
@@ -5244,7 +6199,8 @@
         {
           "id": "11-27",
           "label": {
-            "en-US": "St. Maximus, Bishop"
+            "en-US": "St. Maximus, Bishop",
+            "pt-BR": "São Máximo, Bispo"
           },
           "sections": [
             {
@@ -5258,7 +6214,8 @@
         {
           "id": "11-28",
           "label": {
-            "en-US": "St. James of La Marca of Ancona"
+            "en-US": "St. James of La Marca of Ancona",
+            "pt-BR": "São Tiago de La Marca de Ancona"
           },
           "sections": [
             {
@@ -5272,7 +6229,8 @@
         {
           "id": "11-29",
           "label": {
-            "en-US": "St. Saturninus, Martyr"
+            "en-US": "St. Saturninus, Martyr",
+            "pt-BR": "São Saturnino, Mártir"
           },
           "sections": [
             {
@@ -5286,7 +6244,8 @@
         {
           "id": "11-30",
           "label": {
-            "en-US": "St. Andrew, Apostle"
+            "en-US": "St. Andrew, Apostle",
+            "pt-BR": "Santo André, Apóstolo"
           },
           "sections": [
             {
@@ -5300,7 +6259,8 @@
         {
           "id": "12-01",
           "label": {
-            "en-US": "St. Eligius"
+            "en-US": "St. Eligius",
+            "pt-BR": "Santo Elói"
           },
           "sections": [
             {
@@ -5314,7 +6274,8 @@
         {
           "id": "12-02",
           "label": {
-            "en-US": "St. Bibiana, Virgin, Martyr"
+            "en-US": "St. Bibiana, Virgin, Martyr",
+            "pt-BR": "Santa Bibiana, Virgem, Mártir"
           },
           "sections": [
             {
@@ -5328,7 +6289,8 @@
         {
           "id": "12-03",
           "label": {
-            "en-US": "St. Francis Xavier"
+            "en-US": "St. Francis Xavier",
+            "pt-BR": "São Francisco Xavier"
           },
           "sections": [
             {
@@ -5342,7 +6304,8 @@
         {
           "id": "12-04",
           "label": {
-            "en-US": "St. Barbara, Virgin, Martyr"
+            "en-US": "St. Barbara, Virgin, Martyr",
+            "pt-BR": "Santa Bárbara, Virgem, Mártir"
           },
           "sections": [
             {
@@ -5356,7 +6319,8 @@
         {
           "id": "12-05",
           "label": {
-            "en-US": "St. Sabas, Abbot"
+            "en-US": "St. Sabas, Abbot",
+            "pt-BR": "São Sabas, Abade"
           },
           "sections": [
             {
@@ -5370,7 +6334,8 @@
         {
           "id": "12-06",
           "label": {
-            "en-US": "St. Nicholas of Bari"
+            "en-US": "St. Nicholas of Bari",
+            "pt-BR": "São Nicolau de Bari"
           },
           "sections": [
             {
@@ -5384,7 +6349,8 @@
         {
           "id": "12-07",
           "label": {
-            "en-US": "St. Ambrose, Bishop"
+            "en-US": "St. Ambrose, Bishop",
+            "pt-BR": "Santo Ambrósio, Bispo"
           },
           "sections": [
             {
@@ -5398,7 +6364,8 @@
         {
           "id": "12-08",
           "label": {
-            "en-US": "The Feast of the Immaculate Conception"
+            "en-US": "The Feast of the Immaculate Conception",
+            "pt-BR": "A Festa da Imaculada Conceição"
           },
           "sections": [
             {
@@ -5412,7 +6379,8 @@
         {
           "id": "12-09",
           "label": {
-            "en-US": "St. Leocadia, Virgin, Martyr"
+            "en-US": "St. Leocadia, Virgin, Martyr",
+            "pt-BR": "Santa Leocádia, Virgem, Mártir"
           },
           "sections": [
             {
@@ -5426,7 +6394,8 @@
         {
           "id": "12-10",
           "label": {
-            "en-US": "St. Eulalia, Virgin, Martyr"
+            "en-US": "St. Eulalia, Virgin, Martyr",
+            "pt-BR": "Santa Eulália, Virgem, Mártir"
           },
           "sections": [
             {
@@ -5440,7 +6409,8 @@
         {
           "id": "12-11",
           "label": {
-            "en-US": "St. Damasus, Pope"
+            "en-US": "St. Damasus, Pope",
+            "pt-BR": "São Dâmaso, Papa"
           },
           "sections": [
             {
@@ -5454,7 +6424,8 @@
         {
           "id": "12-12",
           "label": {
-            "en-US": "St. Valery, Abbot. St. Finian, Bishop"
+            "en-US": "St. Valery, Abbot. St. Finian, Bishop",
+            "pt-BR": "São Valério, Abade. São Finiano, Bispo"
           },
           "sections": [
             {
@@ -5468,7 +6439,8 @@
         {
           "id": "12-13",
           "label": {
-            "en-US": "St. Lucy, Virgin, Martyr"
+            "en-US": "St. Lucy, Virgin, Martyr",
+            "pt-BR": "Santa Luzia, Virgem, Mártir"
           },
           "sections": [
             {
@@ -5482,7 +6454,8 @@
         {
           "id": "12-14",
           "label": {
-            "en-US": "St. Nicasius, Archbishop, and his Companions, Martyrs"
+            "en-US": "St. Nicasius, Archbishop, and his Companions, Martyrs",
+            "pt-BR": "São Nicásio, Arcebispo, e seus Companheiros, Mártires"
           },
           "sections": [
             {
@@ -5496,7 +6469,8 @@
         {
           "id": "12-15",
           "label": {
-            "en-US": "St. Mesmin"
+            "en-US": "St. Mesmin",
+            "pt-BR": "São Mesmin"
           },
           "sections": [
             {
@@ -5510,7 +6484,8 @@
         {
           "id": "12-16",
           "label": {
-            "en-US": "St. Eusebius, Bishop"
+            "en-US": "St. Eusebius, Bishop",
+            "pt-BR": "Santo Eusébio, Bispo"
           },
           "sections": [
             {
@@ -5524,7 +6499,8 @@
         {
           "id": "12-17",
           "label": {
-            "en-US": "St. Olympias, Widow"
+            "en-US": "St. Olympias, Widow",
+            "pt-BR": "Santa Olímpia, Viúva"
           },
           "sections": [
             {
@@ -5538,7 +6514,8 @@
         {
           "id": "12-18",
           "label": {
-            "en-US": "St. Gatian, Bishop"
+            "en-US": "St. Gatian, Bishop",
+            "pt-BR": "São Gaciano, Bispo"
           },
           "sections": [
             {
@@ -5552,7 +6529,8 @@
         {
           "id": "12-19",
           "label": {
-            "en-US": "St. Nemesion, Martyr"
+            "en-US": "St. Nemesion, Martyr",
+            "pt-BR": "São Nemésio, Mártir"
           },
           "sections": [
             {
@@ -5566,7 +6544,8 @@
         {
           "id": "12-20",
           "label": {
-            "en-US": "St. Philogonius, Bishop"
+            "en-US": "St. Philogonius, Bishop",
+            "pt-BR": "São Filogônio, Bispo"
           },
           "sections": [
             {
@@ -5580,7 +6559,8 @@
         {
           "id": "12-21",
           "label": {
-            "en-US": "St. Thomas, Apostle"
+            "en-US": "St. Thomas, Apostle",
+            "pt-BR": "São Tomé, Apóstolo"
           },
           "sections": [
             {
@@ -5594,7 +6574,8 @@
         {
           "id": "12-22",
           "label": {
-            "en-US": "St. Ischyrion, Martyr"
+            "en-US": "St. Ischyrion, Martyr",
+            "pt-BR": "Santo Isquírion, Mártir"
           },
           "sections": [
             {
@@ -5608,7 +6589,8 @@
         {
           "id": "12-23",
           "label": {
-            "en-US": "St. Servulus"
+            "en-US": "St. Servulus",
+            "pt-BR": "São Sérvulo"
           },
           "sections": [
             {
@@ -5622,7 +6604,8 @@
         {
           "id": "12-24",
           "label": {
-            "en-US": "St. Delphinus, Bishop. Sts. Thrasilla and Emiliana, Virgins"
+            "en-US": "St. Delphinus, Bishop. Sts. Thrasilla and Emiliana, Virgins",
+            "pt-BR": "São Delfino, Bispo. Santas Trasila e Emiliana, Virgens"
           },
           "sections": [
             {
@@ -5636,7 +6619,8 @@
         {
           "id": "12-25",
           "label": {
-            "en-US": "The Nativity of Christ, or Christmas Day"
+            "en-US": "The Nativity of Christ, or Christmas Day",
+            "pt-BR": "A Natividade de Cristo, ou Dia de Natal"
           },
           "sections": [
             {
@@ -5650,7 +6634,8 @@
         {
           "id": "12-26",
           "label": {
-            "en-US": "St. Stephen, First Martyr"
+            "en-US": "St. Stephen, First Martyr",
+            "pt-BR": "Santo Estêvão, Primeiro Mártir"
           },
           "sections": [
             {
@@ -5664,7 +6649,8 @@
         {
           "id": "12-27",
           "label": {
-            "en-US": "St. John, Evangelist"
+            "en-US": "St. John, Evangelist",
+            "pt-BR": "São João, Evangelista"
           },
           "sections": [
             {
@@ -5678,7 +6664,8 @@
         {
           "id": "12-28",
           "label": {
-            "en-US": "The Holy Innocents"
+            "en-US": "The Holy Innocents",
+            "pt-BR": "Os Santos Inocentes"
           },
           "sections": [
             {
@@ -5692,7 +6679,8 @@
         {
           "id": "12-29",
           "label": {
-            "en-US": "St. Thomas of Canterbury"
+            "en-US": "St. Thomas of Canterbury",
+            "pt-BR": "São Tomás de Cantuária"
           },
           "sections": [
             {
@@ -5706,7 +6694,8 @@
         {
           "id": "12-30",
           "label": {
-            "en-US": "St. Sabinus, Bishop, and his Companions, Martyrs"
+            "en-US": "St. Sabinus, Bishop, and his Companions, Martyrs",
+            "pt-BR": "São Sabino, Bispo, e seus Companheiros, Mártires"
           },
           "sections": [
             {
@@ -5720,7 +6709,8 @@
         {
           "id": "12-31",
           "label": {
-            "en-US": "St. Sylvester, Pope"
+            "en-US": "St. Sylvester, Pope",
+            "pt-BR": "São Silvestre, Papa"
           },
           "sections": [
             {

--- a/scripts/build-saint-of-day.mjs
+++ b/scripts/build-saint-of-day.mjs
@@ -1,0 +1,221 @@
+/**
+ * Build the Saint of the Day artifacts from the Pictorial Lives of the Saints book
+ * + the existing saint-of-the-day flow.
+ *
+ * Outputs:
+ *   - apps/app/src/features/saints/data/saintOfDayNames.ts — bilingual lookup
+ *     (name + first chapter's reflection) used by the home/Explore cards.
+ *   - content/practices/saint-of-the-day/flow.json — regenerated with bilingual
+ *     labels on every per-day option and a nested `select` for multi-saint days.
+ *
+ * Inputs (the day → chapters editorial mapping is read from the current flow.json
+ * so this is idempotent — re-running produces no diff once migrated):
+ *   - content/practices/saint-of-the-day/flow.json
+ *   - content/books/pictorial-lives-of-saints/book.json
+ *   - content/books/pictorial-lives-of-saints/{en-US,pt-BR}/<chapter>.md
+ *
+ * Usage: node scripts/build-saint-of-day.mjs
+ */
+import { spawnSync } from 'node:child_process'
+import { readFileSync, writeFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const flowPath = resolve(root, 'content/practices/saint-of-the-day/flow.json')
+const bookPath = resolve(root, 'content/books/pictorial-lives-of-saints/book.json')
+const enChaptersDir = resolve(root, 'content/books/pictorial-lives-of-saints/en-US')
+const ptChaptersDir = resolve(root, 'content/books/pictorial-lives-of-saints/pt-BR')
+const dataOutPath = resolve(root, 'apps/app/src/features/saints/data/saintOfDayNames.ts')
+
+const NUMBER_PREFIX = /^\d+\.\s*/
+const TAB_ID_PREFIX = /^[a-z]{3}-\d{2}-/
+const REFLECTION_RE = /^\*\*(?:Reflection|Reflexão)\*\*—(.+)$/m
+
+function stripNumberPrefix(s) {
+  return s.replace(NUMBER_PREFIX, '')
+}
+
+// Recursively flatten the book's toc into a { chapterId: { 'en-US', 'pt-BR' } } map.
+function buildTitleMap(book) {
+  const titles = {}
+  function walk(node) {
+    if (Array.isArray(node)) {
+      for (const child of node) walk(child)
+      return
+    }
+    if (node && typeof node === 'object') {
+      if (node.id && node.title) titles[node.id] = node.title
+      if (Array.isArray(node.children)) walk(node.children)
+    }
+  }
+  walk(book.toc ?? [])
+  return titles
+}
+
+// Pull the reflection paragraph from a chapter's markdown (first match wins).
+function readReflection(dir, chapterId) {
+  const path = resolve(dir, `${chapterId}.md`)
+  let text
+  try {
+    text = readFileSync(path, 'utf8')
+  } catch {
+    return undefined
+  }
+  const m = text.match(REFLECTION_RE)
+  if (!m) return undefined
+  return m[1].trim()
+}
+
+// Walk a per-day option's sections and collect chapter refs in order. Handles
+// both the flat shape ([prose, divider, prose]) and the migrated shape (a
+// single `select` wrapping per-saint options).
+function collectChapters(sections) {
+  const chapters = []
+  function walk(node) {
+    if (!node || typeof node !== 'object') return
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item)
+      return
+    }
+    if (node.type === 'prose' && typeof node.chapter === 'string') {
+      chapters.push(node.chapter)
+      return
+    }
+    if (node.type === 'select' && Array.isArray(node.options)) {
+      for (const opt of node.options) walk(opt.sections ?? [])
+      return
+    }
+  }
+  walk(sections)
+  return chapters
+}
+
+const flow = JSON.parse(readFileSync(flowPath, 'utf8'))
+const book = JSON.parse(readFileSync(bookPath, 'utf8'))
+const titles = buildTitleMap(book)
+
+// Find the outer `select on: dateKey` that holds the per-day options.
+const dateSelect = flow.sections.find((s) => s?.type === 'select' && s.on === 'dateKey')
+if (!dateSelect || !Array.isArray(dateSelect.options)) {
+  throw new Error('Could not find outer select on dateKey in saint-of-the-day flow.json')
+}
+
+const dataEntries = []
+
+for (const option of dateSelect.options) {
+  const dateKey = option.id
+  const chapters = collectChapters(option.sections ?? [])
+  if (chapters.length === 0) {
+    throw new Error(`Day ${dateKey} has no chapter refs`)
+  }
+
+  // Build bilingual joined name for the cycle label + card.
+  const namePerLang = { 'en-US': [], 'pt-BR': [] }
+  for (const chapter of chapters) {
+    const title = titles[chapter]
+    if (!title) throw new Error(`Chapter ${chapter} (day ${dateKey}) missing from book.json toc`)
+    namePerLang['en-US'].push(stripNumberPrefix(title['en-US'] ?? ''))
+    namePerLang['pt-BR'].push(stripNumberPrefix(title['pt-BR'] ?? title['en-US'] ?? ''))
+  }
+  const name = {
+    'en-US': namePerLang['en-US'].join(' · '),
+    'pt-BR': namePerLang['pt-BR'].join(' · '),
+  }
+
+  // First chapter that has reflections in both languages becomes the card subtitle.
+  let reflection
+  for (const chapter of chapters) {
+    const en = readReflection(enChaptersDir, chapter)
+    const pt = readReflection(ptChaptersDir, chapter)
+    if (en && pt) {
+      reflection = { 'en-US': en, 'pt-BR': pt }
+      break
+    }
+  }
+
+  dataEntries.push({ dateKey, name, reflection })
+
+  // Rewrite the option in place: bilingual label + nested select for multi-saint days.
+  option.label = name
+  if (chapters.length === 1) {
+    option.sections = [
+      {
+        type: 'prose',
+        book: 'pictorial-lives-of-saints',
+        chapter: chapters[0],
+        langPolicy: 'book-default',
+      },
+    ]
+  } else {
+    option.sections = [
+      {
+        type: 'select',
+        label: { 'en-US': 'Saint', 'pt-BR': 'Santo' },
+        options: chapters.map((chapter) => {
+          const title = titles[chapter]
+          return {
+            id: chapter.replace(TAB_ID_PREFIX, ''),
+            label: {
+              'en-US': stripNumberPrefix(title['en-US'] ?? ''),
+              'pt-BR': stripNumberPrefix(title['pt-BR'] ?? title['en-US'] ?? ''),
+            },
+            sections: [
+              {
+                type: 'prose',
+                book: 'pictorial-lives-of-saints',
+                chapter,
+                langPolicy: 'book-default',
+              },
+            ],
+          }
+        }),
+      },
+    ]
+  }
+}
+
+writeFileSync(flowPath, `${JSON.stringify(flow, null, 2)}\n`, 'utf8')
+
+// Emit the bilingual data file.
+const dataLines = [
+  '// AUTO-GENERATED by scripts/build-saint-of-day.mjs — do not edit by hand.',
+  '// Per-day saint name + first available reflection from Pictorial Lives of the Saints.',
+  'export type SaintOfDayEntry = {',
+  "  name: { 'en-US': string; 'pt-BR': string }",
+  "  reflection?: { 'en-US': string; 'pt-BR': string }",
+  '}',
+  '',
+  'export const saintOfDay: Record<string, SaintOfDayEntry> = {',
+]
+for (const { dateKey, name, reflection } of dataEntries) {
+  dataLines.push(`  '${dateKey}': {`)
+  dataLines.push(
+    `    name: { 'en-US': ${JSON.stringify(name['en-US'])}, 'pt-BR': ${JSON.stringify(name['pt-BR'])} },`,
+  )
+  if (reflection) {
+    dataLines.push(
+      `    reflection: { 'en-US': ${JSON.stringify(reflection['en-US'])}, 'pt-BR': ${JSON.stringify(reflection['pt-BR'])} },`,
+    )
+  }
+  dataLines.push('  },')
+}
+dataLines.push('}')
+dataLines.push('')
+
+writeFileSync(dataOutPath, dataLines.join('\n'), 'utf8')
+
+// Let biome own the final formatting (single quotes, line wrapping) so re-runs
+// produce no diff against a previously-formatted tree.
+const biome = spawnSync('pnpm', ['exec', 'biome', 'check', '--write', dataOutPath], {
+  cwd: root,
+  stdio: 'inherit',
+})
+if (biome.status !== 0) {
+  console.warn('biome formatting step skipped or failed — run `pnpm exec biome check --write` manually.')
+}
+
+console.log(
+  `Wrote ${dataEntries.length} days to ${dataOutPath} and rewrote ${flowPath} ` +
+    `(${dataEntries.filter((e) => e.reflection).length} days with reflection).`,
+)


### PR DESCRIPTION
## Summary

- The "Santo do Dia" home card now shows the saint name in pt-BR (e.g. **São Justino, Mártir**) and the day's actual reflection paragraph from *Pictorial Lives of the Saints* as the subtitle, falling back to the generic tagline only when no reflection is mapped.
- On multi-saint days (06-01 = Justin + Pamphilus, 01-02 = Fulgentius + Macarius, etc.), the practice itself now surfaces a select with one tab per saint instead of stacking chapters with dividers — so secondary saints stop being silently hidden.
- Both artifacts (the bilingual `saintOfDay` data file + the rewritten `flow.json`) are produced by a new idempotent generator at `scripts/build-saint-of-day.mjs`. The day → chapters editorial mapping is preserved by reading the existing `flow.json` each run; re-running produces no diff.

## Test plan

- [ ] On 2026-06-01 (pt-BR): home card reads "São Justino, Mártir · São Pânfilo, Mártir" with Justin's reflection as the subtitle.
- [ ] Switch language to English in settings — name and reflection both update without reload.
- [ ] Tap the card — practice opens with two tabs ("São Justino, Mártir" / "São Pânfilo, Mártir"); the second tab swaps to Pamphilus's chapter client-side.
- [ ] Open a single-saint day (e.g. 01-03 St. Genevieve, Virgin) — no tab, just the chapter.
- [ ] Spot-check a day with no reflection — the subtitle falls back to "A vida e a reflexão de hoje…" rather than going blank.
- [ ] Explore feed saint block matches the home card (title + subtitle).
- [ ] `node scripts/build-saint-of-day.mjs` is idempotent — re-running produces no diff.