### PR TITLE
Log practice completions against the logical day (4am cutoff)

### DIFF
--- a/apps/app/src/features/practices/components/PracticeFlow/hooks/usePracticeCompletion.ts
+++ b/apps/app/src/features/practices/components/PracticeFlow/hooks/usePracticeCompletion.ts
@@ -10,6 +10,7 @@ import {
   useLogCompletion,
   useRestartProgram,
 } from '@/features/plan-of-life'
+import { getToday } from '@/hooks/useToday'
 import { successBuzz } from '@/lib/haptics'
 import { parseSlotKey } from '@/lib/slotKey'
 import { findTrackIds } from '../findTrackIds'
@@ -37,7 +38,7 @@ export function usePracticeCompletion(
   const [showCompleteModal, setShowCompleteModal] = useState(false)
 
   const handleComplete = useCallback(() => {
-    const today = format(new Date(), 'yyyy-MM-dd')
+    const today = format(getToday(), 'yyyy-MM-dd')
     const subId = slotId ?? parseSlotKey(currentSlot?.id ?? `${practiceId}::default`).slotId
 
     logCompletionMutation.mutate(


### PR DESCRIPTION
## Summary
- Completing a practice between civil midnight and 4am was logging the completion to today's calendar date instead of yesterday's logical day, so an 'amen' tap at 00:30 landed on tomorrow's entry while the home page still showed the previous day.
- Switched the date used by `usePracticeCompletion` to `getToday()` so the write side honors the same 4am cutoff that the rest of the app reads.

## Test plan
- [ ] Time-travel (or system clock) to ~00:30 local time, open a practice from the home page, tap Amen, confirm it shows as completed on the same row you opened from (not on the next day).
- [ ] After 4am, complete a practice and confirm it still logs to the current civil date.