### PR TITLE
Sacred Scripture: redesign with art-rich hero + cards passage picker

### DIFF
--- a/apps/app/src/features/bible/components/BibleDiscovery.tsx
+++ b/apps/app/src/features/bible/components/BibleDiscovery.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { YStack } from 'tamagui'
 
-import { PageBreakOrnament, PageHeader, ScreenLayout } from '@/components'
+import { PageHeader, ScreenLayout, SectionDivider } from '@/components'
 import { ContinueReading } from './ContinueReading'
 import { GospelOfTheDay } from './GospelOfTheDay'
 import { OpenBibleCard } from './OpenBibleCard'
@@ -15,10 +15,12 @@ export function BibleDiscovery() {
       <YStack gap="$lg" paddingVertical="$lg">
         <PageHeader title={t('bible.discovery.title')} variant="sacred" />
         <GospelOfTheDay />
-        <OpenBibleCard />
+        <YStack gap="$sm">
+          <ContinueReading />
+          <OpenBibleCard />
+        </YStack>
+        <SectionDivider />
         <ThemedReadings />
-        <ContinueReading />
-        <PageBreakOrnament />
       </YStack>
     </ScreenLayout>
   )

--- a/apps/app/src/features/bible/components/ContinueReading.tsx
+++ b/apps/app/src/features/bible/components/ContinueReading.tsx
@@ -1,61 +1,60 @@
 import { useRouter } from 'expo-router'
 import { BookMarked } from 'lucide-react-native'
 import { useTranslation } from 'react-i18next'
-import { Text, useTheme, XStack, YStack } from 'tamagui'
+import { XStack, YStack } from 'tamagui'
 
-import { AnimatedPressable, SectionDivider } from '@/components'
+import { AnimatedPressable } from '@/components'
+import { Typography } from '@/components/typography'
+import { blockInk, toneForKey } from '@/features/explore/bgColor'
 import { useBibleStore } from '@/stores/bibleStore'
 
 export function ContinueReading() {
   const { t } = useTranslation()
   const router = useRouter()
-  const theme = useTheme()
   const { bookId, chapter, hydrated } = useBibleStore()
 
   if (!hydrated || (bookId === 'genesis' && chapter === 1)) return null
 
   const bookName = t(`bookName.${bookId}`, { defaultValue: bookId })
+  const tone = toneForKey(`bible-continue-${bookId}`)
 
   return (
-    <>
-      <SectionDivider />
-      <AnimatedPressable
-        onPress={() => router.push('/bible/reader')}
-        accessibilityRole="link"
-        accessibilityLabel={`${t('bible.discovery.continueReading')}: ${bookName} ${chapter}`}
-      >
-        <XStack
-          backgroundColor="$backgroundSurface"
-          borderRadius="$lg"
-          padding="$md"
-          gap="$md"
+    <AnimatedPressable
+      onPress={() => router.push('/bible/reader')}
+      accessibilityRole="link"
+      accessibilityLabel={`${t('bible.discovery.continueReading')}: ${bookName} ${chapter}`}
+    >
+      <XStack backgroundColor="$backgroundSurface" borderRadius="$md" overflow="hidden">
+        <YStack
+          width={96}
+          alignSelf="stretch"
+          backgroundColor={tone.from}
           alignItems="center"
-          borderWidth={1}
-          borderColor="$borderColor"
+          justifyContent="center"
         >
-          <YStack
-            width={36}
-            height={36}
-            alignItems="center"
-            justifyContent="center"
-            backgroundColor="$accentSubtle"
-            borderRadius="$md"
+          <BookMarked size={28} color={blockInk} strokeWidth={1.4} />
+        </YStack>
+        <YStack
+          flex={1}
+          gap={4}
+          paddingVertical="$md"
+          paddingHorizontal="$md"
+          justifyContent="center"
+        >
+          <Typography
+            variant="marker"
+            textAlign="left"
+            color="$accent"
+            fontSize="$1"
+            letterSpacing={1.5}
           >
-            <BookMarked size={20} color={theme.accent.val} />
-          </YStack>
-          <YStack flex={1} gap={2}>
-            <Text fontFamily="$heading" fontSize="$3" color="$color">
-              {t('bible.discovery.continueReading')}
-            </Text>
-            <Text fontFamily="$body" fontSize="$2" color="$colorSecondary">
-              {bookName} {chapter}
-            </Text>
-          </YStack>
-          <Text fontFamily="$body" fontSize="$2" color="$colorSecondary">
-            ›
-          </Text>
-        </XStack>
-      </AnimatedPressable>
-    </>
+            {t('bible.discovery.continueReading')}
+          </Typography>
+          <Typography variant="sacred-title" textAlign="left" fontSize="$3" color="$color">
+            {bookName} {chapter}
+          </Typography>
+        </YStack>
+      </XStack>
+    </AnimatedPressable>
   )
 }

