### PR TITLE
Book details TOC: make full row tappable

### DIFF
--- a/apps/app/src/app/(tabs)/(today,explore,library,you,search)/browse/book/[bookId]/index.tsx
+++ b/apps/app/src/app/(tabs)/(today,explore,library,you,search)/browse/book/[bookId]/index.tsx
@@ -353,6 +353,7 @@ function CompactSectionRow({
       onPress={() => router.push(buildHref(target))}
       accessibilityRole="link"
       accessibilityLabel={title}
+      style={{ width: '100%' }}
     >
       <XStack
         alignItems="center"
@@ -431,6 +432,7 @@ function TocNodeRow({
       onPress={() => router.push(buildHref(node.id))}
       accessibilityRole="link"
       accessibilityLabel={title}
+      style={{ width: '100%' }}
     >
       <XStack
         alignItems="center"


### PR DESCRIPTION
## Summary
- In the book details page, each TOC row was only tappable on the title text — empty space (and the gap before the chevron) silently missed the press.
- The wrapping `Pressable` was sizing to its content because React Native's `Pressable` doesn't stretch across the cross-axis of a column flex parent by default. Adding `style={{ width: '100%' }}` to both `TocNodeRow` and `CompactSectionRow` makes the entire row the hit target.

## Test plan
- [ ] Open a book details page with a TOC (e.g. any pinned book) and tap on the right-hand whitespace of a row — the reader opens.
- [ ] Same for the compact view (Catholic Encyclopedia or another 200+ node TOC).