### PR TITLE
Opus Dei template: hook up Preces, add Three Hail Marys + Friday mortification

### DIFF
--- a/content/plan-of-life-templates/opus-dei.json
+++ b/content/plan-of-life-templates/opus-dei.json
@@ -116,34 +116,19 @@
       }
     },
     {
-      "placeholder": true,
-      "name": {
-        "en-US": "The Preces",
-        "pt-BR": "As Preces"
-      },
+      "ref": "preces-opus-dei",
       "tier": "essential",
-      "cadence": {
-        "en-US": "Daily",
-        "pt-BR": "Diário"
-      },
-      "icon": "scroll",
+      "schedule": { "type": "daily" },
       "note": {
         "en-US": "The vocal prayers of the Work, prayed each day — a litany that binds the member to the whole of Opus Dei, to the Church, the Pope, and the souls entrusted to its apostolate.",
         "pt-BR": "As orações vocais da Obra, rezadas a cada dia — uma ladainha que une o membro a todo o Opus Dei, à Igreja, ao Papa e às almas confiadas ao seu apostolado."
       }
     },
     {
-      "placeholder": true,
-      "name": {
-        "en-US": "Three Hail Marys",
-        "pt-BR": "Três Ave-Marias"
-      },
+      "ref": "three-hail-marys-opus-dei",
       "tier": "ideal",
-      "cadence": {
-        "en-US": "Daily, before sleep",
-        "pt-BR": "Diário, antes de dormir"
-      },
-      "icon": "rosary",
+      "schedule": { "type": "daily" },
+      "time": "22:30",
       "note": {
         "en-US": "Three Hail Marys before sleep, asking Our Lady for the gift of holy purity to guard the day just ended and the one to come.",
         "pt-BR": "Três Ave-Marias antes de dormir, pedindo a Nossa Senhora o dom da santa pureza para guardar o dia que termina e o que há de vir."
@@ -167,17 +152,9 @@
       }
     },
     {
-      "placeholder": true,
-      "name": {
-        "en-US": "Friday mortification",
-        "pt-BR": "Mortificação de sexta-feira"
-      },
+      "ref": "friday-mortification",
       "tier": "ideal",
-      "cadence": {
-        "en-US": "Weekly, Friday",
-        "pt-BR": "Semanal, sexta-feira"
-      },
-      "icon": "cross",
+      "schedule": { "type": "days-of-week", "days": [5] },
       "note": {
         "en-US": "A penance offered each Friday in memory of the Passion — small, hidden, and concrete, so that love is proven in the body and not only intended.",
         "pt-BR": "Uma penitência oferecida em cada sexta-feira em memória da Paixão — pequena, oculta e concreta, para que o amor se prove no corpo e não fique apenas na intenção."

--- a/content/practices/friday-mortification/flow.json
+++ b/content/practices/friday-mortification/flow.json
@@ -1,0 +1,61 @@
+{
+	"sections": [
+		{
+			"type": "subheading",
+			"text": {
+				"en-US": "In memory of the Passion",
+				"pt-BR": "Em memória da Paixão"
+			}
+		},
+		{
+			"type": "rubric",
+			"text": {
+				"en-US": "Friday is the day Christ died. The Church asks every Friday a small penance of her faithful — and the spirit of Opus Dei asks that it be hidden, constant, and concrete. Not a great gesture; a real one.",
+				"pt-BR": "A sexta-feira é o dia em que Cristo morreu. A Igreja pede em cada sexta-feira uma pequena penitência aos seus fiéis — e o espírito do Opus Dei pede que ela seja oculta, constante e concreta. Não um gesto grandioso; um gesto real."
+			}
+		},
+		{
+			"type": "divider"
+		},
+		{
+			"type": "subheading",
+			"text": {
+				"en-US": "Small, hidden, concrete",
+				"pt-BR": "Pequena, oculta, concreta"
+			}
+		},
+		{
+			"type": "meditation",
+			"text": {
+				"en-US": "*That mortification of yours, that constant mortification… is worth more than great penances done by fits and starts.* (Camino §175)\n\nWhere will you mortify today? — food (a second helping refused, sweets passed by), comfort (the elevator skipped, the cold of the shower kept a moment longer), speech (a sharp word swallowed, a complaint not voiced), gaze (a screen put down, a glance held back), or time (five minutes given without grudge, a task done at once that you would rather delay).\n\nChoose one. Small. Hidden. Concrete.",
+				"pt-BR": "*Essa tua mortificação, essa mortificação constante… vale mais que grandes penitências por arrancos.* (Caminho §175)\n\nOnde você vai mortificar-se hoje? — na comida (uma segunda porção recusada, um doce dispensado), no conforto (o elevador deixado de lado, o frio do chuveiro mantido por mais um instante), na palavra (uma resposta áspera engolida, uma queixa não dita), no olhar (uma tela deixada de lado, um olhar contido) ou no tempo (cinco minutos dados sem ranço, uma tarefa feita já, que você adiaria).\n\nEscolha uma. Pequena. Oculta. Concreta."
+			}
+		},
+		{
+			"type": "capture-resolution",
+			"level": "daily",
+			"for": "current",
+			"prompt": {
+				"en-US": "Your mortification for this Friday.",
+				"pt-BR": "Sua mortificação desta sexta-feira."
+			}
+		},
+		{
+			"type": "divider"
+		},
+		{
+			"type": "subheading",
+			"text": {
+				"en-US": "Offering",
+				"pt-BR": "Oferecimento"
+			}
+		},
+		{
+			"type": "prayer",
+			"inline": {
+				"en-US": "All for You, Jesus crucified.\nFor love of You, and through the Heart of Your Mother,\nI offer this small thing in union with Your Passion —\nfor the Church, for souls, and for the cleansing of my own.\nAmen.",
+				"pt-BR": "Tudo por Vós, Jesus crucificado.\nPor vosso amor, e pelo Coração de Vossa Mãe,\nofereço esta pequena coisa em união à vossa Paixão —\npela Igreja, pelas almas e pela purificação da minha.\nAmém."
+			}
+		}
+	]
+}

--- a/content/practices/friday-mortification/manifest.json
+++ b/content/practices/friday-mortification/manifest.json
@@ -1,0 +1,39 @@
+{
+	"id": "friday-mortification",
+	"icon": "cross",
+	"source": {
+		"en-US": "St. Josemaría Escrivá, *The Way* (Camino) §§ 173, 175, 178, 186, 195 — *little mortifications*: hidden, constant, concrete; cf. *Furrow* §§ 988–989 on Friday penance. Friday penance as a universal duty of the faithful: CIC 1250–1253.",
+		"pt-BR": "São Josemaria Escrivá, *Caminho* §§ 173, 175, 178, 186, 195 — *pequenas mortificações*: ocultas, constantes, concretas; cf. *Sulco* §§ 988–989 sobre a penitência da sexta-feira. A penitência da sexta-feira como dever universal dos fiéis: CIC 1250–1253."
+	},
+	"name": {
+		"en-US": "Friday Mortification",
+		"pt-BR": "Mortificação de Sexta-Feira"
+	},
+	"categories": ["weekly", "penitential"],
+	"estimatedMinutes": 3,
+	"flowMode": "step",
+	"completion": "flow-end",
+	"flow": "flow.json",
+	"description": {
+		"en-US": "A small, hidden, concrete penance offered each Friday in memory of the Passion. Not the cilice or the discipline — broadly applicable mortification: food, comfort, speech, gaze, time. *Without mortification there is no happiness on earth* (Camino §186).",
+		"pt-BR": "Uma penitência pequena, oculta e concreta, oferecida em cada sexta-feira em memória da Paixão. Não o cilício nem a disciplina — uma mortificação amplamente aplicável: comida, conforto, palavra, olhar, tempo. *Sem mortificação não há felicidade na terra* (Caminho §186)."
+	},
+	"history": {
+		"en-US": "Friday penance is a duty of the universal Church (CIC 1250–1253), kept by the faithful since apostolic times in memory of the day Christ died. In the spirituality of Opus Dei, St. Josemaría insisted that the penance be *small, hidden, and concrete* — the *little mortifications* of *The Way*: a glance held back, a word swallowed, a comfort declined, a second helping refused. Done out of love, not pride, and never on display.",
+		"pt-BR": "A penitência da sexta-feira é um dever da Igreja universal (CIC 1250–1253), guardado pelos fiéis desde os tempos apostólicos em memória do dia em que Cristo morreu. Na espiritualidade do Opus Dei, São Josemaria insistia que a penitência fosse *pequena, oculta e concreta* — as *pequenas mortificações* de *Caminho*: um olhar contido, uma palavra retida, um conforto declinado, uma segunda porção recusada. Feita por amor, não por orgulho, e nunca em exibição."
+	},
+	"howToPray": {
+		"en-US": "Each Friday, recall briefly the Passion of Christ. Choose one concrete mortification for the day — small enough that no one sees it, real enough that you feel it. Note it down. Offer it with a short aspiration through the day, and renew the offering when it costs.",
+		"pt-BR": "A cada sexta-feira, recorde brevemente a Paixão de Cristo. Escolha uma mortificação concreta para o dia — pequena o bastante para ninguém ver, real o bastante para você sentir. Anote-a. Ofereça-a com uma breve jaculatória ao longo do dia, e renove o oferecimento quando custar."
+	},
+	"tags": ["opus-dei", "friday", "penance", "passion", "weekly"],
+	"defaults": {
+		"sortOrder": 12,
+		"slots": [
+			{
+				"schedule": { "type": "days-of-week", "days": [5] },
+				"tier": "ideal"
+			}
+		]
+	}
+}

--- a/content/practices/three-hail-marys-opus-dei/flow.json
+++ b/content/practices/three-hail-marys-opus-dei/flow.json
@@ -8,25 +8,37 @@
 			}
 		},
 		{
-			"type": "prayer",
-			"inline": {
-				"en-US": "For purity of body:\n\nHail Mary, full of grace, the Lord is with thee; blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus. Holy Mary, Mother of God, pray for us sinners, now and at the hour of our death. Amen.",
-				"pt-BR": "Pela pureza do corpo:\n\nAve Maria, cheia de graça, o Senhor é convosco; bendita sois Vós entre as mulheres, e bendito é o fruto do vosso ventre, Jesus. Santa Maria, Mãe de Deus, rogai por nós, pecadores, agora e na hora de nossa morte. Amém."
+			"type": "rubric",
+			"text": {
+				"en-US": "For purity of body.",
+				"pt-BR": "Pela pureza do corpo."
 			}
 		},
 		{
 			"type": "prayer",
-			"inline": {
-				"en-US": "For purity of mind:\n\nHail Mary, full of grace, the Lord is with thee; blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus. Holy Mary, Mother of God, pray for us sinners, now and at the hour of our death. Amen.",
-				"pt-BR": "Pela pureza da mente:\n\nAve Maria, cheia de graça, o Senhor é convosco; bendita sois Vós entre as mulheres, e bendito é o fruto do vosso ventre, Jesus. Santa Maria, Mãe de Deus, rogai por nós, pecadores, agora e na hora de nossa morte. Amém."
+			"ref": "hail-mary"
+		},
+		{
+			"type": "rubric",
+			"text": {
+				"en-US": "For purity of mind.",
+				"pt-BR": "Pela pureza da mente."
 			}
 		},
 		{
 			"type": "prayer",
-			"inline": {
-				"en-US": "For purity of heart:\n\nHail Mary, full of grace, the Lord is with thee; blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus. Holy Mary, Mother of God, pray for us sinners, now and at the hour of our death. Amen.",
-				"pt-BR": "Pela pureza do coração:\n\nAve Maria, cheia de graça, o Senhor é convosco; bendita sois Vós entre as mulheres, e bendito é o fruto do vosso ventre, Jesus. Santa Maria, Mãe de Deus, rogai por nós, pecadores, agora e na hora de nossa morte. Amém."
+			"ref": "hail-mary"
+		},
+		{
+			"type": "rubric",
+			"text": {
+				"en-US": "For purity of heart.",
+				"pt-BR": "Pela pureza do coração."
 			}
+		},
+		{
+			"type": "prayer",
+			"ref": "hail-mary"
 		},
 		{
 			"type": "prayer",

--- a/content/practices/three-hail-marys-opus-dei/flow.json
+++ b/content/practices/three-hail-marys-opus-dei/flow.json
@@ -1,0 +1,39 @@
+{
+	"sections": [
+		{
+			"type": "rubric",
+			"text": {
+				"en-US": "Before sleep, three Hail Marys to Our Lady for the gift of holy purity — the counsel St. Josemaría gave again and again. Pray them slowly, recalling that you are a child of God and that she is watching over you.",
+				"pt-BR": "Antes de dormir, três Ave-Marias a Nossa Senhora pelo dom da santa pureza — o conselho que São Josemaria dava uma e outra vez. Reze-as pausadamente, recordando que você é filho de Deus e que ela vela por você."
+			}
+		},
+		{
+			"type": "prayer",
+			"inline": {
+				"en-US": "For purity of body:\n\nHail Mary, full of grace, the Lord is with thee; blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus. Holy Mary, Mother of God, pray for us sinners, now and at the hour of our death. Amen.",
+				"pt-BR": "Pela pureza do corpo:\n\nAve Maria, cheia de graça, o Senhor é convosco; bendita sois Vós entre as mulheres, e bendito é o fruto do vosso ventre, Jesus. Santa Maria, Mãe de Deus, rogai por nós, pecadores, agora e na hora de nossa morte. Amém."
+			}
+		},
+		{
+			"type": "prayer",
+			"inline": {
+				"en-US": "For purity of mind:\n\nHail Mary, full of grace, the Lord is with thee; blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus. Holy Mary, Mother of God, pray for us sinners, now and at the hour of our death. Amen.",
+				"pt-BR": "Pela pureza da mente:\n\nAve Maria, cheia de graça, o Senhor é convosco; bendita sois Vós entre as mulheres, e bendito é o fruto do vosso ventre, Jesus. Santa Maria, Mãe de Deus, rogai por nós, pecadores, agora e na hora de nossa morte. Amém."
+			}
+		},
+		{
+			"type": "prayer",
+			"inline": {
+				"en-US": "For purity of heart:\n\nHail Mary, full of grace, the Lord is with thee; blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus. Holy Mary, Mother of God, pray for us sinners, now and at the hour of our death. Amen.",
+				"pt-BR": "Pela pureza do coração:\n\nAve Maria, cheia de graça, o Senhor é convosco; bendita sois Vós entre as mulheres, e bendito é o fruto do vosso ventre, Jesus. Santa Maria, Mãe de Deus, rogai por nós, pecadores, agora e na hora de nossa morte. Amém."
+			}
+		},
+		{
+			"type": "prayer",
+			"inline": {
+				"en-US": "Mater purissima, ora pro nobis.\nMother most pure, pray for us.",
+				"pt-BR": "Mater purissima, ora pro nobis.\nMãe puríssima, rogai por nós."
+			}
+		}
+	]
+}

--- a/content/practices/three-hail-marys-opus-dei/manifest.json
+++ b/content/practices/three-hail-marys-opus-dei/manifest.json
@@ -1,0 +1,51 @@
+{
+	"id": "three-hail-marys-opus-dei",
+	"icon": "rosary",
+	"alternativeTo": {
+		"id": "three-hail-marys",
+		"label": {
+			"en-US": "Opus Dei (for purity, before sleep)",
+			"pt-BR": "Opus Dei (pela pureza, antes de dormir)"
+		},
+		"description": {
+			"en-US": "Three Hail Marys prayed each night asking Our Lady for the gift of holy purity — the counsel St. Josemaría gave again and again.",
+			"pt-BR": "Três Ave-Marias rezadas a cada noite pedindo a Nossa Senhora o dom da santa pureza — o conselho que São Josemaria deu uma e outra vez."
+		}
+	},
+	"source": {
+		"en-US": "St. Josemaría Escrivá, *The Way* (Camino) §514 — *My son, every day pray three Hail Marys to Our Lady for your purity*; cf. §§ 174, 282. Closing aspiration *Mater purissima* from the Litany of Loreto.",
+		"pt-BR": "São Josemaria Escrivá, *Caminho* §514 — *Filhinho meu, reza todos os dias três Ave-Marias a Nossa Senhora pela tua pureza*; cf. §§ 174, 282. Jaculatória final *Mãe puríssima* da Ladainha de Loreto."
+	},
+	"name": {
+		"en-US": "Three Hail Marys (Opus Dei)",
+		"pt-BR": "Três Ave-Marias (Opus Dei)"
+	},
+	"categories": ["daily", "marian"],
+	"estimatedMinutes": 2,
+	"flowMode": "scroll",
+	"completion": "flow-end",
+	"flow": "flow.json",
+	"description": {
+		"en-US": "Three Hail Marys prayed before sleep, asking Our Lady for the gift of holy purity — a counsel St. Josemaría gave continually to those who came to him for spiritual direction.",
+		"pt-BR": "Três Ave-Marias rezadas antes de dormir, pedindo a Nossa Senhora o dom da santa pureza — conselho que São Josemaria dava continuamente aos que iam até ele em direção espiritual."
+	},
+	"history": {
+		"en-US": "Among the counsels St. Josemaría repeated most often to his spiritual children was the nightly prayer of three Hail Marys for holy purity. *Camino* §514 puts it plainly: *My son, every day pray three Hail Marys to Our Lady for your purity, that you may close the night clean and rise unstained.* The practice predates Opus Dei in popular Spanish devotion, but Escrivá made it the small Marian seal of every member's day — short, hidden, and never to be omitted.",
+		"pt-BR": "Entre os conselhos que São Josemaria repetia com mais insistência aos seus filhos espirituais estava a oração noturna de três Ave-Marias pela santa pureza. *Caminho* §514 o diz com simplicidade: *Filhinho meu, reza todos os dias três Ave-Marias a Nossa Senhora pela tua pureza, para que feches a noite limpo e te levantes sem mancha.* A prática é anterior ao Opus Dei na devoção popular espanhola, mas Escrivá fez dela o pequeno selo mariano do dia de cada membro — breve, oculto e nunca a ser omitido."
+	},
+	"howToPray": {
+		"en-US": "At the end of the day, before sleep, recall briefly that you are a child of God and that Our Lady guards your purity. Pray three Hail Marys slowly, asking her for purity of body, of mind, and of heart. Close with the aspiration *Mater purissima, ora pro nobis.*",
+		"pt-BR": "Ao final do dia, antes de dormir, recorde brevemente que você é filho de Deus e que Nossa Senhora guarda a sua pureza. Reze três Ave-Marias pausadamente, pedindo-lhe pureza de corpo, de mente e de coração. Encerre com a jaculatória *Mãe puríssima, rogai por nós.*"
+	},
+	"tags": ["opus-dei", "marian", "night", "purity", "josemaria"],
+	"defaults": {
+		"sortOrder": 9,
+		"slots": [
+			{
+				"schedule": { "type": "daily" },
+				"time": "22:30",
+				"tier": "ideal"
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

- **Preces placeholder → real ref** to the existing `preces-opus-dei` practice (already fully authored in PR #247, the template just never got swapped over).
- **New `three-hail-marys-opus-dei`** — bedtime Marian variant *for purity*, modeled on the `morning-offering-opus-dei` precedent from PR #249 (`alternativeTo` swap-on-adopt). Sources: *Camino* §514, Litany of Loreto.
- **New `friday-mortification`** — step-mode reflection (rubric → meditation on *small, hidden, concrete* penance → `capture-resolution` → "All for You, Jesus crucified" offering). Sources: *Camino* §§ 173, 175, 178, 186, 195; *Sulco* §§ 988–989; CIC 1250–1253. Scheduled `days-of-week: [5]`.

Three remaining placeholders (Circle of formation, Day of recollection, Annual retreat) stay as placeholders — they're real-world commitments and events, not prayer flows the app should host.

## Test plan

- [x] `pnpm build:corpus` clean — all three target practice ids (`preces-opus-dei`, `three-hail-marys-opus-dei`, `friday-mortification`) present in catalog
- [x] OD template still has exactly 3 `placeholder: true` entries (the right ones)
- [ ] Adopt the OD plan and verify the three newly-real practices no longer show "coming soon" badges
- [ ] Walk each new flow end-to-end in `en-US` and `pt-BR`:
  - Three Hail Marys (OD): scroll-mode, 3 Aves + Mater purissima closes cleanly
  - Friday mortification: steps advance, capture-resolution accepts input, offering shows
- [ ] Confirm `three-hail-marys-opus-dei` appears as a variant of `three-hail-marys` in the swap-on-adopt UI (matching morning-offering behavior)