### PR TITLE
Preces (Opus Dei): fix Sérviam/Orémus types + Portuguese response

### DIFF
--- a/content/practices/preces-opus-dei/flow.json
+++ b/content/practices/preces-opus-dei/flow.json
@@ -1,8 +1,8 @@
 {
 	"sections": [
 		{
-			"type": "heading",
-			"text": {
+			"type": "prayer",
+			"inline": {
 				"la": "Sérviam!",
 				"en-US": "Sérviam! — I shall serve!",
 				"pt-BR": "Sérviam! — Servirei!"
@@ -305,14 +305,15 @@
 					"r": {
 						"la": "Et cum spíritu tuo.",
 						"en-US": "And with your spirit.",
-						"pt-BR": "Ele está no meio de nós."
+						"pt-BR": "E com o teu espírito."
 					}
 				}
 			]
 		},
 		{
-			"type": "rubric",
-			"text": {
+			"type": "prayer",
+			"speaker": "priest",
+			"inline": {
 				"la": "Orémus.",
 				"en-US": "Let us pray.",
 				"pt-BR": "Oremos."


### PR DESCRIPTION
## Summary
- **Sérviam!** was typed as `heading` → switched to `prayer` (it's the opening acclamation, not a section title)
- **Orémus** was typed as `rubric` → switched to `prayer` with `speaker: priest`, matching the convention in ef-gloria, ef-communion-rite, ef-asperges, ef-leonine-prayers, and angelus
- **Portuguese response to *Dóminus vobíscum*** corrected from `Ele está no meio de nós.` (Brazilian OF Mass vernacular) to `E com o teu espírito.` — the standard published on the official Opus Dei site ([opusdei.org/pt-pt/article/as-preces-do-opus-dei](https://opusdei.org/pt-pt/article/as-preces-do-opus-dei/)) and a literal rendering of the singular `spíritu tuo`

## Test plan
- [ ] Open the Preces (Opus Dei) practice and confirm Sérviam renders as inline prayer text (not as a big section title)
- [ ] Confirm Orémus before the collects renders as a priest-spoken line (not as italic rubric chrome)
- [ ] Switch to pt-BR and confirm the response to *O Senhor esteja convosco* reads *E com o teu espírito.*