--- a/apps/app/src/features/bible/components/GospelOfTheDay.tsx
+++ b/apps/app/src/features/bible/components/GospelOfTheDay.tsx
@@ -1,66 +1,35 @@
+import { Image } from 'expo-image'
 import { useRouter } from 'expo-router'
-import { BookOpen } from 'lucide-react-native'
 import { useTranslation } from 'react-i18next'
-import { Text, useTheme, XStack, YStack } from 'tamagui'
+import { StyleSheet } from 'react-native'
+import { YStack } from 'tamagui'
 
-import { AnimatedPressable } from '@/components'
-import { useTodayCelebration } from '@/features/calendar/hooks'
-import { localizeContent } from '@/lib/i18n'
+import { AnimatedPressable, InlineRetry } from '@/components'
+import { Typography } from '@/components/typography'
+import { blockInk, blockLabelInk, toneForKey } from '@/features/explore/bgColor'
+import { evangelistArtFor } from '@/features/explore/evangelistArt'
+import { useToday } from '@/hooks/useToday'
 import { useGospelOfTheDay as useGospelOfTheDayQuery } from '@/lib/mass-of/use-gospel-of-the-day'
+
+const dayMs = 86_400_000
 
 export function GospelOfTheDay() {
   const { t } = useTranslation()
   const router = useRouter()
-  const theme = useTheme()
+  const today = useToday()
   const { data: gospel, isLoading, isError, refetch } = useGospelOfTheDayQuery()
-  const dayCalendar = useTodayCelebration()
 
   if (isError) {
-    return (
-      <XStack
-        backgroundColor="$backgroundSurface"
-        borderRadius="$lg"
-        padding="$md"
-        gap="$sm"
-        alignItems="center"
-        borderWidth={1}
-        borderColor="$borderColor"
-        borderStyle="dashed"
-      >
-        <YStack
-          width={32}
-          height={32}
-          alignItems="center"
-          justifyContent="center"
-          backgroundColor="$accentSubtle"
-          borderRadius="$md"
-        >
-          <BookOpen size={18} color={theme.accent.val} />
-        </YStack>
-        <Text flex={1} fontFamily="$body" fontSize="$2" color="$colorSecondary">
-          {t('bible.discovery.gospelOffline')}
-        </Text>
-        <AnimatedPressable
-          onPress={refetch}
-          accessibilityRole="button"
-          accessibilityLabel={t('common.retry')}
-          hitSlop={8}
-        >
-          <Text fontFamily="$heading" fontSize="$2" color="$accent">
-            {t('common.retry')}
-          </Text>
-        </AnimatedPressable>
-      </XStack>
-    )
+    return <InlineRetry onRetry={refetch} />
   }
 
   if (isLoading || !gospel) return null
 
-  const celebrationName = dayCalendar?.principal
-    ? localizeContent(dayCalendar.principal.entry.name)
-    : undefined
-
-  const preview = gospel.text.length > 180 ? `${gospel.text.slice(0, 180)}...` : gospel.text
+  const dayIndex = Math.floor(today.getTime() / dayMs)
+  const image = evangelistArtFor(gospel.citation, dayIndex)
+  const tone = toneForKey('gospel-of-the-day')
+  const preview = gospel.text.length > 180 ? `${gospel.text.slice(0, 180).trimEnd()}…` : gospel.text
+  const title = gospel.citation ?? t('bible.discovery.gospelOfTheDay')
 
   return (
     <AnimatedPressable
@@ -74,44 +43,49 @@ export function GospelOfTheDay() {
       accessibilityLabel={t('bible.discovery.gospelOfTheDay')}
     >
       <YStack
-        backgroundColor="$backgroundSurface"
-        borderRadius="$lg"
-        padding="$md"
-        gap="$sm"
-        borderWidth={1}
-        borderColor="$borderColor"
+        height={340}
+        borderRadius={18}
+        overflow="hidden"
+        backgroundColor={tone.from}
+        justifyContent="flex-end"
       >
-        <XStack gap="$sm" alignItems="center">
-          <YStack
-            width={32}
-            height={32}
-            alignItems="center"
-            justifyContent="center"
-            backgroundColor="$accentSubtle"
-            borderRadius="$md"
+        {image && (
+          <Image
+            source={image}
+            style={StyleSheet.absoluteFill}
+            contentFit="cover"
+            transition={250}
+            cachePolicy="memory-disk"
+          />
+        )}
+        <YStack
+          padding="$lg"
+          gap="$xs"
+          backgroundColor={image ? 'rgba(0,0,0,0.42)' : 'transparent'}
+        >
+          <Typography
+            variant="marker"
+            textAlign="left"
+            color={blockLabelInk}
+            fontSize="$1"
+            letterSpacing={2}
           >
-            <BookOpen size={18} color={theme.accent.val} />
-          </YStack>
-          <Text fontFamily="$heading" fontSize="$2" color="$accent" letterSpacing={1}>
-            {t('bible.discovery.gospelOfTheDay').toUpperCase()}
-          </Text>
-        </XStack>
-
-        {celebrationName && (
-          <Text fontFamily="$heading" fontSize="$3" color="$color">
-            {celebrationName}
-          </Text>
-        )}
-
-        {gospel.citation && (
-          <Text fontFamily="$body" fontSize="$2" color="$colorSecondary" fontStyle="italic">
-            {gospel.citation}
-          </Text>
-        )}
-
-        <Text fontFamily="$body" fontSize="$2" color="$colorSecondary" numberOfLines={3}>
-          {preview}
-        </Text>
+            {t('bible.discovery.gospelOfTheDay')}
+          </Typography>
+          <Typography
+            variant="sacred-title"
+            textAlign="left"
+            color={blockInk}
+            fontSize={30}
+            lineHeight={34}
+            numberOfLines={2}
+          >
+            {title}
+          </Typography>
+          <Typography variant="whisper" color="rgba(245,239,226,0.82)" numberOfLines={3}>
+            {preview}
+          </Typography>
+        </YStack>
       </YStack>
     </AnimatedPressable>
   )

--- a/apps/app/src/features/bible/components/OpenBibleCard.tsx
+++ b/apps/app/src/features/bible/components/OpenBibleCard.tsx
@@ -1,14 +1,16 @@
 import { useRouter } from 'expo-router'
-import { Book } from 'lucide-react-native'
+import { BookOpen } from 'lucide-react-native'
 import { useTranslation } from 'react-i18next'
-import { Text, useTheme, XStack, YStack } from 'tamagui'
+import { XStack, YStack } from 'tamagui'
 
 import { AnimatedPressable } from '@/components'
+import { Typography } from '@/components/typography'
+import { blockInk, toneForKey } from '@/features/explore/bgColor'
 
 export function OpenBibleCard() {
   const { t } = useTranslation()
   const router = useRouter()
-  const theme = useTheme()
+  const tone = toneForKey('bible-reader')
 
   return (
     <AnimatedPressable
@@ -16,33 +18,39 @@ export function OpenBibleCard() {
       accessibilityRole="link"
       accessibilityLabel={t('bible.discovery.openBible')}
     >
-      <XStack
-        backgroundColor="$backgroundSurface"
-        borderRadius="$lg"
-        padding="$md"
-        gap="$md"
-        alignItems="center"
-        borderWidth={1}
-        borderColor="$borderColor"
-      >
+      <XStack backgroundColor="$backgroundSurface" borderRadius="$md" overflow="hidden">
         <YStack
-          width={36}
-          height={36}
+          width={96}
+          alignSelf="stretch"
+          backgroundColor={tone.from}
           alignItems="center"
           justifyContent="center"
-          backgroundColor="$accentSubtle"
-          borderRadius="$md"
         >
-          <Book size={20} color={theme.accent.val} />
+          <BookOpen size={28} color={blockInk} strokeWidth={1.4} />
         </YStack>
-        <YStack flex={1} gap={2}>
-          <Text fontFamily="$heading" fontSize="$3" color="$color">
+        <YStack
+          flex={1}
+          gap={4}
+          paddingVertical="$md"
+          paddingHorizontal="$md"
+          justifyContent="center"
+        >
+          <Typography
+            variant="marker"
+            textAlign="left"
+            color="$accent"
+            fontSize="$1"
+            letterSpacing={1.5}
+          >
+            {t('bible.discovery.openBibleLabel')}
+          </Typography>
+          <Typography variant="sacred-title" textAlign="left" fontSize="$3" color="$color">
             {t('bible.discovery.openBible')}
-          </Text>
+          </Typography>
+          <Typography variant="whisper" fontSize="$1" color="$colorSecondary" numberOfLines={1}>
+            {t('bible.discovery.openBibleHint')}
+          </Typography>
         </YStack>
-        <Text fontFamily="$body" fontSize="$2" color="$colorSecondary">
-          ›
-        </Text>
       </XStack>
     </AnimatedPressable>
   )

--- a/apps/app/src/features/bible/components/ThemedReadings.tsx
+++ b/apps/app/src/features/bible/components/ThemedReadings.tsx
@@ -1,23 +1,29 @@
-import { useRouter } from 'expo-router'
+import { Link } from 'expo-router'
 import {
+  Anchor,
+  BookOpen,
   Flame,
   HandHeart,
   Heart,
   type LucideIcon,
   Shield,
-  Smile,
   Sparkles,
   Sun,
   Waves,
 } from 'lucide-react-native'
 import { useTranslation } from 'react-i18next'
-import { Text, useTheme, XStack, YStack } from 'tamagui'
+import { useWindowDimensions } from 'react-native'
+import { Text, XStack, YStack } from 'tamagui'
 
-import { AnimatedPressable, SectionDivider } from '@/components'
+import { AnimatedPressable } from '@/components'
+import { Typography } from '@/components/typography'
 import { getAllManifests } from '@/content/resolver'
-import type { PracticeManifest } from '@/content/types'
+import { type BlockTone, blockInk, toneForKey } from '@/features/explore/bgColor'
 import { localizeContent } from '@/lib/i18n'
 
+// Per-theme icon, matched on the practice id suffix. Keeps the semantic of the
+// pre-facelift grid (Waves = anxiety, Shield = courage…) so a glance still tells
+// you what each tile is — abstract versal letters were too quiet here.
 const themeIcons: Record<string, LucideIcon> = {
   'scripture-anxiety': Waves,
   'scripture-gratitude': Sun,
@@ -25,90 +31,114 @@ const themeIcons: Record<string, LucideIcon> = {
   'scripture-joy': Sparkles,
   'scripture-forgiveness': HandHeart,
   'scripture-courage': Shield,
-  'scripture-trust': Heart,
-  'scripture-love': Smile,
+  // Anchor of the soul (Heb. 6:19) — trust as a steady anchor, freeing Heart
+  // for love (its more universal symbol).
+  'scripture-trust': Anchor,
+  'scripture-love': Heart,
 }
 
 function resolveIcon(id: string): LucideIcon {
   for (const [key, icon] of Object.entries(themeIcons)) {
     if (id.endsWith(key)) return icon
   }
-  return Sparkles
+  return BookOpen
 }
 
-function ScriptureTile({ manifest, onPress }: { manifest: PracticeManifest; onPress: () => void }) {
-  const theme = useTheme()
-  const Icon = resolveIcon(manifest.id)
-  const name = localizeContent(manifest.name)
+const columns = 2
+const gutter = 14
 
-  return (
-    <AnimatedPressable
-      onPress={onPress}
-      style={{ width: '48%' }}
-      accessibilityRole="link"
-      accessibilityLabel={name}
-    >
-      <YStack
-        backgroundColor="$backgroundSurface"
-        borderRadius="$lg"
-        padding="$md"
-        gap="$sm"
-        borderWidth={1}
-        borderColor="$borderColor"
-        aspectRatio={1}
-        justifyContent="center"
-        alignItems="center"
-      >
-        <Icon size={28} color={theme.accent.val} />
-        <Text fontFamily="$heading" fontSize="$3" color="$color" textAlign="center">
-          {name}
-        </Text>
-      </YStack>
-    </AnimatedPressable>
-  )
+function useCardSize(): number {
+  const { width } = useWindowDimensions()
+  const content = Math.min(width, 640) - 24 * 2
+  return Math.floor((content - gutter * (columns - 1)) / columns)
 }
 
 export function ThemedReadings() {
   const { t } = useTranslation()
-  const router = useRouter()
+  const size = useCardSize()
 
+  // Drop Gospel of the Day — it already has its own hero card above this grid.
+  // `endsWith` covers bare ids and any future namespace prefix (`practice/…`).
   const scripturePractices = getAllManifests().filter(
-    (m) =>
-      m.categories?.includes('scripture') &&
-      m.id !== 'gospel-of-the-day' &&
-      !m.id.endsWith(':gospel-of-the-day'),
+    (m) => m.categories?.includes('scripture') && !m.id.endsWith('gospel-of-the-day'),
   )
 
   if (scripturePractices.length === 0) return null
 
   return (
-    <>
-      <SectionDivider />
-      <YStack gap="$sm">
-        <Text
-          fontFamily="$heading"
-          fontSize="$2"
-          color="$colorSecondary"
-          textTransform="uppercase"
-          letterSpacing={1}
+    <YStack gap="$md">
+      <Typography
+        variant="marker"
+        textAlign="left"
+        color="$colorSecondary"
+        fontSize="$1"
+        letterSpacing={1.5}
+      >
+        {t('bible.discovery.themedReadings')}
+      </Typography>
+      <XStack flexWrap="wrap" gap={gutter}>
+        {scripturePractices.map((manifest) => (
+          <ThemeTile
+            key={manifest.id}
+            id={manifest.id}
+            title={localizeContent(manifest.name)}
+            tone={toneForKey(manifest.id)}
+            size={size}
+          />
+        ))}
+      </XStack>
+    </YStack>
+  )
+}
+
+function ThemeTile({
+  id,
+  title,
+  tone,
+  size,
+}: {
+  id: string
+  title: string
+  tone: BlockTone
+  size: number
+}) {
+  const Icon = resolveIcon(id)
+  const iconSize = Math.round(size * 0.28)
+
+  return (
+    <Link
+      href={{ pathname: '/pray/[practiceId]', params: { practiceId: id } }}
+      asChild
+      accessibilityLabel={title}
+    >
+      <AnimatedPressable accessibilityRole="link" accessibilityLabel={title}>
+        <YStack
+          width={size}
+          height={size}
+          borderRadius={14}
+          overflow="hidden"
+          backgroundColor={tone.from}
+          alignItems="center"
+          justifyContent="center"
+          padding="$md"
+          gap="$sm"
+          shadowColor="#000"
+          shadowOffset={{ width: 0, height: 6 }}
+          shadowOpacity={0.18}
+          shadowRadius={12}
         >
-          {t('bible.discovery.themedReadings')}
-        </Text>
-        <XStack flexWrap="wrap" gap="$sm" justifyContent="space-between">
-          {scripturePractices.map((manifest) => (
-            <ScriptureTile
-              key={manifest.id}
-              manifest={manifest}
-              onPress={() =>
-                router.push({
-                  pathname: '/pray/[practiceId]',
-                  params: { practiceId: manifest.id },
-                })
-              }
-            />
-          ))}
-        </XStack>
-      </YStack>
-    </>
+          <Icon size={iconSize} color={blockInk} strokeWidth={1.2} />
+          <Text
+            fontFamily="$heading"
+            fontSize="$3"
+            color={blockInk}
+            textAlign="center"
+            numberOfLines={2}
+          >
+            {title}
+          </Text>
+        </YStack>
+      </AnimatedPressable>
+    </Link>
   )
 }

--- a/apps/app/src/lib/i18n/locales/en-US.ts
+++ b/apps/app/src/lib/i18n/locales/en-US.ts
@@ -957,6 +957,8 @@ export default {
       themedReadings: 'Find Something to Read',
       continueReading: 'Continue Reading',
       openBible: 'Browse the Bible',
+      openBibleLabel: 'The Word',
+      openBibleHint: 'Old & New Testaments, by book',
     },
   },
 

--- a/apps/app/src/lib/i18n/locales/pt-BR.ts
+++ b/apps/app/src/lib/i18n/locales/pt-BR.ts
@@ -965,6 +965,8 @@ export default {
       themedReadings: 'Encontre Algo para Ler',
       continueReading: 'Continuar Leitura',
       openBible: 'Navegar na Bíblia',
+      openBibleLabel: 'A Palavra',
+      openBibleHint: 'Antigo e Novo Testamento, por livro',
     },
   },
 

--- a/content/practices/scripture-anxiety/flow.json
+++ b/content/practices/scripture-anxiety/flow.json
@@ -8,7 +8,7 @@
 			}
 		},
 		{
-			"type": "select",
+			"type": "options",
 			"label": {
 				"en-US": "Passage",
 				"pt-BR": "Passagem"
@@ -66,7 +66,8 @@
 						}
 					]
 				}
-			]
+			],
+			"pickerStyle": "cards"
 		}
 	]
 }

