### PR TITLE
Add defaultOpen to prayer refs; apply in Dies Domini flows

### DIFF
--- a/apps/app/src/components/PrimitiveBlock.tsx
+++ b/apps/app/src/components/PrimitiveBlock.tsx
@@ -182,6 +182,7 @@ function renderContainer(
           title={behavior.title}
           text={behavior.text}
           count={behavior.count}
+          defaultOpen={behavior.defaultOpen}
           sections={children}
           renderSection={renderChild}
         />

--- a/apps/app/src/components/prayer/CollapsiblePrayer.tsx
+++ b/apps/app/src/components/prayer/CollapsiblePrayer.tsx
@@ -12,14 +12,16 @@ export function CollapsiblePrayer<T>({
   count,
   sections,
   renderSection,
+  defaultOpen,
 }: {
   title: BilingualText
   text: BilingualText
   count?: number
   sections?: T[]
   renderSection?: (section: T, index: number) => React.ReactNode
+  defaultOpen?: boolean
 }) {
-  const [expanded, setExpanded] = useState(false)
+  const [expanded, setExpanded] = useState(defaultOpen ?? false)
   const theme = useTheme()
 
   return (

--- a/apps/app/src/content/preprocessFlow.ts
+++ b/apps/app/src/content/preprocessFlow.ts
@@ -191,6 +191,7 @@ async function preprocessSection(
             title: section.title,
             text: section.text,
             count: section.count,
+            defaultOpen: section.defaultOpen,
           },
           children,
         }

--- a/apps/app/src/content/primitives.ts
+++ b/apps/app/src/content/primitives.ts
@@ -185,7 +185,13 @@ export type ContainerBehavior =
     }
   | { kind: 'options'; label: BilingualText; pickerStyle?: PickerStyle; options: ContainerOption[] }
   | { kind: 'color-scope'; color: LiturgicalColor }
-  | { kind: 'prayer'; title: BilingualText; text: BilingualText; count?: number }
+  | {
+      kind: 'prayer'
+      title: BilingualText
+      text: BilingualText
+      count?: number
+      defaultOpen?: boolean
+    }
   | { kind: 'liturgical-prayer'; speaker: 'priest' | 'people' | 'all'; text: BilingualText }
   | {
       kind: 'choice-rich-text'

--- a/content/practices/friday-passion/flow.json
+++ b/content/practices/friday-passion/flow.json
@@ -52,24 +52,24 @@
 		},
 		{
 			"type": "prayer",
-			"ref": "prayer-before-crucifix"
-		},
-		{
-			"type": "divider"
-		},
-		{
-			"type": "rubric",
-			"text": {
-				"en-US": "Pause for the Litany of the Sacred Heart — pinned in the *Go Deeper* section of today's collection. Pray it now if you have the time; the Act of Reparation that follows belongs with it.",
-				"pt-BR": "Pause para a Ladainha do Sagrado Coração — fixada na seção *Aprofundar* da coleção de hoje. Reze-a agora se tiver tempo; o Ato de Reparação que segue lhe pertence."
-			}
+			"ref": "prayer-before-crucifix",
+			"defaultOpen": true
 		},
 		{
 			"type": "divider"
 		},
 		{
 			"type": "prayer",
-			"ref": "act-of-reparation"
+			"ref": "litany-sacred-heart",
+			"defaultOpen": true
+		},
+		{
+			"type": "divider"
+		},
+		{
+			"type": "prayer",
+			"ref": "act-of-reparation",
+			"defaultOpen": true
 		},
 		{
 			"type": "divider"

--- a/content/practices/monday-souls/flow.json
+++ b/content/practices/monday-souls/flow.json
@@ -18,7 +18,8 @@
 		},
 		{
 			"type": "prayer",
-			"ref": "de-profundis"
+			"ref": "de-profundis",
+			"defaultOpen": true
 		},
 		{
 			"type": "divider"
@@ -112,14 +113,16 @@
 		},
 		{
 			"type": "prayer",
-			"ref": "st-gertrude-souls"
+			"ref": "st-gertrude-souls",
+			"defaultOpen": true
 		},
 		{
 			"type": "divider"
 		},
 		{
 			"type": "prayer",
-			"ref": "eternal-rest"
+			"ref": "eternal-rest",
+			"defaultOpen": true
 		},
 		{
 			"type": "prayer",

--- a/content/practices/saturday-mary/flow.json
+++ b/content/practices/saturday-mary/flow.json
@@ -25,7 +25,8 @@
 		},
 		{
 			"type": "prayer",
-			"ref": "sub-tuum-praesidium"
+			"ref": "sub-tuum-praesidium",
+			"defaultOpen": true
 		},
 		{
 			"type": "divider"
@@ -42,7 +43,8 @@
 		},
 		{
 			"type": "prayer",
-			"ref": "three-hail-marys"
+			"ref": "three-hail-marys",
+			"defaultOpen": true
 		},
 		{
 			"type": "divider"
@@ -65,7 +67,11 @@
 						"pt-BR": "Alma Redemptoris Mater (Advento–Apresentação)"
 					},
 					"sections": [
-						{ "type": "prayer", "ref": "alma-redemptoris-mater" }
+						{
+							"type": "prayer",
+							"ref": "alma-redemptoris-mater",
+							"defaultOpen": true
+						}
 					]
 				},
 				{
@@ -75,7 +81,11 @@
 						"pt-BR": "Ave Regina Caelorum (Apresentação–Quarta-feira Santa)"
 					},
 					"sections": [
-						{ "type": "prayer", "ref": "ave-regina-caelorum" }
+						{
+							"type": "prayer",
+							"ref": "ave-regina-caelorum",
+							"defaultOpen": true
+						}
 					]
 				},
 				{
@@ -85,7 +95,11 @@
 						"pt-BR": "Regina Caeli (Tempo Pascal)"
 					},
 					"sections": [
-						{ "type": "prayer", "ref": "regina-caeli" }
+						{
+							"type": "prayer",
+							"ref": "regina-caeli",
+							"defaultOpen": true
+						}
 					]
 				},
 				{
@@ -95,7 +109,11 @@
 						"pt-BR": "Salve Rainha (Tempo Comum)"
 					},
 					"sections": [
-						{ "type": "prayer", "ref": "hail-holy-queen" }
+						{
+							"type": "prayer",
+							"ref": "hail-holy-queen",
+							"defaultOpen": true
+						}
 					]
 				}
 			]
