### PR TITLE
Render markdown in detail-page narrative text

### DIFF
--- a/apps/app/src/app/(tabs)/(today,explore,library,you,search)/creators/[creatorId].tsx
+++ b/apps/app/src/app/(tabs)/(today,explore,library,you,search)/creators/[creatorId].tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next'
 import { Text, useTheme, XStack, YStack } from 'tamagui'
 
 import { AnimatedPressable, ScreenLayout, Typography } from '@/components'
+import { ProseBlock } from '@/components/prayer'
 import { openExternalUrl } from '@/config/links'
 import { bareId } from '@/content/contentIndex'
 import type { CreatorChannel, CreatorChannelKind } from '@/content/manifestTypes'
@@ -211,9 +212,7 @@ export default function CreatorProfile() {
         </YStack>
 
         {/* Bio */}
-        <Text fontFamily="$body" fontSize="$2" color="$color" lineHeight={24}>
-          {localizeContent(manifest.bio)}
-        </Text>
+        <ProseBlock text={{ primary: localizeContent(manifest.bio) }} />
 
         {/* Channel tabs */}
         {channelTabs.length > 1 && (

--- a/apps/app/src/components/prayer/InlineMarkdown.tsx
+++ b/apps/app/src/components/prayer/InlineMarkdown.tsx
@@ -1,0 +1,55 @@
+import { Fragment } from 'react'
+import { Text as RNText } from 'react-native'
+
+import { bodyFont } from '@/config/fonts'
+
+import { parseInline } from './parseMarkdown'
+
+/**
+ * Inline markdown renderer for short text fields that live inside a parent
+ * `<Text>` wrapper (annotation rows, todo notes, compact metadata). Renders
+ * only inline emphasis (bold, italic, bold-italic) — block-level constructs
+ * pass through as plain text. Inherits font size and color from the parent;
+ * swaps the concrete font face for emphasis since RN's Text drops inherited
+ * fontWeight/fontStyle when fontFamily is set.
+ */
+function bodyFace(weight: 400 | 700, italic: boolean): string {
+  const variants = bodyFont.face?.[weight]
+  return (italic ? variants?.italic : variants?.normal) ?? bodyFont.family
+}
+
+export function InlineMarkdown({ source }: { source: string }) {
+  const nodes = parseInline(source)
+  return (
+    <>
+      {nodes.map((node, i) => {
+        switch (node.type) {
+          case 'bold':
+            // biome-ignore lint/suspicious/noArrayIndexKey: parsed nodes never reorder
+            return (
+              <RNText key={i} style={{ fontFamily: bodyFace(700, false) }}>
+                {node.text}
+              </RNText>
+            )
+          case 'italic':
+            // biome-ignore lint/suspicious/noArrayIndexKey: parsed nodes never reorder
+            return (
+              <RNText key={i} style={{ fontFamily: bodyFace(400, true) }}>
+                {node.text}
+              </RNText>
+            )
+          case 'bolditalic':
+            // biome-ignore lint/suspicious/noArrayIndexKey: parsed nodes never reorder
+            return (
+              <RNText key={i} style={{ fontFamily: bodyFace(700, true) }}>
+                {node.text}
+              </RNText>
+            )
+          default:
+            // biome-ignore lint/suspicious/noArrayIndexKey: parsed nodes never reorder
+            return <Fragment key={i}>{node.text}</Fragment>
+        }
+      })}
+    </>
+  )
+}

--- a/apps/app/src/components/prayer/index.ts
+++ b/apps/app/src/components/prayer/index.ts
@@ -6,6 +6,7 @@ export { CollapsiblePrayer } from './CollapsiblePrayer'
 export { GalleryBlock } from './GalleryBlock'
 export { HolyCardBlock } from './HolyCardBlock'
 export { ImageBlock } from './ImageBlock'
+export { InlineMarkdown } from './InlineMarkdown'
 export { LiturgicalColorBlock } from './LiturgicalColorBlock'
 export {
   LiturgicalColorProvider,

--- a/apps/app/src/features/calendar/components/DayDetail.tsx
+++ b/apps/app/src/features/calendar/components/DayDetail.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { Text, YStack } from 'tamagui'
 
 import { ObligationBadges } from '@/components'
+import { ProseBlock } from '@/components/prayer'
 import { localizeContent } from '@/lib/i18n'
 import type { DayCalendar } from '@/lib/liturgical'
 import { useObligations } from '@/lib/liturgical'
@@ -47,9 +48,10 @@ export function DayDetail({ day }: { day: DayCalendar | undefined }) {
               {localizeContent(c.entry.name)}
             </Text>
             <RankBadge rank={c.rank} />
-            <Text fontFamily="$body" fontSize="$2" color="$colorSecondary" fontStyle="italic">
-              {localizeContent(c.entry.description)}
-            </Text>
+            {(() => {
+              const description = localizeContent(c.entry.description)
+              return description ? <ProseBlock text={{ primary: description }} /> : null
+            })()}
             {c.entry.holyDayOfObligation && (
               <Text fontFamily="$body" fontSize="$1" color="$accent">
                 {t('calendar.holyDay')}

--- a/apps/app/src/features/collections/AnnotationRow.tsx
+++ b/apps/app/src/features/collections/AnnotationRow.tsx
@@ -14,6 +14,7 @@
 import { useTranslation } from 'react-i18next'
 import { Text, XStack, YStack } from 'tamagui'
 
+import { InlineMarkdown } from '@/components/prayer'
 import type { CollectionItemAnnotation } from '@/content/manifestTypes'
 import { localizeContent } from '@/lib/i18n'
 
@@ -52,7 +53,7 @@ export function AnnotationRow({
             {row.glyph}
           </Text>
           <Text flex={1} fontFamily="$body" fontSize="$1" color="$colorSecondary">
-            {row.text}
+            <InlineMarkdown source={row.text} />
           </Text>
         </XStack>
       ))}

--- a/apps/app/src/features/collections/Prose.tsx
+++ b/apps/app/src/features/collections/Prose.tsx
@@ -1,34 +1,11 @@
-import { YStack } from 'tamagui'
-
-import { Typography } from '@/components/typography'
+import { ProseBlock as PrayerProseBlock } from '@/components/prayer'
 
 /**
- * The prologue: justified paragraphs at a comfortable reading leading. Shared by
- * the collection frontispiece (its prologue) and the practice frontispiece (the
- * "about" description), so prose reads identically across both doorways.
+ * The prologue: markdown-rendered prose. Shared by the collection frontispiece
+ * (its prologue) and the practice frontispiece (the "about" description), so
+ * prose reads identically across both doorways.
  */
 export function PrologueProse({ text }: { text: string }) {
-  const paras = text
-    .split(/\n{2,}/)
-    .map((p) => p.trim())
-    .filter(Boolean)
-  if (paras.length === 0) return null
-  return (
-    <YStack gap="$sm">
-      {paras.map((p, i) => (
-        <Typography
-          // biome-ignore lint/suspicious/noArrayIndexKey: positional paragraphs
-          key={i}
-          selectable
-          variant="interface"
-          fontSize={18}
-          lineHeight={27}
-          textAlign="justify"
-          color="$color"
-        >
-          {p}
-        </Typography>
-      ))}
-    </YStack>
-  )
+  if (!text.trim()) return null
+  return <PrayerProseBlock text={{ primary: text }} />
 }

--- a/apps/app/src/features/collections/TodoCard.tsx
+++ b/apps/app/src/features/collections/TodoCard.tsx
@@ -2,6 +2,7 @@ import { CircleDashed } from 'lucide-react-native'
 import { useTranslation } from 'react-i18next'
 import { Text, useTheme, XStack, YStack } from 'tamagui'
 
+import { InlineMarkdown } from '@/components/prayer'
 import type { CollectionTodo } from '@/content/manifestTypes'
 import { localizeContent } from '@/lib/i18n'
 
@@ -37,7 +38,7 @@ export function TodoCard({ todo }: { todo: CollectionTodo }) {
         </XStack>
         {notes && (
           <Text fontFamily="$body" fontSize="$1" color="$colorSecondary" fontStyle="italic">
-            {notes}
+            <InlineMarkdown source={notes} />
           </Text>
         )}
         <Text

--- a/apps/app/src/features/home/components/CelebrationOfDay.tsx
+++ b/apps/app/src/features/home/components/CelebrationOfDay.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { Text, XStack, YStack } from 'tamagui'
 
 import { AnimatedPressable } from '@/components'
+import { ProseBlock } from '@/components/prayer'
 import { useYearCalendar } from '@/features/calendar'
 import { localizeContent } from '@/lib/i18n'
 import { getCelebrationsForDate, type ResolvedCelebration } from '@/lib/liturgical'
@@ -33,9 +34,7 @@ function CelebrationRow({
           {rankLabel(celebration, t).toUpperCase()}
         </Text>
       </XStack>
-      <Text fontFamily="$body" fontSize="$2" color="$colorSecondary" fontStyle="italic">
-        {description}
-      </Text>
+      {description && <ProseBlock text={{ primary: description }} />}
       {celebration.entry.holyDayOfObligation && (
         <Text fontFamily="$body" fontSize="$1" color="$accent">
           {t('calendar.holyDay')}

--- a/apps/app/src/features/home/components/SeasonalContext.tsx
+++ b/apps/app/src/features/home/components/SeasonalContext.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { Text, YStack } from 'tamagui'
 
 import { AnimatedPressable } from '@/components'
+import { ProseBlock } from '@/components/prayer'
 import { useUpcomingCelebration } from '@/features/calendar'
 import { localizeContent } from '@/lib/i18n'
 import { normalizeDate } from '@/lib/liturgical'
@@ -52,15 +53,9 @@ export function SeasonalContext({ date }: { date: Date }) {
           {when}
         </Text>
         {description && (
-          <Text
-            fontFamily="$body"
-            fontSize="$2"
-            color="$colorSecondary"
-            maxWidth={520}
-            numberOfLines={3}
-          >
-            {description}
-          </Text>
+          <YStack maxWidth={520}>
+            <ProseBlock text={{ primary: description }} />
+          </YStack>
         )}
       </YStack>
     </AnimatedPressable>


### PR DESCRIPTION
## Summary

- Collection / book / template / practice detail pages rendered narrative prose fields (prologues, descriptions, bios, histories) without parsing markdown, so `**bold**` and `*italic*` syntax leaked through as literal characters.
- Root cause: `PrologueProse` (the shared component used by all four detail-page kinds) split paragraphs but never invoked the markdown parser. A handful of other detail-page text fields rendered plain `<Text>` with the same result.
- Fix routes those fields through the existing `ProseBlock` markdown renderer (already used for collection section descriptions, so the engine itself was sound).

## Changes

- **`features/collections/Prose.tsx`** — `PrologueProse` now delegates to `ProseBlock`. One change fixes collection prologue, book intro, template intro, and practice description / history / how-to-pray.
- **`app/(tabs)/.../creators/[creatorId].tsx`**, **`features/calendar/components/DayDetail.tsx`**, **`features/home/components/CelebrationOfDay.tsx`**, **`features/home/components/SeasonalContext.tsx`** — narrative fields (bio, celebration descriptions, upcoming feast) render via `ProseBlock`. Drops the obsolete `numberOfLines={3}` truncation in `SeasonalContext`.
- **`components/prayer/InlineMarkdown.tsx`** (new) — lightweight helper that parses only inline emphasis (bold / italic / bold-italic) while inheriting the parent `<Text>`'s size and color. Needed for compact inline metadata where `ProseBlock`'s block layout would break the design.
- **`features/collections/AnnotationRow.tsx`**, **`features/collections/TodoCard.tsx`** — annotation rubric / indulgence / attribution / context and todo notes now render with `InlineMarkdown`.

## Test plan

- [ ] Open a collection with markdown in its prologue (e.g. "Oração Mental"). Confirm `**bold**` renders bold instead of showing asterisks.
- [ ] Open a book in Browse → Library; confirm intro markdown renders.
- [ ] Open a practice (Rosary / Mass / Aquinas prayer). Expand History and How to Pray; confirm markdown renders in all three sections.
- [ ] Open a creator profile (e.g. Aquinas); confirm bio renders with formatting.
- [ ] Open today's Day detail in Calendar and the home screen; confirm celebration descriptions render via the new pipeline.
- [ ] Find a collection item with a rubric / indulgence / attribution; confirm bold/italic inside those small rows still renders inline at the original size and muted color.
- [ ] Find a collection with a `todo` block; confirm `todo.notes` renders bold/italic inline.
- [ ] Sanity-check no console errors and that pages with empty descriptions still render cleanly.