--- a/content/practices/scripture-courage/flow.json
+++ b/content/practices/scripture-courage/flow.json
@@ -8,7 +8,7 @@
 			}
 		},
 		{
-			"type": "select",
+			"type": "options",
 			"label": {
 				"en-US": "Passage",
 				"pt-BR": "Passagem"
@@ -66,7 +66,8 @@
 						}
 					]
 				}
-			]
+			],
+			"pickerStyle": "cards"
 		}
 	]
 }

--- a/content/practices/scripture-forgiveness/flow.json
+++ b/content/practices/scripture-forgiveness/flow.json
@@ -8,7 +8,7 @@
 			}
 		},
 		{
-			"type": "select",
+			"type": "options",
 			"label": {
 				"en-US": "Passage",
 				"pt-BR": "Passagem"
@@ -66,7 +66,8 @@
 						}
 					]
 				}
-			]
+			],
+			"pickerStyle": "cards"
 		}
 	]
 }

--- a/content/practices/scripture-gratitude/flow.json
+++ b/content/practices/scripture-gratitude/flow.json
@@ -8,7 +8,7 @@
 			}
 		},
 		{
-			"type": "select",
+			"type": "options",
 			"label": {
 				"en-US": "Passage",
 				"pt-BR": "Passagem"
@@ -66,7 +66,8 @@
 						}
 					]
 				}