@@ -105,7 +123,8 @@
 		},
 		{
 			"type": "prayer",
-			"ref": "memorare"
+			"ref": "memorare",
+			"defaultOpen": true
 		},
 		{
 			"type": "divider"

--- a/content/practices/sunday-devotion/flow.json
+++ b/content/practices/sunday-devotion/flow.json
@@ -45,7 +45,8 @@
 		},
 		{
 			"type": "prayer",
-			"ref": "te-deum"
+			"ref": "te-deum",
+			"defaultOpen": true
 		},
 		{
 			"type": "divider"

--- a/content/practices/thursday-eucharist/flow.json
+++ b/content/practices/thursday-eucharist/flow.json
@@ -18,7 +18,8 @@
 		},
 		{
 			"type": "prayer",
-			"ref": "o-salutaris-hostia"
+			"ref": "o-salutaris-hostia",
+			"defaultOpen": true
 		},
 		{
 			"type": "divider"
@@ -35,24 +36,16 @@
 		},
 		{
 			"type": "prayer",
-			"ref": "adoro-te-devote"
+			"ref": "adoro-te-devote",
+			"defaultOpen": true
 		},
 		{
 			"type": "divider"
 		},
 		{
-			"type": "rubric",
-			"text": {
-				"en-US": "A Spiritual Communion — for when sacramental communion is not possible.",
-				"pt-BR": "Comunhão Espiritual — para quando a comunhão sacramental não é possível."
-			}
-		},
-		{
 			"type": "prayer",
-			"inline": {
-				"en-US": "My Jesus, I believe that Thou art present in the Most Holy Sacrament. I love Thee above all things, and I desire to receive Thee into my soul. Since I cannot at this moment receive Thee sacramentally, come at least spiritually into my heart. I embrace Thee as if Thou wert already there, and unite myself wholly to Thee. Never permit me to be separated from Thee. Amen.",
-				"pt-BR": "Meu Jesus, creio que estais real e verdadeiramente presente no Santíssimo Sacramento. Amo-Vos sobre todas as coisas e desejo receber-Vos em minha alma. Já que não Vos posso agora receber sacramentalmente, vinde ao menos espiritualmente ao meu coração. Eu Vos abraço como se já estivésseis presente e me uno inteiramente a Vós. Nunca permitais que me separe de Vós. Amém."
-			}
+			"ref": "spiritual-communion",
+			"defaultOpen": true
 		},
 		{
 			"type": "divider"
@@ -66,7 +59,8 @@
 		},
 		{
 			"type": "prayer",
-			"ref": "divine-praises"
+			"ref": "divine-praises",
+			"defaultOpen": true
 		},
 		{
 			"type": "divider"
@@ -90,7 +84,8 @@
 		},
 		{
 			"type": "prayer",
-			"ref": "anima-christi"
+			"ref": "anima-christi",
+			"defaultOpen": true
 		},
 		{
 			"type": "prayer",

--- a/content/practices/tuesday-angels/flow.json
+++ b/content/practices/tuesday-angels/flow.json
@@ -45,64 +45,17 @@
 			"type": "divider"
 		},
 		{
-			"type": "rubric",
-			"text": {
-				"en-US": "The long Leonine prayer to St. Michael — composed by Pope Leo XIII in 1890, after a reported vision of the trials to come for the Church.",
-				"pt-BR": "A oração leonina longa a São Miguel — composta pelo Papa Leão XIII em 1890, após uma visão atribuída das provações vindouras da Igreja."
-			}
-		},
-		{
 			"type": "prayer",
-			"inline": {
-				"en-US": "In the Name of the Father, and of the Son, and of the Holy Ghost. Amen.\n\nMost glorious Prince of the Heavenly Armies, Saint Michael the Archangel; defend us in our battle against principalities and powers, against the rulers of this world of darkness, against the spirits of wickedness in the high places. Come to the assistance of men whom God has created to His likeness and whom He has redeemed at a great price from the tyranny of the devil.\n\nHoly Church venerates thee as her guardian and protector; to thee the Lord has entrusted the souls of the redeemed to be led into heaven. Pray, therefore, the God of Peace to put Satan under our feet, so completely subdued that he may no longer be able to hold men captive and harm the Church. Offer our prayers in the sight of the Most High, so that the mercies of the Lord may quickly come to our aid, that thou mayest seize the dragon, the ancient serpent, who is the devil and Satan, and that having bound him, thou mayest cast him into the bottomless pit, that he may no more seduce the nations.",
-				"pt-BR": "Em nome do Pai, do Filho e do Espírito Santo. Amém.\n\nGloriosíssimo Príncipe dos Exércitos Celestiais, São Miguel Arcanjo; defendei-nos em nosso combate contra principados e potestades, contra os príncipes das trevas deste século, contra os espíritos de maldade nos lugares celestiais. Vinde em auxílio dos homens que Deus criou à Sua semelhança e que remiu a grande preço da tirania do demônio.\n\nA Santa Igreja te venera como seu guardião e protetor; a ti o Senhor confiou as almas dos remidos para serem conduzidas ao paraíso. Rogai, portanto, ao Deus da Paz que ponha Satanás sob nossos pés, tão completamente subjugado que não possa mais reter os homens em seu cativeiro e prejudicar a Igreja. Apresentai ao Altíssimo as nossas preces para que as misericórdias do Senhor venham rapidamente em nosso auxílio; para que tu agarres o dragão, a antiga serpente, que é o diabo e Satanás, e o acorrentando, o precipites no abismo, para que não possa mais seduzir as nações."
-			}
-		},
-		{
-			"type": "response",
-			"verses": [
-				{
-					"v": {
-						"en-US": "Behold the Cross of the Lord; flee ye hostile powers.",
-						"pt-BR": "Eis a Cruz do Senhor; fugi, potências adversas."
-					},
-					"r": {
-						"en-US": "The Lion of the tribe of Judah, the Root of David, hath conquered.",
-						"pt-BR": "Venceu o Leão da tribo de Judá, a Raiz de Davi."
-					}
-				},
-				{
-					"v": {
-						"en-US": "O Lord, hear my prayer.",
-						"pt-BR": "Senhor, escutai a minha oração."
-					},
-					"r": {
-						"en-US": "And let my cry come unto Thee.",
-						"pt-BR": "E chegue a Vós o meu clamor."
-					}
-				}
-			]
-		},
-		{
-			"type": "rubric",
-			"text": {
-				"en-US": "Let us pray.",
-				"pt-BR": "Oremos."
-			}
-		},
-		{
-			"type": "prayer",
-			"inline": {
-				"en-US": "O God, the Father of our Lord Jesus Christ, we call upon Thy holy Name, and as supplicants we implore Thy clemency, that by the intercession of Mary, ever Virgin Immaculate and our Mother, and of the glorious Archangel Saint Michael, Thou wouldst deign to help us against Satan and all other unclean spirits, who wander about the world for the injury of the human race and the ruin of souls. Amen.",
-				"pt-BR": "Ó Deus, Pai de Nosso Senhor Jesus Cristo, invocamos o Vosso santo Nome e como suplicantes imploramos a Vossa clemência para que, pela intercessão de Maria, sempre Virgem Imaculada e Nossa Mãe, e do glorioso Arcanjo São Miguel, digneis ajudar-nos contra Satanás e todos os outros espíritos imundos que vagueiam pelo mundo para dano do gênero humano e perdição das almas. Amém."
-			}
+			"ref": "prayer-st-michael",
+			"defaultOpen": true
 		},
 		{
 			"type": "divider"
 		},
 		{
 			"type": "prayer",
-			"ref": "angele-dei"
+			"ref": "angele-dei",
+			"defaultOpen": true
 		},
 		{
 			"type": "rubric",

--- a/content/practices/wednesday-joseph/flow.json
+++ b/content/practices/wednesday-joseph/flow.json
@@ -45,17 +45,16 @@
 		},
 		{
 			"type": "prayer",
-			"ref": "memorare-st-joseph"
+			"ref": "memorare-st-joseph",
+			"defaultOpen": true
 		},
 		{
 			"type": "divider"
 		},
 		{
-			"type": "rubric",
-			"text": {
-				"en-US": "Pause for the Litany of St. Joseph — pinned in the *Go Deeper* section of today's collection, or prayed elsewhere if it is already in your rule.",
-				"pt-BR": "Pause para a Ladainha de São José — fixada na seção *Aprofundar* da coleção de hoje, ou rezada em outro lugar se já estiver na sua regra."
-			}
+			"type": "prayer",
+			"ref": "litany-st-joseph",
+			"defaultOpen": true
 		},
 		{
 			"type": "divider"
@@ -69,10 +68,8 @@
 		},
 		{
 			"type": "prayer",
-			"inline": {
-				"en-US": "To thee, O blessed Joseph, we have recourse in our affliction, and having implored the help of thy most holy Spouse, we confidently invoke thy patronage also.\n\nBy that charity which united thee to the Immaculate Virgin Mother of God, and by that fatherly love with which thou didst embrace the Child Jesus, we beseech thee graciously to regard the inheritance which Jesus Christ has purchased by His Blood, and by thy powerful intercession, to help us in our necessities.\n\nGuard, O most watchful Guardian of the Holy Family, the chosen people of Jesus Christ; keep far from us, O most loving Father, all blight of error and corruption; aid us from on high, O our most mighty protector, in this conflict with the powers of darkness; and even as of old thou didst rescue the Child Jesus from the supreme peril of His life, so now defend God's Holy Church from the snares of the enemy and from all adversity; keep us one and all under thy continual protection, that we may be supported by thine example and thine assistance, may be enabled to lead a holy life, to die a holy death, and to obtain everlasting happiness in heaven. Amen.",
-				"pt-BR": "A vós, ó bem-aventurado José, recorremos na nossa aflição, e depois de implorar o auxílio de vossa santíssima Esposa, confiantes imploramos também o vosso patrocínio.\n\nPela caridade que vos uniu à Imaculada Virgem Mãe de Deus e pelo amor paternal com que abraçastes o Menino Jesus, suplicamos-vos que olheis com bondade para a herança que Jesus Cristo resgatou com o Seu Sangue e que, com vossa poderosa intercessão, nos ajudeis nas nossas necessidades.\n\nGuardai, ó vigilantíssimo Guarda da Santa Família, o povo eleito de Jesus Cristo; afastai de nós, ó amantíssimo Pai, toda a corrupção do vício e do erro; socorrei-nos do alto, ó nosso poderosíssimo protetor, neste combate com as potências das trevas; e assim como outrora livrastes o Menino Jesus do supremo perigo da vida, assim agora defendei a santa Igreja de Deus das ciladas do inimigo e de toda adversidade; guardai-nos a todos com a vossa contínua proteção, para que, apoiados no vosso exemplo e auxílio, possamos viver santamente, morrer santamente e alcançar a felicidade eterna no Céu. Amém."
-			}
+			"ref": "prayer-st-joseph",
+			"defaultOpen": true
 		},
 		{
 			"type": "divider"

--- a/packages/content-engine/src/engine/__tests__/flow.test.ts
+++ b/packages/content-engine/src/engine/__tests__/flow.test.ts
@@ -108,6 +108,46 @@ describe('resolveFlow — collapsible primitive', () => {
   })
 })
 
