### PR TITLE
Dies Domini: drop hero left border, stretch day-row thumbnail

### DIFF
--- a/apps/app/src/app/(tabs)/(today,explore,library,you,search)/dies-domini/index.tsx
+++ b/apps/app/src/app/(tabs)/(today,explore,library,you,search)/dies-domini/index.tsx
@@ -106,13 +106,7 @@ function TodayHero({ dayKey, onPress }: { dayKey: DayKey; onPress: () => void })
             />
           </YStack>
         )}
-        <YStack
-          gap="$sm"
-          padding="$lg"
-          borderLeftWidth={3}
-          borderLeftColor="$accent"
-          backgroundColor="$backgroundSurface"
-        >
+        <YStack gap="$sm" padding="$lg" backgroundColor="$backgroundSurface">
           <XStack alignItems="baseline" gap="$sm">
             <Text
               fontFamily="$heading"
@@ -162,7 +156,7 @@ function OtherDayRow({ dayKey, onPress }: { dayKey: DayKey; onPress: () => void 
     >
       <XStack backgroundColor="$backgroundSurface" borderRadius="$md" overflow="hidden" gap="$md">
         {image ? (
-          <YStack width={96} height={96} backgroundColor="$background">
+          <YStack width={96} alignSelf="stretch" backgroundColor="$background">
             <Image
               source={image}
               style={StyleSheet.absoluteFill}


### PR DESCRIPTION
## Summary
- Remove the gold left accent border on the today hero card
- Stretch the 96px thumbnail on each rest-of-week row to the full row height so there's no empty background gap below the image

## Test plan
- [ ] Open Dies Domini screen — confirm hero card no longer has gold left border
- [ ] Confirm each day-of-week row's thumbnail fills the full row height (no dark gap below)