### PR TITLE
OF Mass: weekday solemnities use the Sunday cycle for readings

### DIFF
--- a/packages/mass/src/calendar.test.ts
+++ b/packages/mass/src/calendar.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { pickCycle } from './calendar'
+import type { Celebration } from './types'
+
+function celebration(readings: Record<string, unknown>): Celebration {
+  return {
+    id: 'x',
+    title: {},
+    rite: 'mass',
+    rank: 'solemnity',
+    primary: { id: 'x', source: 'tempore', readings },
+    alternates: [],
+  }
+}
+
+describe('pickCycle', () => {
+  // Corpus Christi 2026 = Thursday 2026-06-04. A Thursday solemnity must still
+  // resolve to the Sunday cycle (A/B/C) — its formulary doesn't carry I/II keys,
+  // so falling back to the weekday cycle would leave every reading slot empty.
+  it('uses the Sunday cycle when the formulary keys readings under A/B/C', () => {
+    const cycle = pickCycle(new Date(2026, 5, 4), celebration({ A: {}, B: {}, C: {} }))
+    expect(['A', 'B', 'C']).toContain(cycle)
+  })
+
+  it("returns 'default' when the formulary has default-keyed readings", () => {
+    const cycle = pickCycle(new Date(2026, 0, 6), celebration({ default: {} }))
+    expect(cycle).toBe('default')
+  })
+
+  it('uses the weekday cycle when the formulary keys readings under I/II', () => {
+    const cycle = pickCycle(new Date(2026, 5, 2), celebration({ I: {}, II: {} }))
+    expect(['I', 'II']).toContain(cycle)
+  })
+
+  it('falls back to date-based cycle when no celebration is supplied', () => {
+    expect(['A', 'B', 'C']).toContain(pickCycle(new Date(2026, 5, 7))) // Sunday
+    expect(['I', 'II']).toContain(pickCycle(new Date(2026, 5, 4))) // Thursday
+  })
+})

--- a/packages/mass/src/calendar.ts
+++ b/packages/mass/src/calendar.ts
@@ -1,16 +1,28 @@
 import { getLiturgicalYear, getSundayCycle, getWeekdayCycle } from '@ember/liturgical'
-import type { CycleId } from './types'
+import type { Celebration, CycleId } from './types'
 
 /**
- * Pick the lectionary cycle for a date. Sunday → A/B/C; weekday → I/II;
- * fixed feasts use 'default' (we don't track those at this layer).
+ * Pick the lectionary cycle for the day's principal celebration.
+ *
+ * Each formulary keys its `readings` under exactly one scheme: A/B/C for
+ * Sunday-cycle lectionaries (Sundays + solemnities/feasts of the Lord, which
+ * keep the Sunday cycle even when they fall on a weekday — Corpus Christi
+ * Thursday, Sacred Heart Friday, Ascension Thursday), I/II for Ordinary Time
+ * weekdays, or `default` for fixed feasts whose readings don't vary by year.
+ * Inspecting the formulary's actual keys lets a Thursday solemnity surface its
+ * Sunday-cycle readings instead of falling through to the weekday cycle slot
+ * (which doesn't exist on that formulary, leaving every reading blank).
  *
  * Date → celebration → tempore-id resolution lives in `@ember/liturgical`
  * (`ofTemporeIds` / `resolveOfDay`); this package only fetches the propers for
  * the celebration the resolver selects.
  */
-export function pickCycle(date: Date): CycleId {
+export function pickCycle(date: Date, principal?: Celebration): CycleId {
   const litYear = getLiturgicalYear(date)
-  const isSunday = date.getDay() === 0
-  return isSunday ? getSundayCycle(litYear) : getWeekdayCycle(litYear)
+  const readings = principal?.primary.readings as Record<string, unknown> | undefined
+  const keys = readings ? Object.keys(readings) : []
+  if (keys.includes('default')) return 'default'
+  if (keys.some((k) => k === 'A' || k === 'B' || k === 'C')) return getSundayCycle(litYear)
+  if (keys.some((k) => k === 'I' || k === 'II')) return getWeekdayCycle(litYear)
+  return date.getDay() === 0 ? getSundayCycle(litYear) : getWeekdayCycle(litYear)
 }

--- a/packages/mass/src/source.test.ts
+++ b/packages/mass/src/source.test.ts
@@ -147,4 +147,25 @@ describe('massOfSource', () => {
     const result = (await source.load({}, makeCtx(new Date(2026, 5, 9)))) as DayLiturgies
     expect(['I', 'II']).toContain(result.cycle)
   })
+
+  it('uses the Sunday cycle for a solemnity falling on a weekday (Corpus Christi)', async () => {
+    // Corpus Christi 2026 = Thursday 2026-06-04. Its formulary keys readings
+    // under A/B/C even though Thursday's default cycle is I/II — so the picker
+    // must read off the formulary's actual reading keys.
+    const corpusChristi = {
+      id: 'tempore.solemnity.corpus-christi',
+      source: 'tempore',
+      rank: 'solemnity',
+      title: { 'en-US': 'Corpus Christi' },
+      readings: { A: {}, B: {}, C: {} },
+    }
+    const source = createMassOfSource(
+      makeData({
+        masses: { 'mass/of/tempore/solemnity/corpus-christi': corpusChristi },
+        ordinaries: { 'of/ordinary/ordinario': {} },
+      }),
+    )
+    const result = (await source.load({}, makeCtx(new Date(2026, 5, 4)))) as DayLiturgies
+    expect(['A', 'B', 'C']).toContain(result.cycle)
+  })
 })

--- a/packages/mass/src/source.ts
+++ b/packages/mass/src/source.ts
@@ -274,7 +274,7 @@ export function createMassOfSource(data: MassOfDataSource): DataSource {
       return {
         celebrations,
         ordinary,
-        cycle: pickCycle(date),
+        cycle: pickCycle(date, celebrations[0]),
       }
     },
   }


### PR DESCRIPTION
## Summary

- Reported: opening the Novus Ordo Mass for Corpus Christi (Thursday 2026-06-04) showed no readings — the Liturgy of the Word rendered the rubrics and headings but every First Reading / Psalm / Second Reading / Sequence / Gospel Acclamation / Gospel slot was empty.
- Root cause: `pickCycle(date)` only looked at the day of week, returning the weekday cycle `II` on a Thursday. The Corpus Christi formulary (like Sacred Heart, Ascension Thursday, Christmas-as-weekday, etc.) keys its `readings` under `A`/`B`/`C`, so `readings.II.firstReading` resolved to nothing.
- Fix: drive the cycle off the principal celebration's actual `readings` keys — `A/B/C` → current Sunday cycle, `I/II` → current weekday cycle, `default` → `'default'` — falling back to the date-based heuristic only when no celebration is bound.

## Test plan

- [x] `pnpm vitest run packages/mass/src/calendar.test.ts packages/mass/src/source.test.ts` — 9/9 pass (4 new `pickCycle` cases + the new Corpus-Christi regression in `source.test.ts`).
- [x] Full `packages/mass` suite — 51/68 pass; the 17 failing `integration.test.ts` cases pre-exist on `main` and are unrelated.
- [ ] Open the Novus Ordo Mass for Thursday 2026-06-04 in the app and confirm all five reading slots populate.
- [ ] Spot-check another weekday solemnity (e.g. Sacred Heart on the Friday after).
- [ ] Spot-check a regular OT weekday (e.g. 2026-06-02) still resolves to the I/II ferial readings.