+describe('resolveFlow — prayer ref defaultOpen', () => {
+  function ecWithPrayer() {
+    const ec = makeEngineContext()
+    ec.prayers = {
+      'te-deum': {
+        title: { 'pt-BR': 'Te Deum' },
+        body: [{ type: 'prayer', inline: { 'pt-BR': 'Te Deum laudamus...' } }],
+      },
+    }
+    return ec
+  }
+
+  it('omits defaultOpen by default (asset stays collapsed)', () => {
+    const result = resolveFlow(
+      flow({ type: 'prayer', ref: 'te-deum' }),
+      makeContext(),
+      ecWithPrayer(),
+    )
+    expect((result[0] as { defaultOpen?: boolean }).defaultOpen).toBeUndefined()
+  })
+
+  it('carries defaultOpen: true into the rendered prayer section', () => {
+    const result = resolveFlow(
+      flow({ type: 'prayer', ref: 'te-deum', defaultOpen: true }),
+      makeContext(),
+      ecWithPrayer(),
+    )
+    expect((result[0] as { defaultOpen?: boolean }).defaultOpen).toBe(true)
+  })
+
+  it('carries defaultOpen onto an unknown-ref placeholder too', () => {
+    const result = resolveFlow(
+      flow({ type: 'prayer', ref: 'no-such-prayer', defaultOpen: true }),
+      makeContext(),
+      makeEngineContext(),
+    )
+    expect((result[0] as { defaultOpen?: boolean }).defaultOpen).toBe(true)
+  })
+})
+
 describe('resolveFlow — prose with resolvedProse', () => {
   it('silently skips missing prose keys when resolvedProse is set', () => {
     expect(

--- a/packages/content-engine/src/engine/resolve.ts
+++ b/packages/content-engine/src/engine/resolve.ts
@@ -125,7 +125,8 @@ export function resolveSection(
       ]
 
     case 'prayer':
-      if ('ref' in section) return resolvePrayerRef(section.ref, context, ec, resolveSection)
+      if ('ref' in section)
+        return resolvePrayerRef(section.ref, context, ec, resolveSection, section.defaultOpen)
       if ('inline' in section) return [resolveInlinePrayer(section.inline, ec, section.speaker)]
       if ('title' in section && 'sections' in section) {
         const resolved = section.sections.flatMap((s) => resolveSection(s, context, ec))
@@ -135,6 +136,7 @@ export function resolveSection(
             title: ec.localize(section.title),
             text: bilingualEmpty,
             sections: resolved,
+            ...(section.defaultOpen ? { defaultOpen: true } : {}),
           },
         ]
       }

--- a/packages/content-engine/src/engine/sections/prayer.ts
+++ b/packages/content-engine/src/engine/sections/prayer.ts
@@ -12,7 +12,9 @@ export function resolvePrayerRef(
   context: FlowContext,
   ec: EngineContext,
   resolveSection: SectionResolver,
+  defaultOpen?: boolean,
 ): RenderedSection[] {
+  const openProp = defaultOpen ? { defaultOpen: true } : {}
   const asset = ec.prayers[ref]
   if (!asset) {
     return [
@@ -20,6 +22,7 @@ export function resolvePrayerRef(
         type: 'prayer',
         title: bilingualOf(ref),
         text: bilingualOf(`[Unknown prayer ref: ${ref}]`),
+        ...openProp,
       },
     ]
   }
@@ -30,6 +33,7 @@ export function resolvePrayerRef(
         type: 'prayer',
         title: ec.localize(asset.title),
         text: ec.localize(asset.body as unknown as LocalizedContent),
+        ...openProp,
       },
     ]
   }
@@ -37,7 +41,7 @@ export function resolvePrayerRef(
   // Single inline prayer: attach the asset title for collapsible rendering
   const first = resolved[0]
   if (resolved.length === 1 && first?.type === 'prayer') {
-    return [{ ...first, title: ec.localize(asset.title) }]
+    return [{ ...first, title: ec.localize(asset.title), ...openProp }]
   }
   // Multi-section prayer: wrap in a prayer section with nested sections
   return [
@@ -46,6 +50,7 @@ export function resolvePrayerRef(
       title: ec.localize(asset.title),
       text: bilingualEmpty,
       sections: resolved,
+      ...openProp,
     },
   ]
 }

--- a/packages/content-engine/src/types.ts
+++ b/packages/content-engine/src/types.ts
@@ -86,9 +86,14 @@ export type FlowSection = { lang?: string } & (
       from?: string
     }
   | { type: 'image'; src: string; caption?: LocalizedText; attribution?: LocalizedText }
-  | { type: 'prayer'; ref: string }
+  // `defaultOpen: true` renders the embedded prayer expanded on first paint
+  // (still tappable to collapse). Use when the prayer isn't reliably known by
+  // heart and the text being on the page matters — Te Deum, Anima Christi,
+  // litanies, Marian antiphons, the Leonine St. Michael, the *En ego*, etc.
+  // Default collapsed is right for Hail Mary, Sign of the Cross, Glory Be.
+  | { type: 'prayer'; ref: string; defaultOpen?: boolean }
   | { type: 'prayer'; speaker?: 'priest' | 'people' | 'all'; inline: LocalizedContent }
-  | { type: 'prayer'; title: LocalizedText; sections: FlowSection[] }
+  | { type: 'prayer'; title: LocalizedText; sections: FlowSection[]; defaultOpen?: boolean }
   | { type: 'hymn'; ref: string }
   | { type: 'hymn'; inline: LocalizedContent }
   | { type: 'canticle'; ref: string }
@@ -331,6 +336,7 @@ export type RenderedSection =
       count?: number
       speaker?: 'priest' | 'people' | 'all'
       sections?: RenderedSection[]
+      defaultOpen?: boolean
     }
   | { type: 'hymn'; title: BilingualText; text: BilingualText }
   | {


### PR DESCRIPTION
## Summary

Referenced prayers (\`{type: \"prayer\", ref: X}\`) always render collapsed today (\`CollapsiblePrayer.tsx:22\` hard-codes \`useState(false)\`). That's right for prayers everyone knows by heart (Sign of the Cross, Glory Be, Hail Mary), wrong for the Te Deum, Anima Christi, Adoro Te Devote, litanies, Marian antiphons, the *En ego*, etc. — those should be on the page, not behind a tap.

The \`collapsible\` container already solves the same shape with \`defaultOpen?: boolean\` (\`packages/content-engine/src/types.ts:240\`). This PR threads the same field through the prayer-ref path.

### Wire-up

New optional \`defaultOpen?: boolean\` on:
- \`FlowSection\` \`{type: 'prayer'; ref}\` and \`{type: 'prayer'; title; sections}\` variants
- \`RenderedSection\` prayer shape
- \`ContainerBehavior\` \`kind: 'prayer'\`
- \`CollapsiblePrayer\` prop (\`useState(defaultOpen ?? false)\`)

Threaded through: \`resolve.ts\` (case 'prayer') → \`resolvePrayerRef\` → \`preprocessFlow.ts\` (case 'prayer') → \`PrimitiveBlock\` (container/prayer arm) → \`CollapsiblePrayer\`.

**Chevron stays.** \`defaultOpen: true\` flips the initial expanded state; the user can still tap to collapse. Same UX as \`CollapsibleBlock\`. No special-case rendering.

### Applied to Dies Domini flows

Every non-by-heart ref in the 7 day flows now carries \`\"defaultOpen\": true\`. The by-heart set is: \`sign-of-cross\`, \`glory-be\`, \`hail-mary\`, \`our-father\`, \`fatima-prayer\`, the creeds. Concretely after this PR, only the opening/closing Sign of the Cross and Sunday's Glory Be ×3 remain collapsed.

The earlier follow-up commit's workarounds — swapping unreachable refs for rubrics-pointing-to-Go-Deeper (\`litany-st-joseph\`, \`litany-sacred-heart\`) and inlining prayer text (\`prayer-st-michael\` Leonine, \`prayer-st-joseph\` Ad te beate, \`spiritual-communion\`) — are reverted. Those refs are reachable now, and centralizing the text in their own practice is the right place for it.

### Tests

3 new engine tests in \`flow.test.ts\` alongside the existing collapsible-defaultOpen tests:
- Prayer ref without \`defaultOpen\` resolves without the field (no behavior change for existing flows).
- Prayer ref with \`defaultOpen: true\` carries the field into the rendered section.
- An unknown-ref placeholder still carries \`defaultOpen\` (so a missing prayer doesn't silently fall back to collapsed).

Full \`flow.test.ts\` suite: 37 → 40 passing.

## Test plan
- [x] \`pnpm test --run flow.test\` in \`packages/content-engine\` — all 40 pass
- [x] \`pnpm build:corpus\` clean
- [x] \`pnpm biome check\` clean on changed files (one pre-existing unused-import warning unrelated)
- [ ] Manual on web: open each of the 7 dies-domini practices — every non-by-heart prayer renders open on first paint, chevron present and tappable to collapse
- [ ] Negative: open the Rosary — Hail Mary still collapsed
- [ ] pt-BR walk-through one day flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)