### PR TITLE
Fix: edge-swipe back from book detail skips collection

### DIFF
--- a/apps/app/src/app/(tabs)/(today,explore,library,you,search)/browse/_layout.tsx
+++ b/apps/app/src/app/(tabs)/(today,explore,library,you,search)/browse/_layout.tsx
@@ -9,8 +9,6 @@ export default function LibraryLayout() {
         headerShown: false,
         contentStyle: { backgroundColor: theme.background.val },
       }}
-    >
-      <Stack.Screen name="book" options={{ gestureEnabled: false }} />
-    </Stack>
+    />
   )
 }


### PR DESCRIPTION
## Summary
- Drop the leftover `gestureEnabled: false` override on the `book` nested layout in `(today,explore,library,you,search)/browse/_layout.tsx`.
- The override dated from when `/browse/book/[bookId]` *was* the reader (Hearth v2). Since the book-reader v2 refactor split it into `[bookId]/index` (detail) + `[bookId]/read` (fullScreenModal), the override only served to refuse the edge-swipe at the browse-stack layer, so the gesture fell through to the outer five-tab array-group stack and popped to the tab anchor (`/search`) instead of the collection.
- The reader's own swipe-down-dismiss is owned by `READER_MODAL_OPTIONS` in `browse/book/_layout.tsx` and is unaffected.

## Test plan
- [ ] Search tab → type a query → tap a collection result → tap a book → edge-swipe from the left edge → lands on the collection (not on search).
- [ ] Same flow, but tap the chevron in `BookHero` instead → lands on the collection (regression check for `router.back()`).
- [ ] From a book detail, tap "Start reading" → swipe down on the reader → reader dismisses cleanly to the detail (reader gesture unchanged).
- [ ] Library tab → collection → book → edge-swipe back → lands on the collection.
- [ ] Open and close the reader several times, then tap around the frontispiece and other tabs — no taps-go-dead regression.