### PR TITLE
Project programs across day-carousel time travel

### DIFF
--- a/apps/app/src/app/(tabs)/(today,explore,library,you,search)/index.tsx
+++ b/apps/app/src/app/(tabs)/(today,explore,library,you,search)/index.tsx
@@ -49,6 +49,7 @@ import {
   useCompletionDatesBySlot,
   useCompletionRange,
   useCompletionsForDate,
+  useProgramHidesForDate,
   useRestartNeededPractices,
   useSlots,
   useToggleSlot,
@@ -85,6 +86,7 @@ export default function HomeScreen() {
     (s) => s.liturgicalCalendar,
   ) as LiturgicalCalendarForm
   const anchorDate = format(useStableToday(), 'yyyy-MM-dd')
+  const isFutureDate = selectedDate > anchorDate
   const setTimeTravelEphemeral = usePreferencesStore((s) => s.setTimeTravelDateEphemeral)
   const router = useRouter()
   const slots = useSlots()
@@ -185,9 +187,13 @@ export default function HomeScreen() {
   ]
 
   const completionsBySlot = useCompletionDatesBySlot()
+  const programHides = useProgramHidesForDate(selectedDate)
   const todaySlots = useMemo(
-    () => filterSlotsForDate(slots, selectedDate, scheduleCtx, completionsBySlot),
-    [slots, selectedDate, scheduleCtx, completionsBySlot],
+    () =>
+      filterSlotsForDate(slots, selectedDate, scheduleCtx, completionsBySlot).filter(
+        (s) => !programHides.has(s.id),
+      ),
+    [slots, selectedDate, scheduleCtx, completionsBySlot, programHides],
   )
   const completedIds = useMemo(() => toCompletedSet(todayCompletions), [todayCompletions])
   const wallData = useMemo(() => buildTieredWallData(wallLogs, slots), [wallLogs, slots])
@@ -312,6 +318,7 @@ export default function HomeScreen() {
                       state={state}
                       completed={completed}
                       total={total}
+                      readOnly={isFutureDate}
                       onToggle={(item, done) =>
                         toggle.mutate({
                           practiceId: item.practice_id,

--- a/apps/app/src/app/(tabs)/(today,explore,library,you,search)/practices/[manifestId]/program.tsx
+++ b/apps/app/src/app/(tabs)/(today,explore,library,you,search)/practices/[manifestId]/program.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/features/plan-of-life'
 import { computeAllDayStates } from '@/features/plan-of-life/program'
 import { ProgramRestartModal } from '@/features/practices/components'
-import { getToday } from '@/hooks/useToday'
+import { getToday, useToday } from '@/hooks/useToday'
 import { localizeContent } from '@/lib/i18n'
 
 function getDayTitles(cycleData: Record<string, CycleData> | undefined): string[] {
@@ -43,7 +43,8 @@ export default function ProgramDetailScreen() {
   const theme = useTheme()
 
   const manifest = manifestId ? getManifest(manifestId) : undefined
-  const progress = useProgramProgress(manifest?.id ?? '', manifest?.program)
+  const today = useToday()
+  const progress = useProgramProgress(manifest?.id ?? '', manifest?.program, today)
   const restartProgramMutation = useRestartProgram()
   const backfillMutation = useBackfillMissedDays()
 
@@ -64,7 +65,14 @@ export default function ProgramDetailScreen() {
     )
   }
 
-  const { programDay, totalDays, isComplete, completionBehavior, shouldPromptRestart } = progress
+  const {
+    programDay,
+    totalDays,
+    isComplete,
+    completionBehavior,
+    shouldPromptRestart,
+    isProjection,
+  } = progress
   const dayStates = computeAllDayStates(progress)
   const iconKey = getManifestIconKey(manifest.id)
   const progressPercent = isComplete ? 100 : ((programDay + 1) / totalDays) * 100
@@ -164,7 +172,7 @@ export default function ProgramDetailScreen() {
           </YStack>
         )}
 
-        {shouldPromptRestart && !isComplete && (
+        {shouldPromptRestart && !isComplete && !isProjection && (
           <ProgramRestartModal
             practiceName={localizeContent(manifest.name)}
             missedDays={progress.missedDays}
@@ -197,7 +205,7 @@ export default function ProgramDetailScreen() {
                 isMissed={state.isMissed}
                 missedLabel={t('program.missed')}
                 onPress={
-                  shouldPromptRestart
+                  shouldPromptRestart || isProjection
                     ? undefined
                     : () =>
                         router.push({

--- a/apps/app/src/features/home/components/TimeBlockSection.tsx
+++ b/apps/app/src/features/home/components/TimeBlockSection.tsx
@@ -23,6 +23,7 @@ export function TimeBlockSection({
   state,
   completed,
   total,
+  readOnly,
   onToggle,
   onToggleCollapse,
   onPressItem,
@@ -34,6 +35,7 @@ export function TimeBlockSection({
   state: BlockState
   completed: number
   total: number
+  readOnly?: boolean
   onToggle: (item: ChecklistItem, completed: boolean) => void
   onToggleCollapse: () => void
   onPressItem?: (item: ChecklistItem) => void
@@ -149,6 +151,17 @@ export function TimeBlockSection({
             <XStack paddingVertical="$md" paddingHorizontal="$xs" alignItems="center" gap="$md">
               {needsRestart ? (
                 <AlertTriangle size={22} color={theme.accent?.val} />
+              ) : readOnly ? (
+                <View width={24} height={24} alignItems="center" justifyContent="center">
+                  <Text
+                    fontFamily="$body"
+                    fontSize="$3"
+                    color={done ? '$accent' : '$colorSecondary'}
+                    opacity={0.5}
+                  >
+                    {done ? '✓' : '–'}
+                  </Text>
+                </View>
               ) : (
                 <View width={24} height={24} alignItems="center" justifyContent="center">
                   <AnimatedCheckbox

--- a/apps/app/src/features/plan-of-life/hooks.ts
+++ b/apps/app/src/features/plan-of-life/hooks.ts
@@ -26,12 +26,12 @@ import {
   updateSlot,
 } from '@/db/repositories'
 import type { Completion, UserPractice } from '@/db/schema'
-import { getToday } from '@/hooks/useToday'
+import { getToday, useStableToday, useToday } from '@/hooks/useToday'
 import i18n from '@/lib/i18n'
 import { rescheduleAllReminders } from '@/lib/notifications'
 import { composeSlotKey } from '@/lib/slotKey'
 
-import { computeProgramProgress, resolveCalendarDay } from './program'
+import { projectProgramAtDate } from './program'
 import { parseSchedule } from './schedule'
 import { getPracticeStreak } from './utils'
 
@@ -157,7 +157,18 @@ export function usePracticeCompletionStats(practiceId: string) {
   }, [completionsByPractice, completions, practiceId])
 }
 
+function sortedCompletionDates(
+  ids: Set<number> | undefined,
+  completions: Map<number, Completion>,
+): string[] {
+  const dates = new Set<string>()
+  for (const c of resolveCompletions(ids, completions)) dates.add(c.date)
+  return [...dates].sort()
+}
+
 export function useRestartNeededPractices(): Set<string> {
+  const realToday = useStableToday()
+  const realKey = realToday.getTime()
   const { slots, practices, cursors, completionsByPractice, completions } = useEventStore(
     useShallow((s) => ({
       slots: s.slots,
@@ -168,8 +179,8 @@ export function useRestartNeededPractices(): Set<string> {
     })),
   )
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: realKey gates recomputation; realToday is captured by closure
   return useMemo(() => {
-    const today = getToday()
     const result = new Set<string>()
 
     for (const slot of slots.values()) {
@@ -184,28 +195,32 @@ export function useRestartNeededPractices(): Set<string> {
       const cursor = cursors.get(`program/${slot.practice_id}`)
       if (!cursor) continue
 
-      const resolved = resolveCompletions(completionsByPractice.get(slot.practice_id), completions)
-      const dates = new Set<string>()
-      for (const c of resolved) {
-        if (c.date >= cursor.started_at) dates.add(c.date)
-      }
-      const completionCount = dates.size
-
-      const calendarDay = resolveCalendarDay(
-        parseSchedule(slot.schedule),
+      const projection = projectProgramAtDate({
+        program,
+        schedule: parseSchedule(slot.schedule),
         cursor,
-        today,
-        program.totalDays,
-      )
-      const progress = computeProgramProgress({ program, completionCount, calendarDay })
-      if (progress.shouldPromptRestart) result.add(slot.practice_id)
+        completionDatesAsc: sortedCompletionDates(
+          completionsByPractice.get(slot.practice_id),
+          completions,
+        ),
+        realToday,
+        targetDate: realToday,
+      })
+      if (projection.shouldPromptRestart) result.add(slot.practice_id)
     }
 
     return result
-  }, [slots, practices, cursors, completionsByPractice, completions])
+  }, [slots, practices, cursors, completionsByPractice, completions, realKey])
 }
 
-export function useProgramProgress(practiceId: string, program: ProgramConfig | undefined) {
+export function useProgramProgress(
+  practiceId: string,
+  program: ProgramConfig | undefined,
+  targetDate?: Date,
+) {
+  const fallbackTarget = useToday()
+  const realToday = useStableToday()
+  const target = targetDate ?? fallbackTarget
   const { slots, cursors, completionsByPractice, completions } = useEventStore(
     useShallow((s) => ({
       slots: s.slots,
@@ -215,34 +230,75 @@ export function useProgramProgress(practiceId: string, program: ProgramConfig | 
     })),
   )
 
+  // Date refs change every render; the primitive *Key derived from getTime()
+  // is the stable cache key. `realToday` / `target` are read from the closure.
+  const targetKey = target.getTime()
+  const realKey = realToday.getTime()
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: targetKey/realKey gate recomputation; the Date refs are captured by closure
   return useMemo(() => {
     if (!program) return undefined
 
-    const cursor = cursors.get(`program/${practiceId}`)
+    const cursor = cursors.get(`program/${practiceId}`) ?? null
+    const slot = [...slots.values()].find((s) => s.practice_id === practiceId)
+    if (!slot) return undefined
 
-    const resolved = resolveCompletions(completionsByPractice.get(practiceId), completions)
-    const startDate = cursor?.started_at ?? '1970-01-01'
-    const dates = new Set<string>()
-    for (const c of resolved) {
-      if (c.date >= startDate) dates.add(c.date)
+    return projectProgramAtDate({
+      program,
+      schedule: parseSchedule(slot.schedule),
+      cursor,
+      completionDatesAsc: sortedCompletionDates(completionsByPractice.get(practiceId), completions),
+      realToday,
+      targetDate: target,
+    })
+  }, [slots, cursors, completionsByPractice, completions, practiceId, program, targetKey, realKey])
+}
+
+export function useProgramHidesForDate(dateStr: string): ReadonlySet<string> {
+  const realToday = useStableToday()
+  const { slots, practices, cursors, completionsByPractice, completions } = useEventStore(
+    useShallow((s) => ({
+      slots: s.slots,
+      practices: s.practices,
+      cursors: s.cursors,
+      completionsByPractice: s.completionsByPractice,
+      completions: s.completions,
+    })),
+  )
+
+  const realKey = realToday.getTime()
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: realKey gates recomputation; realToday is captured by closure
+  return useMemo(() => {
+    const result = new Set<string>()
+    const targetDate = new Date(`${dateStr}T00:00:00`)
+
+    for (const slot of slots.values()) {
+      if (!slot.enabled) continue
+      const practice = practices.get(slot.practice_id)
+      if (practice?.archived) continue
+
+      const manifest = getManifest(slot.practice_id)
+      const program = manifest?.program
+      if (!program) continue
+
+      const cursor = cursors.get(`program/${slot.practice_id}`) ?? null
+      const projection = projectProgramAtDate({
+        program,
+        schedule: parseSchedule(slot.schedule),
+        cursor,
+        completionDatesAsc: sortedCompletionDates(
+          completionsByPractice.get(slot.practice_id),
+          completions,
+        ),
+        realToday,
+        targetDate,
+      })
+      if (!projection.visible) result.add(slot.id)
     }
-    const completionCount = dates.size
 
-    let calendarDay: number | undefined
-    if (program.progressPolicy !== 'wait') {
-      const slot = [...slots.values()].find((s) => s.practice_id === practiceId)
-      if (slot) {
-        calendarDay = resolveCalendarDay(
-          parseSchedule(slot.schedule),
-          cursor ?? null,
-          getToday(),
-          program.totalDays,
-        )
-      }
-    }
-
-    return computeProgramProgress({ program, completionCount, calendarDay })
-  }, [slots, cursors, completionsByPractice, completions, practiceId, program])
+    return result
+  }, [slots, practices, cursors, completionsByPractice, completions, dateStr, realKey])
 }
 
 // --- Archive reads ---

--- a/apps/app/src/features/plan-of-life/index.ts
+++ b/apps/app/src/features/plan-of-life/index.ts
@@ -24,6 +24,7 @@ export {
   useLogCompletion,
   usePractice,
   usePracticeCompletionStats,
+  useProgramHidesForDate,
   useProgramProgress,
   useRemoveCompletion,
   useReorderSlots,

--- a/apps/app/src/features/plan-of-life/program.test.ts
+++ b/apps/app/src/features/plan-of-life/program.test.ts
@@ -5,6 +5,7 @@ import {
   computeMissedDays,
   computeProgramProgress,
   computeShouldRestart,
+  projectProgramAtDate,
   resolveCalendarDay,
   selectEnrollmentSchedule,
 } from './program'
@@ -282,6 +283,220 @@ describe('selectEnrollmentSchedule', () => {
     const daily: Schedule = { type: 'daily' }
     const result = selectEnrollmentSchedule('restart', daily, 9, '2026-01-01')
     expect(result).toEqual({ type: 'fixed-program', totalDays: 9, startDate: '2026-01-01' })
+  })
+})
+
+// --- projectProgramAtDate ---
+
+describe('projectProgramAtDate', () => {
+  const waitProgram: ProgramConfig = {
+    totalDays: 9,
+    progressPolicy: 'wait',
+    completionBehavior: 'auto-disable',
+  }
+  const continueProgram: ProgramConfig = {
+    totalDays: 9,
+    progressPolicy: 'continue',
+    completionBehavior: 'auto-disable',
+  }
+  const dailySchedule: Schedule = { type: 'daily' }
+  const fixedSchedule: Schedule = {
+    type: 'fixed-program',
+    totalDays: 9,
+    startDate: '2026-06-01',
+  }
+  const cursor = { started_at: '2026-06-01' }
+
+  describe('wait policy', () => {
+    const completions = ['2026-06-01', '2026-06-03', '2026-06-05']
+    const realToday = date(2026, 6, 6)
+
+    it('hides before start date', () => {
+      const p = projectProgramAtDate({
+        program: waitProgram,
+        schedule: dailySchedule,
+        cursor,
+        completionDatesAsc: completions,
+        realToday,
+        targetDate: date(2026, 5, 30),
+      })
+      expect(p.visible).toBe(false)
+    })
+
+    it('past in window shows count up to that date', () => {
+      const p = projectProgramAtDate({
+        program: waitProgram,
+        schedule: dailySchedule,
+        cursor,
+        completionDatesAsc: completions,
+        realToday,
+        targetDate: date(2026, 6, 3),
+      })
+      expect(p.visible).toBe(true)
+      expect(p.programDay).toBe(2) // 2 completions by Jun 3 → working on day 3
+    })
+
+    it('today shows current count', () => {
+      const p = projectProgramAtDate({
+        program: waitProgram,
+        schedule: dailySchedule,
+        cursor,
+        completionDatesAsc: completions,
+        realToday,
+        targetDate: realToday,
+      })
+      expect(p.visible).toBe(true)
+      expect(p.programDay).toBe(3)
+      expect(p.isProjection).toBe(false)
+    })
+
+    it('future projects on-track from today', () => {
+      const p = projectProgramAtDate({
+        program: waitProgram,
+        schedule: dailySchedule,
+        cursor,
+        completionDatesAsc: completions,
+        realToday,
+        targetDate: date(2026, 6, 9),
+      })
+      expect(p.visible).toBe(true)
+      expect(p.programDay).toBe(6) // 3 + 3 days ahead
+      expect(p.isProjection).toBe(true)
+    })
+
+    it('future hides when projected end reached', () => {
+      // 3 done + 6 days ahead = 9 (= totalDays) → complete → hide
+      const p = projectProgramAtDate({
+        program: waitProgram,
+        schedule: dailySchedule,
+        cursor,
+        completionDatesAsc: completions,
+        realToday,
+        targetDate: date(2026, 6, 12),
+      })
+      expect(p.visible).toBe(false)
+      expect(p.isComplete).toBe(true)
+    })
+
+    it('caps programDay at totalDays - 1 on the last visible day', () => {
+      // 3 done + 5 days ahead = 8 (= totalDays - 1) → still visible
+      const p = projectProgramAtDate({
+        program: waitProgram,
+        schedule: dailySchedule,
+        cursor,
+        completionDatesAsc: completions,
+        realToday,
+        targetDate: date(2026, 6, 11),
+      })
+      expect(p.visible).toBe(true)
+      expect(p.programDay).toBe(8)
+    })
+
+    it('past hides after the user finished the novena', () => {
+      const done = Array.from({ length: 9 }, (_, i) => `2026-06-0${i + 1}`)
+      const p = projectProgramAtDate({
+        program: waitProgram,
+        schedule: dailySchedule,
+        cursor,
+        completionDatesAsc: done,
+        realToday: date(2026, 6, 15),
+        targetDate: date(2026, 6, 12),
+      })
+      expect(p.visible).toBe(false)
+    })
+
+    it('hides when no cursor', () => {
+      const p = projectProgramAtDate({
+        program: waitProgram,
+        schedule: dailySchedule,
+        cursor: null,
+        completionDatesAsc: [],
+        realToday,
+        targetDate: realToday,
+      })
+      expect(p.visible).toBe(false)
+    })
+  })
+
+  describe('continue/restart policy', () => {
+    const realToday = date(2026, 6, 6)
+    const completions = ['2026-06-01', '2026-06-02', '2026-06-03', '2026-06-04', '2026-06-05']
+
+    it('hides before start date', () => {
+      const p = projectProgramAtDate({
+        program: continueProgram,
+        schedule: fixedSchedule,
+        cursor,
+        completionDatesAsc: completions,
+        realToday,
+        targetDate: date(2026, 5, 25),
+      })
+      expect(p.visible).toBe(false)
+    })
+
+    it('within window uses calendar day', () => {
+      const p = projectProgramAtDate({
+        program: continueProgram,
+        schedule: fixedSchedule,
+        cursor,
+        completionDatesAsc: completions,
+        realToday,
+        targetDate: date(2026, 6, 5),
+      })
+      expect(p.visible).toBe(true)
+      expect(p.programDay).toBe(4)
+    })
+
+    it('hides past end of window', () => {
+      const p = projectProgramAtDate({
+        program: continueProgram,
+        schedule: fixedSchedule,
+        cursor,
+        completionDatesAsc: completions,
+        realToday,
+        targetDate: date(2026, 6, 10),
+      })
+      // June 1 + 9 days = June 10 (day 9 = out of range)
+      expect(p.visible).toBe(false)
+    })
+
+    it('forward projection suppresses missed/restart diagnostics', () => {
+      const restartCfg: ProgramConfig = {
+        ...continueProgram,
+        progressPolicy: 'restart',
+        restartThreshold: 1,
+      }
+      // 2 completions, real today is day 5 — restart should fire today
+      const p = projectProgramAtDate({
+        program: restartCfg,
+        schedule: fixedSchedule,
+        cursor,
+        completionDatesAsc: ['2026-06-01', '2026-06-02'],
+        realToday: date(2026, 6, 5),
+        targetDate: date(2026, 6, 7),
+      })
+      expect(p.isProjection).toBe(true)
+      expect(p.missedDays).toBe(0)
+      expect(p.shouldPromptRestart).toBe(false)
+    })
+
+    it('today on restart-needed program flags restart', () => {
+      const restartCfg: ProgramConfig = {
+        ...continueProgram,
+        progressPolicy: 'restart',
+        restartThreshold: 1,
+      }
+      const p = projectProgramAtDate({
+        program: restartCfg,
+        schedule: fixedSchedule,
+        cursor,
+        completionDatesAsc: ['2026-06-01', '2026-06-02'],
+        realToday: date(2026, 6, 5),
+        targetDate: date(2026, 6, 5),
+      })
+      expect(p.shouldPromptRestart).toBe(true)
+      expect(p.missedDays).toBeGreaterThan(0)
+    })
   })
 })
 

--- a/apps/app/src/features/plan-of-life/program.ts
+++ b/apps/app/src/features/plan-of-life/program.ts
@@ -1,3 +1,5 @@
+import { differenceInCalendarDays, parseISO, startOfDay } from 'date-fns'
+
 import type { ProgramConfig } from '@/content/manifestTypes'
 
 import { getOccurrenceBasedProgramDay, getProgramDay, type Schedule } from './schedule'
@@ -13,6 +15,11 @@ export type ProgramProgress = {
   completionBehavior: ProgramConfig['completionBehavior']
   missedDays: number
   shouldPromptRestart: boolean
+  isProjection: boolean
+}
+
+export type ProjectedProgramState = ProgramProgress & {
+  visible: boolean
 }
 
 export type DayState = {
@@ -66,6 +73,105 @@ export function computeProgramProgress(params: {
     isComplete,
     policy: program.progressPolicy,
     completionBehavior: program.completionBehavior,
+    missedDays,
+    shouldPromptRestart,
+    isProjection: false,
+  }
+}
+
+// --- Date-aware projection (carousel time-travel) ---
+
+/**
+ * Compute a program's state as it would appear on `targetDate`, given the
+ * user's real present (`realToday`). Forward dates project on the assumption
+ * the user stays on track — for `wait` policy this means today's completion
+ * count plus the gap to the target. Diagnostics that describe real state
+ * (`missedDays`, `shouldPromptRestart`) are zeroed on projected dates.
+ *
+ * `visible` answers the plan-of-life filter: hide before start, hide after
+ * the program's projected end.
+ */
+export function projectProgramAtDate(args: {
+  program: ProgramConfig
+  schedule: Schedule
+  cursor: { started_at: string } | null
+  completionDatesAsc: string[]
+  realToday: Date
+  targetDate: Date
+}): ProjectedProgramState {
+  const { program, schedule, cursor, completionDatesAsc, realToday, targetDate } = args
+  const totalDays = program.totalDays
+  const target = startOfDay(targetDate)
+  const today = startOfDay(realToday)
+  const isProjection = differenceInCalendarDays(target, today) > 0
+  const policy = program.progressPolicy
+
+  const empty: ProjectedProgramState = {
+    visible: false,
+    programDay: 0,
+    totalDays,
+    completionCount: 0,
+    isComplete: false,
+    policy,
+    completionBehavior: program.completionBehavior,
+    missedDays: 0,
+    shouldPromptRestart: false,
+    isProjection,
+  }
+
+  if (!cursor) return empty
+  const startedAt = parseISO(cursor.started_at)
+  if (differenceInCalendarDays(target, startedAt) < 0) return empty
+
+  const countUpTo = (d: Date) => {
+    const startStr = cursor.started_at
+    const upTo = d.toISOString().slice(0, 10)
+    let n = 0
+    for (const c of completionDatesAsc) {
+      if (c >= startStr && c <= upTo) n++
+    }
+    return n
+  }
+
+  if (policy === 'wait') {
+    const baseCount = countUpTo(today)
+    const rawProgramDay = isProjection
+      ? baseCount + differenceInCalendarDays(target, today)
+      : countUpTo(target)
+    const isComplete = rawProgramDay >= totalDays
+    const programDay = Math.min(rawProgramDay, totalDays - 1)
+    return {
+      ...empty,
+      visible: !isComplete,
+      programDay,
+      completionCount: baseCount,
+      isComplete,
+    }
+  }
+
+  // continue / restart: calendar-anchored. Visibility window is governed by
+  // the schedule's own `isApplicableOn`, but we mirror its logic here so the
+  // hook is the single source of truth.
+  const calendarDay = resolveCalendarDay(schedule, cursor, target, totalDays)
+  if (calendarDay === undefined) return empty
+
+  const baseCount = countUpTo(today)
+  const programDay = Math.min(calendarDay, totalDays - 1)
+  const isComplete = baseCount >= totalDays
+
+  let missedDays = 0
+  let shouldPromptRestart = false
+  if (!isProjection && !isComplete) {
+    missedDays = computeMissedDays(policy, calendarDay, baseCount)
+    shouldPromptRestart = computeShouldRestart(policy, missedDays, program.restartThreshold ?? 1)
+  }
+
+  return {
+    ...empty,
+    visible: !isComplete,
+    programDay,
+    completionCount: baseCount,
+    isComplete,
     missedDays,
     shouldPromptRestart,
   }

--- a/apps/app/src/features/practices/components/PracticeFlow/PracticeFlowView.tsx
+++ b/apps/app/src/features/practices/components/PracticeFlow/PracticeFlowView.tsx
@@ -23,7 +23,7 @@ import { PreprocessProvider } from '@/content/preprocessRuntime'
 import { ProgramCompleteModal } from '@/features/practices/components/ProgramCompleteModal'
 import { ReadingSettingsSheet } from '@/features/practices/components/ReadingSettingsSheet'
 import { useReadingMargin } from '@/hooks/useReadingStyle'
-import { useToday } from '@/hooks/useToday'
+import { useStableToday, useToday } from '@/hooks/useToday'
 import { lightTap } from '@/lib/haptics'
 import { localizeContent } from '@/lib/i18n'
 import { formatLocalized } from '@/lib/i18n/dateLocale'
@@ -112,6 +112,8 @@ function PracticeReady({
   const theme = useTheme()
   const insets = useSafeAreaInsets()
   const now = useToday()
+  const realToday = useStableToday()
+  const isFutureDate = now.getTime() > realToday.getTime()
   const readingMargin = useReadingMargin()
   const practiceName = localizeContent(manifest.name)
   const formattedDate = formatLocalized(now, 'EEEE, MMMM d, yyyy')
@@ -162,7 +164,7 @@ function PracticeReady({
                 ))}
               </YStack>
 
-              {manifest.completion !== 'manual' && (
+              {manifest.completion !== 'manual' && !isFutureDate && (
                 <YStack paddingHorizontal={readingMargin} paddingTop="$lg">
                   <AnimatedPressable
                     onPress={completion.handleComplete}


### PR DESCRIPTION
## Summary

Time-travel today (via the day carousel) now propagates to plan-of-life slots and the practice/program screen so a novena reflects the scrubbed date instead of always reading "real today".

For a 9-day novena:
- **Before start** → slot hidden in plan-of-life
- **During window** → slot visible; tapping shows the projected day at that date
- **After projected end** → slot hidden
- **Future dates** → checkboxes and tap-to-complete disabled (completing a day that hasn't happened is meaningless)

"Projected" varies by policy:
- `continue` / `restart` are calendar-anchored — day index = `targetDate − startDate`
- `wait` is completion-anchored — forward dates assume the user stays on track (`todayCount + daysAhead`), and the slot disappears once the projected count reaches `totalDays`

Restart prompts and missed-day banners are suppressed on projected (future) dates. They still fire on real today.

## Design

A single helper `projectProgramAtDate(program, schedule, cursor, completionDatesAsc, realToday, targetDate)` returns `{ visible, programDay, isComplete, isProjection, missedDays, shouldPromptRestart }`. Both the plan-of-life visibility filter (`useProgramHidesForDate`) and the practice screen (`useProgramProgress` now accepts a `targetDate`) route through it.

`useRestartNeededPractices` anchors on `useStableToday()` so the banner doesn't flicker as the user scrubs ephemeral time-travel.

## Files changed

- `apps/app/src/features/plan-of-life/program.ts` — `projectProgramAtDate` + types
- `apps/app/src/features/plan-of-life/hooks.ts` — date-parameterized `useProgramProgress`, new `useProgramHidesForDate`, stable-today anchor for restart prompt
- `apps/app/src/features/plan-of-life/program.test.ts` — 13 new unit tests for the projection helper
- `apps/app/src/app/(tabs)/(today,explore,library,you,search)/index.tsx` — apply hide filter + `isFutureDate` lockout
- `apps/app/src/app/(tabs)/(today,explore,library,you,search)/practices/[manifestId]/program.tsx` — pass `useToday()` through; gate restart/backfill/day-tap on `!isProjection`
- `apps/app/src/features/home/components/TimeBlockSection.tsx` — `readOnly` prop renders static ✓/– instead of the checkbox

## Test plan
- [ ] Daytime: enroll a `continue` novena starting today. Scrub back → slot hidden. Scrub past day 9 → slot hidden.
- [ ] `wait` novena: complete 2-3 days. Forward scrub shows projected day increasing 1/day. Slot disappears once projected count = totalDays.
- [ ] Practice screen: scrub forward, no restart prompt / no "missed days" banner; "Day N of M" reflects projection. Day-row tap disabled.
- [ ] Future dates: every slot row has read-only ✓/– marker; no checkbox toggle.
- [ ] Past dates: checkboxes remain interactive (legitimate backfill).
- [ ] `vitest run src/features/plan-of-life` → all 99 tests pass.