### PR TITLE
Add Catholic Classics podcast (Ascension) as a creator

### DIFF
--- a/content/creators/catholic-classics/manifest.json
+++ b/content/creators/catholic-classics/manifest.json
@@ -1,0 +1,27 @@
+{
+  "name": {
+    "en-US": "Catholic Classics",
+    "pt-BR": "Catholic Classics"
+  },
+  "byline": {
+    "en-US": "Ascension · Reading the great Catholic spiritual writings"
+  },
+  "bio": {
+    "en-US": "Each season, a Catholic priest reads through a great Catholic spiritual writing with insightful commentary and practical guidance. Hosts have included Fr. Mike Schmitz, Fr. Gregory Pine, OP, Fr. Jacob Bertrand Mary, and Fr. Michael-Joseph Paris. Produced by Ascension."
+  },
+  "languages": ["en-US"],
+  "charism": "lay",
+  "role": "lay-theologian",
+  "channels": [
+    {
+      "kind": "podcast",
+      "feedUrl": "https://feeds.fireside.fm/catholicclassics/rss",
+      "format": "lecture",
+      "title": { "en-US": "Catholic Classics" }
+    }
+  ],
+  "links": {
+    "website": "https://catholicclassics.fireside.fm"
+  },
+  "tags": ["spiritual-classics", "formation", "commentary"]
+}


### PR DESCRIPTION
## Summary
- Adds the **Catholic Classics** podcast as a new creator at `content/creators/catholic-classics/manifest.json`.
- Ascension-produced show that reads through a great Catholic spiritual writing each season (current: *The Practice of the Presence of God*), with rotating priest hosts (Fr. Mike Schmitz, Fr. Gregory Pine OP, Fr. Jacob Bertrand Mary, Fr. Michael-Joseph Paris).
- Single podcast channel (`https://feeds.fireside.fm/catholicclassics/rss`), `format: lecture`. Channel image + shorts list will populate automatically on the next `build-creator-meta.py` CI run.

## Test plan
- [ ] `pnpm build:corpus` succeeds and the catalog includes `creator/catholic-classics`.
- [ ] After Hearth deploy, the creator appears in the in-app Creators directory with avatar + bio.
- [ ] Opening the profile renders the Listen tab with episodes from the Fireside RSS feed.