-			]
+			],
+			"pickerStyle": "cards"
 		}
 	]
 }

--- a/content/practices/scripture-joy/flow.json
+++ b/content/practices/scripture-joy/flow.json
@@ -8,7 +8,7 @@
 			}
 		},
 		{
-			"type": "select",
+			"type": "options",
 			"label": {
 				"en-US": "Passage",
 				"pt-BR": "Passagem"
@@ -66,7 +66,8 @@
 						}
 					]
 				}
-			]
+			],
+			"pickerStyle": "cards"
 		}
 	]
 }

--- a/content/practices/scripture-love/flow.json
+++ b/content/practices/scripture-love/flow.json
@@ -8,7 +8,7 @@
 			}
 		},
 		{
-			"type": "select",
+			"type": "options",
 			"label": {
 				"en-US": "Passage",
 				"pt-BR": "Passagem"
@@ -66,7 +66,8 @@
 						}
 					]
 				}
-			]
+			],
+			"pickerStyle": "cards"
 		}
 	]
 }

--- a/content/practices/scripture-suffering/flow.json
+++ b/content/practices/scripture-suffering/flow.json
@@ -8,7 +8,7 @@
 			}
 		},
 		{
-			"type": "select",
+			"type": "options",
 			"label": {
 				"en-US": "Passage",
 				"pt-BR": "Passagem"
@@ -66,7 +66,8 @@
 						}
 					]
 				}
