### PR TITLE
Show collections above books in search results

### DIFF
--- a/apps/app/src/features/practices/components/SearchAutocomplete.tsx
+++ b/apps/app/src/features/practices/components/SearchAutocomplete.tsx
@@ -21,7 +21,7 @@ type SearchResult =
 
 type Scored<T> = { score: number; item: T }
 
-const groupOrder: SearchResult['kind'][] = ['practice', 'book', 'collection']
+const groupOrder: SearchResult['kind'][] = ['practice', 'collection', 'book']
 
 function bareId(corpusId: string): string {
   const slash = corpusId.indexOf('/')


### PR DESCRIPTION
## Summary
- Reorder the search autocomplete groups so collections render above books (practices remain on top).

## Test plan
- [ ] Open search, type a query that matches a collection and a book (e.g. "Aquina") and confirm collections appear before books.