-			]
+			],
+			"pickerStyle": "cards"
 		}
 	]
 }

--- a/content/practices/scripture-trust/flow.json
+++ b/content/practices/scripture-trust/flow.json
@@ -8,7 +8,7 @@
 			}
 		},
 		{
-			"type": "select",
+			"type": "options",
 			"label": {
 				"en-US": "Passage",
 				"pt-BR": "Passagem"
@@ -66,7 +66,8 @@
 						}
 					]
 				}
-			]
+			],
+			"pickerStyle": "cards"
 		}
 	]
 }


### PR DESCRIPTION
## Summary
- Promotes the Sacred Scripture page into the same art-rich register as Dies Domini and All Collections: Gospel of the Day is now a 340px editorial hero with the day's evangelist painting, Continue Reading + Browse the Bible become mini-hero rows, and the themed-readings grid keeps the per-theme Lucide icon (cream-on-jewel-tone) — easier to scan than versal letters.
- Swaps the themed `select` block in each `scripture-*` flow for `type: "options"` + `pickerStyle: "cards"` — the fancier passage picker Mass already uses for greetings, eucharistic prayers, and aspersion antiphons.
- Icon swaps: `love` → Heart (was Smile); `trust` → Anchor (anchor of the soul, Heb. 6:19) — freeing Heart for love. Broadens the Gospel-of-the-Day filter to `endsWith('gospel-of-the-day')` so the hero practice never appears in the themed grid.

## Test plan
- [ ] Open the Sacred Scripture tab: Gospel hero shows today's evangelist painting (Matthew/Mark/Luke/John rotation), citation + preview legible over the scrim.
- [ ] Scroll past the gospel hero: Continue Reading row only appears once you've moved past Genesis 1; Browse the Bible row always present.
- [ ] Themed-readings grid: icons match the theme (Waves/anxiety, Shield/courage, Heart/love, Anchor/trust, etc.), title sits inside the colored tile, Gospel of the Day not duplicated in the grid.
- [ ] Open any themed practice (e.g. Quando Ansioso, Coragem): passage picker renders as full-width cards with the label on each card, instead of small chip tabs.
- [ ] pt-BR locale: hero label, "A Palavra" / "Antigo e Novo Testamento, por livro" hint on the Browse row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)