### PR TITLE
Import Catechismo Maggiore 1905 (Italian) from Wikisource

### DIFF
--- a/content/books/pius-x-greater-catechism/book.json
+++ b/content/books/pius-x-greater-catechism/book.json
@@ -1,66 +1,96 @@
 {
   "id": "pius-x-greater-catechism",
   "name": {
-    "it": "Catechismo Maggiore"
+    "it": "Catechismo Maggiore",
+    "pt-BR": "Catecismo Maior",
+    "en-US": "Greater Catechism"
   },
   "author": {
-    "it": "San Pio X"
+    "it": "San Pio X",
+    "pt-BR": "São Pio X",
+    "en-US": "Pope Saint Pius X"
   },
   "description": {
-    "it": "Il Catechismo Maggiore promulgato da Papa San Pio X il 14 giugno 1905 per la Diocesi e Provincia di Roma. Edizione ampia in circa 993 domande e risposte, distinta dal più breve Catechismo della Dottrina Cristiana del 1912. Comprende l'Avvertenza, la lettera di promulgazione, le Orazioni quotidiane ed altre preci (preghiere del mattino e della sera, atti di fede/speranza/carità/contrizione, preparazione alla Confessione e alla Santa Comunione, misteri del Rosario, modo di servire la S. Messa), le Prime nozioni di catechismo, la Lezione preliminare e le cinque parti canoniche: Credo, Orazione, Comandamenti, Sacramenti, Virtù."
+    "it": "Il Catechismo Maggiore promulgato da Papa San Pio X il 14 giugno 1905 per la Diocesi e Provincia di Roma. Edizione ampia in circa 993 domande e risposte, distinta dal più breve Catechismo della Dottrina Cristiana del 1912. Comprende l'Avvertenza, la lettera di promulgazione, le Orazioni quotidiane ed altre preci (preghiere del mattino e della sera, atti di fede/speranza/carità/contrizione, preparazione alla Confessione e alla Santa Comunione, misteri del Rosario, modo di servire la S. Messa), le Prime nozioni di catechismo, la Lezione preliminare e le cinque parti canoniche: Credo, Orazione, Comandamenti, Sacramenti, Virtù.",
+    "pt-BR": "O Catecismo Maior promulgado pelo Papa São Pio X em 14 de junho de 1905 para a Diocese e Província de Roma. Edição ampla com cerca de 993 perguntas e respostas, distinta do Catecismo da Doutrina Cristã, mais breve, de 1912. Compreende a Advertência, a carta de promulgação, as Orações cotidianas e outras preces (orações da manhã e da noite, atos de fé/esperança/caridade/contrição, preparação para a Confissão e para a Sagrada Comunhão, mistérios do Rosário, modo de servir a Santa Missa), as Primeiras noções de catecismo, a Lição preliminar e as cinco partes canônicas: Credo, Oração, Mandamentos, Sacramentos, Virtudes.",
+    "en-US": "The Greater Catechism promulgated by Pope Saint Pius X on 14 June 1905 for the Diocese and Province of Rome. A full edition in roughly 993 questions and answers, distinct from the shorter Catechism of Christian Doctrine of 1912. Includes the editor's notice, the letter of promulgation, the Daily Prayers and other devotions (morning and evening prayers, acts of faith/hope/charity/contrition, preparation for Confession and Holy Communion, Mysteries of the Rosary, how to serve at Holy Mass), the First Notions of catechism, the Preliminary Lesson, and the five canonical Parts: Creed, Prayer, Commandments, Sacraments, Virtues."
   },
   "composed": 1905,
   "languages": [
-    "it"
+    "it",
+    "pt-BR",
+    "en-US"
   ],
   "sources": [
     {
       "language": "it",
       "url": "https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana",
       "description": "Trascrizione critica al 100% del Compendio della dottrina cristiana (Roma, 1905) su Wikisource italiano, comprensiva della lettera di promulgazione, delle Prime nozioni di catechismo e del Catechismo Maggiore integrale (Lezione preliminare e cinque parti)."
+    },
+    {
+      "language": "pt-BR",
+      "description": "Tradução para o português do Brasil baseada no original italiano canônico (Wikisource), produzida internamente para o Ember. Mantém alinhamento estrutural integral com o original (mesmas perguntas, mesma divisão em capítulos)."
+    },
+    {
+      "language": "en-US",
+      "description": "English translation from the canonical 1905 Italian (Wikisource), produced in-house for Ember to provide a complete edition — the widely circulated 1910 Hagan translation omits the front-matter daily-prayers section. Maintains full structural alignment with the original (same questions, same chapter divisions)."
     }
   ],
   "toc": [
     {
       "id": "avvertenza",
       "title": {
-        "it": "Avvertenza"
+        "it": "Avvertenza",
+        "pt-BR": "Advertência",
+        "en-US": "Editor's Notice"
       }
     },
     {
       "id": "lettera-promulgazione",
       "title": {
-        "it": "Lettera di S.S. Papa Pio X al Cardinale Pietro Respighi"
+        "it": "Lettera di S.S. Papa Pio X al Cardinale Pietro Respighi",
+        "pt-BR": "Carta de S.S. o Papa Pio X ao Cardeal Pietro Respighi",
+        "en-US": "Letter of His Holiness Pope Pius X to Cardinal Pietro Respighi"
       }
     },
     {
       "id": "orazioni-quotidiane",
       "title": {
-        "it": "Orazioni quotidiane ed altre preci"
+        "it": "Orazioni quotidiane ed altre preci",
+        "pt-BR": "Orações cotidianas e outras preces",
+        "en-US": "Daily Prayers and Other Devotions"
       }
     },
     {
       "id": "prime-nozioni",
       "title": {
-        "it": "Prime nozioni di catechismo"
+        "it": "Prime nozioni di catechismo",
+        "pt-BR": "Primeiras noções de catecismo",
+        "en-US": "First Notions of Catechism"
       },
       "children": [
         {
           "id": "prime-nozioni-capo-i",
           "title": {
-            "it": "Capo I — Delle verità principali di nostra santa Fede"
+            "it": "Capo I — Delle verità principali di nostra santa Fede",
+            "pt-BR": "Capítulo I — Das verdades principais de nossa santa Fé",
+            "en-US": "Chapter I — On the principal truths of our holy Faith"
           }
         },
         {
           "id": "prime-nozioni-capo-ii",
           "title": {
-            "it": "Capo II — Parti principali della Dottrina cristiana"
+            "it": "Capo II — Parti principali della Dottrina cristiana",
+            "pt-BR": "Capítulo II — Partes principais da Doutrina cristã",
+            "en-US": "Chapter II — Principal parts of Christian Doctrine"
           }
         },
         {
           "id": "prime-nozioni-capo-iii",
           "title": {
-            "it": "Capo III — Atti di Fede, di Speranza, di Carità e di Contrizione"
+            "it": "Capo III — Atti di Fede, di Speranza, di Carità e di Contrizione",
+            "pt-BR": "Capítulo III — Atos de Fé, de Esperança, de Caridade e de Contrição",
+            "en-US": "Chapter III — Acts of Faith, Hope, Charity and Contrition"
           }
         }
       ]
@@ -68,91 +98,121 @@
     {
       "id": "lezione-preliminare",
       "title": {
-        "it": "Lezione preliminare — Della dottrina cristiana e delle sue parti principali"
+        "it": "Lezione preliminare — Della dottrina cristiana e delle sue parti principali",
+        "pt-BR": "Lição preliminar — Da doutrina cristã e de suas partes principais",
+        "en-US": "Preliminary Lesson — On Christian Doctrine and its principal parts"
       }
     },
     {
       "id": "parte-prima",
       "title": {
-        "it": "Parte I — Il Credo o Simbolo apostolico"
+        "it": "Parte I — Il Credo o Simbolo apostolico",
+        "pt-BR": "Parte I — O Credo ou Símbolo Apostólico",
+        "en-US": "Part I — The Creed, or Apostles' Symbol"
       },
       "children": [
         {
           "id": "parte-prima-capo-i",
           "title": {
-            "it": "Capo I — Del «Credo» in generale"
+            "it": "Capo I — Del «Credo» in generale",
+            "pt-BR": "Capítulo I — Do «Credo» em geral",
+            "en-US": "Chapter I — On the «Creed» in general"
           }
         },
         {
           "id": "parte-prima-capo-ii",
           "title": {
-            "it": "Capo II — Del primo articolo del Simbolo"
+            "it": "Capo II — Del primo articolo del Simbolo",
+            "pt-BR": "Capítulo II — Do primeiro artigo do Símbolo",
+            "en-US": "Chapter II — On the first article of the Creed"
           }
         },
         {
           "id": "parte-prima-capo-iii",
           "title": {
-            "it": "Capo III — Del secondo articolo"
+            "it": "Capo III — Del secondo articolo",
+            "pt-BR": "Capítulo III — Do segundo artigo",
+            "en-US": "Chapter III — On the second article"
           }
         },
         {
           "id": "parte-prima-capo-iv",
           "title": {
-            "it": "Capo IV — Del terzo articolo"
+            "it": "Capo IV — Del terzo articolo",
+            "pt-BR": "Capítulo IV — Do terceiro artigo",
+            "en-US": "Chapter IV — On the third article"
           }
         },
         {
           "id": "parte-prima-capo-v",
           "title": {
-            "it": "Capo V — Del quarto articolo"
+            "it": "Capo V — Del quarto articolo",
+            "pt-BR": "Capítulo V — Do quarto artigo",
+            "en-US": "Chapter V — On the fourth article"
           }
         },
         {
           "id": "parte-prima-capo-vi",
           "title": {
-            "it": "Capo VI — Del quinto articolo"
+            "it": "Capo VI — Del quinto articolo",
+            "pt-BR": "Capítulo VI — Do quinto artigo",
+            "en-US": "Chapter VI — On the fifth article"
           }
         },
         {
           "id": "parte-prima-capo-vii",
           "title": {
-            "it": "Capo VII — Del sesto articolo"
+            "it": "Capo VII — Del sesto articolo",
+            "pt-BR": "Capítulo VII — Do sexto artigo",
+            "en-US": "Chapter VII — On the sixth article"
           }
         },
         {
           "id": "parte-prima-capo-viii",
           "title": {
-            "it": "Capo VIII — Del settimo articolo"
+            "it": "Capo VIII — Del settimo articolo",
+            "pt-BR": "Capítulo VIII — Do sétimo artigo",
+            "en-US": "Chapter VIII — On the seventh article"
           }
         },
         {
           "id": "parte-prima-capo-ix",
           "title": {
-            "it": "Capo IX — Dell'ottavo articolo"
+            "it": "Capo IX — Dell'ottavo articolo",
+            "pt-BR": "Capítulo IX — Do oitavo artigo",
+            "en-US": "Chapter IX — On the eighth article"
           }
         },
         {
           "id": "parte-prima-capo-x",
           "title": {
-            "it": "Capo X — Del nono articolo"
+            "it": "Capo X — Del nono articolo",
+            "pt-BR": "Capítulo X — Do nono artigo",
+            "en-US": "Chapter X — On the ninth article"
           }
         },
         {
           "id": "parte-prima-capo-xi",
           "title": {
-            "it": "Capo XI — Del decimo articolo"
+            "it": "Capo XI — Del decimo articolo",
+            "pt-BR": "Capítulo XI — Do décimo artigo",
+            "en-US": "Chapter XI — On the tenth article"
           }
         },
         {
           "id": "parte-prima-capo-xii",
           "title": {
-            "it": "Capo XII — Dell'undecimo articolo"
+            "it": "Capo XII — Dell'undecimo articolo",
+            "pt-BR": "Capítulo XII — Do décimo primeiro artigo",
+            "en-US": "Chapter XII — On the eleventh article"
           }
         },
         {
           "id": "parte-prima-capo-xiii",
           "title": {
-            "it": "Capo XIII — Del dodicesimo articolo"
+            "it": "Capo XIII — Del dodicesimo articolo",
+            "pt-BR": "Capítulo XIII — Do décimo segundo artigo",
+            "en-US": "Chapter XIII — On the twelfth article"
           }
         }
       ]
@@ -160,31 +220,41 @@
     {
       "id": "parte-seconda",
       "title": {
-        "it": "Parte II — Dell'orazione"
+        "it": "Parte II — Dell'orazione",
+        "pt-BR": "Parte II — Da oração",
+        "en-US": "Part II — On Prayer"
       },
       "children": [
         {
           "id": "parte-seconda-capo-i",
           "title": {
-            "it": "Capo I — Dell'orazione in generale"
+            "it": "Capo I — Dell'orazione in generale",
+            "pt-BR": "Capítulo I — Da oração em geral",
+            "en-US": "Chapter I — On prayer in general"
           }
         },
         {
           "id": "parte-seconda-capo-ii",
           "title": {
-            "it": "Capo II — Dell'orazione domenicale"
+            "it": "Capo II — Dell'orazione domenicale",
+            "pt-BR": "Capítulo II — Da oração dominical",
+            "en-US": "Chapter II — On the Lord's Prayer"
           }
         },
         {
           "id": "parte-seconda-capo-iii",
           "title": {
-            "it": "Capo III — Dell'«Ave Maria»"
+            "it": "Capo III — Dell'«Ave Maria»",
+            "pt-BR": "Capítulo III — Da «Ave-Maria»",
+            "en-US": "Chapter III — On the «Hail Mary»"
           }
         },
         {
           "id": "parte-seconda-capo-iv",
           "title": {
-            "it": "Capo IV — Dell'invocazione dei Santi"
+            "it": "Capo IV — Dell'invocazione dei Santi",
+            "pt-BR": "Capítulo IV — Da invocação dos Santos",
+            "en-US": "Chapter IV — On the invocation of the Saints"
           }
         }
       ]
@@ -192,37 +262,49 @@
     {
       "id": "parte-terza",
       "title": {
-        "it": "Parte III — Dei comandamenti di Dio e della Chiesa"
+        "it": "Parte III — Dei comandamenti di Dio e della Chiesa",
+        "pt-BR": "Parte III — Dos mandamentos de Deus e da Igreja",
+        "en-US": "Part III — On the Commandments of God and of the Church"
       },
       "children": [
         {
           "id": "parte-terza-capo-i",
           "title": {
-            "it": "Capo I — Dei comandamenti di Dio in generale"
+            "it": "Capo I — Dei comandamenti di Dio in generale",
+            "pt-BR": "Capítulo I — Dos mandamentos de Deus em geral",
+            "en-US": "Chapter I — On the Commandments of God in general"
           }
         },
         {
           "id": "parte-terza-capo-ii",
           "title": {
-            "it": "Capo II — Dei comandamenti che riguardano Dio"
+            "it": "Capo II — Dei comandamenti che riguardano Dio",
+            "pt-BR": "Capítulo II — Dos mandamentos que se referem a Deus",
+            "en-US": "Chapter II — On the Commandments concerning God"
           }
         },
         {
           "id": "parte-terza-capo-iii",
           "title": {
-            "it": "Capo III — Dei comandamenti che riguardano il prossimo"
+            "it": "Capo III — Dei comandamenti che riguardano il prossimo",
+            "pt-BR": "Capítulo III — Dos mandamentos que se referem ao próximo",
+            "en-US": "Chapter III — On the Commandments concerning our neighbor"
           }
         },
         {
           "id": "parte-terza-capo-iv",
           "title": {
-            "it": "Capo IV — Dei precetti della Chiesa"
+            "it": "Capo IV — Dei precetti della Chiesa",
+            "pt-BR": "Capítulo IV — Dos preceitos da Igreja",
+            "en-US": "Chapter IV — On the precepts of the Church"
           }
         },
         {
           "id": "parte-terza-capo-v",
           "title": {
-            "it": "Capo V — Dei doveri particolari del proprio stato e dei consigli evangelici"
+            "it": "Capo V — Dei doveri particolari del proprio stato e dei consigli evangelici",
+            "pt-BR": "Capítulo V — Dos deveres particulares do próprio estado e dos conselhos evangélicos",
+            "en-US": "Chapter V — On the particular duties of one's state and the evangelical counsels"
           }
         }
       ]
@@ -230,61 +312,81 @@
     {
       "id": "parte-quarta",
       "title": {
-        "it": "Parte IV — Dei sacramenti"
+        "it": "Parte IV — Dei sacramenti",
+        "pt-BR": "Parte IV — Dos sacramentos",
+        "en-US": "Part IV — On the Sacraments"
       },
       "children": [
         {
           "id": "parte-quarta-capo-i",
           "title": {
-            "it": "Capo I — Dei sacramenti in generale"
+            "it": "Capo I — Dei sacramenti in generale",
+            "pt-BR": "Capítulo I — Dos sacramentos em geral",
+            "en-US": "Chapter I — On the Sacraments in general"
           }
         },
         {
           "id": "parte-quarta-capo-ii",
           "title": {
-            "it": "Capo II — Del Battesimo"
+            "it": "Capo II — Del Battesimo",
+            "pt-BR": "Capítulo II — Do Batismo",
+            "en-US": "Chapter II — On Baptism"
           }
         },
         {
           "id": "parte-quarta-capo-iii",
           "title": {
-            "it": "Capo III — Della Cresima o Confermazione"
+            "it": "Capo III — Della Cresima o Confermazione",
+            "pt-BR": "Capítulo III — Da Crisma ou Confirmação",
+            "en-US": "Chapter III — On Confirmation"
           }
         },
         {
           "id": "parte-quarta-capo-iv",
           "title": {
-            "it": "Capo IV — Dell'Eucaristia"
+            "it": "Capo IV — Dell'Eucaristia",
+            "pt-BR": "Capítulo IV — Da Eucaristia",
+            "en-US": "Chapter IV — On the Eucharist"
           }
         },
         {
           "id": "parte-quarta-capo-v",
           "title": {
-            "it": "Capo V — Del santo sacrificio della Messa"
+            "it": "Capo V — Del santo sacrificio della Messa",
+            "pt-BR": "Capítulo V — Do santo sacrifício da Missa",
+            "en-US": "Chapter V — On the Holy Sacrifice of the Mass"
           }
         },
         {
           "id": "parte-quarta-capo-vi",
           "title": {
-            "it": "Capo VI — Della Penitenza"
+            "it": "Capo VI — Della Penitenza",
+            "pt-BR": "Capítulo VI — Da Penitência",
+            "en-US": "Chapter VI — On Penance"
           }
         },
         {
           "id": "parte-quarta-capo-vii",
           "title": {
-            "it": "Capo VII — Dell'Estrema Unzione"
+            "it": "Capo VII — Dell'Estrema Unzione",
+            "pt-BR": "Capítulo VII — Da Extrema-Unção",
+            "en-US": "Chapter VII — On Extreme Unction"
           }
         },
         {
           "id": "parte-quarta-capo-viii",
           "title": {
-            "it": "Capo VIII — Dell'Ordine Sacro"
+            "it": "Capo VIII — Dell'Ordine Sacro",
+            "pt-BR": "Capítulo VIII — Da Ordem Sacra",
+            "en-US": "Chapter VIII — On Holy Orders"
           }
         },
         {
           "id": "parte-quarta-capo-ix",
           "title": {
-            "it": "Capo IX — Del Matrimonio"
+            "it": "Capo IX — Del Matrimonio",
+            "pt-BR": "Capítulo IX — Do Matrimônio",
+            "en-US": "Chapter IX — On Matrimony"
           }
         }
       ]
@@ -292,55 +394,73 @@
     {
       "id": "parte-quinta",
       "title": {
-        "it": "Parte V — Delle virtù principali e delle altre cose necessarie a sapersi del cristiano"
+        "it": "Parte V — Delle virtù principali e delle altre cose necessarie a sapersi del cristiano",
+        "pt-BR": "Parte V — Das virtudes principais e das outras coisas que o cristão deve saber",
+        "en-US": "Part V — On the principal virtues and other things a Christian must know"
       },
       "children": [
         {
           "id": "parte-quinta-capo-i",
           "title": {
-            "it": "Capo I — Delle virtù principali"
+            "it": "Capo I — Delle virtù principali",
+            "pt-BR": "Capítulo I — Das virtudes principais",
+            "en-US": "Chapter I — On the principal virtues"
           }
         },
         {
           "id": "parte-quinta-capo-ii",
           "title": {
-            "it": "Capo II — Dei doni dello Spirito Santo"
+            "it": "Capo II — Dei doni dello Spirito Santo",
+            "pt-BR": "Capítulo II — Dos dons do Espírito Santo",
+            "en-US": "Chapter II — On the gifts of the Holy Spirit"
           }
         },
         {
           "id": "parte-quinta-capo-iii",
           "title": {
-            "it": "Capo III — Delle Beatitudini evangeliche"
+            "it": "Capo III — Delle Beatitudini evangeliche",
+            "pt-BR": "Capítulo III — Das Bem-aventuranças evangélicas",
+            "en-US": "Chapter III — On the evangelical Beatitudes"
           }
         },
         {
           "id": "parte-quinta-capo-iv",
           "title": {
-            "it": "Capo IV — Delle opere di misericordia"
+            "it": "Capo IV — Delle opere di misericordia",
+            "pt-BR": "Capítulo IV — Das obras de misericórdia",
+            "en-US": "Chapter IV — On the works of mercy"
           }
         },
         {
           "id": "parte-quinta-capo-v",
           "title": {
-            "it": "Capo V — Dei peccati e delle loro specie principali"
+            "it": "Capo V — Dei peccati e delle loro specie principali",
+            "pt-BR": "Capítulo V — Dos pecados e de suas espécies principais",
+            "en-US": "Chapter V — On sins and their principal kinds"
           }
         },
         {
           "id": "parte-quinta-capo-vi",
           "title": {
-            "it": "Capo VI — Dei vizi capitali e di altri peccati più gravi"
+            "it": "Capo VI — Dei vizi capitali e di altri peccati più gravi",
+            "pt-BR": "Capítulo VI — Dos vícios capitais e de outros pecados mais graves",
+            "en-US": "Chapter VI — On the capital vices and other graver sins"
           }
         },
         {
           "id": "parte-quinta-capo-vii",
           "title": {
-            "it": "Capo VII — Dei Novissimi e di altri mezzi principali per evitare il peccato"
+            "it": "Capo VII — Dei Novissimi e di altri mezzi principali per evitare il peccato",
+            "pt-BR": "Capítulo VII — Dos Novíssimos e de outros meios principais para evitar o pecado",
+            "en-US": "Chapter VII — On the Last Things and other principal means of avoiding sin"
           }
         },
         {
           "id": "parte-quinta-capo-viii",
           "title": {
-            "it": "Capo VIII — Degli esercizi divoti che si consigliano al cristiano per ogni giorno"
+            "it": "Capo VIII — Degli esercizi divoti che si consigliano al cristiano per ogni giorno",
+            "pt-BR": "Capítulo VIII — Dos exercícios devotos que se recomendam ao cristão para cada dia",
+            "en-US": "Chapter VIII — On the devout exercises recommended to the Christian for each day"
           }
         }
       ]

--- a/content/books/pius-x-greater-catechism/book.json
+++ b/content/books/pius-x-greater-catechism/book.json
@@ -7,7 +7,7 @@
     "it": "San Pio X"
   },
   "description": {
-    "it": "Il Catechismo Maggiore promulgato da Papa San Pio X il 14 giugno 1905 per la Diocesi e Provincia di Roma. Edizione ampia in circa 993 domande e risposte, distinta dal più breve Catechismo della Dottrina Cristiana del 1912. Comprende le preghiere quotidiane, gli atti di fede/speranza/carità/contrizione, la lezione preliminare e le cinque parti canoniche: Credo, Orazione, Comandamenti, Sacramenti, Virtù."
+    "it": "Il Catechismo Maggiore promulgato da Papa San Pio X il 14 giugno 1905 per la Diocesi e Provincia di Roma. Edizione ampia in circa 993 domande e risposte, distinta dal più breve Catechismo della Dottrina Cristiana del 1912. Comprende l'Avvertenza, la lettera di promulgazione, le Orazioni quotidiane ed altre preci (preghiere del mattino e della sera, atti di fede/speranza/carità/contrizione, preparazione alla Confessione e alla Santa Comunione, misteri del Rosario, modo di servire la S. Messa), le Prime nozioni di catechismo, la Lezione preliminare e le cinque parti canoniche: Credo, Orazione, Comandamenti, Sacramenti, Virtù."
   },
   "composed": 1905,
   "languages": [
@@ -22,9 +22,21 @@
   ],
   "toc": [
     {
+      "id": "avvertenza",
+      "title": {
+        "it": "Avvertenza"
+      }
+    },
+    {
       "id": "lettera-promulgazione",
       "title": {
         "it": "Lettera di S.S. Papa Pio X al Cardinale Pietro Respighi"
+      }
+    },
+    {
+      "id": "orazioni-quotidiane",
+      "title": {
+        "it": "Orazioni quotidiane ed altre preci"
       }
     },
     {

--- a/content/books/pius-x-greater-catechism/book.json
+++ b/content/books/pius-x-greater-catechism/book.json
@@ -1,0 +1,337 @@
+{
+  "id": "pius-x-greater-catechism",
+  "name": {
+    "it": "Catechismo Maggiore"
+  },
+  "author": {
+    "it": "San Pio X"
+  },
+  "description": {
+    "it": "Il Catechismo Maggiore promulgato da Papa San Pio X il 14 giugno 1905 per la Diocesi e Provincia di Roma. Edizione ampia in circa 993 domande e risposte, distinta dal più breve Catechismo della Dottrina Cristiana del 1912. Comprende le preghiere quotidiane, gli atti di fede/speranza/carità/contrizione, la lezione preliminare e le cinque parti canoniche: Credo, Orazione, Comandamenti, Sacramenti, Virtù."
+  },
+  "composed": 1905,
+  "languages": [
+    "it"
+  ],
+  "sources": [
+    {
+      "language": "it",
+      "url": "https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana",
+      "description": "Trascrizione critica al 100% del Compendio della dottrina cristiana (Roma, 1905) su Wikisource italiano, comprensiva della lettera di promulgazione, delle Prime nozioni di catechismo e del Catechismo Maggiore integrale (Lezione preliminare e cinque parti)."
+    }
+  ],
+  "toc": [
+    {
+      "id": "lettera-promulgazione",
+      "title": {
+        "it": "Lettera di S.S. Papa Pio X al Cardinale Pietro Respighi"
+      }
+    },
+    {
+      "id": "prime-nozioni",
+      "title": {
+        "it": "Prime nozioni di catechismo"
+      },
+      "children": [
+        {
+          "id": "prime-nozioni-capo-i",
+          "title": {
+            "it": "Capo I — Delle verità principali di nostra santa Fede"
+          }
+        },
+        {
+          "id": "prime-nozioni-capo-ii",
+          "title": {
+            "it": "Capo II — Parti principali della Dottrina cristiana"
+          }
+        },
+        {
+          "id": "prime-nozioni-capo-iii",
+          "title": {
+            "it": "Capo III — Atti di Fede, di Speranza, di Carità e di Contrizione"
+          }
+        }
+      ]
+    },
+    {
+      "id": "lezione-preliminare",
+      "title": {
+        "it": "Lezione preliminare — Della dottrina cristiana e delle sue parti principali"
+      }
+    },
+    {
+      "id": "parte-prima",
+      "title": {
+        "it": "Parte I — Il Credo o Simbolo apostolico"
+      },
+      "children": [
+        {
+          "id": "parte-prima-capo-i",
+          "title": {
+            "it": "Capo I — Del «Credo» in generale"
+          }
+        },
+        {
+          "id": "parte-prima-capo-ii",
+          "title": {
+            "it": "Capo II — Del primo articolo del Simbolo"
+          }
+        },
+        {
+          "id": "parte-prima-capo-iii",
+          "title": {
+            "it": "Capo III — Del secondo articolo"
+          }
+        },
+        {
+          "id": "parte-prima-capo-iv",
+          "title": {
+            "it": "Capo IV — Del terzo articolo"
+          }
+        },
+        {
+          "id": "parte-prima-capo-v",
+          "title": {
+            "it": "Capo V — Del quarto articolo"
+          }
+        },
+        {
+          "id": "parte-prima-capo-vi",
+          "title": {
+            "it": "Capo VI — Del quinto articolo"
+          }
+        },
+        {
+          "id": "parte-prima-capo-vii",
+          "title": {
+            "it": "Capo VII — Del sesto articolo"
+          }
+        },
+        {
+          "id": "parte-prima-capo-viii",
+          "title": {
+            "it": "Capo VIII — Del settimo articolo"
+          }
+        },
+        {
+          "id": "parte-prima-capo-ix",
+          "title": {
+            "it": "Capo IX — Dell'ottavo articolo"
+          }
+        },
+        {
+          "id": "parte-prima-capo-x",
+          "title": {
+            "it": "Capo X — Del nono articolo"
+          }
+        },
+        {
+          "id": "parte-prima-capo-xi",
+          "title": {
+            "it": "Capo XI — Del decimo articolo"
+          }
+        },
+        {
+          "id": "parte-prima-capo-xii",
+          "title": {
+            "it": "Capo XII — Dell'undecimo articolo"
+          }
+        },
+        {
+          "id": "parte-prima-capo-xiii",
+          "title": {
+            "it": "Capo XIII — Del dodicesimo articolo"
+          }
+        }
+      ]
+    },
+    {
+      "id": "parte-seconda",
+      "title": {
+        "it": "Parte II — Dell'orazione"
+      },
+      "children": [
+        {
+          "id": "parte-seconda-capo-i",
+          "title": {
+            "it": "Capo I — Dell'orazione in generale"
+          }
+        },
+        {
+          "id": "parte-seconda-capo-ii",
+          "title": {
+            "it": "Capo II — Dell'orazione domenicale"
+          }
+        },
+        {
+          "id": "parte-seconda-capo-iii",
+          "title": {
+            "it": "Capo III — Dell'«Ave Maria»"
+          }
+        },
+        {
+          "id": "parte-seconda-capo-iv",
+          "title": {
+            "it": "Capo IV — Dell'invocazione dei Santi"
+          }
+        }
+      ]
+    },
+    {
+      "id": "parte-terza",
+      "title": {
+        "it": "Parte III — Dei comandamenti di Dio e della Chiesa"
+      },
+      "children": [
+        {
+          "id": "parte-terza-capo-i",
+          "title": {
+            "it": "Capo I — Dei comandamenti di Dio in generale"
+          }
+        },
+        {
+          "id": "parte-terza-capo-ii",
+          "title": {
+            "it": "Capo II — Dei comandamenti che riguardano Dio"
+          }
+        },
+        {
+          "id": "parte-terza-capo-iii",
+          "title": {
+            "it": "Capo III — Dei comandamenti che riguardano il prossimo"
+          }
+        },
+        {
+          "id": "parte-terza-capo-iv",
+          "title": {
+            "it": "Capo IV — Dei precetti della Chiesa"
+          }
+        },
+        {
+          "id": "parte-terza-capo-v",
+          "title": {
+            "it": "Capo V — Dei doveri particolari del proprio stato e dei consigli evangelici"
+          }
+        }
+      ]
+    },
+    {
+      "id": "parte-quarta",
+      "title": {
+        "it": "Parte IV — Dei sacramenti"
+      },
+      "children": [
+        {
+          "id": "parte-quarta-capo-i",
+          "title": {
+            "it": "Capo I — Dei sacramenti in generale"
+          }
+        },
+        {
+          "id": "parte-quarta-capo-ii",
+          "title": {
+            "it": "Capo II — Del Battesimo"
+          }
+        },
+        {
+          "id": "parte-quarta-capo-iii",
+          "title": {
+            "it": "Capo III — Della Cresima o Confermazione"
+          }
+        },
+        {
+          "id": "parte-quarta-capo-iv",
+          "title": {
+            "it": "Capo IV — Dell'Eucaristia"
+          }
+        },
+        {
+          "id": "parte-quarta-capo-v",
+          "title": {
+            "it": "Capo V — Del santo sacrificio della Messa"
+          }
+        },
+        {
+          "id": "parte-quarta-capo-vi",
+          "title": {
+            "it": "Capo VI — Della Penitenza"
+          }
+        },
+        {
+          "id": "parte-quarta-capo-vii",
+          "title": {
+            "it": "Capo VII — Dell'Estrema Unzione"
+          }
+        },
+        {
+          "id": "parte-quarta-capo-viii",
+          "title": {
+            "it": "Capo VIII — Dell'Ordine Sacro"
+          }
+        },
+        {
+          "id": "parte-quarta-capo-ix",
+          "title": {
+            "it": "Capo IX — Del Matrimonio"
+          }
+        }
+      ]
+    },
+    {
+      "id": "parte-quinta",
+      "title": {
+        "it": "Parte V — Delle virtù principali e delle altre cose necessarie a sapersi del cristiano"
+      },
+      "children": [
+        {
+          "id": "parte-quinta-capo-i",
+          "title": {
+            "it": "Capo I — Delle virtù principali"
+          }
+        },
+        {
+          "id": "parte-quinta-capo-ii",
+          "title": {
+            "it": "Capo II — Dei doni dello Spirito Santo"
+          }
+        },
+        {
+          "id": "parte-quinta-capo-iii",
+          "title": {
+            "it": "Capo III — Delle Beatitudini evangeliche"
+          }
+        },
+        {
+          "id": "parte-quinta-capo-iv",
+          "title": {
+            "it": "Capo IV — Delle opere di misericordia"
+          }
+        },
+        {
+          "id": "parte-quinta-capo-v",
+          "title": {
+            "it": "Capo V — Dei peccati e delle loro specie principali"
+          }
+        },
+        {
+          "id": "parte-quinta-capo-vi",
+          "title": {
+            "it": "Capo VI — Dei vizi capitali e di altri peccati più gravi"
+          }
+        },
+        {
+          "id": "parte-quinta-capo-vii",
+          "title": {
+            "it": "Capo VII — Dei Novissimi e di altri mezzi principali per evitare il peccato"
+          }
+        },
+        {
+          "id": "parte-quinta-capo-viii",
+          "title": {
+            "it": "Capo VIII — Degli esercizi divoti che si consigliano al cristiano per ogni giorno"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/content/books/pius-x-greater-catechism/en-US/avvertenza.md
+++ b/content/books/pius-x-greater-catechism/en-US/avvertenza.md
@@ -1,0 +1,9 @@
+# Editor's Notice
+
+Instruction of young people in Christian Doctrine is divided into two Classes or Sections: to the first corresponds the Short Catechism, intended principally for children who have not yet made their First Communion; to the second, the Greater Catechism for young people already instructed in what is taught in the Short Catechism. This is preceded by a few pages of first notions of Catechism for children of tender age who, at home or in nursery schools, are beginning to learn the first rudiments of the Faith.
+
+The Greater Catechism is followed by an Instruction on the principal feasts of the Church and a very brief compendium of the History of Religion, so that nothing may be lacking to young people of what is suited to their religious instruction.
+
+Reproduction is forbidden under the terms of the law.
+
+The publishers reserve the right to grant to individual Most Excellent Bishops who request it the authorization to reproduce this edition.

--- a/content/books/pius-x-greater-catechism/en-US/lettera-promulgazione.md
+++ b/content/books/pius-x-greater-catechism/en-US/lettera-promulgazione.md
@@ -1,0 +1,17 @@
+# Letter of His Holiness Pope Pius X to Cardinal Pietro Respighi
+
+TO THE LORD CARDINAL
+
+PIETRO RESPIGHI
+
+our Vicar General
+
+Lord Cardinal,
+
+The need to provide, as far as possible, for the religious instruction of tender youth has counseled Us to print a Catechism that sets forth clearly the rudiments of the holy faith and those divine truths to which the life of every Christian must conform. Accordingly, having had examined the many textbooks already in use in the Dioceses of Italy, it seemed fitting to Us to adopt, with slight modifications, the text already approved for several years by the Bishops of Piedmont, Liguria, Lombardy, Emilia and Tuscany. The use of this text shall be obligatory for public and private teaching in the Diocese of Rome and in all the others of the Roman Province; and We trust that the other Dioceses too will wish to adopt it, so as to arrive at that single text — at least throughout all Italy — which is the universal desire.
+
+With this sweet hope We impart from Our whole heart to you, Lord Cardinal, the Apostolic Blessing.
+
+From the Vatican, 14 June 1905.
+
+PIUS PP. X

--- a/content/books/pius-x-greater-catechism/en-US/lezione-preliminare.md
+++ b/content/books/pius-x-greater-catechism/en-US/lezione-preliminare.md
@@ -1,0 +1,59 @@
+# Preliminary Lesson — On Christian Doctrine and its principal parts
+
+ON CHRISTIAN DOCTRINE AND ITS PRINCIPAL PARTS
+
+**1.** Are you a Christian?
+
+*Yes, I am a Christian by the grace of God.*
+
+**2.** Why do you say: by the grace of God?
+
+*I say: by the grace of God, because to be a Christian is a wholly free gift of God, which we could not have merited.*
+
+**3.** Who is a true Christian?
+
+*A true Christian is one who is baptized, who believes and professes Christian doctrine, and who obeys the lawful Pastors of the Church.*
+
+**4.** What is Christian doctrine?
+
+*Christian doctrine is the doctrine that Jesus Christ our Lord taught us in order to show us the way of salvation.*
+
+**5.** Is it necessary to learn the doctrine taught by Jesus Christ?
+
+*It is certainly necessary to learn the doctrine taught by Jesus Christ, and those who neglect to do so fail gravely.*
+
+**6.** Are parents and masters obliged to send their children and dependents to catechism?
+
+*Parents and masters are obliged to see that their children and dependents learn Christian doctrine, and they make themselves guilty before God if they neglect this obligation.*
+
+**7.** From whom must we receive and learn Christian doctrine?
+
+*We must receive and learn Christian doctrine from the holy Catholic Church.*
+
+**8.** How are we sure that the Christian doctrine we receive from the holy Catholic Church is truly true?
+
+*We are sure that the Christian doctrine we receive from the Catholic Church is true, because Jesus Christ, the divine author of this doctrine, entrusted it through His Apostles to the Church founded by Him and constituted by Him the infallible teacher of all men, promising her His divine assistance to the end of the ages.*
+
+**9.** Are there other proofs of the truth of Christian doctrine?
+
+*The truth of Christian doctrine is shown also by the eminent holiness of so many who have professed and still profess it, by the heroic fortitude of the martyrs, by its rapid and wonderful spread throughout the world, and by its full preservation through so many centuries of varied and continual struggles.*
+
+**10.** How many and which are the principal and most necessary parts of Christian doctrine?
+
+*The principal and most necessary parts of Christian doctrine are four: the Creed, the Pater Noster, the Commandments, and the Sacraments.*
+
+**11.** What does the Creed teach us?
+
+*The Creed teaches us the principal articles of our holy faith.*
+
+**12.** What does the Pater Noster teach us?
+
+*The Pater Noster teaches us all that we must hope for from God and all that we must ask of Him.*
+
+**13.** What do the Commandments teach us?
+
+*The Commandments teach us all that we must do to please God; which is all summed up in loving God above all things and our neighbor as ourselves, for love of God.*
+
+**14.** What does the doctrine of the Sacraments teach us?
+
+*The doctrine of the Sacraments makes known to us the nature and right use of those means which Jesus Christ instituted in order to forgive our sins, to communicate His grace to us, and to infuse and increase in us the virtues of faith, hope, and charity.*

--- a/content/books/pius-x-greater-catechism/en-US/orazioni-quotidiane.md
+++ b/content/books/pius-x-greater-catechism/en-US/orazioni-quotidiane.md
@@ -1,0 +1,349 @@
+# Daily Prayers and Other Devotions
+
+## For the Morning
+
+After making the Sign of the Cross, you will say:
+
+*I adore You, my God, and I love You with all my heart: I thank You for having created me, made me a Christian, and preserved me this night: I offer You all my actions, I pray You to preserve me this day from sin and to deliver me from every evil. Amen.*
+
+Then you will say the *Pater Noster*, the *Ave Maria*, the *Credo*, and the *Acts of Faith*, *Hope*, and *Charity*; the *Salve Regina* and the *Angele Dei*.
+
+## During the Day
+
+**Before work.** — *Lord, I offer You this work; I pray You to bless it, that it may turn out to Your glory.*
+
+**Before eating.** — *Lord, I offer You this food, and I pray You to bless it.*
+
+**After eating.** — *Lord, I thank You for the food You have given me, and make me worthy to be admitted to Your heavenly table.*
+
+**In temptations.** — *My Jesus, help me and give me the grace not to offend You.*
+
+## Prayers for the Evening
+
+*I adore You, my God, and I love You with all my heart; I thank You for having created me, made me a Christian, and preserved me this day: I offer You all the good I have done today, and I pray You to deliver me from every evil. Amen.*
+
+Then you will say: *Pater Noster*, *Ave Maria*, *Gloria Patri*, *Act of Contrition*.
+
+*Jesus, Joseph and Mary, I give you my heart and my soul.*
+
+*Jesus, Joseph and Mary, assist me in my last agony.*
+
+*Jesus, Joseph and Mary, may my soul breathe forth its last in peace with you.*
+
+## Brief Preparation for Confession
+
+*Most loving Savior, give me the grace to approach this sacrament of Penance for the salvation of my soul and for Your glory.*
+
+*Most holy Virgin, Mother of Jesus and my Mother, obtain for me from your blessed Son the grace to know, to detest, and to confess sincerely all my sins.*
+
+*Pater Noster* and *Ave Maria*. Then let the examination be made diligently, before God, on the sins committed in thoughts, words, deeds, and omissions, against the Commandments of God and of the Church, and against the obligations of one's state.
+
+Afterward, in order to stir up sorrow for the sins committed, consider the great evil one has done by sinning: namely, that through mortal sin one has lost the grace of God and heaven, has merited the pains of hell, and has offended God our Lord and Father, who has bestowed on us so many benefits, who so loves us, and who has infinite merit to be loved above all things and faithfully served.
+
+Recite the *Act of Contrition*.
+
+## After Confession
+
+First of all, give thanks to the Lord for the inestimable benefit of forgiveness: at once perform the penance imposed by the confessor; renew the resolution to avoid sins and their occasions.
+
+Then recite the following prayer:
+
+*How good You have been to me, O Lord! Instead of punishing me for the many sins I have committed, You have, with infinite mercy, forgiven them all in this holy confession. Once again I repent of them with all my heart, and I promise, with the help of Your grace, never to offend You again, and to make up with equal love for the offenses I have committed against You throughout my life.*
+
+*Most holy Virgin, Angels and Saints of heaven, I thank you for your assistance: and do you also give thanks to the Lord for me for His mercy, and obtain for me constancy and growth in good.*
+
+*Pater Noster*, *Ave Maria*, *Gloria Patri*, and *Angele Dei*.
+
+## Brief Preparation for Holy Communion
+
+### Act of Faith
+
+*My Lord Jesus Christ, I firmly believe that You are really present in the Most Holy Sacrament with Your Body, Blood, Soul, and Divinity.*
+
+### Act of Adoration
+
+*Lord, I adore You in this Sacrament, and I acknowledge You as my Creator, Redeemer, and sovereign Master, my supreme and only good.*
+
+### Act of Humility
+
+*Lord, I am not worthy that You should come into me, but only say the word and my soul shall be healed.*
+
+### Act of Contrition
+
+*Lord, I detest all my sins, which make me unworthy to receive You into my heart, and I resolve, with Your grace, not to commit them anymore for the future, to flee their occasions, and to do penance for them.*
+
+### Act of Hope
+
+*Lord, I hope that, by giving Yourself entirely to me in this divine Sacrament, You will show me mercy and grant me all the graces that are necessary for my eternal salvation.*
+
+### Act of Charity
+
+*Lord, You are infinitely lovable, You are my father, my Redeemer, my God: and therefore I love You with all my heart above all things, and for love of You I love my neighbor as myself, and I forgive from my heart anyone who has offended me.*
+
+### Act of Desire
+
+*Lord, I ardently desire that You come into my soul, that I may no longer be separated from You, but may live always in Your grace.*
+
+## Brief Thanksgiving after Holy Communion
+
+### Act of Faith
+
+*My Lord Jesus Christ, I believe that You are truly in me with Your Body, Blood, Soul, and Divinity, and I believe it more firmly than if I saw it with my own eyes.*
+
+### Act of Adoration
+
+*O my Jesus, I adore You present within me; and I unite myself with the Most Holy Mary, with the Angels, and with the Saints to adore You as You deserve.*
+
+### Act of Thanksgiving
+
+*Jesus, my Lord, I thank You with all my heart for having come into my soul. Most Holy Virgin Mary, my Guardian Angel, and you all, Angels and Saints of paradise, give thanks to Jesus for me.*
+
+### Act of Charity
+
+*O Jesus, my God, I love You as much as I know how and am able, and I desire to love You as much as You deserve: grant that I may love You above all things now and for all eternity.*
+
+### Act of Offering
+
+*O my Jesus, You have given Yourself entirely to me; behold, I give myself entirely to You; I offer You my heart and my soul, I consecrate to You my whole life, and I wish to be Yours for all eternity.*
+
+### Act of Hope
+
+*O my Jesus, now that You have come into my soul, I hope that You will never again be separated from me, but will always remain with me with Your divine grace.*
+
+### Act of Petition
+
+*O my Jesus, grant me, I beseech You, all those spiritual and temporal graces which You know to be useful to my soul; and assist my superiors, parents, friends, benefactors, and the holy souls of purgatory.*
+
+Then you will say: *Pater Noster*, *Ave Maria*, *Gloria Patri*.
+
+## Mysteries of the Holy Rosary
+
+### Joyful (Monday and Thursday)
+
+1. The Annunciation of the Angel to the Most Holy Mary.
+2. The visit of the Virgin Mary to Saint Elizabeth.
+3. The Nativity of Jesus Christ in the stable of Bethlehem.
+4. The Presentation of the Child Jesus in the temple.
+5. The finding of Jesus among the doctors in the temple.
+
+### Sorrowful (Tuesday and Friday)
+
+1. The prayer of Jesus Christ in the garden.
+2. The scourging of Jesus Christ at the pillar.
+3. The crowning with thorns.
+4. The journey to Calvary of Jesus Christ laden with the cross.
+5. The crucifixion and death of Jesus Christ.
+
+### Glorious (Wednesday, Saturday, and Sunday)
+
+1. The resurrection of Jesus Christ.
+2. The ascension of Jesus Christ into heaven.
+3. The coming of the Holy Spirit upon the Apostles and upon the Most Holy Mary.
+4. The assumption of the Virgin Mary into heaven.
+5. The crowning of the Virgin Mary above all the Angels and Saints.
+
+## Litany of the Blessed Virgin
+
+*The text of the Litany of Loreto is not reproduced in the 1905 Wikisource transcription.*
+
+## Hymns to the Most Holy Sacrament
+
+*Blessed be God:*
+
+*Blessed be His holy Name:*
+
+*Blessed be Jesus Christ, true God and true man:*
+
+*Blessed be the name of Jesus:*
+
+*Blessed be His most sacred Heart:*
+
+*Blessed be Jesus in the Most Holy Sacrament of the altar:*
+
+*Blessed be the great Mother of God, the Most Holy Mary:*
+
+*Blessed be her holy and immaculate Conception:*
+
+*Blessed be the name of Mary, Virgin and Mother:*
+
+*Blessed be God in His Angels and in His Saints.*
+
+## How to Serve at Holy Mass
+
+### At the Beginning
+
+**S.** In nomine Patris et Filii, et Spiritus Sancti. Amen. Introibo ad altare Dei.
+
+**C.** Ad Deum qui lætificat iuventutem meam.
+
+**S.** Iudica me, Deus, et discerne causam meam de gente non sancta, ab homine iniquo et doloso erue me.
+
+**C.** Quia tu es, Deus, fortitudo mea; quare me repulisti, et quare tristis incedo, dum affligit me inimicus?
+
+**S.** Emitte lucem tuam et veritatem tuam: ipsa me deduxerunt et adduxerunt in montem sanctum tuum et in tabernacula tua.
+
+**C.** Et introibo ad altare Dei; ad Deum qui lætificat iuventutem meam.
+
+**S.** Confitebor tibi in cithara, Deus, Deus meus, quare tristis es anima mea, et quare conturbas me?
+
+**C.** Spera in Deo, quoniam adhuc confitebor illi, salutare vultus mei et Deus meus.
+
+**S.** Gloria Patri et Filio et Spiritui Sancto.
+
+**C.** Sicut erat in principio, et nunc et semper, et in sæcula sæculorum. Amen.
+
+**S.** Introibo ad altare Dei.
+
+**C.** Ad Deum, qui lætificat iuventutem meam.
+
+**S.** Adiutorium nostrum in nomine Domini.
+
+**C.** Qui fecit cœlum et terram.
+
+**S.** Confiteor, etc.
+
+**C.** Misereatur tui omnipotens Deus, et dimissis peccatis tuis, perducat te ad vitam æternam.
+
+**S.** Amen.
+
+**C.** Confiteor Deo omnipotenti, beatæ Mariæ semper Virgini, beato Michaëli archangelo, beato Ioanni Baptistae, sanctis apostolis Petro et Paulo, omnibus sanctis et tibi, pater; quia peccavi nimis cogitatione, verbo et opere; mea culpa, mea culpa, mea maxima culpa. Ideo precor beatam Mariam semper Virginem, beatum Michaëlem archangelum, beatum Ioannem Baptistam, sanctos apostolos Petrum et Paulum, omnes sanctos et te, pater, orare pro me ad Dominum Deum nostrum.
+
+**S.** Misereatur… vitam aeternam.
+
+**C.** Amen.
+
+**S.** Indulgentiam… misericors Dominus.
+
+**C.** Amen.
+
+**S.** Deus, tu conversus vivificabis nos.
+
+**C.** Et plebs tua lætabitur in te.
+
+**S.** Ostende nobis, Domine, misericordiam tuam.
+
+**C.** Et salutare tuum da nobis.
+
+**S.** Domine, exaudi orationem meam.
+
+**C.** Et clamor meus ad te veniat.
+
+**S.** Dominus vobiscum.
+
+### At the «Kyrie eleison»
+
+**C.** Kyrie, eleison; Christe, eleison; Christe, eleison; Kyrie, eleison.
+
+### After the «Kyrie» or the «Gloria in excelsis»
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+### At the end of the «Oremus» one responds
+
+**C.** Amen.
+
+### When the Epistle is finished, one responds
+
+**C.** Deo gratias.
+
+### Before the Gospel
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+**S.** Initium or Sequentia sancti Evangelii secundum N.
+
+**C.** Gloria tibi, Domine.
+
+### When the Gospel is finished, one responds
+
+**C.** Laus tibi, Christe.
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+### At the «Orate fratres»
+
+**C.** Suscipiat Dominus sacrificium de manibus tuis ad laudem et gloriam nominis sui; ad utilitatem quoque nostram, totiusque Ecclesiæ suæ sanctæ.
+
+### At the Preface
+
+**S.** Per omnia saecula saeculorum.
+
+**C.** Amen.
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+**S.** Sursum corda.
+
+**C.** Habemus ad Dominum.
+
+**S.** Gratias agamus Domino Deo nostro.
+
+**C.** Dignum et iustum est.
+
+### Before the «Pater Noster»
+
+**S.** Per omnia saecula saeculorum.
+
+**C.** Amen.
+
+### At the end of the «Pater Noster»
+
+**S.** Et ne nos inducas in tentationem.
+
+**C.** Sed libera nos a malo.
+
+### At the breaking of the Host
+
+**S.** Per omnia saecula saeculorum.
+
+**C.** Amen.
+
+**S.** Pax Domini sit semper vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+### After the Communion
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+### At the end of the «Oremus» one responds
+
+**C.** Amen.
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+**S.** Ite, missa est, or Benedicamus Domino.
+
+**C.** Deo gratias.
+
+### At the blessing
+
+**S.** Benedicat vos… Spiritus Sanctus.
+
+**C.** Amen.
+
+### At the Last Gospel
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+**S.** Initium or sequentia sancti Evangelii secundum N.
+
+**C.** Gloria tibi Domine.
+
+### When the Gospel is finished, one responds
+
+**C.** Deo gratias.

--- a/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-i.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-i.md
@@ -1,0 +1,51 @@
+# Chapter I — On the «Creed» in general
+
+**1.** What is the first part of Christian doctrine?
+
+*The first part of Christian doctrine is the Symbol of the Apostles, commonly called the Creed.*
+
+**2.** Why do you call the Creed the Symbol of the Apostles?
+
+*The Creed is called the Symbol of the Apostles because it is a compendium of the truths of the faith taught by the Apostles.*
+
+**3.** How many articles are there in the Creed?
+
+*There are twelve articles in the Creed.*
+
+**4.** Recite them.
+
+*1. I believe in God the Father Almighty, Creator of heaven and earth.*
+
+*2. And in Jesus Christ, His only Son, our Lord.*
+
+*3. Who was conceived by the Holy Spirit, born of the Virgin Mary.*
+
+*4. Suffered under Pontius Pilate, was crucified, died, and was buried.*
+
+*5. He descended into hell; on the third day He rose again from the dead.*
+
+*6. He ascended into heaven; and sits at the right hand of God the Father Almighty.*
+
+*7. From thence He shall come to judge the living and the dead.*
+
+*8. I believe in the Holy Spirit.*
+
+*9. The holy Catholic Church; the communion of saints.*
+
+*10. The forgiveness of sins.*
+
+*11. The resurrection of the body.*
+
+*12. Life everlasting. Amen.*
+
+**5.** What does the word Credo, which you say at the beginning of the Symbol, mean?
+
+*The word Credo means: I hold as most true all that is contained in these twelve articles; and I believe these things more firmly than if I saw them with my own eyes, because God, who can neither deceive nor be deceived, has revealed them to the holy Catholic Church, and through her reveals them also to us.*
+
+**6.** What do the articles of the Creed contain?
+
+*The articles of the Creed contain all that is principally to be believed about God, about Jesus Christ, and about the Church, His spouse.*
+
+**7.** Is it very useful to recite the Creed often?
+
+*It is most useful to recite the Creed often, in order to impress the truths of the faith ever more deeply on the heart.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-ii.md
@@ -1,0 +1,195 @@
+# Chapter II — On the first article of the Creed
+
+## § 1. On God the Father and on creation
+
+**1.** What does the first article — "I believe in God the Father Almighty, Creator of heaven and earth" — teach us?
+
+*The first article of the Creed teaches us that there is one only God, who is almighty, and who has created heaven, earth, and all things contained in heaven and on earth, that is, the entire universe.*
+
+**2.** How do we know that God exists?
+
+*We know that God exists because our reason demonstrates it to us, and faith confirms it.*
+
+**3.** Why is God said to be Father?
+
+*God is said to be Father, 1. because He is Father by nature of the second Person of the Most Holy Trinity, namely, of the Son begotten by Him; 2. because God is Father of all men, whom He has created, preserves, and governs; 3. because, finally, He is Father by grace of all good Christians, who are therefore called the adopted children of God.*
+
+**4.** Why is the Father the first Person of the Most Holy Trinity?
+
+*The Father is the first Person of the Most Holy Trinity because He does not proceed from any other person, but is the principle of the other two persons, namely, of the Son and of the Holy Spirit.*
+
+**5.** What does the word almighty mean?
+
+*The word almighty means that God can do all that He wills.*
+
+**6.** God cannot sin nor die; how then is it said that He can do all things?
+
+*It is said that God can do all things, although He can neither sin nor die, because the power to sin or to die is not an effect of power, but of weakness, which cannot be in God, who is most perfect.*
+
+**7.** What does "Creator of heaven and earth" mean?
+
+*To create means to make out of nothing; therefore God is called Creator of heaven and earth because He made out of nothing heaven and earth and all things contained in heaven and on earth, that is, the entire universe.*
+
+**8.** Was the world created by the Father alone?
+
+*The world was created equally by all three divine persons, because all that one person does with regard to creatures, the others do also by one and the same act.*
+
+**9.** Why, then, is creation attributed particularly to the Father?
+
+*Creation is attributed particularly to the Father because creation is an effect of the divine omnipotence, which is especially attributed to the Father, just as wisdom is attributed to the Son and goodness to the Holy Spirit, although all three persons have the same omnipotence, wisdom, and goodness.*
+
+**10.** Does God take care of the world and of all the things He has created?
+
+*Yes, God takes care of the world and of all the things He has created; He preserves and governs them with His infinite goodness and wisdom, and nothing happens here below without God willing or permitting it.*
+
+**11.** Why do you say that nothing happens without God willing or permitting it?
+
+*It is said that nothing happens here below without God willing or permitting it, because there are things that God wills and commands, and others that He does not prevent, such as sin.*
+
+**12.** Why does God not prevent sin?
+
+*God does not prevent sin because even from the abuse that man makes of the freedom granted to him, He knows how to draw forth a good and to make His mercy, or His justice, shine forth ever more.*
+
+## § 2. On the Angels
+
+**13.** Which are the noblest creatures God has created?
+
+*The noblest creatures created by God are the Angels.*
+
+**14.** Who are the Angels?
+
+*The Angels are intelligent and purely spiritual creatures.*
+
+**15.** For what end did God create the Angels?
+
+*God created the Angels to be honored and served by them and to make them eternally happy.*
+
+**16.** What form and figure do the Angels have?
+
+*The Angels have neither form nor any sensible figure, because they are pure spirits, created by God to subsist without having to be united to any body.*
+
+**17.** Why, then, are the Angels represented under sensible forms?
+
+*The Angels are represented under sensible forms: 1. to aid our imagination; 2. because they have so appeared many times to men, as we read in Sacred Scripture.*
+
+**18.** Were all the Angels faithful to God?
+
+*No, not all the Angels were faithful to God; many of them, through pride, claimed to be equal to Him and independent of Him; and for this sin they were excluded forever from heaven and condemned to hell.*
+
+**19.** What are the Angels called who were excluded forever from heaven and condemned to hell?
+
+*The Angels excluded forever from heaven and condemned to hell are called demons, and their chief is called Lucifer or Satan.*
+
+**20.** Can the demons do us any harm?
+
+*Yes, the demons can do us much harm, both to the soul and to the body, if, however, God gives them permission, chiefly by tempting us to sin.*
+
+**21.** Why do they tempt us?
+
+*The demons tempt us out of the envy they bear us, which makes them desire our eternal damnation, and out of hatred of God, whose image shines in us. God permits the temptations so that we, by overcoming them through His grace, may exercise virtue and gain merits for heaven.*
+
+**22.** How can we overcome temptations?
+
+*Temptations are overcome by vigilance, by prayer, and by Christian mortification.*
+
+**23.** What are the Angels called who remained faithful to God?
+
+*The Angels who remained faithful to God are called good Angels, heavenly Spirits, or simply Angels.*
+
+**24.** What happened to the Angels who remained faithful to God?
+
+*The Angels who remained faithful to God were confirmed in grace; they enjoy the sight of God forever, love Him, bless Him, and praise Him eternally.*
+
+**25.** Does God make use of the Angels as His ministers?
+
+*Yes, God makes use of the Angels as His ministers, and in particular entrusts to many of them the office of being our guardians and protectors.*
+
+**26.** Should we have a special devotion to our Guardian Angel?
+
+*Yes, we should have a special devotion to our Guardian Angel, honor him, invoke his help, follow his inspirations, and be grateful to him for the continual assistance he gives us.*
+
+## § 3. On man
+
+**27.** Which is the noblest creature God has placed on the earth?
+
+*The noblest creature God has placed on the earth is man.*
+
+**28.** What is man?
+
+*Man is a rational creature composed of soul and body.*
+
+**29.** What is the soul?
+
+*The soul is the nobler part of man, because it is a spiritual substance, endowed with intellect and will, capable of knowing God and of possessing Him eternally.*
+
+**30.** Can the human soul be seen and touched?
+
+*Our soul can neither be seen nor touched because it is a spirit.*
+
+**31.** Does the human soul die with the body?
+
+*The human soul never dies: faith and reason itself prove that it is immortal.*
+
+**32.** Is man free in his actions?
+
+*Yes, man is free in his actions; and everyone feels within himself that he can do a thing or not do it, or do one thing rather than another.*
+
+**33.** Explain human freedom by an example.
+
+*If I voluntarily tell a lie, I feel that I could refrain from telling it and remain silent, and that I could also speak otherwise, telling the truth.*
+
+**34.** Why is it said that man was created in the image and likeness of God?
+
+*It is said that man was created in the image and likeness of God because the human soul is spiritual and rational, free in its operations, capable of knowing and loving God and of enjoying Him eternally: perfections that reflect in us a ray of the infinite greatness of the Lord.*
+
+**35.** In what state did God place our first parents Adam and Eve?
+
+*God placed Adam and Eve in the state of innocence and grace; but they soon fell from it through sin.*
+
+**36.** Besides innocence and sanctifying grace, did God confer other gifts on our first parents?
+
+*Besides innocence and sanctifying grace, God conferred other gifts on our first parents, which they were to transmit together with sanctifying grace to their descendants; and these were: integrity, that is, the perfect subjection of the senses to reason; immortality; immunity from all pain and misery; and knowledge proportioned to their state.*
+
+**37.** What was Adam's sin?
+
+*Adam's sin was a sin of pride and of grave disobedience.*
+
+**38.** What was the punishment of the sin of Adam and Eve?
+
+*Adam and Eve lost the grace of God and the right they had to heaven; they were driven out of the earthly paradise, subjected to many miseries of soul and body, and condemned to die.*
+
+**39.** If Adam and Eve had not sinned, would they have been exempt from death?
+
+*If Adam and Eve had not sinned, but had remained faithful to God, after a happy and peaceful sojourn on this earth, they would have been transferred by God into heaven, without dying, to enjoy an eternal and glorious life.*
+
+**40.** Were these gifts owed to man?
+
+*These gifts were in no way owed to man, but were entirely free and supernatural; and therefore, when Adam disobeyed the divine precept, God could without injustice deprive Adam and all his posterity of them.*
+
+**41.** Is this sin Adam's alone?
+
+*This sin is not Adam's alone, but is also ours, though in a different way. It is Adam's because he committed it by an act of his own will, and therefore in him it was personal. It is ours because, Adam having sinned as the head and source of the whole human race, it is transmitted by natural generation to all his descendants, and is therefore for us original sin.*
+
+**42.** How is it possible that original sin is transmitted to all men?
+
+*Original sin is transmitted to all men because, God having conferred upon the human race in Adam sanctifying grace and the other supernatural gifts on condition that Adam did not disobey, and Adam having disobeyed in his capacity as head and father of the human race, he rendered human nature rebellious against God. Therefore human nature is transmitted to all the descendants of Adam in a state of rebellion against God, deprived of divine grace and of the other gifts.*
+
+**43.** What harm, then, has original sin done us?
+
+*The harms of original sin are: the privation of grace, the loss of heaven, ignorance, the inclination to evil, all the miseries of this life, and finally death.*
+
+**44.** Do all men contract original sin?
+
+*Yes, all men contract original sin, except the most holy Virgin, who was preserved from it by God by a singular privilege, in view of the merits of Jesus Christ our Savior.*
+
+**45.** After the sin of Adam, would men no longer have been able to save themselves?
+
+*After the sin of Adam, men would no longer have been able to save themselves, had God not shown them mercy.*
+
+**46.** What was the mercy God showed the human race?
+
+*The mercy God showed the human race was to promise to Adam immediately the divine Redeemer, or Messiah, and then to send Him in due time, to free men from the slavery of the devil and of sin.*
+
+**47.** Who is the promised Messiah?
+
+*The promised Messiah is Jesus Christ, as the second article of the Creed teaches us.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-iii.md
@@ -1,0 +1,57 @@
+# Chapter III — On the second article
+
+**1.** What does the second article — "And in Jesus Christ, His only Son, our Lord" — teach us?
+
+*The second article of the Creed teaches us that the Son of God is the second person of the Most Holy Trinity; that He is eternal God, almighty, Creator and Lord, like the Father; that He became man to save us; and that the Son of God made man is called Jesus Christ.*
+
+**2.** Why is the second person called Son?
+
+*The second person is called Son because He is begotten of the Father by way of intellect from all eternity; and for this reason He is also called the eternal Word of the Father.*
+
+**3.** Since we too are children of God, why is Jesus Christ called the only Son of God the Father?
+
+*Jesus Christ is called the only Son of God the Father because He alone is His Son by nature, while we are His children by creation and by adoption.*
+
+**4.** Why is Jesus Christ called our Lord?
+
+*Jesus Christ is called our Lord because, besides having created us together with the Father and the Holy Spirit insofar as He is God, He has also redeemed us as God and man.*
+
+**5.** Why is the Son of God made man called Jesus?
+
+*The Son of God made man is called Jesus, which means Savior, because He has saved us from the eternal death merited by our sins.*
+
+**6.** Who gave the name of Jesus to the Son of God made man?
+
+*The name of Jesus was given to the Son of God made man by the eternal Father Himself, through the archangel Gabriel, when the latter announced to the Virgin the mystery of the Incarnation.*
+
+**7.** Why is the Son of God made man also called Christ?
+
+*The Son of God made man is also called Christ, which means anointed and consecrated, because in ancient times kings, priests, and prophets were anointed; and Jesus is King of kings, supreme priest, and supreme prophet.*
+
+**8.** Was Jesus Christ truly anointed and consecrated with a bodily anointing?
+
+*The anointing of Jesus Christ was not bodily, like that of the ancient kings, priests, and prophets, but wholly spiritual and divine, because the fullness of the divinity dwells in Him substantially.*
+
+**9.** Before His coming, did men have any knowledge of Jesus Christ?
+
+*Yes, men had knowledge of Jesus Christ before His coming, through the promise of the Messiah that God made to our first parents Adam and Eve, and which He renewed to the holy Patriarchs; and through the prophecies and the many figures that designated Him.*
+
+**10.** How do we know that Jesus Christ is truly the promised Messiah and Redeemer?
+
+*We know that Jesus Christ is truly the promised Messiah and Redeemer because there was fulfilled in Him: 1. all that the prophecies announced; 2. all that the figures of the Old Testament represented.*
+
+**11.** What did the prophecies foretell about the Redeemer?
+
+*The prophecies foretold of the Redeemer the tribe and family from which He was to come; the place and time of His birth; His miracles and the most minute circumstances of His passion and death; His resurrection and ascension into heaven; His spiritual, universal, and perpetual kingdom, which is the holy Catholic Church.*
+
+**12.** Which are the principal figures of the Redeemer in the Old Testament?
+
+*The principal figures of the Redeemer in the Old Testament are the innocent Abel, the supreme priest Melchizedek, the sacrifice of Isaac; Joseph sold by his brothers, the prophet Jonah, the paschal lamb, and the bronze serpent raised up by Moses in the desert.*
+
+**13.** How do we know that Jesus Christ is true God?
+
+*We know that Jesus Christ is true God: 1. from the testimony of the Father when He said, "This is my beloved Son, in whom I am well pleased; hear ye Him"; 2. from the attestation of Jesus Christ Himself, confirmed by the most stupendous miracles; 3. from the doctrine of the Apostles; 4. from the constant tradition of the Catholic Church.*
+
+**14.** Which are the principal miracles worked by Jesus Christ?
+
+*The principal miracles worked by Jesus Christ are, besides His resurrection, the restoring of health to the sick, of sight to the blind, of hearing to the deaf, of life to the dead.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-iv.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-iv.md
@@ -1,0 +1,53 @@
+# Chapter IV — On the third article
+
+**1.** What does the third article — "Who was conceived by the Holy Spirit, born of the Virgin Mary" — teach us?
+
+*The third article of the Creed teaches us that the Son of God took a body and a soul, like ours, in the most pure womb of the Virgin Mary by the work of the Holy Spirit, and that He was born of this Virgin.*
+
+**2.** Did the Father and the Son also concur in forming the body and creating the soul of Jesus Christ?
+
+*Yes, in forming the body and creating the soul of Jesus Christ all three divine Persons concurred.*
+
+**3.** Why is it said only: was conceived by the Holy Spirit?
+
+*It is said only "was conceived by the Holy Spirit" because the incarnation of the Son of God is a work of goodness and of love, and works of goodness and love are attributed to the Holy Spirit.*
+
+**4.** Did the Son of God, in becoming man, cease to be God?
+
+*No, the Son of God became man, without ceasing to be God.*
+
+**5.** So is Jesus Christ both God and man?
+
+*Yes, the Son of God incarnate, that is, Jesus Christ, is both God and man, perfect God and perfect man.*
+
+**6.** Are there, then, two natures in Jesus Christ?
+
+*Yes, in Jesus Christ, who is God and man, there are two natures: the divine and the human.*
+
+**7.** Are there in Jesus Christ also two persons, the divine and the human?
+
+*No, in the Son of God made man there is but one person only, namely, the divine.*
+
+**8.** How many wills are there in Jesus Christ?
+
+*In Jesus Christ there are two wills: one divine, the other human.*
+
+**9.** Did Jesus Christ have a free will?
+
+*Yes, Jesus Christ had a free will, but He could not do evil, because the power to do evil is a defect, not a perfection of freedom.*
+
+**10.** Are the Son of God and the Son of Mary the same person?
+
+*The Son of God and the Son of Mary are the same person, namely, Jesus Christ, true God and true man.*
+
+**11.** Is the Virgin Mary the Mother of God?
+
+*Yes, the Virgin Mary is the Mother of God, because she is the Mother of Jesus Christ, who is true God.*
+
+**12.** In what way did Mary become the Mother of Jesus Christ?
+
+*Mary became the Mother of Jesus Christ solely by the operation and power of the Holy Spirit.*
+
+**13.** Is it of faith that Mary was always a Virgin?
+
+*Yes, it is of faith that the Most Holy Mary was always a Virgin, and she is called the Virgin par excellence.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-ix.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-ix.md
@@ -1,0 +1,49 @@
+# Chapter IX — On the eighth article
+
+**1.** What does the eighth article — "I believe in the Holy Spirit" — teach us?
+
+*The eighth article of the Creed teaches us that there is the Holy Spirit, the third Person of the Most Holy Trinity, that He is eternal God, infinite, almighty, Creator and Lord of all things, like the Father and the Son.*
+
+**2.** From whom does the Holy Spirit proceed?
+
+*The Holy Spirit proceeds from the Father and the Son by way of will and of love, as from one single principle.*
+
+**3.** If the Son proceeds from the Father, and the Holy Spirit proceeds from the Father and the Son, it seems that the Father and the Son are before the Holy Spirit: how then is it said that all three Persons are eternal?
+
+*It is said that all three Persons are eternal because the Father from eternity has begotten the Son, and from the Father and the Son from eternity the Holy Spirit proceeds.*
+
+**4.** Why is the third Person of the Most Holy Trinity called in particular by the name of Holy Spirit?
+
+*The third Person of the Most Holy Trinity is called in particular by the name of Holy Spirit because He proceeds from the Father and the Son by way of spiration and of love.*
+
+**5.** Which work is especially attributed to the Holy Spirit?
+
+*The sanctification of souls is especially attributed to the Holy Spirit.*
+
+**6.** Do the Father and the Son sanctify us equally with the Holy Spirit?
+
+*Yes, all three divine Persons sanctify us equally.*
+
+**7.** If this is so, why is the sanctification of souls attributed in particular to the Holy Spirit?
+
+*The sanctification of souls is attributed in particular to the Holy Spirit because it is a work of love, and works of love are attributed to the Holy Spirit.*
+
+**8.** When did the Holy Spirit descend upon the Apostles?
+
+*The Holy Spirit descended upon the Apostles on the day of Pentecost, that is, fifty days after the Resurrection of Jesus Christ, and ten days after His Ascension.*
+
+**9.** Where were the Apostles during the ten days before Pentecost?
+
+*The Apostles were gathered in the upper room together with the Virgin Mary and the other disciples, and persevered in prayer, awaiting the Holy Spirit whom Jesus Christ had promised them.*
+
+**10.** What effects did the Holy Spirit produce in the Apostles?
+
+*The Holy Spirit confirmed the Apostles in the faith, filled them with light, strength, charity, and the abundance of all His gifts.*
+
+**11.** Was the Holy Spirit sent for the Apostles alone?
+
+*The Holy Spirit was sent for the whole Church, and for every faithful soul.*
+
+**12.** What does the Holy Spirit do in the Church?
+
+*The Holy Spirit, like the soul in the body, gives life to the Church with His grace and His gifts; He establishes therein the reign of truth and of love; and assists her so that she may surely lead her children along the way of heaven.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-v.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-v.md
@@ -1,0 +1,77 @@
+# Chapter V — On the fourth article
+
+**1.** What does the fourth article — "Suffered under Pontius Pilate, was crucified, died, and was buried" — teach us?
+
+*The fourth article of the Creed teaches us that Jesus Christ, in order to redeem the world with His precious Blood, suffered under Pontius Pilate, governor of Judea, and died on the wood of the cross, from which, being taken down, He was buried.*
+
+**2.** What does the word suffered mean?
+
+*The word suffered expresses all the pains endured by Jesus Christ in His passion.*
+
+**3.** Did Jesus Christ suffer as God, or as man?
+
+*Jesus Christ suffered as man only, because as God He could neither suffer nor die.*
+
+**4.** What sort of death was the death of the cross?
+
+*The death of the cross was, in those times, the most cruel and ignominious of all forms of execution.*
+
+**5.** Who was it that condemned Jesus Christ to be crucified?
+
+*The one who condemned Jesus Christ to be crucified was Pontius Pilate, governor of Judea, who had recognized His innocence; but he cowardly yielded to the threatening insistence of the people of Jerusalem.*
+
+**6.** Could Jesus Christ not have freed Himself from the hands of the Jews and of Pilate?
+
+*Yes, Jesus Christ could have freed Himself from the hands of the Jews and of Pilate, but knowing that it was the will of His Eternal Father that He should suffer and die for our salvation, He submitted to it voluntarily; indeed, He Himself went out to meet His enemies, and allowed Himself willingly to be taken and led to death.*
+
+**7.** Where was Jesus Christ crucified?
+
+*Jesus Christ was crucified on Mount Calvary.*
+
+**8.** What did Jesus Christ do on the cross?
+
+*On the cross Jesus Christ prayed for His enemies; gave as mother to the disciple Saint John, and in his person to us all, His own mother, the most Holy Mary; offered His death in sacrifice; and made satisfaction to the justice of God for the sins of men.*
+
+**9.** Would it not have been enough for an Angel to come to make satisfaction for us?
+
+*No, it would not have been enough for an Angel to come to make satisfaction for us, because the offense given to God by sin was, in a certain respect, infinite, and to make satisfaction for it there was needed a person who had infinite merit.*
+
+**10.** In order to make satisfaction to the divine Justice, was it necessary that Jesus Christ be both God and man?
+
+*Yes, it was necessary that Jesus Christ be man in order to be able to suffer and die, and necessary that He be God so that His sufferings might be of infinite value.*
+
+**11.** Why was it necessary that the merits of Jesus Christ be of infinite value?
+
+*It was necessary that the merits of Jesus Christ be of infinite value, because the majesty of God, offended by sin, is infinite.*
+
+**12.** Was it necessary that Jesus should suffer so much?
+
+*No, it was not absolutely necessary that Jesus should suffer so much, because the least of His sufferings would have been sufficient for our redemption, each of His acts being of infinite value.*
+
+**13.** Why, then, did Jesus will to suffer so much?
+
+*Jesus willed to suffer so much in order to satisfy more abundantly the divine justice, to show us His love more fully, and to inspire in us the greatest horror of sin.*
+
+**14.** Did wonders occur at the death of Jesus?
+
+*Yes, at the death of Jesus the sun was darkened, the earth shook, the tombs opened, and many of the dead rose again.*
+
+**15.** Where was the body of Jesus Christ buried?
+
+*The body of Jesus Christ was buried in a new sepulcher, hewn out of the rock of the mountain, not far from the place where He had been crucified.*
+
+**16.** In the death of Jesus Christ, was the divinity separated from the body and from the soul?
+
+*In the death of Jesus Christ the divinity was separated neither from the body nor from the soul, but only the soul was separated from the body.*
+
+**17.** For whom did Jesus Christ die?
+
+*Jesus Christ died for the salvation of all men, and made satisfaction for all.*
+
+**18.** If Jesus Christ died for the salvation of all, why are not all saved?
+
+*Jesus Christ died for all, but not all are saved, because not all are willing to acknowledge Him, not all observe His law, and not all avail themselves of the means of sanctification He has left us.*
+
+**19.** Is it enough for our salvation that Jesus Christ died for us?
+
+*For our salvation it is not enough that Jesus Christ died for us; it is also necessary that the fruit and the merits of His passion and death be applied to each of us, which happens chiefly by means of the sacraments instituted for this end by Jesus Christ Himself; and since many either do not receive the sacraments, or do not receive them well, they thereby render the death of Jesus Christ useless to themselves.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-vi.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-vi.md
@@ -1,0 +1,21 @@
+# Chapter VI — On the fifth article
+
+**1.** What does the fifth article — "He descended into hell; on the third day He rose again from the dead" — teach us?
+
+*The fifth article of the Creed teaches us that the soul of Jesus Christ, once separated from the body, went to the Limbo of the holy Fathers, and that on the third day it was united again to His body, never to be separated from it again.*
+
+**2.** What is meant here by hell?
+
+*By hell is meant here the Limbo of the holy Fathers, that is, the place where the souls of the just were detained, awaiting the redemption of Jesus Christ.*
+
+**3.** Why were the souls of the holy Fathers not led into heaven before the death of Jesus Christ?
+
+*The souls of the holy Fathers were not led into heaven before the death of Jesus Christ because, on account of Adam's sin, heaven was closed, and it was fitting that Jesus Christ, who reopened it by His death, should be the first to enter it.*
+
+**4.** Why did Jesus Christ will to defer His resurrection until the third day?
+
+*Jesus Christ willed to defer His resurrection until the third day in order to make it evident that He was truly dead.*
+
+**5.** Was the resurrection of Jesus Christ like the resurrection of the other men who were raised?
+
+*No, the resurrection of Jesus Christ was not like the resurrection of the other men who were raised, because Jesus Christ rose by His own power, while the others were raised by the power of God.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-vii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-vii.md
@@ -1,0 +1,21 @@
+# Chapter VII — On the sixth article
+
+**1.** What does the sixth article — "He ascended into heaven; and sits at the right hand of God the Father Almighty" — teach us?
+
+*The sixth article of the Creed teaches us that Jesus Christ, forty days after His resurrection, in the presence of His disciples, ascended of His own power into heaven, and that, being as God equal to the Father in glory, as man He has been exalted above all the Angels and all the Saints, and constituted Lord of all things.*
+
+**2.** Why did Jesus Christ remain forty days on earth after His resurrection, before ascending into heaven?
+
+*Jesus Christ remained forty days on earth after His resurrection, before ascending into heaven, in order to prove by various appearances that He had truly risen, and to instruct ever more and to confirm the Apostles in the truths of the faith.*
+
+**3.** Why did Jesus Christ ascend into heaven?
+
+*Jesus Christ ascended into heaven: 1. to take possession of His kingdom merited by His death; 2. to prepare our place of glory and to be our Mediator and Advocate with the Father; 3. to send the Holy Spirit to His Apostles.*
+
+**4.** Why is it said of Jesus Christ that He ascended into heaven, and of His most holy Mother that she was assumed?
+
+*It is said of Jesus Christ that He ascended into heaven, and of His most holy Mother that she was assumed, because Jesus Christ, being God-Man, ascended into heaven by His own power, but the Mother, who was a creature, although the most worthy of all, ascended into heaven by the power of God.*
+
+**5.** Explain to me the words: sits at the right hand of God the Father Almighty.
+
+*The word "sits" signifies the peaceful possession which Jesus Christ has of His glory, and the words "at the right hand of God the Father Almighty" express that He has the place of honor above all creatures.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-viii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-viii.md
@@ -1,0 +1,25 @@
+# Chapter VIII — On the seventh article
+
+**1.** What does the seventh article — "From thence He shall come to judge the living and the dead" — teach us?
+
+*The seventh article of the Creed teaches us that at the end of the world Jesus Christ, full of glory and majesty, will come from heaven to judge all men, the good and the wicked, and to give to each the reward or the punishment he shall have merited.*
+
+**2.** If each person, immediately after death, must be judged by Jesus Christ in the particular judgment, why must we all be judged in the universal judgment?
+
+*We must all be judged in the universal judgment for several reasons: 1. for the glory of God; 2. for the glory of Jesus Christ; 3. for the glory of the Saints; 4. for the confounding of the wicked; 5. finally, that the body may share with the soul its sentence of reward or punishment.*
+
+**3.** In the universal judgment, how will the glory of God be manifested?
+
+*In the universal judgment the glory of God will be manifested, because all will know with what justice God governs the world, although at times we now see the good in affliction and the wicked in prosperity.*
+
+**4.** In the universal judgment, how will the glory of Jesus Christ be manifested?
+
+*In the universal judgment the glory of Jesus Christ will be manifested, because He, having been unjustly condemned by men, will then appear before all the world as supreme judge of all.*
+
+**5.** In the universal judgment, how will the glory of the Saints be manifested?
+
+*In the universal judgment the glory of the Saints will be manifested, because many of them, who died despised by the wicked, will be glorified in the presence of the whole world.*
+
+**6.** In the universal judgment, what will the confusion of the wicked be?
+
+*In the universal judgment the confusion of the wicked will be very great, especially for those who oppressed the just and for those who took pains during life to be esteemed as men of virtue and goodness, seeing the sins they have committed, even the most secret, made manifest to the whole world.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-x.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-x.md
@@ -1,0 +1,381 @@
+# Chapter X — On the ninth article
+
+## § 1. On the Church in general
+
+**1.** What does the ninth article — "the holy Catholic Church, the communion of saints" — teach us?
+
+*The ninth article of the Creed teaches us that Jesus Christ founded on earth a visible society called the Catholic Church, and that all the persons who form part of this Church are in communion with one another.*
+
+**2.** Why, after the article that treats of the Holy Spirit, is the Catholic Church spoken of at once?
+
+*After the article that treats of the Holy Spirit, the Catholic Church is spoken of at once to indicate that all the holiness of the Church derives from the Holy Spirit, who is the author of every holiness.*
+
+**3.** What does this word Church mean?
+
+*The word Church means a convocation or gathering of many persons.*
+
+**4.** Who has convoked or called us to the Church of Jesus Christ?
+
+*We have been called to the Church of Jesus Christ by a special grace of God, that by the light of faith and the observance of the divine law we may render Him due worship and attain to eternal life.*
+
+**5.** Where are the members of the Church to be found?
+
+*The members of the Church are found partly in heaven, and form the Church triumphant; partly in purgatory, and form the Church suffering; partly on earth, and form the Church militant.*
+
+**6.** Do these different parts of the Church constitute one single Church?
+
+*Yes, these different parts of the Church constitute one single Church and one single body, because they have the same head, who is Jesus Christ; the same spirit which animates and unites them; and the same end, which is eternal happiness, already enjoyed by some and awaited by others.*
+
+**7.** To which part of the Church does this ninth article principally refer?
+
+*This ninth article of the Creed principally refers to the Church militant, which is the Church in which we are at present.*
+
+## § 2. On the Church in particular
+
+**8.** What is the Catholic Church?
+
+*The Catholic Church is the society or congregation of all the baptized who, living on earth, profess the same faith and law of Christ, partake of the same sacraments, and obey their lawful Pastors, principally the Roman Pontiff.*
+
+**9.** State distinctly what is necessary to be a member of the Church.
+
+*To be a member of the Church it is necessary to be baptized, to believe and profess the doctrine of Jesus Christ, to partake of the same sacraments, and to acknowledge the Pope and the other lawful Pastors of the Church.*
+
+**10.** Who are the lawful Pastors of the Church?
+
+*The lawful Pastors of the Church are the Roman Pontiff, that is, the Pope, who is the universal Pastor, and the Bishops. Furthermore, in dependence on the Bishops and the Pope, the other priests, and especially the parish priests, have a share in the office of pastors.*
+
+**11.** Why do you say that the Roman Pontiff is the universal Pastor of the Church?
+
+*Because Jesus Christ said to Saint Peter, the first Pope: "Thou art Peter, and upon this rock I will build my Church, and I will give to thee the keys of the kingdom of heaven; and whatsoever thou shalt bind on earth shall be bound also in heaven, and whatsoever thou shalt loose on earth shall be loosed also in heaven." And He said to him further: "Feed my lambs, feed my sheep."*
+
+**12.** Do not, then, the many societies of baptized men who do not acknowledge the Roman Pontiff as their head belong to the Church of Jesus Christ?
+
+*No, all those who do not acknowledge the Roman Pontiff as their head do not belong to the Church of Jesus Christ.*
+
+**13.** How can the Church of Jesus Christ be distinguished from the many societies or sects founded by men, which call themselves Christian?
+
+*The true Church of Jesus Christ can be easily distinguished from the many societies or sects founded by men, which call themselves Christian, by four marks. She is One, Holy, Catholic, and Apostolic.*
+
+**14.** Why is the Church called One?
+
+*The true Church is called One because her children, of every time and place, are united with one another in the same faith, the same worship, the same law, and the participation of the same sacraments, under one and the same visible head, the Roman Pontiff.*
+
+**15.** Could there not be several Churches?
+
+*No, there cannot be several Churches, because, as there is one only God, one only Faith, and one only Baptism, so there is, and can be, but one only true Church.*
+
+**16.** But are not the faithful united together of a nation or of a diocese also called Churches?
+
+*The faithful united together of a nation or of a diocese are also called Churches, but they are always portions of the universal Church, and form together with her one single Church.*
+
+**17.** Why is the true Church called Holy?
+
+*The true Church is called Holy because her invisible head, who is Jesus Christ, is holy; many of her members are holy; her faith, her law, and her sacraments are holy; and outside of her there is not, nor can there be, true holiness.*
+
+**18.** Why is the Church called Catholic?
+
+*The true Church is called Catholic, which means universal, because she embraces the faithful of all times, of all places, of every age and condition, and all the men of the world are called to form part of her.*
+
+**19.** Why is the Church further called Apostolic?
+
+*The true Church is further called Apostolic because she goes back without interruption to the Apostles; because she believes and teaches all that the Apostles believed and taught; and because she is guided and governed by their lawful successors.*
+
+**20.** And why is the true Church also called Roman?
+
+*The true Church is also called Roman because the four marks of unity, holiness, catholicity, and apostolicity are found only in the Church that acknowledges as her head the Bishop of Rome, the successor of Saint Peter.*
+
+**21.** How is the Church of Jesus Christ constituted?
+
+*The Church of Jesus Christ is constituted as a true and perfect society; and in her, as in a moral person, we may distinguish the soul and the body.*
+
+**22.** In what does the soul of the Church consist?
+
+*The soul of the Church consists in that which she has of inward and spiritual, namely, faith, hope, charity, the gifts of grace and of the Holy Spirit, and all the heavenly treasures that have come to her through the merits of Christ the Redeemer and of the Saints.*
+
+**23.** In what does the body of the Church consist?
+
+*The body of the Church consists in that which she has of visible and external, whether in the association of those who are gathered together, or in worship and the ministry of teaching, or in her external order and government.*
+
+**24.** Is it enough for salvation merely to be a member of the Catholic Church in any way?
+
+*No, it is not enough for salvation merely to be a member of the Catholic Church in any way, but one must be a living member of her.*
+
+**25.** Who are the living members of the Church?
+
+*The living members of the Church are all and only the just, those, that is, who are actually in the grace of God.*
+
+**26.** And who are the dead members?
+
+*The dead members of the Church are the faithful who are in mortal sin.*
+
+**27.** Can anyone be saved outside the Catholic, Apostolic, Roman Church?
+
+*No, outside the Catholic, Apostolic, Roman Church no one can be saved, just as no one could be saved from the flood outside the Ark of Noah, which was a figure of this Church.*
+
+**28.** How then were the ancient Patriarchs, the Prophets, and all the other just men of the Old Testament saved?
+
+*All the just of the Old Testament were saved by virtue of the faith they had in Christ to come, by means of which they already belonged spiritually to this Church.*
+
+**29.** But could one who, through no fault of his own, finds himself outside the Church, be saved?
+
+*One who, finding himself, through no fault of his own — that is, in good faith — outside the Church, had received Baptism, or had at least the implicit desire of it; and who, moreover, sincerely sought the truth and did the will of God as best he could; although separated from the body of the Church, would be united to her soul, and therefore on the way of salvation.*
+
+**30.** And one who, being a member of the Catholic Church, did not put her teachings into practice, would he be saved?
+
+*One who, being a member of the Catholic Church, did not put her teachings into practice would be a dead member of her, and therefore would not be saved; because for the salvation of an adult there is required not only baptism and faith, but also works conformed to the faith.*
+
+**31.** Are we obliged to believe all the truths that the Church teaches us?
+
+*Yes, we are obliged to believe all the truths that the Church teaches us, and Jesus Christ declares that he who does not believe is already condemned.*
+
+**32.** Are we likewise obliged to do all that the Church commands?
+
+*Yes, we are obliged to do all that the Church commands, because Jesus Christ said to the Pastors of the Church: "He who hears you hears Me, and he who despises you despises Me."*
+
+**33.** Can the Church err in the things which she proposes to us to believe?
+
+*No, in the things she proposes to us to believe, the Church cannot err, because, according to the promise of Jesus Christ, she is perpetually assisted by the Holy Spirit.*
+
+**34.** Is the Catholic Church, then, infallible?
+
+*Yes, the Catholic Church is infallible, and therefore those who refuse her definitions lose the faith and become heretics.*
+
+**35.** Can the Catholic Church be destroyed or perish?
+
+*No; the Catholic Church can be persecuted, but cannot be destroyed nor perish. She will last to the end of the world, because to the end of the world Jesus Christ will be with her, as He has promised.*
+
+**36.** Why is the Catholic Church so much persecuted?
+
+*The Catholic Church is so much persecuted because her divine Founder was also so persecuted, and because she rebukes vices, combats the passions, and condemns all injustices and all errors.*
+
+**37.** Are there other duties of Catholics toward the Church?
+
+*Every Catholic must have for the Church a boundless love, esteem himself infinitely honored and happy to belong to her, and labor for her glory and increase by all the means in his power.*
+
+## § 3. On the teaching Church and the learning Church
+
+**38.** Is there any distinction among the members who compose the Church?
+
+*Among the members who compose the Church there is a very notable distinction, because there are those who command and those who obey, those who teach and those who are taught.*
+
+**39.** What is that part of the Church called which teaches?
+
+*The part of the Church which teaches is called the teaching Church.*
+
+**40.** What is the part of the Church called which is taught?
+
+*The part of the Church which is taught is called the learning Church.*
+
+**41.** Who established this distinction in the Church?
+
+*This distinction in the Church was established by Jesus Christ Himself.*
+
+**42.** Are the teaching Church and the learning Church, then, two distinct Churches?
+
+*The teaching Church and the learning Church are two distinct parts of one and the same Church, just as in the human body the head is distinct from the other members and yet forms together with them one single body.*
+
+**43.** Of whom is the teaching Church composed?
+
+*The teaching Church is composed of all the Bishops with the Roman Pontiff at their head, whether they be dispersed or gathered together in a Council.*
+
+**44.** And of whom is the learning Church composed?
+
+*The learning Church is composed of all the faithful.*
+
+**45.** Which persons, then, have in the Church the authority to teach?
+
+*The authority to teach in the Church belongs to the Pope and the Bishops, and, in dependence on them, to the other sacred ministers.*
+
+**46.** Are we obliged to listen to the teaching Church?
+
+*Yes, without doubt, we are all obliged to listen to the teaching Church under pain of eternal condemnation, because Jesus Christ said to the Pastors of the Church, in the person of the Apostles: "He who hears you hears Me, and he who despises you despises Me."*
+
+**47.** Besides the authority to teach, does the Church have any other power?
+
+*Yes, besides the authority to teach, the Church has especially the power to administer holy things, to make laws, and to require their observance.*
+
+**48.** Does the power which the members of the ecclesiastical hierarchy have come from the people?
+
+*The power which the members of the ecclesiastical hierarchy have does not come from the people, and it would be heresy to say so, but comes solely from God.*
+
+**49.** To whom belongs the exercise of these powers?
+
+*The exercise of these powers belongs solely to the hierarchical body, that is, to the Pope and the Bishops subordinate to him.*
+
+## § 4. On the Pope and the Bishops
+
+**50.** Who is the Pope?
+
+*The Pope, whom we also call the Supreme Pontiff, or also the Roman Pontiff, is the successor of Saint Peter in the See of Rome, the Vicar of Jesus Christ on earth, and the visible head of the Church.*
+
+**51.** Why is the Roman Pontiff the successor of Saint Peter?
+
+*The Roman Pontiff is the successor of Saint Peter, because Saint Peter united in his own person the dignity of Bishop of Rome and of head of the Church; he established by divine disposition his see at Rome and there he died; therefore he who is elected Bishop of Rome is also the heir of all his authority.*
+
+**52.** Why is the Roman Pontiff the Vicar of Jesus Christ?
+
+*The Roman Pontiff is the Vicar of Jesus Christ because he represents Him on earth and takes His place in the government of the Church.*
+
+**53.** Why is the Roman Pontiff the visible head of the Church?
+
+*The Roman Pontiff is the visible head of the Church because he rules her visibly with the very authority of Jesus Christ, who is her invisible head.*
+
+**54.** What, then, is the dignity of the Pope?
+
+*The dignity of the Pope is the greatest of all earthly dignities, and gives him supreme and immediate power over each and all the Pastors and the faithful.*
+
+**55.** Can the Pope err in teaching the Church?
+
+*The Pope cannot err, that is, he is infallible, in the definitions that concern faith and morals.*
+
+**56.** For what reason is the Pope infallible?
+
+*The Pope is infallible by reason of the promise of Jesus Christ and the continual assistance of the Holy Spirit.*
+
+**57.** When is the Pope infallible?
+
+*The Pope is infallible only when, in his capacity as Pastor and Teacher of all Christians, by virtue of his supreme apostolic authority, he defines a doctrine concerning faith or morals to be held by the whole Church.*
+
+**58.** What sin would one commit who did not believe the solemn definitions of the Pope?
+
+*One who did not believe the solemn definitions of the Pope, or even merely doubted them, would sin against the faith, and if he persisted obstinately in this unbelief, he would no longer be a Catholic, but a heretic.*
+
+**59.** For what end has God granted the Pope the gift of infallibility?
+
+*God has granted the Pope the gift of infallibility so that we may all be certain and assured of the truth that the Church teaches.*
+
+**60.** When was it defined that the Pope is infallible?
+
+*That the Pope is infallible was defined by the Church in the Vatican Council, and if anyone should presume to contradict this definition, he would be a heretic and excommunicated.*
+
+**61.** In defining that the Pope is infallible, did the Church perhaps establish a new truth of faith?
+
+*No, the Church, in defining that the Pope is infallible, did not establish a new truth of faith, but only, in order to oppose new errors, defined that the infallibility of the Pope, already contained in Sacred Scripture and in Tradition, is a truth revealed by God, and therefore to be believed as a dogma or article of faith.*
+
+**62.** How must every Catholic behave toward the Pope?
+
+*Every Catholic must acknowledge the Pope as Father, Pastor, and universal Teacher, and remain united to him in mind and heart.*
+
+**63.** After the Pope, who are by divine institution the most venerable persons in the Church?
+
+*After the Pope, by divine institution the most venerable persons of the Church are the Bishops.*
+
+**64.** Who are the Bishops?
+
+*The Bishops are the pastors of the faithful, placed by the Holy Spirit to govern the Church of God in the sees entrusted to them, in dependence on the Roman Pontiff.*
+
+**65.** What is the Bishop in his own diocese?
+
+*The Bishop in his own diocese is the lawful Pastor, the Father, the Teacher, the superior of all the faithful, clergy and laity, who belong to that same diocese.*
+
+**66.** Why is the Bishop called the lawful Pastor?
+
+*The Bishop is called the lawful Pastor because the jurisdiction, that is, the power he has to govern the faithful of his own diocese, was conferred on him according to the norms and laws of the Church.*
+
+**67.** Whose successors are the Pope and the Bishops?
+
+*The Pope is the successor of Saint Peter, the prince of the Apostles, and the Bishops are the successors of the Apostles, in what regards the ordinary government of the Church.*
+
+**68.** Must the faithful remain united to their own Bishop?
+
+*Yes, every member of the faithful, clergy and laity, must remain united in mind and heart to his own Bishop in grace and communion with the Apostolic See.*
+
+**69.** How must the faithful behave toward their Bishop?
+
+*Every member of the faithful, clergy and laity, must reverence, love, and honor his Bishop, and render him obedience in all that concerns the care of souls and the spiritual government of the diocese.*
+
+**70.** By whom is the Bishop assisted in the care of souls?
+
+*The Bishop in the care of souls is assisted by the priests, and principally by the parish priests.*
+
+**71.** Who is the Parish Priest?
+
+*The Parish Priest is a priest deputed to preside over and direct, in dependence on the Bishop, a portion of the diocese that is called a parish.*
+
+**72.** What duties do the faithful have toward their parish priest?
+
+*The faithful must remain united to their parish priest, listen to him docilely, and show him respect and submission in all that concerns the care of the parish.*
+
+## § 5. On the communion of saints
+
+**73.** What does the ninth article of the Creed teach us by the words: the communion of saints?
+
+*By the words "the communion of saints," the ninth article of the Creed teaches us that in the Church, by reason of the intimate union that exists among all her members, the spiritual goods, both internal and external, which belong to her, are common.*
+
+**74.** What are the common internal goods in the Church?
+
+*The common internal goods in the Church are: the grace received in the sacraments, faith, hope, charity, the infinite merits of Jesus Christ, the superabundant merits of the Virgin and of the Saints, and the fruit of all the good works that are done in this Church.*
+
+**75.** What are the common external goods in the Church?
+
+*The common external goods in the Church are: the sacraments, the sacrifice of the Holy Mass, the public prayers, the religious functions, and all the other exterior practices that unite the faithful together.*
+
+**76.** Do all the children of the Church share in this communion of goods?
+
+*In the communion of internal goods share the Christians who are in the grace of God; those, however, who are in mortal sin do not partake of these goods.*
+
+**77.** Why do those who are in mortal sin not share in these goods?
+
+*Because the grace of God is what unites the faithful with God and with one another; and therefore those who are in mortal sin, being without the grace of God, are excluded from the communion of spiritual goods.*
+
+**78.** Have the Christians who are in mortal sin, then, no benefit at all from the internal and spiritual goods of the Church?
+
+*Christians who are in mortal sin have still some benefit from the internal and spiritual goods of the Church of which they are deprived, inasmuch as they preserve the character of the Christian, which is indelible, and are helped by the prayers and good works of the faithful to obtain the grace of conversion to God.*
+
+**79.** Can those who are in mortal sin share in the external goods of the Church?
+
+*Those who are in mortal sin can share in the external goods of the Church, unless they are separated from the Church by excommunication.*
+
+**80.** Why are the members of this communion, taken together, called saints?
+
+*The members of this communion are called saints because all are called to holiness and were sanctified through Baptism, and many of them have already attained to perfect holiness.*
+
+**81.** Does the communion of saints extend also to heaven and to purgatory?
+
+*Yes, the communion of saints extends also to heaven and to purgatory, because charity unites the three Churches — triumphant, suffering, and militant; and the Saints pray to God for us and for the souls in purgatory, and we give honor and glory to the Saints and can relieve the souls in purgatory by applying in their suffrage Masses, alms, indulgences, and other good works.*
+
+## § 6. On those who are outside the Church
+
+**82.** Who are those who do not belong to the communion of saints?
+
+*Those who do not belong to the communion of saints in the other life are the damned, and in this life those who are outside the true Church.*
+
+**83.** Who are those who are outside the true Church?
+
+*Outside the true Church are the infidels, the Jews, the heretics, the apostates, the schismatics, and the excommunicated.*
+
+**84.** Who are the infidels?
+
+*The infidels are those who have not Baptism and do not believe in Jesus Christ; whether because they believe in and adore false divinities, as the idolaters; or because, although admitting the one true God, they do not believe in Christ the Messiah, neither as having come in the person of Jesus Christ nor as still to come, such as the Mohammedans and others like them.*
+
+**85.** Who are the Jews?
+
+*The Jews are those who profess the law of Moses; they have not received baptism and do not believe in Jesus Christ.*
+
+**86.** Who are the heretics?
+
+*The heretics are the baptized who pertinaciously refuse to believe some truth revealed by God and taught as of faith by the Catholic Church; for example, the Arians, the Nestorians, and the various sects of the Protestants.*
+
+**87.** Who are the apostates?
+
+*The apostates are those who abjure, that is, renounce by an external act the Catholic faith which they previously professed.*
+
+**88.** Who are the schismatics?
+
+*The schismatics are the Christians who, not explicitly denying any dogma, voluntarily separate themselves from the Church of Jesus Christ, that is, from the lawful pastors.*
+
+**89.** Who are the excommunicated?
+
+*The excommunicated are those who, for very grave failings, are struck with excommunication by the Pope or the Bishop, and therefore, as unworthy, are separated from the body of the Church, which awaits and desires their conversion.*
+
+**90.** Is excommunication to be feared?
+
+*Excommunication is to be feared greatly, because it is the gravest and most terrible punishment that the Church can inflict on her rebellious and obstinate children.*
+
+**91.** Of what goods are the excommunicated deprived?
+
+*The excommunicated are deprived of the public prayers, the sacraments, the indulgences, and ecclesiastical burial.*
+
+**92.** Can we in any way help the excommunicated?
+
+*We can in some way help the excommunicated and all the others who are outside the true Church, by salutary advice, by prayers, and by good works, beseeching God in His mercy to grant them the grace of conversion to the faith and of entering into the communion of the Saints.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-xi.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-xi.md
@@ -1,0 +1,17 @@
+# Chapter XI — On the tenth article
+
+**1.** What does the tenth article — "The forgiveness of sins" — teach us?
+
+*The tenth article of the Creed teaches us that Jesus Christ has left to His Church the power to forgive sins.*
+
+**2.** Can the Church forgive every kind of sin?
+
+*Yes, the Church can forgive all sins, however many and however grave, because Jesus Christ has given her full power to loose and to bind.*
+
+**3.** Who are those in the Church who exercise this power to forgive sins?
+
+*Those who in the Church exercise the power to forgive sins are, in the first place, the Pope, who alone possesses the fullness of this power; then the Bishops, and, in dependence on the Bishops, the priests.*
+
+**4.** How does the Church forgive sins?
+
+*The Church forgives sins by the merits of Jesus Christ, by conferring the sacraments instituted by Him for this purpose, principally Baptism and Penance.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-xii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-xii.md
@@ -1,0 +1,29 @@
+# Chapter XII — On the eleventh article
+
+**1.** What does the eleventh article — "The resurrection of the body" — teach us?
+
+*The eleventh article of the Creed teaches us that all men shall rise again, each soul taking up again the body it had in this life.*
+
+**2.** How shall the resurrection of the dead come about?
+
+*The resurrection of the dead shall come about by the power of almighty God, to whom nothing is impossible.*
+
+**3.** When shall the resurrection of the dead come about?
+
+*The resurrection of all the dead shall come about at the end of the world, and then shall follow the universal judgment.*
+
+**4.** Why does God will the resurrection of the bodies?
+
+*God wills the resurrection of the bodies, because, since the soul has worked good or evil united to the body, it may also be rewarded or punished together with it.*
+
+**5.** Shall all men rise again in the same manner?
+
+*No, there shall be a very great difference between the bodies of the elect and the bodies of the damned, because the bodies of the elect alone shall have, in likeness to the risen Jesus Christ, the endowments of glorified bodies.*
+
+**6.** What are these endowments which shall adorn the bodies of the elect?
+
+*The endowments which shall adorn the glorified bodies of the elect are: 1. impassibility, by which they shall no longer be subject to evils, to pains of any kind, nor to the need of food, of rest, or of anything else; 2. brightness, by which they shall shine like the sun and like so many stars; 3. agility, by which they shall be able to pass in a moment and without effort from one place to another, and from earth to heaven; 4. subtlety, by which without hindrance they shall be able to penetrate any body, as the risen Jesus Christ did.*
+
+**7.** How shall the bodies of the damned be?
+
+*The bodies of the damned shall be deprived of the endowments of the glorified bodies of the Blessed, and shall bear the horrible mark of eternal reprobation.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-xiii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-prima-capo-xiii.md
@@ -1,0 +1,29 @@
+# Chapter XIII — On the twelfth article
+
+**1.** What does the last article — "Life everlasting" — teach us?
+
+*The last article of the Creed teaches us that after this present life there is another life, either eternally blessed for the elect in heaven, or eternally unhappy for the damned in hell.*
+
+**2.** Can we comprehend the happiness of heaven?
+
+*No, we cannot comprehend the happiness of heaven, because it surpasses the knowledge of our limited mind, and because the goods of heaven cannot be compared with the goods of this world.*
+
+**3.** In what does the happiness of the elect consist?
+
+*The happiness of the elect consists in seeing, loving, and possessing forever God, the source of every good.*
+
+**4.** In what does the unhappiness of the damned consist?
+
+*The unhappiness of the damned consists in being forever deprived of the sight of God and punished with eternal torments in hell.*
+
+**5.** Are the goods of heaven and the evils of hell only for the souls?
+
+*The goods of heaven and the evils of hell are at present only for the souls, because only the souls are now in heaven or in hell; but after the resurrection of the body, men, in the fullness of their nature, that is, in soul and body, shall be either happy or tormented forever.*
+
+**6.** Shall the goods of heaven be equal for the blessed, and the evils of hell equal for the damned?
+
+*The goods of heaven for the blessed, and the evils of hell for the damned, shall be equal in substance and in eternal duration; but in measure, that is, in degree, they shall be greater or less, according to the merits or demerits of each.*
+
+**7.** What does the word Amen at the end of the Creed mean?
+
+*The word Amen at the end of prayers means: So be it; at the end of the Creed it means: So it is; that is to say: I believe to be most true all that is contained in these twelve articles, and I am more certain of it than if I saw it with my own eyes.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-i.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-i.md
@@ -1,0 +1,143 @@
+# Chapter I — On the Sacraments in general
+
+## § 1. Nature of the sacraments
+
+**1.** What is treated of in the fourth part of Christian Doctrine?
+
+*In the fourth part of Christian Doctrine, the sacraments are treated.*
+
+**2.** What is meant by the word sacrament?
+
+*By the word sacrament is meant a sensible and efficacious sign of grace, instituted by Jesus Christ to sanctify our souls.*
+
+**3.** Why do you call the sacraments sensible and efficacious signs of grace?
+
+*I call the sacraments sensible and efficacious signs of grace because all the sacraments signify, by means of sensible things, the divine grace which they produce in our soul.*
+
+**4.** Explain by an example how the sacraments are sensible and efficacious signs of grace.
+
+*In Baptism, the pouring of water on the head of the person, and the words "I baptize thee," that is, "I wash thee," "in the name of the Father, and of the Son, and of the Holy Spirit," are a sensible sign of what Baptism does in the soul; because, as water washes the body, so the grace given by Baptism cleanses the soul from sin.*
+
+**5.** How many and which are the sacraments?
+
+*The sacraments are seven, namely: Baptism, Confirmation, Eucharist, Penance, Extreme Unction, Holy Orders, Matrimony.*
+
+**6.** How many things are required to make a sacrament?
+
+*To make a sacrament there are required the matter, the form, and the minister, who has the intention to do what the Church does.*
+
+**7.** What is the matter of the sacraments?
+
+*The matter of the sacraments is the sensible thing which is used to make the sacrament; as for example natural water in Baptism; oil and balsam in Confirmation.*
+
+**8.** What is the form of the sacraments?
+
+*The form of the sacraments is the words that are pronounced to make it.*
+
+**9.** Who is the minister of the sacraments?
+
+*The minister of the sacraments is the person who makes or confers the sacrament.*
+
+## § 2. On the principal effect of the sacraments, which is grace
+
+**10.** What is grace?
+
+*The grace of God is an internal, supernatural gift, given to us without any merit of our own, but for the merits of Jesus Christ, in view of eternal life.*
+
+**11.** How is grace distinguished?
+
+*Grace is distinguished into sanctifying grace, which is also called habitual, and actual grace.*
+
+**12.** What is sanctifying grace?
+
+*Sanctifying grace is a supernatural gift inherent in our soul, which makes us just, adopted children of God, and heirs of Paradise.*
+
+**13.** Of how many kinds is sanctifying grace?
+
+*Sanctifying grace is of two kinds: first grace and second grace.*
+
+**14.** What is first grace?
+
+*First grace is that by which man passes from the state of mortal sin to the state of justice.*
+
+**15.** And what is second grace?
+
+*Second grace is an increase of first grace.*
+
+**16.** What is actual grace?
+
+*Actual grace is a supernatural gift which enlightens our mind and moves and strengthens our will, that we may do good and abstain from evil.*
+
+**17.** Can we resist the grace of God?
+
+*Yes, we can resist the grace of God, because it does not destroy our free will.*
+
+**18.** By our own powers alone, can we do anything that avails us for eternal life?
+
+*Without the help of the grace of God, by our own powers alone, we can do nothing that avails us for eternal life.*
+
+**19.** How is grace communicated to us by God?
+
+*Grace is communicated to us by God principally by means of the holy sacraments.*
+
+**20.** Besides sanctifying grace, do the sacraments confer other grace on us?
+
+*Besides sanctifying grace, the sacraments also confer sacramental grace.*
+
+**21.** What is sacramental grace?
+
+*Sacramental grace consists in the right that is acquired by receiving any sacrament whatever, to have at the opportune time the actual graces necessary to fulfill the obligations that derive from the sacrament received. Thus we, when we were baptized, received the right to have graces in order to live as Christians.*
+
+**22.** Do the sacraments always give grace to those who receive them?
+
+*The sacraments always give grace, provided they are received with the necessary dispositions.*
+
+**23.** Who has given the sacraments the power to confer grace?
+
+*The power to confer grace was given to the sacraments by Jesus Christ through His passion and death.*
+
+**24.** Which are the sacraments that confer the first sanctifying grace?
+
+*The sacraments that confer the first sanctifying grace, which makes us friends of God, are two: Baptism and Penance.*
+
+**25.** What are these two sacraments therefore called?
+
+*These two sacraments, namely Baptism and Penance, are therefore called sacraments of the dead, because they are instituted principally to restore to souls dead by sin the life of grace.*
+
+**26.** Which are the sacraments that increase grace in him who possesses it?
+
+*The sacraments that increase grace in him who possesses it are the other five, namely Confirmation, the Eucharist, Extreme Unction, Holy Orders, and Matrimony, which confer second grace.*
+
+**27.** What are these five sacraments therefore called?
+
+*These five sacraments, namely Confirmation, the Eucharist, Extreme Unction, Holy Orders, and Matrimony, are called sacraments of the living, because those who receive them must be without mortal sin, that is, already alive to sanctifying grace.*
+
+**28.** What sin does one commit who receives one of the sacraments of the living knowing that he is not in the grace of God?
+
+*One who receives one of the sacraments of the living, knowing that he is not in the grace of God, commits a grave sacrilege.*
+
+**29.** Which are the sacraments most necessary for our salvation?
+
+*The sacraments most necessary for our salvation are two: Baptism and Penance: Baptism is necessary for all, and Penance is necessary for all those who have sinned mortally after Baptism.*
+
+**30.** Which is the greatest of all the sacraments?
+
+*The greatest of all the sacraments is that of the Eucharist, because it contains not only grace, but also Jesus Christ, the author of grace and of the sacraments.*
+
+## § 3. On the character which some Sacraments impress
+
+**31.** Which sacraments can be received only once?
+
+*The sacraments that can be received only once are three: Baptism, Confirmation, and Holy Orders.*
+
+**32.** Why can the three sacraments, Baptism, Confirmation, and Holy Orders, be received only once?
+
+*The three sacraments, Baptism, Confirmation, and Holy Orders, can be received only once, because each of them imprints the character.*
+
+**33.** What is the character which each of the three sacraments, Baptism, Confirmation, and Holy Orders, imprints on the soul?
+
+*The character which each of the three sacraments, Baptism, Confirmation, and Holy Orders, imprints on the soul is a spiritual sign, which is never effaced.*
+
+**34.** What use is the character that these three sacraments imprint on the soul?
+
+*The character that these three Sacraments imprint on the soul serves to mark us out in Baptism as members of Jesus Christ, in Confirmation as His soldiers, and in Holy Orders as His ministers.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-ii.md
@@ -1,0 +1,115 @@
+# Chapter II — On Baptism
+
+## § 1. Nature and effects of Baptism
+
+**1.** What is the sacrament of Baptism?
+
+*Baptism is the sacrament by which we are born again to the grace of God and become Christians.*
+
+**2.** What are the effects of the sacrament of Baptism?
+
+*The sacrament of Baptism confers the first sanctifying grace, by which original sin is wiped away, and also actual sin if there be any; it remits all the punishment due for them; it imprints the character of Christians; makes us children of God, members of the Church, and heirs of heaven, and renders us capable of receiving the other sacraments.*
+
+**3.** What is the matter of Baptism?
+
+*The matter of Baptism is natural water, which is poured on the head of the one being baptized in such quantity that it flows.*
+
+**4.** What is the form of Baptism?
+
+*The form of Baptism is this: "I baptize thee in the name of the Father and of the Son and of the Holy Spirit."*
+
+## § 2. Minister of Baptism
+
+**5.** To whom does it belong to give Baptism?
+
+*The giving of Baptism belongs by right to Bishops and parish priests; but, in case of necessity, any person can give it, whether man or woman, even a heretic or an infidel, provided he performs the rite of Baptism and has the intention to do what the Church does.*
+
+**6.** If there were need to baptize a person who is in danger of death, and many were present, who should give the Baptism?
+
+*If there were need to baptize a person in danger of death, and many were present, the priest should baptize him, if there were one; and in his absence, an ecclesiastic of an inferior order; and in the absence of such, a layman in preference to a woman, unless indeed the greater skill of the woman, or decency, should require otherwise.*
+
+**7.** What intention must one have who baptizes?
+
+*One who baptizes must have the intention to do what the holy Church does in baptizing.*
+
+## § 3. Rite of Baptism and dispositions of one who receives it as an adult
+
+**8.** How is Baptism given?
+
+*Baptism is given by pouring water on the head of the one to be baptized, and, if not on the head, on some other principal part of the body, and saying at the same time: "I baptize thee in the name of the Father and of the Son and of the Holy Spirit."*
+
+**9.** If one were to pour the water, and another to pronounce the words, would the person be baptized?
+
+*If one were to pour the water and another to pronounce the words, the person would not be baptized; but it is necessary that the same person both pour the water and pronounce the words.*
+
+**10.** When it is doubtful whether the person is dead, must one omit to baptize him?
+
+*When it is doubtful whether the person is dead, one must baptize him under condition, saying: "If thou art alive, I baptize thee in the name of the Father and of the Son and of the Holy Spirit."*
+
+**11.** When must children be brought to the church to be baptized?
+
+*Children must be brought to the church to be baptized as soon as possible.*
+
+**12.** Why must such great care be taken to have children receive Baptism?
+
+*The greatest care must be taken to have children baptized, because, by reason of their tender age, they are exposed to many dangers of dying, and they cannot be saved without Baptism.*
+
+**13.** Do fathers and mothers, then, who through their negligence let their children die without Baptism, or defer it, sin?
+
+*Yes, fathers and mothers who through their negligence let their children die without Baptism sin gravely, because they deprive their children of eternal life; and they also sin gravely by long deferring Baptism, because they expose them to the danger of dying without having received it.*
+
+**14.** When one who is being baptized is an adult, what dispositions must he have?
+
+*The adult who is being baptized must, besides faith, have at least imperfect sorrow for the mortal sins he may have committed.*
+
+**15.** If an adult were to be baptized in mortal sin without this sorrow, what would he receive?
+
+*If an adult were baptized in mortal sin without this sorrow, he would receive the character of Baptism, but not the forgiveness of sins, nor sanctifying grace. And these effects would remain suspended until the impediment were removed by perfect sorrow for sins, or by the sacrament of Penance.*
+
+## § 4. Necessity of Baptism and duties of the baptized
+
+**16.** Is Baptism necessary for salvation?
+
+*Baptism is absolutely necessary for salvation, the Lord having expressly said: "He who is not born again of water and the Holy Spirit cannot enter the kingdom of heaven."*
+
+**17.** Can the lack of Baptism be supplied in any way?
+
+*The lack of the sacrament of Baptism can be supplied by martyrdom, which is called Baptism of blood, or by an act of perfect love of God or of contrition, joined with the desire, at least implicit, of Baptism; and this is called Baptism of desire.*
+
+**18.** To what is one who receives Baptism bound?
+
+*One who receives Baptism is bound always to profess the faith, and to observe the law of Jesus Christ and of His Church.*
+
+**19.** What is renounced in receiving holy Baptism?
+
+*In receiving holy Baptism, one renounces forever the devil, his works, and his pomps.*
+
+**20.** What is meant by the works or the pomps of the devil?
+
+*By works and pomps of the devil are meant sins, and the maxims of the world contrary to the maxims of the holy Gospel.*
+
+## § 5. Name and Godparents
+
+**21.** Why is the name of a Saint given to the one being baptized?
+
+*The name of a Saint is given to the one being baptized in order to place him under the special protection of a heavenly patron and to encourage him to imitate his examples.*
+
+**22.** Who are the godfathers and godmothers of Baptism?
+
+*The godfathers and godmothers of Baptism are those persons who, by the disposition of the Church, hold the children at the sacred font, respond in their stead, and make themselves guarantors before God of their Christian education, especially should the parents fail in it.*
+
+**23.** Are we obliged to abide by those promises and renunciations which our godparents made for us?
+
+*We are obliged without doubt to abide by the promises and renunciations which our godparents made for us, because God has received us into His grace only on these conditions.*
+
+**24.** What persons must be chosen as godfathers and godmothers?
+
+*As godfathers and godmothers must be chosen Catholic persons, of good morals, and obedient to the laws of the Church.*
+
+**25.** What are the obligations of godfathers and godmothers?
+
+*Godfathers and godmothers are obliged to see that their spiritual children are instructed in the truths of the faith, and live as good Christians, edifying them by good example.*
+
+**26.** What bond do the godparents of Baptism contract?
+
+*Godparents contract a spiritual kinship with the baptized and with his parents, which gives rise to an impediment of marriage with the same.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-iii.md
@@ -1,0 +1,77 @@
+# Chapter III — On Confirmation
+
+**1.** What is the sacrament of Confirmation?
+
+*Confirmation is a sacrament that gives us the Holy Spirit, imprints on our soul the character of a soldier of Jesus Christ, and makes us perfect Christians.*
+
+**2.** In what way does the sacrament of Confirmation make us perfect Christians?
+
+*Confirmation makes us perfect Christians, because it confirms us in the faith and perfects the other virtues and gifts which we have received in holy Baptism; and therefore it is called Confirmation.*
+
+**3.** Which are the gifts of the Holy Spirit that are received in Confirmation?
+
+*The gifts of the Holy Spirit that are received in Confirmation are these seven: Wisdom, Understanding, Counsel, Fortitude, Knowledge, Piety, and Fear of God.*
+
+**4.** What is the matter of this sacrament?
+
+*The matter of this sacrament, besides the imposition of the Bishop's hands, is the anointing made on the forehead of the baptized with sacred Chrism; and therefore it is also called Chrism, that is, Anointing.*
+
+**5.** What is sacred Chrism?
+
+*Sacred Chrism is oil mixed with balsam, which the Bishop has consecrated on Holy Thursday.*
+
+**6.** What do the oil and the balsam signify in this sacrament?
+
+*In this sacrament, the oil, which spreads and strengthens, signifies the abundant grace which is poured forth in the soul of the Christian to confirm him in the faith; and the balsam, which is fragrant and protects from corruption, signifies that the Christian, strengthened by this grace, is fit to give the good odor of Christian virtues and to preserve himself from the corruption of vices.*
+
+**7.** What is the form of the sacrament of Confirmation?
+
+*The form of the sacrament of Confirmation is this: "I sign thee with the sign of the Cross and confirm thee with the chrism of salvation in the name of the Father and of the Son and of the Holy Spirit. Amen."*
+
+**8.** Who is the minister of the sacrament of Confirmation?
+
+*The ordinary minister of the sacrament of Confirmation is the Bishop alone.*
+
+**9.** With what rite does the Bishop administer Confirmation?
+
+*The Bishop, in order to administer the sacrament of Confirmation, first extends his hands over those to be confirmed, invoking upon them the Holy Spirit; then he makes an anointing in the form of a cross with sacred Chrism on the forehead of each one, saying the words of the form; then with his right hand he gives a light blow on the cheek of the confirmed, saying to him: "Peace be with thee"; finally he solemnly blesses all the confirmed.*
+
+**10.** Why is the anointing made on the forehead?
+
+*The anointing is made on the forehead, where the signs of fear and of blushing appear, that the one confirmed may understand that he must not be ashamed of the name and profession of a Christian, nor be afraid of the enemies of the faith.*
+
+**11.** Why is a light blow given to the one confirmed?
+
+*A light blow is given to the one confirmed so that he may know that he must be ready to suffer every affront and every pain for the faith of Jesus Christ.*
+
+**12.** Must all seek to receive the sacrament of Confirmation?
+
+*Yes, all must seek to receive the sacrament of Confirmation and to have it received by their dependents.*
+
+**13.** At what age is it good to receive the sacrament of Confirmation?
+
+*The age at which it is good to receive the sacrament of Confirmation is about seven years; because then temptations are wont to begin, and the grace of this sacrament can be sufficiently understood, and the having received it can be remembered.*
+
+**14.** What dispositions are required to receive worthily the sacrament of Confirmation?
+
+*To receive worthily the sacrament of Confirmation, one must be in the grace of God, know the principal mysteries of our holy faith, and approach it with reverence and devotion.*
+
+**15.** Would one sin who received Confirmation a second time?
+
+*He would commit a sacrilege, because Confirmation is one of those sacraments that imprint the character on the soul, and which can therefore be received only once.*
+
+**16.** What must the Christian do to preserve the grace of Confirmation?
+
+*To preserve the grace of Confirmation, the Christian must pray often, do good works, and live according to the law of Jesus Christ, without human respects.*
+
+**17.** Why, also in Confirmation, are there godfathers and godmothers?
+
+*That these may direct, by their words and examples, the one confirmed in the way of salvation and help him in the spiritual warfare.*
+
+**18.** What conditions are required in the godfather?
+
+*The godfather must be of suitable age, Catholic, confirmed, instructed in the things most necessary to religion, and of good morals.*
+
+**19.** Does the godfather of Confirmation contract any kinship with the one confirmed and with his parents?
+
+*The godfather of Confirmation contracts the same spiritual kinship as one who holds at baptism.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-iv.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-iv.md
@@ -1,0 +1,237 @@
+# Chapter IV — On the Eucharist
+
+## § 1. On the nature of this sacrament and the real presence of Jesus Christ therein
+
+**1.** What is the sacrament of the Eucharist?
+
+*The Eucharist is a sacrament in which, by the wonderful conversion of all the substance of bread into the Body of Jesus Christ, and of all the substance of wine into His precious Blood, there are truly, really, and substantially contained the Body, Blood, Soul, and Divinity of the same Jesus Christ our Lord, under the species of bread and wine, to be our spiritual nourishment.*
+
+**2.** Is there in the Eucharist the same Jesus Christ who is in heaven and who was born on earth of the most holy Virgin?
+
+*Yes, in the Eucharist there is truly the same Jesus Christ who is in heaven and who was born on earth of the most holy Virgin.*
+
+**3.** Why do you believe that in the sacrament of the Eucharist there is truly Jesus Christ?
+
+*I believe that in the sacrament of the Eucharist Jesus Christ is truly present, because He Himself has said so, and because the holy Church teaches it to me.*
+
+**4.** What is the matter of the sacrament of the Eucharist?
+
+*The matter of the sacrament of the Eucharist is that used by Jesus Christ, namely, wheaten bread and wine of the vine.*
+
+**5.** What is the form of the sacrament of the Eucharist?
+
+*The form of the sacrament of the Eucharist consists in the words used by Jesus Christ: "This is my Body; this is my Blood."*
+
+**6.** What, then, is the host before the consecration?
+
+*The host before the consecration is bread.*
+
+**7.** After the consecration, what is the host?
+
+*After the consecration the host is the true Body of Our Lord Jesus Christ under the species of bread.*
+
+**8.** What is in the chalice before the consecration?
+
+*Before the consecration there is in the chalice wine with a few drops of water.*
+
+**9.** After the consecration, what is in the chalice?
+
+*After the consecration there is in the chalice the true Blood of Our Lord Jesus Christ under the species of wine.*
+
+**10.** When is the conversion of the bread into the Body, and of the wine into the Blood, of Jesus Christ made?
+
+*The conversion of the bread into the Body, and of the wine into the Blood, of Jesus Christ is made in the very act in which the priest, at Holy Mass, pronounces the words of the consecration.*
+
+**11.** What is the consecration?
+
+*The consecration is the renewal, by means of the priest, of the miracle worked by Jesus Christ at the Last Supper of changing bread and wine into His adorable Body and Blood, saying: "This is my body, this is my blood."*
+
+**12.** What is the miraculous conversion of the bread and wine into the Body and Blood of Jesus Christ called by the Church?
+
+*The miraculous conversion which is wrought every day on our altars is called by the Church transubstantiation.*
+
+**13.** Who has given such power to the words of the consecration?
+
+*Our Lord Jesus Christ Himself, who is almighty God, has given such power to the words of the consecration.*
+
+**14.** After the consecration, does nothing of the bread and wine remain?
+
+*After the consecration only the species of bread and wine remain.*
+
+**15.** What are the species of bread and wine?
+
+*The species are the quantity and the sensible qualities of bread and wine, such as figure, color, and taste.*
+
+**16.** In what way can the species of bread and wine remain without their substance?
+
+*The species of bread and wine remain miraculously without their substance, by the power of almighty God.*
+
+**17.** Under the species of bread is there only the Body of Jesus Christ, and under the species of wine only His Blood?
+
+*Both under the species of bread and under the species of wine there is the whole living Jesus Christ, in Body, Blood, Soul, and Divinity.*
+
+**18.** Could you tell me why both in the host and in the chalice there is the whole Jesus Christ?
+
+*Both in the host and in the chalice there is the whole Jesus Christ, because He is in the Eucharist alive and immortal as in heaven; therefore where His Body is, there too is His Blood, Soul, and Divinity; and where His Blood is, there is also His Body, Soul, and Divinity, all this being inseparable in Jesus Christ.*
+
+**19.** When Jesus is in the host, does He cease to be in heaven?
+
+*When Jesus is in the host, He does not cease to be in heaven, but is at the same time in heaven and in the Most Holy Sacrament.*
+
+**20.** Is Jesus Christ in all the consecrated hosts in the world?
+
+*Yes, Jesus Christ is in all the consecrated hosts.*
+
+**21.** How can it be that Jesus Christ is in all the consecrated hosts?
+
+*Jesus Christ is in all the consecrated hosts by the omnipotence of God, to whom nothing is impossible.*
+
+**22.** When the host is broken, is the Body of Jesus Christ broken?
+
+*When the host is broken, the Body of Jesus Christ is not broken, but only the species of bread are broken.*
+
+**23.** In which part of the host does the Body of Jesus Christ remain?
+
+*The Body of Jesus Christ remains entire in all the parts into which the host has been divided.*
+
+**24.** Is Jesus Christ as much in a large host as in a small particle of a host?
+
+*As much in a large host as in a small particle of a host there is the same Jesus Christ.*
+
+**25.** For what reason is the Most Holy Eucharist preserved in the churches?
+
+*The Most Holy Eucharist is preserved in the churches so that it may be adored by the faithful and carried to the sick as need requires.*
+
+**26.** Must the Eucharist be adored?
+
+*The Eucharist must be adored by all, because it contains truly, really, and substantially our Lord Jesus Christ Himself.*
+
+## § 2. On the institution and effects of the sacrament of the Eucharist
+
+**27.** At what time did Jesus Christ institute the sacrament of the Eucharist?
+
+*Jesus Christ instituted the sacrament of the Eucharist at the Last Supper, which He took with His disciples on the evening before His passion.*
+
+**28.** Why did Jesus Christ institute the Most Holy Eucharist?
+
+*Jesus Christ instituted the Most Holy Eucharist for three principal reasons:*
+
+*1. That it might be the sacrifice of the new law.*
+
+*2. That it might be the food of our soul.*
+
+*3. That it might be a perpetual memorial of His passion and death, and a precious pledge of His love toward us, and of eternal life.*
+
+**29.** Why did Jesus Christ institute this sacrament under the species of bread and wine?
+
+*Jesus Christ instituted this sacrament under the species of bread and wine, because the Eucharist was to be our spiritual nourishment, and it was therefore fitting that it be given to us in the form of food and drink.*
+
+**30.** What effects does the Most Holy Eucharist produce in us?
+
+*The principal effects which the Most Holy Eucharist produces in him who receives it worthily are these: 1. it preserves and increases the life of the soul, which is grace, as material food sustains and increases the life of the body; 2. it remits venial sins and preserves from mortal sins; 3. it produces spiritual consolation.*
+
+**31.** Does the Most Holy Eucharist not produce other effects in us?
+
+*Yes, the Most Holy Eucharist produces in us three other effects, namely: 1. it weakens our passions, and in particular it quenches in us the flames of concupiscence; 2. it increases in us the fervor of charity toward God and toward our neighbor, and helps us to act in conformity with the desires of Jesus Christ; 3. it gives us a pledge of future glory and of the resurrection itself of our body.*
+
+## § 3. On the dispositions necessary for receiving Communion well
+
+**32.** Does the sacrament of the Eucharist always produce in us its wonderful effects?
+
+*The sacrament of the Eucharist produces in us its wonderful effects when it is received with the due dispositions.*
+
+**33.** How many things are necessary for making a good Communion?
+
+*For making a good Communion three things are necessary: 1. to be in the grace of God; 2. to be fasting from midnight until the act of Communion; 3. to know what one is going to receive, and to approach Holy Communion with devotion.*
+
+**34.** What does it mean to be in the grace of God?
+
+*To be in the grace of God means to have a conscience pure and clean of every mortal sin.*
+
+**35.** What must one do before communicating who knows that he is in mortal sin?
+
+*One who knows that he is in mortal sin must, before communicating, make a good confession; an act of perfect contrition without confession is not sufficient for one who is in mortal sin to communicate as he ought.*
+
+**36.** Why is even an act of perfect contrition not sufficient for one who knows that he is in mortal sin to be able to communicate?
+
+*Because the Church has established, out of respect for this sacrament, that one who is guilty of mortal sin should not dare to make Communion unless he has first confessed.*
+
+**37.** If one were to communicate in mortal sin, would he receive Jesus Christ?
+
+*One who communicated in mortal sin would receive Jesus Christ, but not His grace; rather, he would commit sacrilege and would make himself deserving of the sentence of damnation.*
+
+**38.** What is the fast required before Communion?
+
+*Before Communion the natural fast is required, which is broken by every small thing taken in the manner of food or drink.*
+
+**39.** If one swallows something remaining between the teeth, or some drop of water that has entered his mouth, may he still communicate?
+
+*One who swallowed something remaining between the teeth, or some drop of water in washing himself, may still communicate, because in that case these things are either not taken in the manner of food or drink, or have already lost their nature.*
+
+**40.** Is it ever permitted to make Communion without being fasting?
+
+*To make Communion without being fasting is permitted to the sick who are in danger of death, and to him who has obtained a special faculty from the Pope on account of prolonged infirmity. Communion made by the sick in danger of death is called Viaticum, because it sustains them on the journey they make from this life to eternity.*
+
+**41.** What does it mean to "know what one is going to receive"?
+
+*To know what one is going to receive means to know those things which are taught about this sacrament in Christian Doctrine, and to believe them firmly.*
+
+**42.** What does it mean to communicate with devotion?
+
+*To communicate with devotion means to approach Holy Communion with humility and modesty, both in person and in dress; and to make the preparation before, and the thanksgiving after, Holy Communion.*
+
+**43.** In what does the preparation before Communion consist?
+
+*The preparation before Communion consists in spending some time considering whom we are going to receive and who we are; and in making acts of faith, hope, charity, contrition, adoration, humility, and desire to receive Jesus Christ.*
+
+**44.** In what does the thanksgiving after Communion consist?
+
+*The thanksgiving after Communion consists in remaining recollected to honor within ourselves the Lord, renewing the acts of faith, hope, charity, adoration, thanksgiving, offering, and petition, especially of those graces which are most necessary for us and for those for whom we are obliged to pray.*
+
+**45.** What must one do on the day of Communion?
+
+*On the day of Communion one must remain recollected as much as possible, occupy oneself in works of piety, and fulfill with greater diligence the duties of one's state.*
+
+**46.** After Holy Communion, how long does Jesus Christ remain in us?
+
+*After Holy Communion Jesus Christ remains in us with His grace until we sin mortally; and with His real presence He remains in us until the sacramental species are consumed.*
+
+## § 4. On the manner of communicating
+
+**47.** How must one present oneself in the act of receiving Holy Communion?
+
+*In the act of receiving Holy Communion one must be kneeling, hold the head moderately raised, the eyes modest and turned to the sacred particle, the mouth sufficiently open, and the tongue slightly forward on the lips.*
+
+**48.** How must the Communion cloth or paten be held?
+
+*The Communion cloth or paten must be held in such a way that it may catch the sacred particle should it fall.*
+
+**49.** When must the sacred particle be swallowed?
+
+*We must try to swallow the sacred particle as soon as possible, and for some time to refrain from spitting.*
+
+**50.** If the sacred particle should stick to the palate, what should be done?
+
+*If the sacred particle should stick to the palate, it must be detached with the tongue, and never with the finger.*
+
+## § 5. On the precept of Communion
+
+**51.** When is there the obligation of communicating?
+
+*There is the obligation of communicating every year, at Easter, each one in his own parish; and also in danger of death.*
+
+**52.** At what age does the commandment of Easter Communion begin to oblige?
+
+*The commandment of Easter Communion begins to oblige at the age at which a child is capable of approaching it with the due dispositions.*
+
+**53.** Do those sin who are of an age capable of being admitted to Communion and do not communicate?
+
+*Those who, being of an age capable of being admitted to Communion, do not communicate, either because they will not, or because they are uninstructed through their own fault, sin without doubt. Their parents, or those who take their place, also sin if the deferral of Communion takes place through their fault, and they shall have to render a great account of it to God.*
+
+**54.** Is it a good and useful thing to communicate often?
+
+*It is a most excellent thing to communicate often, provided it be done with the due dispositions.*
+
+**55.** With what frequency may one go to Communion?
+
+*Each one may go to Communion with such greater frequency as is advised him by a pious and learned confessor.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-ix.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-ix.md
@@ -1,0 +1,111 @@
+# Chapter IX — On Matrimony
+
+## § 1. Nature of the sacrament of Matrimony
+
+**1.** What is the sacrament of Matrimony?
+
+*Matrimony is a sacrament, instituted by our Lord Jesus Christ, which establishes a holy and indissoluble union between man and woman, and gives them the grace to love each other in holiness and to bring up their children as Christians.*
+
+**2.** By whom was Matrimony instituted?
+
+*Matrimony was instituted by God Himself in the earthly paradise, and in the new Testament was raised by Jesus Christ to the dignity of a sacrament.*
+
+**3.** Has the sacrament of Matrimony some special meaning?
+
+*The sacrament of Matrimony signifies the indissoluble union of Jesus Christ with the holy Church, His spouse and our most loving mother.*
+
+**4.** Why is it said that the bond of matrimony is indissoluble?
+
+*It is said that the bond of matrimony is indissoluble, that is, that it cannot be dissolved save by the death of one of the spouses, because so has God ordained from the beginning, and so has our Lord Jesus Christ solemnly proclaimed.*
+
+**5.** In Christian marriage can the contract be separated from the sacrament?
+
+*No, in marriage among Christians the contract cannot be separated from the sacrament, because for them marriage is none other than the natural contract itself raised by Jesus Christ to the dignity of a sacrament.*
+
+**6.** Among Christians, then, can there be no true marriage that is not a sacrament?
+
+*Among Christians there can be no true marriage that is not a sacrament.*
+
+**7.** What effects does the sacrament of Matrimony produce?
+
+*The sacrament of Matrimony: 1. gives an increase of sanctifying grace; 2. confers the special grace to faithfully fulfill all the duties of matrimony.*
+
+## § 2. Ministers, rite, and dispositions
+
+**8.** Who are the ministers of this sacrament?
+
+*The ministers of this sacrament are the spouses themselves, who reciprocally confer and receive the sacrament.*
+
+**9.** In what way is this sacrament administered?
+
+*This sacrament, preserving the nature of a contract, is administered by the contracting parties themselves by declaring, in the presence of their parish priest, or of one delegated by him, and of two witnesses, that they unite in matrimony.*
+
+**10.** What use, then, is the blessing the parish priest gives to the spouses?
+
+*The blessing the parish priest gives to the spouses is not necessary to constitute the sacrament, but is given to sanction in the name of the Church their union, and to call ever more upon them the blessings of God.*
+
+**11.** What intention must one who contracts matrimony have?
+
+*One who contracts matrimony must have the intention: 1. to do the will of God, who calls him to such a state; 2. to work in it the salvation of his own soul; 3. to bring up his children as Christians, if God grants him to have any.*
+
+**12.** In what manner must the spouses dispose themselves to receive the sacrament of Matrimony with fruit?
+
+*The spouses, in order to receive the sacrament of Matrimony with fruit, must: 1. heartily commend themselves to God to know His will, and to obtain from Him those graces which are necessary in such a state; 2. consult their own parents before making the promise, as obedience and the respect due to them require; 3. prepare themselves by a good confession, even general, if needful, of their whole life; 4. avoid every dangerous familiarity of behavior and word in conversing together.*
+
+**13.** What are the principal obligations of persons united in matrimony?
+
+*Persons united in matrimony must: 1. keep inviolate conjugal fidelity and always conduct themselves as Christians in all things; 2. love each other mutually, bearing with each other in patience, and live in peace and concord; 3. if they have children, think seriously about providing for them according to need; give them a Christian education; and leave them free to choose the state to which they are called by God.*
+
+## § 3. Conditions and impediments
+
+**14.** What is necessary to validly contract Christian marriage?
+
+*To validly contract Christian marriage it is necessary to be free from every diriment matrimonial impediment, and to freely give one's consent to the contract of marriage before one's own parish priest, or a priest delegated by him, and two witnesses.*
+
+**15.** What is necessary to lawfully contract Christian marriage?
+
+*To lawfully contract Christian marriage it is necessary to be free from impedient matrimonial impediments, to be instructed in the principal things of religion, and to be in the state of grace, otherwise a sacrilege would be committed.*
+
+**16.** What are matrimonial impediments?
+
+*Matrimonial impediments are those circumstances which render marriage either invalid or unlawful. In the first case they are called diriment impediments, in the second impedient impediments.*
+
+**17.** Give me some example of a diriment impediment.
+
+*Diriment impediments are, for example, consanguinity to the fourth degree, spiritual kinship, the solemn vow of chastity, diversity of worship between baptized and non-baptized, etc.*
+
+**18.** Give me some example of an impedient impediment.
+
+*Impedient impediments are, for example, forbidden time, the simple vow of chastity, etc.*
+
+**19.** Are the faithful obliged to make known to the ecclesiastical authority the matrimonial impediments they know of?
+
+*The faithful are obliged to make known to the ecclesiastical authority the matrimonial impediments they know of; and it is for this reason that the publications are made by the parish priests.*
+
+**20.** Who has the power to establish matrimonial impediments, to dispense from them, and to judge of the validity of Christian marriage?
+
+*The Church alone has the power to establish impediments and to judge of the validity of marriage among Christians; just as the Church alone can dispense from those impediments which she has established.*
+
+**21.** Why does the Church alone have the power to establish impediments and to judge of the validity of marriage?
+
+*The Church alone has the power to establish impediments, to judge of the validity of marriage, and to dispense from the impediments which she has set, because in Christian marriage the contract cannot be separated from the sacrament, and therefore the contract too falls under the power of the Church, to whom alone Jesus Christ conferred the right to make laws and decisions in sacred things.*
+
+**22.** Can civil authority dissolve by divorce the bond of Christian marriage?
+
+*No, the bond of Christian marriage cannot be dissolved by civil authority, because it cannot intrude in the matter of sacraments and separate what God has joined together.*
+
+**23.** What is civil marriage?
+
+*Civil marriage is nothing other than a formality prescribed by law for the end of giving and assuring the civil effects to the married and to their offspring.*
+
+**24.** Is it enough for a Christian to perform only civil marriage, that is, the civil contract?
+
+*For a Christian it is not enough to perform only the civil contract, because this is not a sacrament, and therefore is not true marriage.*
+
+**25.** If the spouses lived together only by civil marriage, in what condition would they find themselves?
+
+*If the spouses lived together only by civil marriage, they would be in a state of continual mortal sin, and their union would always remain unlawful before God and the Church.*
+
+**26.** Must civil marriage also be performed?
+
+*Civil marriage must also be performed, because, although this is not a sacrament, it nevertheless serves to guarantee to the contracting parties and to their children the civil effects of the conjugal society; and so, as a general rule, the religious marriage is not permitted by the ecclesiastical authority unless the acts prescribed by civil law have been initiated.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-v.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-v.md
@@ -1,0 +1,97 @@
+# Chapter V — On the Holy Sacrifice of the Mass
+
+## § 1. On the essence, institution, and ends of the Holy Sacrifice of the Mass
+
+**1.** Is the Eucharist to be considered only as a sacrament?
+
+*The Eucharist, besides being a sacrament, is also the permanent sacrifice of the new law, which Jesus Christ left to His Church, to be offered to God by the hands of His priests.*
+
+**2.** In what does sacrifice, in general, consist?
+
+*Sacrifice, in general, consists in offering a sensible thing to God, and destroying it in some manner, in order to acknowledge His supreme dominion over us and over all things.*
+
+**3.** What is this sacrifice of the new law called?
+
+*This sacrifice of the new law is called Holy Mass.*
+
+**4.** What, then, is Holy Mass?
+
+*Holy Mass is the sacrifice of the Body and Blood of Jesus Christ, offered on our altars under the species of bread and wine, in memory of the sacrifice of the Cross.*
+
+**5.** Is the sacrifice of the Mass the same as that of the Cross?
+
+*The sacrifice of the Mass is substantially the same as that of the Cross, inasmuch as the same Jesus Christ who offered Himself on the Cross is the one who offers Himself by the hands of the priests, His ministers, on our altars; but as to the manner in which the sacrifice of the Mass is offered, it differs from the sacrifice of the Cross, while retaining with it the most intimate and essential relation.*
+
+**6.** What difference, then, and relation, is there between the sacrifice of the Mass and that of the Cross?
+
+*Between the sacrifice of the Mass and that of the Cross there is this difference and relation: that Jesus Christ on the Cross offered Himself by shedding His blood and meriting for us; whereas on the altars He sacrifices Himself without the shedding of blood and applies to us the fruits of His Passion and Death.*
+
+**7.** What other relation has the sacrifice of the Mass with that of the Cross?
+
+*Another relation of the sacrifice of the Mass with that of the Cross is that the sacrifice of the Mass represents in a sensible way the shedding of the blood of Jesus Christ on the Cross; because by virtue of the words of consecration, under the species of bread there is rendered present the Body alone, and under the species of wine the Blood alone, of our Savior; though by natural concomitance and by the hypostatic union, the living and true Jesus Christ is present under each of the species.*
+
+**8.** Is not the sacrifice of the Cross the only sacrifice of the new law?
+
+*The sacrifice of the Cross is the only sacrifice of the new law, inasmuch as by it the Lord appeased Divine Justice, acquired all the merits necessary to save us, and so completed on His part our redemption. These merits, however, He applies to us through the means He instituted in His Church, among which is the Holy Sacrifice of the Mass.*
+
+**9.** For what ends, then, is the sacrifice of Holy Mass offered?
+
+*The sacrifice of Holy Mass is offered to God for four ends: 1. to honor Him as is fitting, and for this it is called latreutic; 2. to thank Him for His benefits, and for this it is called eucharistic; 3. to appease Him, to give Him the due satisfaction for our sins, and to suffrage the souls in purgatory; and for this it is called propitiatory; 4. to obtain all the graces that are necessary to us, and for this it is called impetratory.*
+
+**10.** Who is it that offers to God the sacrifice of Holy Mass?
+
+*The first and principal offerer of the sacrifice of Holy Mass is Jesus Christ; and the priest is the minister who, in the name of Jesus Christ, offers the same sacrifice to the Eternal Father.*
+
+**11.** Who instituted the sacrifice of Holy Mass?
+
+*The sacrifice of Holy Mass was instituted by Jesus Christ Himself, when He instituted the sacrament of the Eucharist; and He commanded that it be done in memory of His Passion.*
+
+**12.** To whom is Holy Mass offered?
+
+*Holy Mass is offered to God alone.*
+
+**13.** If Holy Mass is offered to God alone, why are so many Masses celebrated in honor of the Most Holy Virgin and of the Saints?
+
+*The Mass celebrated in honor of the Virgin and of the Saints is always a sacrifice offered to God alone: it is said, however, to be celebrated in honor of the Most Holy Virgin and of the Saints to thank God for the gifts He has given them, and to obtain from Him, by their intercession, more abundantly the graces of which we have need.*
+
+**14.** Who shares in the fruits of the Mass?
+
+*The whole Church shares in the fruits of the Mass, but particularly: 1. the priest and those who assist at Mass, who are considered united to the priest; 2. those for whom the Mass is applied, who may be either living or dead.*
+
+## § 2. On the manner of assisting at Holy Mass
+
+**15.** What things are necessary to hear Holy Mass well and with fruit?
+
+*To hear Holy Mass well and with fruit two things are necessary: 1. modesty of person; 2. devotion of heart.*
+
+**16.** In what does modesty of person consist?
+
+*Modesty of person consists especially in being modestly dressed; in observing silence and recollection; and in remaining, as far as possible, kneeling, except during the two Gospels, which are heard standing.*
+
+**17.** In hearing Holy Mass, what is the best way to practice devotion of heart?
+
+*The best way to practice devotion of heart in hearing Holy Mass is the following:*
+
+*1. To unite from the start one's own intention with that of the priest, offering to God the holy sacrifice for the ends for which it was instituted.*
+
+*2. To accompany the priest in each prayer and action of the sacrifice.*
+
+*3. To meditate on the passion and death of Jesus Christ and to detest from the heart the sins that were the cause of them.*
+
+*4. To make Sacramental Communion, or at least Spiritual Communion, at the time the priest communicates.*
+
+**18.** What is Spiritual Communion?
+
+*Spiritual Communion is a great desire to be united sacramentally to Jesus Christ, saying, for example: "My Lord Jesus Christ, I desire with all my heart to be united to You now and for all eternity"; and making the same acts that are made before and after Sacramental Communion.*
+
+**19.** Does the recitation of the Rosary or of other prayers during Mass prevent one from hearing it with fruit?
+
+*The recitation of these prayers does not prevent one from hearing Mass with fruit, provided one endeavor, as far as possible, to follow the action of the holy sacrifice.*
+
+**20.** Is it a fitting thing to pray also for others while assisting at Holy Mass?
+
+*It is a fitting thing to pray also for others while assisting at Holy Mass; rather, the time of Holy Mass is the most opportune to pray to God for the living and the dead.*
+
+**21.** When Mass is finished, what ought one to do?
+
+*When Mass is finished, one ought to thank God for the grace of having let us assist at this great sacrifice, and ask His pardon for the faults we have committed in assisting at it.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-vi.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-vi.md
@@ -1,0 +1,581 @@
+# Chapter VI — On Penance
+
+## § 1. On Penance in general
+
+**1.** What is the sacrament of Penance?
+
+*Penance, also called Confession, is the sacrament instituted by Jesus Christ to forgive sins committed after Baptism.*
+
+**2.** Why is the name of Penance given to this sacrament?
+
+*The name of Penance is given to this sacrament because, in order to obtain the forgiveness of sins, it is necessary to detest them with repentance, and because he who has committed a fault must submit to the punishment the priest imposes.*
+
+**3.** Why is this sacrament also called Confession?
+
+*This sacrament is also called Confession because, to obtain the forgiveness of sins, it is not enough to detest them, but it is necessary to declare them to the priest, that is, to make the confession of them.*
+
+**4.** When did Jesus Christ institute the sacrament of Penance?
+
+*Jesus Christ instituted the sacrament of Penance on the day of His resurrection, when, having entered the upper room, He solemnly gave to His Apostles the power to forgive sins.*
+
+**5.** How did Jesus Christ give His Apostles the power to forgive sins?
+
+*Jesus Christ gave His Apostles the power to forgive sins by breathing on them and saying: "Receive the Holy Spirit: the sins of those whose sins you shall forgive shall be forgiven; and the sins of those whose sins you shall retain shall be retained."*
+
+**6.** What is the matter of the sacrament of Penance?
+
+*The matter of the sacrament of Penance is distinguished into remote and proximate. The remote matter is constituted by the sins committed by the penitent after Baptism, and the proximate matter is the acts of the penitent himself, namely, contrition, accusation, and satisfaction.*
+
+**7.** What is the form of the sacrament of Penance?
+
+*The form of the sacrament of Penance is this: "I absolve thee from thy sins."*
+
+**8.** Who is the minister of the sacrament of Penance?
+
+*The minister of the sacrament of Penance is the priest approved by the Bishop to hear confessions.*
+
+**9.** Why did you say that the priest must be approved by the Bishop?
+
+*The priest must be approved by the Bishop to hear confessions because, to validly administer this sacrament, the power of orders is not enough, but the power of jurisdiction is also necessary, that is, the faculty to judge, which must be given by the Bishop.*
+
+**10.** How many are the parts of the sacrament of Penance?
+
+*The parts of the sacrament of Penance are: the contrition, the confession, and the satisfaction of the penitent, and the absolution of the priest.*
+
+**11.** What is contrition, that is, sorrow for sins?
+
+*Contrition, that is, sorrow for sins, is a displeasure of soul by which one detests the sins committed and resolves not to commit them again in the future.*
+
+**12.** What does this word contrition mean?
+
+*The word contrition means breaking or shattering, as when a stone is crushed and reduced to powder.*
+
+**13.** Why is the name of contrition given to sorrow for sins?
+
+*The name of contrition is given to sorrow for sins to signify that the hard heart of the sinner in a certain way breaks for sorrow at having offended God.*
+
+**14.** In what does the confession of sins consist?
+
+*Confession consists in a distinct accusation of our sins, made to the confessor in order to obtain absolution and penance for them.*
+
+**15.** Why is confession called accusation?
+
+*Confession is called accusation because it must not be an indifferent recital, but a true and sorrowful manifestation of one's own sins.*
+
+**16.** What is satisfaction or penance?
+
+*Satisfaction or penance is that prayer or other good work which the confessor enjoins on the penitent in expiation of his sins.*
+
+**17.** What is absolution?
+
+*Absolution is the sentence which the priest pronounces in the name of Jesus Christ, to forgive the sins of the penitent.*
+
+**18.** Which of the parts of the sacrament of Penance is the most necessary?
+
+*Of the parts of the sacrament of Penance, the most necessary is contrition, because without it the forgiveness of sins can never be obtained, and with it alone, when it is perfect, the forgiveness can be obtained, provided it be joined with the desire, at least implicit, of confessing.*
+
+## § 2. On the effects and necessity of the sacrament of Penance and on the dispositions for receiving it well
+
+**19.** How many are the effects of the sacrament of Penance?
+
+*The sacrament of Penance confers sanctifying grace, by which are forgiven the mortal sins and also the venial sins that have been confessed and for which one has sorrow; commutes the eternal punishment to temporal, of which also more or less is forgiven according to the dispositions; restores the merits of good works done before committing the mortal sin; gives to the soul opportune helps not to fall again into sin; and restores peace to the conscience.*
+
+**20.** Is the sacrament of Penance necessary for the salvation of all?
+
+*The sacrament of Penance is necessary for the salvation of all those who, after Baptism, have committed some mortal sin.*
+
+**21.** Is it a good thing to confess often?
+
+*To confess often is a most excellent thing, because the sacrament of Penance, besides wiping away sins, gives opportune graces to avoid them in the future.*
+
+**22.** Does the sacrament of Penance have the power to forgive all sins, however many and however great they may be?
+
+*The sacrament of Penance has the power to forgive all sins, however many and however great they may be, provided it is received with the due dispositions.*
+
+**23.** How many things are required to make a good confession?
+
+*To make a good confession five things are required: 1. examination of conscience; 2. sorrow for having offended God; 3. resolution to sin no more; 4. accusation of one's sins; 5. satisfaction or penance.*
+
+**24.** What must we do first of all to confess well?
+
+*To confess well we must first of all pray heartily to the Lord to give us light to know all our sins and strength to detest them.*
+
+## § 3. On examination
+
+**25.** What is the examination of conscience?
+
+*The examination of conscience is a diligent search for the sins committed since the last well-made confession.*
+
+**26.** How is the examination of conscience made?
+
+*The examination of conscience is made by diligently calling to memory, before God, all the sins committed and never confessed, in thoughts, words, deeds, and omissions, against the Commandments of God and of the Church, and the obligations of one's state.*
+
+**27.** What other things must we examine ourselves on?
+
+*We must examine ourselves also on bad habits and on the occasions of sin.*
+
+**28.** In the examination, must we also search out the number of sins?
+
+*In the examination we must also search out the number of mortal sins.*
+
+**29.** What is required for a sin to be mortal?
+
+*For a sin to be mortal three things are required: grave matter, full advertence, and perfect consent of the will.*
+
+**30.** When is there grave matter?
+
+*There is grave matter when it is a question of something notably contrary to the law of God or of the Church.*
+
+**31.** When is there full knowledge in sinning?
+
+*There is full knowledge in sinning when one knows perfectly that he is doing a grave evil.*
+
+**32.** When is there, in sinning, perfect consent of the will?
+
+*There is, in sinning, perfect consent of the will when one deliberately wills to do something, although knowing it to be sinful.*
+
+**33.** What diligence must be used in the examination of conscience?
+
+*In the examination of conscience there must be used the diligence one would use in an affair of great importance.*
+
+**34.** How much time must be spent in the examination?
+
+*One must spend in the examination of conscience more or less time, according to need, that is, according to the number and quality of sins that burden the conscience and according to the time that has elapsed since the last well-made confession.*
+
+**35.** How can the examination for confession be made easier?
+
+## § 4. On sorrow
+
+**36.** What is sorrow for sins?
+
+*Sorrow for sins consists in a displeasure and a sincere detestation of the offense given to God.*
+
+**37.** Of how many kinds is sorrow?
+
+*Sorrow is of two kinds: perfect, that is, of contrition; and imperfect, that is, of attrition.*
+
+**38.** What is perfect sorrow, or contrition?
+
+*Perfect sorrow is the displeasure of having offended God because He is infinitely good and worthy in Himself of being loved.*
+
+**39.** Why do you call the sorrow of contrition perfect?
+
+*I call the sorrow of contrition perfect for two reasons: 1. because it regards exclusively the goodness of God, and not our advantage or harm; 2. because it immediately obtains for us the forgiveness of sins, the obligation of confessing, however, remaining.*
+
+**40.** So does perfect sorrow obtain for us the forgiveness of sins independently of confession?
+
+*Perfect sorrow does not obtain for us the forgiveness of sins independently of confession, because it always includes the will to confess.*
+
+**41.** Why does perfect sorrow, or contrition, produce this effect of restoring us to the grace of God?
+
+*Perfect sorrow, or contrition, produces this effect because it springs from charity, which cannot be in the soul together with mortal sin.*
+
+**42.** What is imperfect sorrow, or attrition?
+
+*Imperfect sorrow, or attrition, is that by which we repent of having offended God as supreme Judge, that is, through fear of the punishments deserved in this life or in the next, or through the very ugliness of sin.*
+
+**43.** What conditions must sorrow have to be good?
+
+*Sorrow, in order to be good, must have four conditions: it must be internal, supernatural, supreme, and universal.*
+
+**44.** What does it mean that sorrow must be internal?
+
+*It means that it must be in the heart and in the will and not in mere words.*
+
+**45.** Why must sorrow be internal?
+
+*Sorrow must be internal because the will, which by sin has turned away from God, must return to God by detesting the sin committed.*
+
+**46.** What does it mean that sorrow must be supernatural?
+
+*It means that it must be excited in us by the grace of the Lord and conceived for motives of faith.*
+
+**47.** Why must sorrow be supernatural?
+
+*Sorrow must be supernatural because supernatural is the end to which it is directed, namely, the forgiveness of God, the acquisition of sanctifying grace, and the right to eternal glory.*
+
+**48.** Explain better the difference between supernatural and natural sorrow.
+
+*He who repents for having offended God, infinitely good and worthy in Himself of being loved, for having lost heaven and merited hell, or for the intrinsic malice of sin, has a supernatural sorrow, because these are motives of faith; whereas one who would repent only for the dishonor, or punishment, that comes to him from men, or for some purely temporal harm, would have a natural sorrow, because he would repent only for human motives.*
+
+**49.** Why must sorrow be supreme?
+
+*Sorrow must be supreme because we must regard and hate sin as the supreme of all evils, since it is an offense against God, the supreme Good.*
+
+**50.** Is it perhaps necessary to weep for sorrow of sins, as at times one weeps for the misfortunes of this life?
+
+*It is not necessary that one materially weep for sorrow of sins; but it is enough that in the heart one make greater account of having offended God than of any other misfortune.*
+
+**51.** What does it mean that sorrow must be universal?
+
+*It means that it must extend to all the mortal sins committed.*
+
+**52.** Why must sorrow extend to all the mortal sins committed?
+
+*Because he who does not repent even of a single mortal sin remains an enemy of God.*
+
+**53.** What must we do to have sorrow for our sins?
+
+*To have sorrow for our sins we must ask it of God from the heart, and excite it in ourselves by the consideration of the great evil we have done in sinning.*
+
+**54.** How will you do to excite yourself to detest sins?
+
+*To excite myself to detest sins: 1. I shall consider the rigor of the infinite justice of God and the deformity of sin, which has deformed my soul and made me deserving of the eternal pains of hell; 2. I shall consider that I have lost the grace, the friendship, the sonship of God, and the inheritance of heaven; 3. that I have offended my Redeemer, who died for me, and that my sins were the cause of His death; 4. that I have despised my Creator, my God; that I have turned my back on Him, my supreme good, worthy of being loved above all things and served faithfully.*
+
+**55.** Must we be greatly solicitous, when we go to confession, to have a true sorrow for our sins?
+
+*When we go to confession, we must certainly be very solicitous to have a true sorrow for our sins, because this is the most important thing of all: and if sorrow is lacking, the confession is worthless.*
+
+**56.** Must one who confesses only venial sins have sorrow for all of them?
+
+*One who confesses only venial sins, in order to confess validly, need only be repentant of some of them; but to obtain the forgiveness of all of them, it is necessary that he repent of all those he recognizes himself to have committed.*
+
+**57.** Does one who confesses only venial sins and is not repentant of even one of them make a good confession?
+
+*One who confesses only venial sins and is not repentant of even one of them makes a confession of no value; which is, moreover, sacrilegious, if the lack of sorrow is adverted to.*
+
+**58.** What is fitting to do to make the confession of only venial sins more certain?
+
+*To make the confession of only venial sins more certain, it is a prudent thing to accuse, with true sorrow, also some graver sin of one's past life, even though already confessed other times.*
+
+**59.** Is it a good thing to make often the act of contrition?
+
+*It is a good and most useful thing to make often the act of contrition, especially before going to sleep, and when one notices or doubts that he has fallen into mortal sin, so as to be restored more quickly to the grace of God; and it serves above all to obtain more easily from God the grace of making a similar act in the greatest need, that is, in the danger of death.*
+
+## § 5. On the resolution
+
+**60.** In what does the resolution consist?
+
+*The resolution consists in a resolute will not to commit sin anymore and to use all the means necessary to flee it.*
+
+**61.** What conditions must the resolution have to be good?
+
+*The resolution, in order to be good, must have principally three conditions: it must be absolute, universal, and effective.*
+
+**62.** What does it mean: absolute resolution?
+
+*It means that the resolution must be without any condition of time, place, or person.*
+
+**63.** What does it mean: the resolution must be universal?
+
+*The resolution must be universal: it means that we must will to flee all mortal sins, both those already committed at other times, and others that we might commit.*
+
+**64.** What does it mean: the resolution must be effective?
+
+*The resolution must be effective: it means that one must have a resolute will to lose everything rather than commit a new sin, to flee dangerous occasions of sinning, to destroy bad habits, and to fulfill the obligations contracted in consequence of our sins.*
+
+**65.** What is meant by bad habit?
+
+*By bad habit is meant the acquired disposition to fall easily into those sins to which we have become accustomed.*
+
+**66.** What must be done to correct bad habits?
+
+*To correct bad habits we must keep vigilant over ourselves, pray much, frequent confession, have a good fixed director, and put into practice the counsels and remedies which he proposes to us.*
+
+**67.** What is meant by dangerous occasions of sinning?
+
+*By dangerous occasions of sinning are meant all those circumstances of time, place, persons, or things which by their own nature, or by our frailty, lead us to commit sin.*
+
+**68.** Are we gravely bound to avoid all dangerous occasions?
+
+*We are gravely bound to avoid those dangerous occasions which ordinarily lead us to commit mortal sin, which are called the proximate occasions of sin.*
+
+**69.** What must one do who cannot flee some occasion of sin?
+
+*One who cannot flee some occasion of sin must tell the confessor and abide by his counsels.*
+
+**70.** What considerations serve to make the resolution?
+
+*To make the resolution there serve the same considerations that avail to excite sorrow; namely, the consideration of the motives we have to fear the justice of God and to love His infinite goodness.*
+
+## § 6. On the accusation of sins to the confessor
+
+**71.** After having well disposed yourself for confession by examination, sorrow, and resolution, what will you do?
+
+*After having well disposed myself by examination, sorrow, and resolution, I shall go to make the accusation of my sins to the confessor in order to obtain absolution from them.*
+
+**72.** Of which sins are we obliged to confess?
+
+*We are obliged to confess all mortal sins; it is well, however, to confess also the venial ones.*
+
+**73.** What conditions must the accusation of sins or confession have?
+
+*The principal conditions which the accusation of sins must have are five: it must be humble, complete, sincere, prudent, and brief.*
+
+**74.** What does it mean: the accusation must be humble?
+
+*The accusation must be humble: it means that the penitent must accuse himself before his confessor without arrogance of soul or words, but with the sentiments of one guilty, who acknowledges his fault and appears before the judge.*
+
+**75.** What does it mean: the accusation must be complete?
+
+*The accusation must be complete: it means that all mortal sins committed after the last well-made confession and of which one is aware must be manifested with their circumstances and in their number.*
+
+**76.** What circumstances must be manifested, that the accusation may be complete?
+
+*That the accusation may be complete, the circumstances that change the species of the sin must be manifested.*
+
+**77.** Which are the circumstances that change the species of the sin?
+
+*The circumstances that change the species of the sin are: 1. those by which a sinful action passes from venial to mortal; 2. those by which a sinful action contains the malice of two or more mortal sins.*
+
+**78.** Give me the example of a circumstance that makes a venial sin become mortal.
+
+*One who, to excuse himself, told a lie from which grave harm to his neighbor resulted, would have to manifest this circumstance, which changes the lie from officious to gravely harmful.*
+
+**79.** Give me now the example of a circumstance by which the same sinful action contains the malice of two or more sins.
+
+*One who had stolen a sacred thing would have to accuse this circumstance, which adds to theft the malice of sacrilege.*
+
+**80.** If someone is not certain of having committed a sin, must he confess it?
+
+*If someone is not certain of having committed a sin, he is not obliged to confess it; if, however, he wishes to accuse it, he should add that he is not certain of having committed it.*
+
+**81.** What must one do who does not exactly remember the number of his sins?
+
+*One who does not exactly remember the number of his sins must accuse the approximate number.*
+
+**82.** Did one who, through pure forgetfulness, kept silent on a mortal sin or a necessary circumstance make a good confession?
+
+*One who, through pure forgetfulness, kept silent on a mortal sin or a necessary circumstance made a good confession, provided he used due diligence in remembering it.*
+
+**83.** If a mortal sin forgotten in confession then comes to mind, are we obliged to accuse it in another confession?
+
+*If a mortal sin forgotten in confession then comes to mind, we are obliged without doubt to accuse it the first time we confess again.*
+
+**84.** What does one commit who, through shame or some other motive, culpably keeps silent in confession on some mortal sin?
+
+*One who, through shame or some other motive, culpably keeps silent on some mortal sin in confession profanes the sacrament and therefore makes himself guilty of a most grave sacrilege.*
+
+**85.** How must one who has culpably kept silent on some mortal sin in confession provide for his own conscience?
+
+*One who has culpably kept silent on some mortal sin in confession must declare to the confessor the sin kept silent, say in how many confessions he kept silent on it, and redo all the confessions from the last well-made one.*
+
+**86.** What must one consider who is tempted to keep silent on some sin in confession?
+
+*One who is tempted to keep silent on a grave sin in confession must consider:*
+
+*1. that he has not blushed to sin in the presence of God, who sees all;*
+
+*2. that it is better to manifest one's sins to the confessor in secret, than to live quietly in sin, to die unhappily, and therefore to be shamed in the day of the universal judgment in the face of the whole world;*
+
+*3. that the confessor is bound to the sacramental seal under the gravest sin and with the threat of most severe temporal and eternal punishments.*
+
+**87.** What does it mean: the accusation must be sincere?
+
+*The accusation must be sincere: it means that we must declare our sins as they are, without excusing them, diminishing them, or increasing them.*
+
+**88.** What does it mean: the confession must be prudent?
+
+*The confession must be prudent: it means that in confessing our sins we must use the most modest terms, and we must guard ourselves from disclosing the sins of others.*
+
+**89.** What does it mean: the confession must be brief?
+
+*The confession must be brief: it means that we must not say anything useless to the confessor.*
+
+**90.** Is it not a burdensome thing to have to confess one's sins to another, especially if they are very shameful?
+
+*Although confessing one's sins to another may be burdensome, it must be done, because it is a divine precept and otherwise the forgiveness of the sins committed cannot be obtained; and moreover because the difficulty of confessing is compensated by many advantages and great consolations.*
+
+## § 7. On the manner of confessing
+
+**91.** How will you present yourself to the confessor?
+
+*I shall kneel at the feet of the confessor and shall say: "Bless me, Father, for I have sinned."*
+
+**92.** What will you do while the confessor gives you the blessing?
+
+*I shall bow humbly to receive the blessing, and I shall make the Sign of the Cross.*
+
+**93.** Having made the Sign of the Cross, what must one say?
+
+*Having made the Sign of the Cross, one must say: "I confess to Almighty God, to the Blessed Virgin Mary, to all the Saints, and to you, my spiritual father, that I have sinned."*
+
+**94.** And then what must be said?
+
+*Then one must say: "I confessed at such a time; by the grace of God I received absolution, did my penance, and went to Communion." Then the accusation of sins is made.*
+
+**95.** When the accusation of sins is finished, what will you do?
+
+*When the accusation of sins is finished, I shall say: "I also accuse myself of all the sins of my past life, especially against such or such virtue" — for example, against purity, against the fourth commandment, etc.*
+
+**96.** After this accusation, what must be said?
+
+*One must say: "Of all these sins and of those I do not remember, I ask pardon of God with all my heart; and from you, my spiritual father, I ask the penance and the absolution."*
+
+**97.** The accusation of sins thus completed, what remains to be done?
+
+*The accusation of sins completed, one must listen with respect to what the confessor says; accept the penance with a sincere will to do it; and while he gives the absolution, renew from the heart the act of contrition.*
+
+**98.** Once absolution is received, what remains to be done?
+
+*Once absolution is received, one must thank the Lord; do the penance as soon as possible; and put into practice the counsels of the confessor.*
+
+## § 8. On absolution
+
+**99.** Must confessors always give absolution to those who confess?
+
+*Confessors must give absolution only to those whom they judge well disposed to receive it.*
+
+**100.** May confessors sometimes defer or refuse absolution?
+
+*Confessors not only may, but must, defer or refuse absolution in certain cases, so as not to profane the sacrament.*
+
+**101.** Which are the penitents who must be considered ill-disposed, and to whom absolution must ordinarily be refused or deferred?
+
+*The penitents who must be considered ill-disposed are principally these:*
+
+*1. those who do not know the principal mysteries of the faith or neglect to learn the other things of Christian Doctrine which they are obliged to know according to their state;*
+
+*2. those who are gravely negligent in making the examination of conscience or give no signs of sorrow and repentance;*
+
+*3. those who, being able, do not wish to restore another's goods, or the reputation taken away;*
+
+*4. those who do not forgive their enemies from the heart;*
+
+*5. those who do not wish to practice the means necessary to amend themselves of their bad habits;*
+
+*6. those who do not wish to leave the proximate occasions of sin.*
+
+**102.** Is the confessor not too strict who defers absolution to a penitent because he does not yet believe him well disposed?
+
+*The confessor who defers absolution to a penitent, because he does not yet believe him well disposed, is not too strict, but rather very charitable, acting as a good physician, who tries every remedy, even unpleasant and painful, to save the life of the sick man.*
+
+**103.** Must the sinner to whom absolution is deferred or refused despair, or withdraw entirely from confession?
+
+*The sinner to whom absolution is deferred or refused must not despair or withdraw entirely from confession; but he must humble himself, recognize his deplorable state, profit by the good counsels which the confessor gives him, and thus place himself as soon as possible in a state to merit absolution.*
+
+**104.** What must the penitent do as to the choice of the confessor?
+
+*The true penitent must commend himself much to God for the choice of a pious, learned, and prudent confessor, then place himself in his hands and submit himself to him as to his judge and physician.*
+
+## § 9. On satisfaction, that is, penance
+
+**105.** What is satisfaction?
+
+*Satisfaction, which is also called sacramental penance, is one of the acts of the penitent, by which he gives some recompense to the justice of God for the sins committed, by performing those works which the confessor imposes on him.*
+
+**106.** Is the penitent obliged to accept the penance enjoined on him by the confessor?
+
+*The penitent is obliged to accept the penance enjoined on him by the confessor, if he can do it; and if he cannot do it, he must say it humbly to the confessor himself, and ask for another.*
+
+**107.** When must the penance be done?
+
+*If the confessor has not prescribed any time, the penance must be done as soon as possible, and one must try to do it in the state of grace.*
+
+**108.** How must the penance be done?
+
+*The penance must be done entirely and with devotion.*
+
+**109.** Why is the penance enjoined in confession?
+
+*The penance is enjoined because, ordinarily, after the sacramental absolution which forgives the guilt and the eternal punishment, there remains a temporal punishment to be expiated in this world or in purgatory.*
+
+**110.** For what reason did the Lord will to remit, in the sacrament of Baptism, all the punishment due to sins, and not in the sacrament of Penance?
+
+*The Lord willed to remit, in the sacrament of Baptism, all the punishment due to sins, and not in the sacrament of Penance, because sins after Baptism are far graver, being committed with greater knowledge and ingratitude toward the benefits of God; and also so that the obligation of making satisfaction for them may be a check to keep us from falling again into sin.*
+
+**111.** Can we by ourselves make satisfaction to God?
+
+*We, by ourselves, cannot make satisfaction to God; but we can do so well by uniting ourselves to Jesus Christ, who by the merit of His passion and death gives value to our actions.*
+
+**112.** Does the penance which the confessor gives always suffice to wipe away the punishment that remains due to sins?
+
+*The penance which the confessor gives ordinarily does not suffice to expiate the punishment that remains due to sins; therefore one must try to supply with other voluntary penances.*
+
+**113.** Which are the works of penance?
+
+*The works of penance can be reduced to three kinds: prayer, fasting, and almsgiving.*
+
+**114.** What do you mean by prayer?
+
+*By prayer is meant every kind of exercise of piety.*
+
+**115.** What is meant by fasting?
+
+*By fasting is meant every kind of mortification.*
+
+**116.** What is meant by almsgiving?
+
+*By almsgiving is meant any work of spiritual and corporal mercy.*
+
+**117.** Which penance is more meritorious, the one the confessor gives or the one we do of our own choice?
+
+*The penance which the confessor gives us is the more meritorious, because, being part of the sacrament, it receives greater power from the merits of the passion of Jesus Christ.*
+
+**118.** Do those who die after receiving absolution, but before having fully satisfied the justice of God, go immediately to heaven?
+
+*No; they go to purgatory there to satisfy the justice of God and to be entirely purified.*
+
+**119.** Can the souls who are in purgatory be relieved by us in their pains?
+
+*Yes, the souls who are in purgatory can be relieved by prayers, almsgiving, by all the other good works, and by indulgences, but above all by the Holy Sacrifice of the Mass.*
+
+**120.** Besides the penance, what else must the penitent do after confession?
+
+*The penitent, after confession, besides the penance, if he has unjustly harmed his neighbor in goods or in honor, or if he has given him scandal, must as soon as possible and as far as he is able restore the goods, repair the honor, and remedy the scandal.*
+
+**121.** How can the scandal one has caused be remedied?
+
+*The scandal one has caused can be remedied by removing its occasion, and by edifying with words and good example those whom we have scandalized.*
+
+**122.** In what manner shall one have to make satisfaction to one's neighbor when he has been offended by us?
+
+*One shall have to make satisfaction to one's neighbor, when he has been offended by us, by asking his pardon or by giving him some other suitable reparation.*
+
+**123.** What fruits does a good confession produce in us?
+
+*A good confession: 1. forgives the sins committed and gives us the grace of God; 2. restores to us the peace and quiet of conscience; 3. reopens to us the gates of heaven, and changes the eternal punishment of hell into temporal punishment; 4. preserves us from relapses and renders us capable of the treasure of indulgences.*
+
+## § 10. On indulgences
+
+**124.** What is an indulgence?
+
+*An indulgence is the remission of the temporal punishment due for our sins, already forgiven as to the guilt; a remission which the Church grants outside the sacrament of Penance.*
+
+**125.** From whom has the Church received the power to give indulgences?
+
+*The Church has received the power to give indulgences from Jesus Christ.*
+
+**126.** In what way does the Church remit to us the temporal punishment by means of indulgences?
+
+*The Church remits to us the temporal punishment by means of indulgences, applying to us the superabundant satisfactions of Jesus Christ, of the Most Holy Mary, and of the Saints, which form what is called the treasury of the Church.*
+
+**127.** Who has the power to grant indulgences?
+
+*The power to grant indulgences belongs only to the Pope in the whole Church, and to the Bishop in his diocese, according to the faculty granted him by the Pope.*
+
+**128.** Of how many kinds are indulgences?
+
+*Indulgences are of two kinds: plenary indulgence and partial indulgence.*
+
+**129.** What is plenary indulgence?
+
+*Plenary indulgence is that by which all the temporal punishment due for our sins is remitted to us. Therefore if someone died after having received such an Indulgence, he would go immediately to Paradise, entirely exempt from the pains of purgatory.*
+
+**130.** What is partial indulgence?
+
+*Partial indulgence is that by which only a part of the temporal punishment due for our sins is remitted to us.*
+
+**131.** What does the Church intend to do in granting indulgences?
+
+*In granting indulgences the Church intends to come to the aid of our inability to expiate in this world all the temporal punishment, making us obtain through works of piety and Christian charity what in the first centuries it caused to be obtained by the rigor of the penitential canons.*
+
+**132.** What is meant by an indulgence of forty or one hundred days, or of seven years, and the like?
+
+*By an indulgence of forty or one hundred days, or of seven years, and the like, is meant the remission of as much temporal punishment as would be expiated by forty or one hundred days, or seven years, of the penance anciently established by the Church.*
+
+**133.** What account must we make of indulgences?
+
+*Of indulgences we must make very great account, because by them satisfaction is made to the justice of God and the possession of heaven is obtained more quickly and more easily.*
+
+**134.** What is required to acquire indulgences?
+
+*To acquire indulgences there is required: 1. the state of grace (at least in the last work that is performed), and freedom even from those venial faults whose punishment one wishes to wipe away; 2. the fulfillment of the works which the Church prescribes to acquire the indulgence; 3. the intention to acquire it.*
+
+**135.** Can indulgences also be applied to the souls in purgatory?
+
+*Yes, indulgences can also be applied to the souls in purgatory, when the one who grants them declares that they can be applied to them.*
+
+**136.** What is the Jubilee?
+
+*The Jubilee, which is ordinarily granted every twenty-five years, is a plenary indulgence to which are annexed many privileges and particular concessions, such as the ability to obtain the absolution of certain reserved sins and of censures, and the commutation of certain vows.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-vii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-vii.md
@@ -1,0 +1,25 @@
+# Chapter VII — On Extreme Unction
+
+**1.** What is the sacrament of Extreme Unction, also called Holy Oil?
+
+*Extreme Unction, also called Holy Oil, is the sacrament instituted for the spiritual and also temporal relief of the sick, in danger of death.*
+
+**2.** What effects does the sacrament of Extreme Unction produce?
+
+*The sacrament of Extreme Unction produces the following effects: 1. it increases sanctifying grace; 2. it wipes away venial sins, and also mortal sins which the repentant sick person could no longer confess; 3. it removes that weakness and languor for good which remains even after having obtained the forgiveness of sins; 4. it gives strength to bear illness patiently, to resist temptations, and to die in holiness; 5. it helps to recover the health of the body, if it be useful to the salvation of the soul.*
+
+**3.** At what time must Holy Oil be received?
+
+*Holy Oil must be received when the illness is dangerous, and after the sick person has received, if he can, the sacraments of Penance and of the Eucharist; indeed, it is well to receive it when one is still sound of mind and with some hope of life.*
+
+**4.** Why is it well to receive Holy Oil when one is still sound of mind and with some hope of life?
+
+*It is well to receive Holy Oil when one is still sound of mind and with some hope of life, because, receiving it with better disposition, greater fruit can be received from it; and also because, this sacrament giving health of body, if it be expedient for the soul, by aiding the powers of nature, one must not wait until health is despaired of.*
+
+**5.** With what dispositions must Holy Oil be received?
+
+*The principal dispositions for receiving Holy Oil are: to be in the grace of God, to trust in the power of the sacrament and in the divine mercy, and to resign oneself to the will of the Lord.*
+
+**6.** What sentiments must the sick person feel at the sight of the priest?
+
+*At the sight of the priest the sick person must feel sentiments of gratitude to God for having sent him; he must receive willingly, and ask, if he can himself, for the comforts of religion.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-viii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quarta-capo-viii.md
@@ -1,0 +1,71 @@
+# Chapter VIII — On Holy Orders
+
+**1.** What is the sacrament of Holy Orders?
+
+*Holy Orders is the sacrament that gives the power to exercise the sacred ministries that concern the worship of God and the salvation of souls, and which imprints on the soul of him who receives it the character of minister of God.*
+
+**2.** Why is it called Order?
+
+*It is called Order because it consists in various degrees, one subordinated to the other, from which results the sacred Hierarchy.*
+
+**3.** Which are these degrees?
+
+*Supreme among them is the Episcopate, which contains the fullness of the priesthood; then the Presbyterate or simple Priesthood; then the Diaconate, and the Orders called minor.*
+
+**4.** Did Jesus Christ immediately institute all the degrees of Holy Orders?
+
+*Jesus Christ immediately instituted the two higher degrees of Holy Orders, which are the Episcopate and the simple Priesthood; through the Apostles, then, He instituted the Diaconate, from which derive the other inferior Orders.*
+
+**5.** When did Jesus Christ institute the Sacerdotal Order?
+
+*Jesus Christ instituted the Sacerdotal Order at the Last Supper, when He conferred on the Apostles and on their successors the power to consecrate the Most Holy Eucharist. On the day of His resurrection He then conferred on them the power to forgive and to retain sins, thus constituting them the first priests of the new law in all the fullness of their power.*
+
+**6.** Who is the minister of this sacrament?
+
+*The minister of this sacrament is the Bishop alone.*
+
+**7.** Is, then, the dignity of the Christian Priesthood great?
+
+*The dignity of the Christian Priesthood is very great, by reason of the twofold power which Jesus Christ has conferred on it over His real Body and over His mystical Body, which is the Church; and by reason of the divine mission entrusted to the priests of leading all men to eternal life.*
+
+**8.** Is the Catholic Priesthood necessary in the Church?
+
+*The Catholic Priesthood is necessary in the Church; because without it the faithful would be without the Holy Sacrifice of the Mass and most of the sacraments, would have no one to instruct them in the faith, and would remain as sheep without a shepherd at the mercy of the wolves; in short, the Church as Jesus Christ instituted her would no longer exist.*
+
+**9.** So, will the Catholic Priesthood never cease on earth?
+
+*The Catholic Priesthood, notwithstanding the war which hell wages against it, shall last to the end of the ages; Jesus Christ having promised that the powers of hell shall never prevail against His Church.*
+
+**10.** Is it a sin to despise priests?
+
+*It is a most grave sin, because the contempt and insults that are directed against priests fall upon Jesus Christ Himself, who said to His Apostles: "He who despises you despises Me."*
+
+**11.** What must be the end of one who embraces the ecclesiastical state?
+
+*The end of one who embraces the ecclesiastical state must be solely the glory of God and the salvation of souls.*
+
+**12.** What is necessary to enter the ecclesiastical state?
+
+*To enter the ecclesiastical state there is necessary, first of all, the divine vocation.*
+
+**13.** What must be done to know whether God calls to the ecclesiastical state?
+
+*To know whether God calls to the ecclesiastical state, one must: 1. pray fervently to the Lord to manifest what His will is; 2. take counsel from one's own Bishop or from a wise and prudent director; 3. examine with diligence whether one has the ability necessary for the studies, the ministries, and the obligations of this state.*
+
+**14.** Would one who entered the ecclesiastical state without a divine vocation do wrong?
+
+*One who entered the ecclesiastical state without a divine vocation would do a grave wrong and would place himself in danger of perdition.*
+
+**15.** Do parents who, for temporal motives, induce their children to embrace without vocation the ecclesiastical state do wrong?
+
+*Parents who, for temporal motives, induce their children to embrace without vocation the ecclesiastical state likewise commit a most grave fault, because by this they usurp the right which God has reserved to Himself alone to choose His ministers, and place their children in danger of eternal damnation.*
+
+**16.** What are the duties of the faithful toward those who are called to the sacred Orders?
+
+*The faithful must:*
+
+*1. leave their children and dependents full freedom to follow the vocation of God;*
+
+*2. pray to God that He deign to grant His Church good pastors and zealous ministers, the fasts of the Ember Days being instituted also for this end;*
+
+*3. have a singular respect for all those who are, through the Orders, consecrated to the service of God.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quinta-capo-i.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quinta-capo-i.md
@@ -1,0 +1,261 @@
+# Chapter I — On the principal virtues
+
+## § 1. On the theological virtues
+
+**1.** What is virtue?
+
+*Virtue is a quality of the soul, by which one has propensity, ease, and readiness to know and do good.*
+
+**2.** How many are the principal supernatural virtues?
+
+*The principal supernatural virtues are seven: namely, three theological and four cardinal.*
+
+**3.** Which are the theological virtues?
+
+*The theological virtues are: Faith, Hope, and Charity.*
+
+**4.** Why are Faith, Hope, and Charity called theological virtues?
+
+*Faith, Hope, and Charity are called theological virtues because they have God as their immediate and principal object, and are infused into us by Him.*
+
+**5.** In what way do the theological virtues have God as their immediate object?
+
+*The theological virtues have God as their immediate object, because by Faith we believe in God, and we believe all that He has revealed; by Hope we hope to possess God; by Charity we love God, and in Him we love ourselves and our neighbor.*
+
+**6.** When does God infuse the theological virtues into our soul?
+
+*God in His goodness infuses the theological virtues into our soul when He adorns us with His sanctifying grace; and therefore when we received Baptism we were enriched with these virtues, and with them, with the gifts of the Holy Spirit.*
+
+**7.** Is it enough for salvation to have received the theological virtues in Baptism?
+
+*For one who has the use of reason, it is not enough to have received the theological virtues in Baptism; it is also necessary to make their acts often.*
+
+**8.** When are we obliged to make the acts of Faith, Hope, and Charity?
+
+*We are obliged to make the acts of Faith, Hope, and Charity: 1. when we attain the use of reason; 2. often during the course of life; 3. in danger of death.*
+
+## § 2. On Faith
+
+**9.** What is Faith?
+
+*Faith is a supernatural virtue, infused by God into our soul, by which we, relying on the authority of God Himself, believe to be true all that He has revealed, and that He proposes to us to believe through the Church.*
+
+**10.** In what manner do we know the truths revealed by God?
+
+*We know the truths revealed by God through the holy Church, which is infallible; that is, through the Pope, successor of Saint Peter, and through the Bishops, successors of the Apostles, who were taught by Jesus Christ Himself.*
+
+**11.** Are we sure of those things which the holy Church teaches us?
+
+*Of those things which the holy Church teaches us, we are most sure, because Jesus Christ has pledged His word that the Church should never be deceived.*
+
+**12.** By what sin is Faith lost?
+
+*Faith is lost by voluntarily denying or doubting even a single article proposed to us to believe.*
+
+**13.** How is Faith regained when lost?
+
+*Faith, once lost, is regained by repenting of the sin committed and believing anew all that the holy Church believes.*
+
+## § 3. On the mysteries
+
+**14.** Can we understand all the truths of Faith?
+
+*No, we cannot understand all the truths of Faith, because some of these truths are mysteries.*
+
+**15.** What are the mysteries?
+
+*Mysteries are truths above reason which we must believe even though we cannot comprehend them.*
+
+**16.** Why must we believe the mysteries?
+
+*We must believe the mysteries because God has revealed them, who, being infinite Truth and Goodness, can neither be deceived nor deceive.*
+
+**17.** Are the mysteries contrary to reason?
+
+*The mysteries are above, but not contrary to, reason; indeed, it is reason itself that persuades us to admit the mysteries.*
+
+**18.** Why cannot the mysteries be contrary to reason?
+
+*The mysteries cannot be contrary to reason, because it is the same God who has given us the light of reason and revealed the mysteries, nor can He contradict Himself.*
+
+## § 4. On Sacred Scripture
+
+**19.** Where are the truths which God has revealed contained?
+
+*The truths which God has revealed are contained in Sacred Scripture and in Tradition.*
+
+**20.** What is Sacred Scripture?
+
+*Sacred Scripture is the collection of books written by the Prophets and Hagiographers, by the Apostles, and by the Evangelists, by the inspiration of the Holy Spirit, and received by the Church as inspired.*
+
+**21.** Into how many parts is Sacred Scripture divided?
+
+*Sacred Scripture is divided into two parts: into the Old and the New Testament.*
+
+**22.** What does the Old Testament contain?
+
+*The Old Testament contains the inspired books written before the coming of Jesus Christ.*
+
+**23.** What does the New Testament contain?
+
+*The New Testament contains the inspired books written after the coming of Jesus Christ.*
+
+**24.** By what name is Sacred Scripture commonly called?
+
+*Sacred Scripture is commonly called by the name of the Holy Bible.*
+
+**25.** What does the word Bible mean?
+
+*The word Bible means the collection of the sacred books, the book par excellence, the book of books, the book inspired by God.*
+
+**26.** Why is Sacred Scripture called the book par excellence?
+
+*Sacred Scripture is called the book par excellence by reason of the excellence of the matter of which it treats and of its Author.*
+
+**27.** Can there be no error in Sacred Scripture?
+
+*In Sacred Scripture there can be no error whatever, because, being wholly inspired, God Himself is the author of all its parts. This does not prevent that in copies and translations of the same some mistake by copyists or translators may have occurred. But in the editions revised and approved by the Catholic Church there can be no error in what concerns faith or morals.*
+
+**28.** Is the reading of the Bible necessary for all Christians?
+
+*The reading of the Bible is not necessary for all Christians, instructed as they are by the Church, but is nevertheless very useful and recommended to all.*
+
+**29.** May any vernacular translation whatever of the Bible be read?
+
+*One may read those vernacular translations of the Bible that are recognized as faithful by the Catholic Church and are accompanied by explanations approved by the Church herself.*
+
+**30.** Why may only translations of the Bible approved by the Church be read?
+
+*Only translations of the Bible approved by the Church may be read, because she alone is the legitimate custodian of the Bible.*
+
+**31.** Through whom can we know the true sense of the Sacred Scriptures?
+
+*The true sense of the Sacred Scriptures we can know only through the Church, because only the Church cannot err in interpreting them.*
+
+**32.** What should a Christian do if the Bible were offered to him by a Protestant or by some emissary of the Protestants?
+
+*If the Bible were offered to a Christian by a Protestant, or by some emissary of the Protestants, he should reject it with horror, because it is forbidden by the Church; and if he had received it without thinking, he should at once cast it into the flames, or hand it over to his own parish priest.*
+
+**33.** Why does the Church forbid the Protestant Bibles?
+
+*The Church forbids the Protestant Bibles because they are either altered and contain errors, or, lacking her approval and the declarative notes on obscure passages, they can harm the Faith. For this reason, the Church also forbids translations of Sacred Scripture already approved by her, but reprinted without the explanations approved by the same.*
+
+## § 5. On Tradition
+
+**34.** Tell me: what is Tradition?
+
+*Tradition is the word of God not written, but communicated by living voice by Jesus Christ and by the Apostles, and having come down to us unaltered, from century to century, through the Church.*
+
+**35.** Where are the teachings of Tradition contained?
+
+*The teachings of Tradition are contained principally in the decrees of the Councils, in the writings of the holy Fathers, in the acts of the Holy See, in the words and usages of the sacred Liturgy.*
+
+**36.** In what account must Tradition be held?
+
+*Tradition must be held in the same account as is held the word of God revealed, contained in Sacred Scripture.*
+
+## § 6. On Hope
+
+**37.** What is Hope?
+
+*Hope is a supernatural virtue, infused by God into our soul, by which we desire and await the eternal life which God has promised to His servants, and the helps necessary to obtain it.*
+
+**38.** For what reason must we hope from God for heaven and the helps necessary to attain it?
+
+*We must hope from God for heaven and the helps necessary to attain it, because God, most merciful, by the merits of our Lord Jesus Christ, has promised it to him who serves Him from the heart; and being most faithful and almighty, He always keeps His promise.*
+
+**39.** What are the conditions necessary to obtain heaven?
+
+*The conditions necessary to obtain heaven are the grace of God, the exercise of good works, and perseverance in His holy love until death.*
+
+**40.** How is Hope lost?
+
+*Hope is lost whenever Faith is lost; it is also lost by the sin of despair or of presumption.*
+
+**41.** How is Hope regained when lost?
+
+*Hope, once lost, is regained by repenting of the sin committed, exciting anew confidence in the divine goodness.*
+
+## § 7. On Charity
+
+**42.** What is Charity?
+
+*Charity is a supernatural virtue, infused by God into our soul, by which we love God for Himself above all things, and our neighbor as ourselves for love of God.*
+
+**43.** For what reasons must we love God?
+
+*We must love God because He is the supreme good, infinitely good and perfect; and moreover for the command He gives us of it, and for the many benefits we receive from Him.*
+
+**44.** How must God be loved?
+
+*God must be loved above all things, with all the heart, with all the mind, with all the soul, and with all our strength.*
+
+**45.** What does it mean to love God above all things?
+
+*To love God above all things means to prefer Him to all creatures, however dear and however perfect, and to be disposed to lose everything rather than offend Him and cease loving Him.*
+
+**46.** What does it mean to love God with all the heart?
+
+*To love God with all the heart means to consecrate to Him all our affections.*
+
+**47.** What does it mean to love God with all the mind?
+
+*To love God with all the mind means to direct to Him all our thoughts.*
+
+**48.** What does it mean to love God with all the soul?
+
+*To love God with all the soul means to consecrate to Him the use of all the powers of our soul.*
+
+**49.** What does it mean to love God with all our strength?
+
+*To love God with all our strength means to strive to grow ever more in love of Him, and to act so that all our actions have for motive and end the love of Him, and the desire to please Him.*
+
+**50.** Why must we love our neighbor?
+
+*We must love our neighbor for love of God, because He commands it of us, and because every man is His image.*
+
+**51.** Are we obliged to love even our enemies?
+
+*Yes, we are obliged to love even our enemies, because they too are our neighbor, and because Jesus Christ has made it an express command.*
+
+**52.** What does it mean to love one's neighbor as oneself?
+
+*To love one's neighbor as oneself means to desire for him, and to do for him as far as one can, that good which we must desire for ourselves, and not to desire nor to do him any evil.*
+
+**53.** When do we love ourselves as we ought?
+
+*We love ourselves as we ought, when we seek to serve God and place in Him all our happiness.*
+
+**54.** How is Charity lost?
+
+*Charity is lost by any mortal sin whatsoever.*
+
+**55.** How is Charity regained?
+
+*Charity is regained by making acts of love of God, by repenting and by confessing as one ought.*
+
+## § 8. On the cardinal virtues
+
+**56.** Which are the cardinal virtues?
+
+*The cardinal virtues are Prudence, Justice, Fortitude, and Temperance.*
+
+**57.** Why are Prudence, Justice, Fortitude, and Temperance called cardinal virtues?
+
+*Prudence, Justice, Fortitude, and Temperance are called cardinal virtues because they are the hinge and the foundation of the moral virtues.*
+
+**58.** What is Prudence?
+
+*Prudence is the virtue that directs every action to its due end, and so seeks suitable means that the work may turn out wholly well done, and therefore acceptable to the Lord.*
+
+**59.** What is Justice?
+
+*Justice is the virtue by which we give to each what is due to him.*
+
+**60.** What is Fortitude?
+
+*Fortitude is the virtue that makes us courageous, so as not to fear any danger, not even death itself, for the service of God.*
+
+**61.** What is Temperance?
+
+*Temperance is the virtue by which we curb the disordered desires for sensible pleasures, and use temporal goods with moderation.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quinta-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quinta-capo-ii.md
@@ -1,0 +1,37 @@
+# Chapter II — On the gifts of the Holy Spirit
+
+**1.** How many and which are the gifts of the Holy Spirit?
+
+*The gifts of the Holy Spirit are seven: 1. the gift of Wisdom; 2. of Understanding; 3. of Counsel; 4. of Fortitude; 5. of Knowledge; 6. of Piety; 7. of the Fear of God.*
+
+**2.** Of what use are the gifts of the Holy Spirit?
+
+*The gifts of the Holy Spirit serve to establish us in Faith, Hope, and Charity; and to render us ready for the acts of the virtues necessary for attaining the perfection of the Christian life.*
+
+**3.** What is Wisdom?
+
+*Wisdom is a gift by which, raising the mind from these earthly and fragile things, we contemplate the eternal, that is, the eternal Truth, who is God, tasting and loving Him, in whom consists our every good.*
+
+**4.** What is Understanding?
+
+*Understanding is a gift by which is made easier for us, so far as it is possible for mortal man, the intelligence of the truths of the Faith and the divine mysteries, which by the natural light of our intellect we cannot know.*
+
+**5.** What is Counsel?
+
+*Counsel is a gift by which, in the doubts and uncertainties of human life, we know what tends most to the glory of God, to our salvation, and to that of our neighbor.*
+
+**6.** What is Fortitude?
+
+*Fortitude is a gift that inspires us with valor and courage to observe faithfully the holy law of God and of the Church, overcoming all the obstacles and assaults of our enemies.*
+
+**7.** What is Knowledge?
+
+*Knowledge is a gift by which we judge rightly of created things, and know the way to use them well and to direct them to the last end, which is God.*
+
+**8.** What is Piety?
+
+*Piety is a gift by which we venerate and love God and the Saints, and preserve a pious and benevolent soul toward our neighbor for love of God.*
+
+**9.** What is the Fear of God?
+
+*The Fear of God is a gift that makes us reverence God and fear to offend His divine Majesty, and turns us away from evil, inciting us to good.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quinta-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quinta-capo-iii.md
@@ -1,0 +1,77 @@
+# Chapter III — On the evangelical Beatitudes
+
+**1.** How many and which are the evangelical Beatitudes?
+
+*The evangelical Beatitudes are eight:*
+
+*1. Blessed are the poor in spirit, for theirs is the kingdom of heaven.*
+
+*2. Blessed are the meek, for they shall possess the earth.*
+
+*3. Blessed are they that mourn, for they shall be comforted.*
+
+*4. Blessed are they that hunger and thirst after justice, for they shall be satisfied.*
+
+*5. Blessed are the merciful, for they shall obtain mercy.*
+
+*6. Blessed are the clean of heart, for they shall see God.*
+
+*7. Blessed are the peacemakers, for they shall be called children of God.*
+
+*8. Blessed are they that suffer persecution for justice' sake, for theirs is the kingdom of heaven.*
+
+**2.** Why did Jesus Christ propose the Beatitudes to us?
+
+*Jesus Christ proposed the Beatitudes to us to make us detest the maxims of the world, and to invite us to love and practice the maxims of His Gospel.*
+
+**3.** Who are those whom the world calls blessed?
+
+*The world calls blessed those who abound in riches and honors, who live merrily, and who have no occasion to suffer.*
+
+**4.** Who are the poor in spirit, whom Jesus Christ calls blessed?
+
+*The poor in spirit, according to the Gospel, are those who have the heart detached from riches; who make good use of them, if they possess them; do not seek them with eagerness, if they have them not; bear with resignation the loss of them, if these are taken from them.*
+
+**5.** Who are the meek?
+
+*The meek are those who treat their neighbor with gentleness, and bear with patience his defects and the wrongs received from him, without complaints, resentment, or revenge.*
+
+**6.** Who are those who mourn, and yet are called blessed?
+
+*Those who mourn, and yet are called blessed, are those who suffer with resignation tribulations, and who are afflicted for the sins committed, for the evils and the scandals seen in the world, for the distance from heaven, and for the danger of losing it.*
+
+**7.** Who are they that hunger and thirst after justice?
+
+*Those who hunger and thirst after justice are those who ardently desire to grow ever more in the divine grace and in the exercise of good and virtuous works.*
+
+**8.** Who are the merciful?
+
+*The merciful are those who love their neighbor in God and for love of God, have compassion on his miseries, both spiritual and corporal, and seek to relieve him according to their powers and their state.*
+
+**9.** Who are the clean of heart?
+
+*The clean of heart are those who have no affection for sin and keep far from it, and avoid above all every kind of impurity.*
+
+**10.** Who are the peacemakers?
+
+*The peacemakers are those who preserve peace with their neighbor and with themselves, and seek to make peace among those who are in discord.*
+
+**11.** Who are those who suffer persecution for justice' sake?
+
+*Those who suffer persecution for justice' sake are those who bear with patience derision, reproaches, and persecutions for the cause of the faith and of the law of Jesus Christ.*
+
+**12.** What do the different rewards promised by Jesus Christ in the Beatitudes signify?
+
+*The different rewards promised by Jesus Christ in the Beatitudes all signify, under different names, the eternal glory of heaven.*
+
+**13.** Do the Beatitudes procure for us only the eternal glory of heaven?
+
+*The Beatitudes do not procure for us only the eternal glory of heaven, but are also the means to lead a happy life, as far as possible, in this world.*
+
+**14.** Do those who follow the Beatitudes receive already some recompense in this life?
+
+*Yes, certainly, those who follow the Beatitudes receive already some recompense even in this life, because they already enjoy an inner peace and contentment, which is the beginning, though imperfect, of eternal happiness.*
+
+**15.** Can those who follow the maxims of the world be called happy?
+
+*No, those who follow the maxims of the world are not happy, because they have not the true peace of soul, and run the danger of being damned.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quinta-capo-iv.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quinta-capo-iv.md
@@ -1,0 +1,45 @@
+# Chapter IV — On the works of mercy
+
+**1.** Which are the good works of which a particular account will be asked of us on the Day of Judgment?
+
+*The good works of which a particular account will be asked of us on the Day of Judgment are the works of mercy.*
+
+**2.** What is meant by a work of mercy?
+
+*A work of mercy is that by which we relieve the corporal or spiritual needs of our neighbor.*
+
+**3.** Which are the corporal works of mercy?
+
+*The corporal works of mercy are:*
+
+*1. To feed the hungry.*
+
+*2. To give drink to the thirsty.*
+
+*3. To clothe the naked.*
+
+*4. To shelter the pilgrim.*
+
+*5. To visit the sick.*
+
+*6. To visit the imprisoned.*
+
+*7. To bury the dead.*
+
+**4.** Which are the spiritual works of mercy?
+
+*The spiritual works of mercy are:*
+
+*1. To counsel the doubtful.*
+
+*2. To instruct the ignorant.*
+
+*3. To admonish sinners.*
+
+*4. To comfort the afflicted.*
+
+*5. To forgive offenses.*
+
+*6. To bear patiently with troublesome persons.*
+
+*7. To pray to God for the living and the dead.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quinta-capo-v.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quinta-capo-v.md
@@ -1,0 +1,57 @@
+# Chapter V — On sins and their principal kinds
+
+**1.** How many kinds of sins are there?
+
+*There are two kinds of sins: original sin and actual sin.*
+
+**2.** What is original sin?
+
+*Original sin is that with which we are all born, and which we contracted through the disobedience of our first father Adam.*
+
+**3.** What harms has Adam's sin caused us?
+
+*The harms of Adam's sin are: the privation of grace, the loss of heaven, ignorance, inclination to evil, death, and all the other miseries.*
+
+**4.** How is original sin wiped away?
+
+*Original sin is wiped away by holy Baptism.*
+
+**5.** What is actual sin?
+
+*Actual sin is that which man, having attained the use of reason, commits with his free will.*
+
+**6.** How many kinds of actual sin are there?
+
+*There are two kinds of actual sin: mortal and venial.*
+
+**7.** What is mortal sin?
+
+*Mortal sin is a transgression of the divine law, by which one gravely fails in his duties toward God, toward his neighbor, toward himself.*
+
+**8.** Why is it called mortal?
+
+*It is called mortal because it gives death to the soul, by making it lose sanctifying grace, which is the life of the soul, as the soul is the life of the body.*
+
+**9.** What harms does mortal sin do to the soul?
+
+*1. Mortal sin deprives the soul of the grace and friendship of God; 2. makes it lose heaven; 3. deprives it of the merits acquired, and renders it incapable of acquiring new ones; 4. makes it a slave of the devil; 5. makes it deserving of hell, and also of the punishments of this life.*
+
+**10.** Besides the gravity of the matter, what else is required to constitute a mortal sin?
+
+*Besides the gravity of the matter, to constitute a mortal sin there is required full advertence of that gravity and the deliberate will to commit the sin.*
+
+**11.** What is venial sin?
+
+*Venial sin is a slight transgression of the divine law, by which one fails only lightly in some duty toward God, toward his neighbor, and toward himself.*
+
+**12.** Why is it called venial?
+
+*Because it is slight in comparison with mortal sin, does not make us lose divine grace, and because God more easily forgives it.*
+
+**13.** So is venial sin not to be made much of?
+
+*This would be a great deception, both because venial sin always contains some offense against God, and because it brings no small harm to the soul.*
+
+**14.** What harms does venial sin bring?
+
+*Venial sin: 1. weakens and cools charity in us; 2. disposes us to mortal sin; 3. renders us deserving of great temporal punishments in this world or in the next.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quinta-capo-vi.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quinta-capo-vi.md
@@ -1,0 +1,37 @@
+# Chapter VI — On the capital vices and other graver sins
+
+**1.** What is vice?
+
+*Vice is an evil disposition of soul to flee good and to do evil, caused by the frequent repetition of evil acts.*
+
+**2.** What difference is there between sin and vice?
+
+*Between sin and vice there is this difference: that sin is an act which passes, while vice is the bad habit contracted of falling into some sin.*
+
+**3.** Which are the vices called capital?
+
+*The vices called capital are seven: 1. Pride; 2. Avarice; 3. Lust; 4. Anger; 5. Gluttony; 6. Envy; 7. Sloth.*
+
+**4.** How are the capital vices overcome?
+
+*The capital vices are overcome by the exercise of the opposite virtues. Thus pride is overcome by humility; avarice by generosity; lust by chastity; anger by patience; gluttony by abstinence; envy by fraternal love; sloth by diligence and fervor in the service of God.*
+
+**5.** Why are these vices called capital?
+
+*These vices are called capital because they are the source and cause of many other vices and sins.*
+
+**6.** How many are the sins against the Holy Spirit?
+
+*The sins against the Holy Spirit are six: 1. despair of salvation; 2. presumption of being saved without merit; 3. impugning the known truth; 4. envy of another's grace; 5. obstinacy in sins; 6. final impenitence.*
+
+**7.** Why are these sins said to be in particular against the Holy Spirit?
+
+*These sins are said to be in particular against the Holy Spirit, because they are committed out of pure malice, which is contrary to the goodness attributed to the Holy Spirit.*
+
+**8.** Which are the sins that are said to cry out for vengeance in the sight of God?
+
+*The sins said to cry out for vengeance in the sight of God are four: 1. willful murder; 2. impure sin against the order of nature; 3. oppression of the poor; 4. defrauding workmen of their wages.*
+
+**9.** Why is it said that these sins cry out for vengeance in the sight of God?
+
+*These sins are said to cry out for vengeance in the sight of God, because the Holy Spirit says it, and because their iniquity is so grave and manifest that it provokes God to punish them with the most severe chastisements.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quinta-capo-vii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quinta-capo-vii.md
@@ -1,0 +1,17 @@
+# Chapter VII — On the Last Things and other principal means of avoiding sin
+
+**1.** What do you understand by the Last Things?
+
+*The Last Things are called in the holy Books the last things that shall happen to man.*
+
+**2.** How many are the Last Things, or last things of man?
+
+*The Last Things, or last things of man, are four: Death, Judgment, Hell, and Heaven.*
+
+**3.** Why are the Last Things called the last things of man?
+
+*The Last Things are called the last things of man, because Death is the last thing that happens to us in this world; the Judgment of God is the last of the judgments we must undergo; Hell is the extreme evil that the wicked shall have; Heaven the supreme good that the good shall have.*
+
+**4.** When must we think of the Last Things?
+
+*It is well to think of the Last Things every day, and especially in making prayer in the morning immediately upon waking, in the evening before going to rest, and every time we are tempted to do evil, because this thought is most efficacious in making us avoid sin.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-quinta-capo-viii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-quinta-capo-viii.md
@@ -1,0 +1,89 @@
+# Chapter VIII — On the devout exercises recommended to the Christian for each day
+
+**1.** What must a good Christian do in the morning as soon as he awakes?
+
+*A good Christian, as soon as he awakes in the morning, must make the Sign of the Holy Cross and offer his heart to God, saying these or other similar words: "My God, I give You my heart and my soul."*
+
+**2.** What should one think of in rising from bed and dressing?
+
+*In rising from bed and dressing, one should think that God is present, that that day may be the last of our life; and rise and dress with all possible modesty.*
+
+**3.** Once risen and dressed, what must a good Christian do?
+
+*A good Christian, as soon as he has risen and dressed, must place himself in the presence of God, and kneel, if he can, before some devout image, saying with devotion: "I adore You, my God, and I love You with all my heart; I thank You for having created me, made me a Christian, and preserved me this night; I offer You all my actions, and I pray You to preserve me this day from sin, and to deliver me from every evil. Amen." Then let him recite the Pater Noster, the Ave Maria, the Credo, and the acts of Faith, Hope, and Charity, accompanying them with lively affection of the heart.*
+
+**4.** What practices of piety should the Christian perform every day?
+
+*The Christian, if able, should every day: 1. assist with devotion at Holy Mass; 2. make a visit, even very brief, to the Most Holy Sacrament; 3. recite the third part of the holy Rosary.*
+
+**5.** What must be done before working?
+
+*Before working, one must offer the work to God, saying from the heart: "Lord, I offer You this work: give me Your blessing."*
+
+**6.** For what end must one work?
+
+*One must work for the glory of God and to do His will.*
+
+**7.** What is it fitting to do before taking food?
+
+*Before taking food, standing, it is fitting to make the Sign of the Holy Cross and then say with devotion: "Lord God, give Your blessing to us and to the food we are about to take to sustain ourselves in Your service."*
+
+**8.** Having finished taking food, what is it fitting to do?
+
+*Having finished taking food, it is fitting to make the Sign of the Holy Cross, and say: "Lord, I thank You for the food You have given me; make me worthy to share in the heavenly table."*
+
+**9.** When one becomes aware of some temptation, what should he do?
+
+*When one becomes aware of some temptation, he should invoke with faith the Most Holy Name of Jesus, or of Mary, or say fervently some ejaculatory prayer, such as: "Give me grace, O Lord, never to offend You," or make the Sign of the Cross; taking care, however, that others may not be aware of his temptations from external signs.*
+
+**10.** When one knows or doubts that he has committed some sin, what must he do?
+
+*When anyone knows or doubts that he has sinned, he must at once make an act of contrition, and seek to confess it as soon as possible.*
+
+**11.** When, outside of church, one hears the signal of the elevation of the host at solemn Mass, or of the blessing of the Most Holy Sacrament, what must be done?
+
+*One must make, at least with the heart, an act of adoration, saying for example: "May the Most Holy and most Divine Sacrament be praised and thanked every moment."*
+
+**12.** What must be said when the Ave Maria is rung at dawn, at noon, and in the evening?
+
+*At the sound of the Ave Maria, the good Christian recites the Angelus Domini, with three Ave Marias.*
+
+**13.** In the evening, before going to rest, what is it fitting to do?
+
+*In the evening before rest, it is fitting to place oneself, as in the morning, in the presence of God, recite devoutly the same prayers, make a brief examination of conscience, and ask God's pardon for the sins committed during the day.*
+
+**14.** What will you do before falling asleep?
+
+*Before falling asleep I shall make the Sign of the Holy Cross, I shall think that I may die in that night, and I shall give my heart to God, saying: "Lord and my God, I give You all my heart; Most Holy Trinity, give me grace to live well and to die well; Jesus, Joseph, and Mary, I commend my soul to you."*
+
+**15.** Besides the morning and evening prayers, in what other way can one have recourse to God in the course of the day?
+
+*In the course of the day one can pray to God frequently with other short prayers called ejaculations.*
+
+**16.** Say some ejaculation.
+
+*Lord, help me. — Lord, may Your most holy will be done. — My Jesus, I wish to be entirely Yours. — My Jesus, mercy. — Sweet Heart of my Jesus, make me love You ever more.*
+
+**17.** Is it useful to say many ejaculations during the day?
+
+*It is a most useful thing to say many ejaculatory prayers during the day, and they can be said even with the heart without uttering words, while walking, working, etc.*
+
+**18.** Besides ejaculatory prayers, in what other thing should the Christian often exercise himself?
+
+*Besides ejaculatory prayers the Christian should exercise himself in Christian mortification.*
+
+**19.** What does it mean to mortify oneself?
+
+*To mortify oneself means to leave, for love of God, what pleases, and to accept what is displeasing according to the senses or self-love.*
+
+**20.** When the Most Holy Sacrament is carried to a sick person, what must be done?
+
+*When the Most Holy Sacrament is carried to some sick person, one must seek, if possible, to accompany it with modesty and recollection; and if not possible, to make an act of adoration wherever one happens to be, and then say: "Console, O Lord, this sick person, and give him grace to conform to Your most holy will and to attain his salvation."*
+
+**21.** Hearing the bell tolling the agony of some dying person, what will you do?
+
+*Hearing the bell tolling for a dying person, I shall, if I can, go to the Church to pray for him; and if I cannot, I shall commend his soul to the Lord, thinking that in a short time I too shall have to find myself in this state.*
+
+**22.** Hearing the signal of someone's death, what will you do?
+
+*Hearing the signal of someone's death, I shall try to say a De profundis or a Requiem for the soul of that deceased, and shall renew the thought of death.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-seconda-capo-i.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-seconda-capo-i.md
@@ -1,0 +1,105 @@
+# Chapter I — On prayer in general
+
+**1.** What is treated of in the second part of Christian Doctrine?
+
+*In the second part of Christian Doctrine, prayer in general and the Pater Noster in particular are treated.*
+
+**2.** What is prayer?
+
+*Prayer is a raising of the mind to God to adore Him, to thank Him, and to ask Him for what we need.*
+
+**3.** How is prayer distinguished?
+
+*Prayer is distinguished into mental and vocal. Mental prayer is that which is made with the mind alone; vocal prayer is that which is made with words accompanied by the attention of the mind and the devotion of the heart.*
+
+**4.** Can prayer be distinguished in another way?
+
+*Prayer can also be distinguished into private and public.*
+
+**5.** What is private prayer?
+
+*Private prayer is that which each one makes in particular for himself or for others.*
+
+**6.** What is public prayer?
+
+*Public prayer is that which is made by the sacred ministers, in the name of the Church, and for the salvation of the faithful people. The prayer made in common and publicly by the faithful, as in processions, pilgrimages, and in the temple, may also be called public.*
+
+**7.** Have we well-founded hope of obtaining through prayer the helps and graces we need?
+
+*The hope of obtaining from God the graces we need is founded on the promises of the Almighty, merciful, and most faithful God, and on the merits of Jesus Christ.*
+
+**8.** In whose name must we ask of God the graces we need?
+
+*We must ask of God the graces we need in the name of Jesus Christ, as He Himself has taught us and as the Church practices, who always ends her prayers with these words: per Dominum nostrum Iesum Christum, that is: through our Lord Jesus Christ.*
+
+**9.** Why must we ask of God graces in the name of Jesus Christ?
+
+*We must ask graces in the name of Jesus Christ because, being our mediator, it is only through Him that we can approach the throne of God.*
+
+**10.** If prayer has so much power, what is the reason why many times our prayers are not granted?
+
+*Many times our prayers are not granted, either because we ask for things that are not suited to our eternal salvation, or because we do not pray as we should.*
+
+**11.** What are the things we must principally ask of God?
+
+*We must principally ask of God His glory, our eternal salvation, and the means to attain it.*
+
+**12.** Is it not lawful also to ask for temporal goods?
+
+*Yes, it is lawful to ask of God also temporal goods, but always with the condition that they be in conformity with His most holy will and not be an impediment to our eternal salvation.*
+
+**13.** If God knows all that is necessary for us, why must we pray?
+
+*Although God knows all that is necessary for us, yet He wills that we should pray to Him, that we may acknowledge Him as the giver of every good, attest to Him our humble submission, and merit His favors.*
+
+**14.** What is the first and best disposition for making our prayers effective?
+
+*The first and best disposition for making our prayers effective is to be in the state of grace, or, if we are not, at least to desire to be restored to that state.*
+
+**15.** What other dispositions are required for praying well?
+
+*For praying well there are especially required recollection, humility, confidence, perseverance, and resignation.*
+
+**16.** What does it mean to pray with recollection?
+
+*It means to think that we are speaking with God, and therefore to pray with all reverence and devotion, avoiding as far as possible distractions, that is, every thought foreign to prayer.*
+
+**17.** Do distractions diminish the merit of prayer?
+
+*Yes, when we ourselves cause them, or do not diligently put them away. But if we do all we can to be recollected in God, then distractions do not diminish the merit of our prayer, but on the contrary may even increase it.*
+
+**18.** What is required for praying with recollection?
+
+*We must, before prayer, remove all the occasions of distraction; and during prayer we must think that we are in the presence of God, who sees and hears us.*
+
+**19.** What does it mean to pray with humility?
+
+*It means to acknowledge sincerely one's own unworthiness, helplessness, and misery, accompanying prayer with the composure of the body.*
+
+**20.** What does it mean to pray with confidence?
+
+*It means that we must have firm hope of being heard, if from this there derives the glory of God and our true good.*
+
+**21.** What does it mean to pray with perseverance?
+
+*It means that we must not grow weary of praying if God does not at once hear us, but rather that we should continue praying with greater fervor.*
+
+**22.** What does it mean to pray with resignation?
+
+*It means that we must conform to the will of God, who knows better than we what is necessary for our eternal salvation, even in the case when our prayers should not be granted.*
+
+**23.** Does God always hear well-made prayers?
+
+*Yes, God always hears well-made prayers; but in the way that He knows to be most useful for our eternal salvation, and not always according to our will.*
+
+**24.** What effects does prayer produce in us?
+
+*Prayer makes us acknowledge our dependence on God, the supreme Lord, in all things; makes us think of heavenly things; makes us progress in virtue; obtains for us mercy from God; strengthens us against temptations; comforts us in tribulations; helps us in our needs; and obtains for us the grace of final perseverance.*
+
+**25.** When must we especially pray?
+
+*We must especially pray in dangers, in temptations, and at the point of death; further, we must pray frequently, and it is well that this should be done in the morning and in the evening and at the beginning of the important actions of the day.*
+
+**26.** For whom must we pray?
+
+*We must pray for all; that is, for ourselves, for our relatives, superiors, benefactors, friends, and enemies; for the conversion of poor sinners, of those who are outside the true Church, and for the holy souls of purgatory.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-seconda-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-seconda-capo-ii.md
@@ -1,0 +1,211 @@
+# Chapter II — On the Lord's Prayer
+
+## § 1. On the Lord's Prayer in general
+
+**1.** Which is the most excellent vocal prayer?
+
+*The most excellent vocal prayer is the one Jesus Christ Himself has taught us, namely, the Pater Noster.*
+
+**2.** Why is the Pater Noster the most excellent prayer?
+
+*The Pater Noster is the most excellent prayer because Jesus Christ Himself composed it and taught it to us; because it contains clearly, in a few words, all that we can hope for from God; and is the rule and model of all other prayers.*
+
+**3.** Is the Pater Noster also the most efficacious prayer?
+
+*The Pater Noster is also the most efficacious prayer, because it is the most acceptable to God, since we pray with the very words that His divine Son has dictated to us.*
+
+**4.** Why is the Pater Noster called the Lord's Prayer?
+
+*The Pater Noster is called the Lord's Prayer, that is, the Prayer of the Lord, precisely because Jesus Christ taught it to us from His own mouth.*
+
+**5.** How many petitions are there in the Pater Noster?
+
+*In the Pater Noster there are seven petitions, preceded by a preamble.*
+
+**6.** Recite the Pater Noster.
+
+*Our Father, who art in heaven:*
+
+*1. Hallowed be Thy name.*
+
+*2. Thy kingdom come.*
+
+*3. Thy will be done, on earth as it is in heaven.*
+
+*4. Give us this day our daily bread.*
+
+*5. And forgive us our trespasses, as we forgive those who trespass against us.*
+
+*6. And lead us not into temptation.*
+
+*7. But deliver us from evil. Amen.*
+
+**7.** Why, in invoking God at the beginning of the Lord's Prayer, do we call Him our Father?
+
+*At the beginning of the Lord's Prayer we call God our Father in order to awaken our confidence in His infinite goodness, since we are His children.*
+
+**8.** Why can we say that we are children of God?
+
+*We are children of God: 1. because He created us in His image and preserves and governs us by His providence; 2. because, by special benevolence, He adopted us in Baptism as brothers of Jesus Christ and coheirs with Him of eternal glory.*
+
+**9.** Why do we call God our Father and not my Father?
+
+*We call God our Father and not my Father because we are all His children, and we must therefore regard and love one another as brothers, and pray for one another.*
+
+**10.** Since God is in every place, why do we say to Him: who art in heaven?
+
+*God is in every place; but we say: Our Father, who art in heaven, to raise our hearts to heaven, where God manifests Himself in glory to His children.*
+
+## § 2. On the first petition
+
+**11.** What do we ask in the first petition: Hallowed be Thy name?
+
+*In the first petition, "Hallowed be Thy name," we ask that God be known, loved, honored, and served by all the world, and by us in particular.*
+
+**12.** What do we mean by asking that God be known, loved, and served by all the world?
+
+*We mean to ask that the infidels may come to the knowledge of the true God, that the heretics may recognize their errors, that the schismatics may return to the unity of the Church, that sinners may repent, and that the just may be perseverant in good.*
+
+**13.** Why, before all else, do we ask that the name of God be hallowed?
+
+*Before all else we ask that the name of God be hallowed, because the glory of God must be more at heart for us than all our goods and advantages.*
+
+**14.** In what way can we procure the glory of God?
+
+*We can procure the glory of God by prayer, by good example, and by directing to Him all our thoughts, affections, and works.*
+
+## § 3. On the second petition
+
+**15.** What do we understand by the kingdom of God?
+
+*By the kingdom of God we understand a threefold spiritual kingdom; namely, the kingdom of God in us, that is, the kingdom of grace; the kingdom of God on earth, that is, the holy Catholic Church; and the kingdom of God in heaven, that is, paradise.*
+
+**16.** What do we ask with the words "Thy kingdom come," with regard to grace?
+
+*With regard to grace we ask that God may reign in us by His sanctifying grace, by which He deigns to dwell in us as a king in his palace, and to keep us united to Him by the virtues of faith, hope, and charity, by which He reigns over our intellect, our heart, and our will.*
+
+**17.** What do we ask with the words "Thy kingdom come," with regard to the Church?
+
+*With regard to the Church we ask that she may ever more spread and propagate herself throughout all the world for the salvation of men.*
+
+**18.** What do we ask with the words "Thy kingdom come," with regard to glory?
+
+*With regard to glory we ask that we may one day be admitted to holy paradise, for which we were created, where we shall be fully happy.*
+
+## § 4. On the third petition
+
+**19.** What do we ask in the third petition: Thy will be done, on earth as it is in heaven?
+
+*In the third petition, "Thy will be done, on earth as it is in heaven," we ask the grace to do in everything the will of God, by obeying His holy commandments as readily as the angels and saints obey Him in heaven. We further ask the grace to correspond to the divine inspirations, and to live resigned to the will of God when He sends us tribulations.*
+
+**20.** Is it necessary to carry out the will of God?
+
+*It is as necessary to carry out the will of God as it is necessary to attain eternal salvation, because Jesus Christ has said that only he who has done the will of His Father shall enter into the kingdom of heaven.*
+
+**21.** In what way can we know the will of God?
+
+*We can know the will of God especially through the Church and our spiritual superiors established by God to guide us on the way of salvation. We can also know this most holy will from the divine inspirations and from the very circumstances in which the Lord has placed us.*
+
+**22.** Must we always recognize the will of God in the prosperous or adverse things of life?
+
+*In the things, whether prosperous or adverse, of the present life we must always recognize also the will of God, who arranges or permits all things for our good.*
+
+## § 5. On the fourth petition
+
+**23.** What do we ask in the fourth petition: Give us this day our daily bread?
+
+*In the fourth petition, "Give us this day our daily bread," we ask of God that which is necessary to us each day, both for the soul and for the body.*
+
+**24.** What do we ask of God for our soul?
+
+*For our soul we ask of God the sustenance of the spiritual life: that is, we pray the Lord to give us His grace, of which we have continual need.*
+
+**25.** How is the life of our soul nourished?
+
+*The life of the soul is nourished especially by the food of the divine word and by the Most Holy Sacrament of the altar.*
+
+**26.** What do we ask of God for our body?
+
+*For our body we ask that which is necessary for the sustenance of temporal life.*
+
+**27.** Why do we say "give us this day our bread," and not rather "give us this day bread"?
+
+*We say "give us this day our bread," and not rather "give us this day bread," in order to exclude every desire of another's goods; therefore we pray the Lord to help us in just and lawful gains, that we may procure our food by our labors, without thefts and deceptions.*
+
+**28.** Why do we say "give us our bread," and not "give me"?
+
+*We say "give us" instead of "give me" to remind ourselves that, since our means come to us from God, so, if He gives us them in abundance, He does so in order that we may dispense the surplus to the poor.*
+
+**29.** Why do we add daily?
+
+*We add daily because we must desire what is necessary for life, and not the abundance of foods and goods of the earth.*
+
+**30.** What else does the word today mean in the fourth petition?
+
+*The word today means that we must not be too anxious about the future, but ask for that which is necessary to us at present.*
+
+## § 6. On the fifth petition
+
+**31.** What do we ask in the fifth petition: And forgive us our trespasses, as we forgive those who trespass against us?
+
+*In the fifth petition, "And forgive us our trespasses, as we forgive those who trespass against us," we ask God to forgive us our sins, as we forgive those who have offended us.*
+
+**32.** Why are our sins called debts?
+
+*Our sins are called debts because for them we must make satisfaction to divine justice either in this life or in the next.*
+
+**33.** Can those who do not forgive their neighbor hope that God will forgive them?
+
+*Those who do not forgive their neighbor have no reason to hope that God will forgive them, all the more so because they condemn themselves, by asking God to forgive them as they forgive their neighbor.*
+
+## § 7. On the sixth petition
+
+**34.** What do we ask in the sixth petition: And lead us not into temptation?
+
+*In the sixth petition, "And lead us not into temptation," we ask God to free us from temptations, either by not allowing us to be tempted, or by giving us the grace not to be overcome.*
+
+**35.** What are temptations?
+
+*Temptations are an incitement to sin which comes to us from the devil, from the wicked, or from our passions.*
+
+**36.** Is it a sin to have temptations?
+
+*No, it is not a sin to have temptations, but it is a sin to consent to them, or voluntarily to expose oneself to the danger of consenting to them.*
+
+**37.** Why does God permit us to be tempted?
+
+*God permits us to be tempted to test our fidelity, to increase our virtues, and to add to our merits.*
+
+**38.** What must we do to avoid temptations?
+
+*To avoid temptations we must flee dangerous occasions, guard our senses, frequently receive the holy sacraments, and make use of prayer.*
+
+## § 8. On the seventh petition
+
+**39.** What do we ask in the seventh petition: But deliver us from evil?
+
+*In the seventh petition, "But deliver us from evil," we ask God to deliver us from past, present, and future evils, and especially from the supreme evil, which is sin, and from eternal damnation, which is its punishment.*
+
+**40.** Why do we say "deliver us from evil," and not "from evils"?
+
+*We say "deliver us from evil," and not "from evils," because we must not desire to be exempt from all the evils of this life, but only from those which are not expedient for our soul; and therefore we ask for deliverance from evil in general, that is, from all that God sees to be evil for us.*
+
+**41.** Is it not lawful to ask for deliverance from some particular evil, for example from an illness?
+
+*Yes, it is lawful to ask for deliverance from some particular evil, but always submitting to the will of God, who may also have ordained that tribulation for the good of our soul.*
+
+**42.** What benefit do we draw from the tribulations God sends us?
+
+*Tribulations benefit us by helping us do penance for our faults, exercise the virtues, and above all imitate Jesus Christ our head, to whom it is just that we conform ourselves in sufferings, if we wish to share in His glory.*
+
+**43.** What does Amen at the end of the Pater mean?
+
+*Amen means: so be it, so I desire, so I pray to the Lord, and so I hope.*
+
+**44.** To obtain the graces asked in the Pater Noster, is it enough to recite it in any manner whatever?
+
+*To obtain the graces asked in the Pater Noster, it must be recited without haste, with attention, and accompanied by the heart.*
+
+**45.** When must we say the Pater?
+
+*We must say the Pater every day, because every day we need the help of God.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-seconda-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-seconda-capo-iii.md
@@ -1,0 +1,61 @@
+# Chapter III — On the «Hail Mary»
+
+**1.** Which prayer are we accustomed to say after the Pater?
+
+*After the Pater, we say the angelic salutation, that is, the Hail Mary, by means of which we have recourse to the most holy Virgin.*
+
+**2.** Why is the Hail Mary called the angelic salutation?
+
+*The Hail Mary is called the angelic salutation because it begins with the greeting which the archangel Gabriel gave to the Virgin Mary.*
+
+**3.** Whose are the words of the Hail Mary?
+
+*The words of the Hail Mary are partly those of the archangel Gabriel, partly those of Saint Elizabeth, and partly those of the Church.*
+
+**4.** What are the words of the archangel Gabriel?
+
+*The words of the archangel Gabriel are: "Hail, full of grace; the Lord is with thee; blessed art thou among women."*
+
+**5.** When did the Angel speak these words to Mary?
+
+*The Angel spoke these words to Mary when he went on God's behalf to announce to her the mystery of the Incarnation that was to be wrought in her.*
+
+**6.** What do we intend in saluting the most holy Virgin with the same words as the Archangel?
+
+*In saluting the most holy Virgin with the words of the Archangel, we rejoice with her, calling to mind the singular privileges and gifts which God has granted her in preference to all other creatures.*
+
+**7.** What are the words of Saint Elizabeth?
+
+*The words of Saint Elizabeth are: "Blessed art thou among women, and blessed is the fruit of thy womb."*
+
+**8.** When did Saint Elizabeth speak these words?
+
+*Saint Elizabeth spoke these words, inspired by God, when, three months before she gave birth to Saint John the Baptist, she was visited by the most holy Virgin, who already bore in her womb her divine Son.*
+
+**9.** What do we do in saying these words?
+
+*In saying the words of Saint Elizabeth we rejoice with the Most Holy Mary at her exalted dignity as Mother of God, and we bless God and thank Him for having given us Jesus Christ through Mary.*
+
+**10.** Whose are the other words of the Hail Mary?
+
+*All the other words of the Hail Mary have been added by the Church.*
+
+**11.** What do we ask with the last words of the Hail Mary?
+
+*With the last words of the Hail Mary we ask the protection of the most holy Virgin throughout the course of this life, and especially at the hour of our death, in which we shall have greatest need of it.*
+
+**12.** Why, after the Pater, do we say the Hail Mary rather than any other prayer?
+
+*Because the Most Holy Virgin is the most powerful Advocate with Jesus Christ, and therefore, after saying the prayer Jesus Christ taught us, we pray to the Most Holy Virgin to obtain for us the graces we have asked.*
+
+**13.** For what reason is the most holy Virgin so powerful?
+
+*The most holy Virgin is so powerful because she is the Mother of God, and it is impossible that she should not be heard by Him.*
+
+**14.** What do the Saints teach us about devotion to Mary?
+
+*On devotion to Mary the Saints teach us that her true devotees are loved and protected by her with the love of a most tender Mother, and through her they are certain of finding Jesus and obtaining paradise.*
+
+**15.** Which devotion to Mary does the Church especially recommend to us?
+
+*The devotion which the Church especially recommends to us toward the Most Holy Mary is the recitation of the holy Rosary.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-seconda-capo-iv.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-seconda-capo-iv.md
@@ -1,0 +1,13 @@
+# Chapter IV — On the invocation of the Saints
+
+**1.** Is it a good and useful thing to have recourse to the intercession of the Saints?
+
+*It is most useful to pray to the Saints, and every Christian must do so. We must especially pray to our Guardian Angels, to Saint Joseph, Patron of the Church, to the holy Apostles, to the Saints whose name we bear, and to the holy Patrons of the diocese and of the parish.*
+
+**2.** What difference is there between the prayers we make to God and those we make to the Saints?
+
+*Between the prayers we make to God and those we make to the Saints there is this difference: that we pray to God so that, as the author of graces, He may give us goods and deliver us from evils; and we pray to the Saints so that, as advocates before God, they may intercede for us.*
+
+**3.** When we say that a Saint has granted a grace, what do we mean?
+
+*When we say that a Saint has granted a grace, we mean that that Saint has obtained from God that grace.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-terza-capo-i.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-terza-capo-i.md
@@ -1,0 +1,55 @@
+# Chapter I — On the Commandments of God in general
+
+**1.** What is treated of in the third part of Christian Doctrine?
+
+*In the third part of Christian Doctrine, the Commandments of God and of the Church are treated.*
+
+**2.** How many are the Commandments of the law of God?
+
+*The Commandments of the law of God are ten:*
+
+*I am the Lord thy God:*
+
+*1. Thou shalt not have other gods before Me.*
+
+*2. Thou shalt not take the name of God in vain.*
+
+*3. Remember to keep holy the feast days.*
+
+*4. Honor thy father and thy mother.*
+
+*5. Thou shalt not kill.*
+
+*6. Thou shalt not commit impure acts.*
+
+*7. Thou shalt not steal.*
+
+*8. Thou shalt not bear false witness.*
+
+*9. Thou shalt not desire another's wife.*
+
+*10. Thou shalt not desire another's goods.*
+
+**3.** Why do the Commandments of God bear this name?
+
+*The Commandments of God bear this name because God Himself has impressed them upon the soul of every man, has promulgated them on Mount Sinai in the old law, engraved on two tablets of stone, and Jesus Christ has confirmed them in the new law.*
+
+**4.** Which are the Commandments of the first tablet?
+
+*The Commandments of the first tablet are the first three, which regard God directly and the duties we have toward Him.*
+
+**5.** Which are the Commandments of the second tablet?
+
+*The Commandments of the second tablet are the last seven, which regard our neighbor and the duties we have toward him.*
+
+**6.** Are we obliged to observe the Commandments?
+
+*Yes, we are all obliged to observe the Commandments, because we must all live according to the will of God who created us, and gravely to transgress even a single one suffices to merit hell.*
+
+**7.** Can we observe the Commandments?
+
+*We can, without doubt, observe the Commandments of God, because God commands no impossible thing and gives the grace to observe them to whoever asks for it as he ought.*
+
+**8.** What is generally to be considered in each Commandment?
+
+*In each Commandment is to be considered the positive part and the negative part, that is, what is commanded of us and what is forbidden.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-terza-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-terza-capo-ii.md
@@ -1,0 +1,203 @@
+# Chapter II — On the Commandments concerning God
+
+## § 1. On the first commandment
+
+**1.** Why is it said at the beginning: I am the Lord thy God?
+
+*At the beginning of the Commandments it is said: "I am the Lord thy God," that we may know that God, being our Creator and Lord, can command what He wills, and we, His creatures, are bound to obey Him.*
+
+**2.** What does God command us with the words of the first commandment: Thou shalt not have other gods before Me?
+
+*With the words of the first commandment, "Thou shalt not have other gods before Me," God commands us to acknowledge, adore, love, and serve Him alone, as our supreme Lord.*
+
+**3.** How is the first commandment fulfilled?
+
+*The first commandment is fulfilled by the exercise of internal and external worship.*
+
+**4.** What is internal worship?
+
+*Internal worship is the honor that is rendered to God with the faculties of the spirit alone, that is, with the mind and the will.*
+
+**5.** What is external worship?
+
+*External worship is the homage that is rendered to God by means of exterior acts and sensible objects.*
+
+**6.** Is it not enough to adore God only internally with the heart?
+
+*No, it is not enough to adore God only internally with the heart; we must also adore Him externally, with the spirit together with the body, because He is the Creator and absolute Lord of both.*
+
+**7.** Can external worship exist without internal worship?
+
+*No, external worship cannot in any way exist without internal worship, because the former, unaccompanied by the latter, remains without life, without merit, and without effect, like a body without a soul.*
+
+**8.** What does the first commandment forbid us?
+
+*The first commandment forbids us idolatry, superstition, sacrilege, heresy, and every other sin against religion.*
+
+**9.** What is idolatry?
+
+*Idolatry is called the giving to some creature, for example to a statue, an image, or a man, the supreme worship of adoration due to God alone.*
+
+**10.** How is this prohibition expressed in Sacred Scripture?
+
+*In Sacred Scripture this prohibition is expressed with the words: "Thou shalt not make to thyself a graven thing, nor the likeness of anything that is in heaven above, or on the earth beneath. Thou shalt not adore such things, nor render them worship."*
+
+**11.** Do these words forbid every kind of image?
+
+*Certainly not; but only those of false divinities, made for the purpose of adoration, as the idolaters did. So true is this that God Himself commanded Moses to make some, such as the two statues of the cherubim on the ark, and the bronze serpent in the desert.*
+
+**12.** What is superstition?
+
+*Superstition is called any devotion contrary to the doctrine and usage of the Church, as also the attributing to an action or to anything whatever a supernatural power that it does not have.*
+
+**13.** What is sacrilege?
+
+*Sacrilege is the profanation of a place, a person, or a thing consecrated to God and destined for His worship.*
+
+**14.** What is heresy?
+
+*Heresy is a culpable error of the intellect, by which one pertinaciously denies some truth of the faith.*
+
+**15.** What other things does the first commandment forbid?
+
+*The first commandment also forbids us any dealings with the devil and joining anti-Christian sects.*
+
+**16.** Would one who has recourse to the devil or invokes him commit a grave sin?
+
+*One who has recourse to the devil or invokes him would commit an enormous sin, because the devil is the most perverse enemy of God and of man.*
+
+**17.** Is it lawful to question the so-called speaking or writing tables, or in any way to consult the souls of the departed by means of spiritism?
+
+*All the practices of spiritism are unlawful, because they are superstitious, and often not free from diabolical intervention, and therefore they have been justly forbidden by the Church.*
+
+**18.** Does the first commandment perhaps forbid us to honor and invoke the Angels and the Saints?
+
+*No, it is not forbidden to honor and invoke the Angels and the Saints; on the contrary, we must do so, because it is a good and useful thing, highly recommended by the Church, since they are the friends of God and our intercessors with Him.*
+
+**19.** Since Jesus Christ is our only Mediator with God, why do we also have recourse to the mediation of the Most Holy Mary and of the Saints?
+
+*Jesus Christ is our Mediator with God in this sense: that, being true God and true Man, He alone, by virtue of His own merits, has reconciled us with God and obtains for us all graces. The Virgin then and the Saints, by virtue of the merits of Jesus Christ and by the charity that unites them to God and to us, help us by their intercession to obtain the graces we ask. And this is one of the great goods of the communion of Saints.*
+
+**20.** May we also honor the sacred images of Jesus Christ and of the Saints?
+
+*Yes, because the honor that is rendered to the sacred images of Jesus Christ and of the Saints is referred to their very persons.*
+
+**21.** And may the relics of the Saints be honored?
+
+*Yes, the relics of the Saints are also to be honored, because their bodies were living members of Jesus Christ and temples of the Holy Spirit, and shall rise gloriously to eternal life.*
+
+**22.** What difference is there between the worship we render to God and the worship we render to the Saints?
+
+*Between the worship we render to God and the worship we render to the Saints there is this difference: that we adore God for His infinite excellence, while we do not adore the Saints, but honor and venerate them as friends of God and our intercessors with Him. The worship that is rendered to God is called latria, that is, of adoration; and the worship that is rendered to the Saints is called dulia, that is, of veneration of the servants of God; and the particular worship which we render to the Most Holy Mary is called hyperdulia, that is, of most special veneration, since she is the Mother of God.*
+
+## § 2. On the second commandment
+
+**23.** What does the second commandment — Thou shalt not take the name of God in vain — forbid us?
+
+*The second commandment, "Thou shalt not take the name of God in vain," forbids us: 1. to take the name of God without reverence; 2. to blaspheme against God, against the Most Holy Virgin, and against the Saints; 3. to make false oaths, or unnecessary oaths, or oaths unlawful in any way.*
+
+**24.** What does it mean to take the name of God without reverence?
+
+*To take the name of God without reverence means to pronounce this holy name and all that refers in a special way to God Himself, such as the name of Jesus, of Mary, and of the Saints, in anger, in jest, or in any other irreverent way.*
+
+**25.** What is blasphemy?
+
+*Blasphemy is a horrible sin which consists in words or acts of contempt or of malediction against God, the Virgin, the Saints, or against holy things.*
+
+**26.** Is there a difference between blasphemy and imprecation?
+
+*There is a difference, because by blasphemy one curses, or wishes evil to, God, our Lady, or the Saints; while by imprecation one curses or wishes evil to oneself or to one's neighbor.*
+
+**27.** What is an oath?
+
+*An oath is the calling of God to witness the truth of what is said or promised.*
+
+**28.** Is swearing always forbidden?
+
+*Swearing is not always forbidden, but is lawful, and even honorable to God, when there is necessity and when the oath is made with truth, with judgment, and with justice.*
+
+**29.** When does one not swear with truth?
+
+*When one affirms by oath what one knows, or believes, to be false, and when one promises by oath to do what one has no intention of carrying out.*
+
+**30.** When does one not swear with judgment?
+
+*When one swears without prudence and without mature consideration, or for matters of little importance.*
+
+**31.** When does one not swear with justice?
+
+*When one swears to do something that is not just or lawful, such as taking revenge, stealing, and similar things.*
+
+**32.** Are we obliged to keep an oath to do unjust or unlawful things?
+
+*Not only are we not obliged, but we would sin in doing them, because they are forbidden by the law of God or of the Church.*
+
+**33.** What sin does one commit who swears falsely?
+
+*One who swears falsely commits a mortal sin, because he gravely dishonors God, who is infinite truth, by calling Him to witness what is false.*
+
+**34.** What does the second commandment order us?
+
+*The second commandment orders us to honor the holy name of God and to fulfill, besides oaths, also vows.*
+
+**35.** What is a vow?
+
+*A vow is a promise made to God of something good and possible for us and better than its opposite, to which we bind ourselves as if it had been commanded of us.*
+
+**36.** If the observance of a vow should prove, in whole or in part, very difficult, what should one do?
+
+*One can ask for commutation or dispensation from one's own Bishop, or from the Supreme Pontiff, according to the nature of the vow.*
+
+**37.** Is it a sin to violate vows?
+
+*To violate vows is a sin, and therefore we must not make vows without mature reflection and, ordinarily, without the counsel of a confessor or of another prudent person, lest we expose ourselves to the danger of sinning.*
+
+**38.** May vows be made to our Lady and to the Saints?
+
+*Vows are made only to God; one can, however, promise God to do something in honor of our Lady or of the Saints.*
+
+## § 3. On the third commandment
+
+**39.** What does the third commandment — Remember to keep holy the feast days — order us?
+
+*The third commandment, "Remember to keep holy the feast days," orders us to honor God by works of worship on the feast days.*
+
+**40.** Which are the feast days?
+
+*In the old law they were the sabbaths and other particularly solemn days for the Hebrew people; in the new law they are the Sundays and other festivals established by the Church.*
+
+**41.** Why, in the new law, is Sunday kept holy instead of Saturday?
+
+*Sunday, which means the day of the Lord, was substituted for Saturday because on that day Jesus Christ our Lord rose again.*
+
+**42.** What work of worship is commanded us on the feast days?
+
+*We are commanded to assist devoutly at the Holy Sacrifice of the Mass.*
+
+**43.** By what other works does a good Christian keep the feast days holy?
+
+*A good Christian keeps the feast days holy: 1. by attending Christian Doctrine, sermons, and the divine offices; 2. by frequently receiving, with the due dispositions, the sacraments of Penance and the Eucharist; 3. by exercising himself in prayer and in works of Christian charity toward his neighbor.*
+
+**44.** What does the third commandment forbid us?
+
+*The third commandment forbids us servile works and any work that hinders us from the worship of God.*
+
+**45.** Which are the servile works forbidden on feast days?
+
+*The servile works forbidden on feast days are the works called manual, that is, those material labors in which the body has a greater part than the spirit; such as those which are ordinarily done by servants, workmen, and artisans.*
+
+**46.** What sin is committed by working on a feast day?
+
+*By working on a feast day mortal sin is committed; the brevity of the time occupied, however, excuses from grave guilt.*
+
+**47.** Is there no servile work that is permitted on feast days?
+
+*On feast days are permitted those works which are necessary to life, or for the service of God; and those which are done for a grave reason, asking permission, if possible, of one's own parish priest.*
+
+**48.** For what end are servile works forbidden on feast days?
+
+*Servile works are forbidden on feast days so that we may better attend to divine worship and to the salvation of our soul, and rest from our labors. For this reason, some honest recreation is not forbidden.*
+
+**49.** What other things must we above all avoid on feast days?
+
+*On feast days we must above all avoid sin and all that may lead us to sin, such as dangerous amusements and gatherings.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-terza-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-terza-capo-iii.md
@@ -1,0 +1,293 @@
+# Chapter III — On the Commandments concerning our neighbor
+
+## § 1. On the fourth commandment
+
+**1.** What does the fourth commandment — Honor thy father and thy mother — order us?
+
+*The fourth commandment, "Honor thy father and thy mother," orders us to respect our father and our mother, to obey them in all that is not sin, and to help them in their spiritual and temporal needs.*
+
+**2.** What does the fourth commandment forbid us?
+
+*The fourth commandment forbids us to offend our parents with words, with deeds, and in any other way.*
+
+**3.** Under the name of father and mother, what other persons does this commandment include?
+
+*Under the name of father and mother this commandment also includes all superiors, both ecclesiastical and secular, whom we must therefore obey and respect.*
+
+**4.** Whence comes to parents the authority to command their children, and the obligation of children to obey them?
+
+*The authority parents have to command their children, and the obligation of children to obey them, come from God, who established and ordained the family, that in it man may find the first means necessary for his material and spiritual perfection.*
+
+**5.** Have parents duties toward their children?
+
+*Parents have the duty of loving, nourishing, and maintaining their children, of providing for their religious and civil education, of giving them good example, of keeping them away from occasions of sin, of correcting them for their failings, and of helping them to embrace the state to which they are called by God.*
+
+**6.** Has God given us the example of a perfect family?
+
+*God has given us the example of a perfect family in the Holy Family, in which Jesus Christ lived subject to the Most Holy Mary and to Saint Joseph until the age of thirty, that is, until He began to exercise the mission entrusted to Him by the Eternal Father, of preaching the Gospel.*
+
+**7.** If families lived alone, separated from one another, could they provide for all their material and moral needs?
+
+*If families lived alone, separated from one another, they could not provide for their needs, and it is necessary that they be united in civil society, in order to help one another for the perfection and the common happiness.*
+
+**8.** What is civil society?
+
+*Civil society is the union of many families dependent on the authority of a head, to help one another in common to attain mutual perfection and temporal happiness.*
+
+**9.** Whence comes to civil society the authority that governs it?
+
+*The authority that governs civil society comes from God, who wills that it be constituted for the common good.*
+
+**10.** Is there an obligation to respect and obey the authority that governs civil society?
+
+*Yes, all those who belong to civil society have the obligation to respect and obey authority, because it comes from God, and because so is required by the common good.*
+
+**11.** Must all the laws imposed by civil authority be respected?
+
+*All the laws that civil authority imposes must be respected, provided that they are not contrary to the law of God, according to the command and example of our Lord Jesus Christ.*
+
+**12.** Besides respect and obedience to the laws imposed by authority, have those who form part of civil society other duties?
+
+*Those who form part of civil society have, besides the obligation of respect and obedience to the laws, the duty of living in concord and of laboring, each with his own means and powers, that society may be virtuous, peaceful, well-ordered, and prosperous to the common advantage.*
+
+## § 2. On the fifth commandment
+
+**13.** What does the fifth commandment — Thou shalt not kill — forbid?
+
+*The fifth commandment, "Thou shalt not kill," forbids putting to death, beating, wounding, or doing any other harm to our neighbor in the body, whether by ourselves or by means of others; likewise, offending him with injurious words and wishing him ill. In this commandment God also forbids the putting of oneself to death, that is, suicide.*
+
+**14.** Why is it a grave sin to kill one's neighbor?
+
+*Because the killer rashly usurps the right that God alone has over the life of man; because he destroys the security of human society; and because he takes from his neighbor life, which is the greatest natural good he has on earth.*
+
+**15.** Are there cases in which it is lawful to kill one's neighbor?
+
+*It is lawful to kill one's neighbor when one fights in a just war; when one carries out, by order of the supreme authority, the death sentence in punishment of some crime; and finally when it is a matter of necessary and legitimate defense of life against an unjust aggressor.*
+
+**16.** Does God, in the fifth commandment, also forbid harming the spiritual life of our neighbor?
+
+*Yes, God in the fifth commandment also forbids harming the spiritual life of our neighbor by scandal.*
+
+**17.** What is scandal?
+
+*Scandal is any word, deed, or omission that is an occasion to others of committing sins.*
+
+**18.** Is scandal a grave sin?
+
+*Scandal is a grave sin, because it tends to destroy the greatest work of God, which is redemption, by the loss of souls; it gives our neighbor the death of the soul, taking from him the life of grace, which is more precious than the life of the body; it is the cause of a multitude of sins. Therefore God threatens the scandalous with the severest punishments.*
+
+**19.** Why, in the fifth commandment, does God forbid the putting of oneself to death, that is, suicide?
+
+*In the fifth commandment, God forbids suicide because man is not master of his life, just as he is not of the lives of others. The Church, moreover, punishes the suicide with the deprivation of ecclesiastical burial.*
+
+**20.** Is the duel also forbidden in the fifth commandment?
+
+*Yes, in the fifth commandment the duel is also forbidden, because the duel partakes of the malice of suicide and homicide, and any one who voluntarily takes part in it, even as a mere spectator, is excommunicated.*
+
+**21.** Is the duel also forbidden when the danger of death is excluded?
+
+*This duel is also forbidden, because not only may we not kill, but we may not even voluntarily wound ourselves or others.*
+
+**22.** Can the defense of one's honor excuse the duel?
+
+*No: because it is not true that the offense is repaired by the duel; and because honor cannot be repaired by an unjust, unreasonable, and barbarous action, such as the duel is.*
+
+**23.** What does the fifth commandment order us?
+
+*The fifth commandment orders us to forgive our enemies and to wish well to all.*
+
+**24.** What must one do who has harmed his neighbor in the life of the body, or in that of the soul?
+
+*One who has harmed his neighbor must not merely confess it, but must also repair the harm done, by making good to his neighbor the damages caused, by retracting the errors taught, and by giving good example.*
+
+## § 3. On the sixth and ninth commandments
+
+**25.** What does the sixth commandment — Thou shalt not commit impure acts — forbid us?
+
+*The sixth commandment, "Thou shalt not commit impure acts," forbids us every act, every look, every discourse contrary to chastity, and infidelity in marriage.*
+
+**26.** What does the ninth commandment forbid?
+
+*The ninth commandment expressly forbids every desire contrary to the fidelity which the spouses have sworn to each other in contracting marriage; and it also forbids every culpable thought or desire of an action forbidden by the sixth commandment.*
+
+**27.** Is impurity a great sin?
+
+*It is a most grave and abominable sin before God and men; it debases man to the condition of brutes, drags him into many other sins and vices, and provokes the most terrible punishments in this life and in the next.*
+
+**28.** Are all the thoughts that come into our minds against purity sins?
+
+*The thoughts that come into our minds against purity are not in themselves sins, but rather temptations and incitements to sin.*
+
+**29.** When are bad thoughts sins?
+
+*Bad thoughts, even when they are ineffectual, are sins when we culpably give them occasion, or consent to them, or expose ourselves to the proximate danger of consenting to them.*
+
+**30.** What do the sixth and ninth commandments order us?
+
+*The sixth commandment orders us to be chaste and modest in acts, in looks, in bearing, and in words. The ninth commandment orders us to be chaste and pure also inwardly, that is, in the mind and the heart.*
+
+**31.** What is it fitting for us to do in order to observe the sixth and ninth commandments?
+
+*To observe well the sixth and ninth commandments, we must pray often and from the heart to God; be devoted to the Virgin Mary, Mother of purity; remember that God sees us; think of death, of the divine punishments, and of the passion of Jesus Christ; guard our senses; practice Christian mortification; and frequent the sacraments with the due dispositions.*
+
+**32.** What must we flee in order to keep ourselves chaste?
+
+*To keep ourselves chaste it is fitting to flee idleness, bad companions, the reading of bad books and newspapers, intemperance, the gazing at indecent images, licentious entertainments, dangerous conversations, and all the other occasions of sin.*
+
+## § 4. On the seventh commandment
+
+**33.** What does the seventh commandment — Thou shalt not steal — forbid us?
+
+*The seventh commandment, "Thou shalt not steal," forbids the taking and retaining unjustly of another's goods, and the doing of any other harm to our neighbor in his goods in any other way.*
+
+**34.** What does it mean to steal?
+
+*It means to take unjustly another's goods against the will of the owner, when, that is, he has every reason and right not to wish to be deprived of them.*
+
+**35.** Why is stealing forbidden?
+
+*Because one sins against justice and does injury to one's neighbor by taking and retaining, against his right and his will, what belongs to him.*
+
+**36.** What are the goods of another?
+
+*They are all that belongs to one's neighbor, who has the ownership or the use of them, or who holds them in trust.*
+
+**37.** In how many ways is another's goods taken unjustly?
+
+*In two ways: by theft and by robbery.*
+
+**38.** How is theft committed?
+
+*Theft is committed by taking secretly the goods of others.*
+
+**39.** How is robbery committed?
+
+*Robbery is committed by taking violently and openly the goods of others.*
+
+**40.** In what cases may one take the goods of others without sinning?
+
+*When the owner is not opposed, or when he unjustly does not wish it — as would happen in the case of one in extreme need — provided he take only what is strictly necessary to relieve his urgent and extreme need.*
+
+**41.** Is it only by theft and robbery that one harms one's neighbor in his goods?
+
+*One also harms him by fraud, by usury, and by any other injustice against his goods.*
+
+**42.** How is fraud committed?
+
+*Fraud is committed by deceiving one's neighbor in commerce by false weights, measures, or coins, and by bad merchandise; by falsifying writings and documents; in sum, by practicing deception in purchases, in sales, and in any other contract, and also when one will not give the just and agreed-upon amount.*
+
+**43.** In what way is usury committed?
+
+*Usury is committed by exacting without lawful title an unlawful interest for a sum lent, taking advantage of another's need and ignorance.*
+
+**44.** What other injustices are committed against the goods of one's neighbor?
+
+*By causing him unjustly to lose what he has; by damaging him in his possessions; by not working according to one's duty; by maliciously not paying debts and due wages; by wounding or killing animals belonging to him; by spoiling things received in custody; by preventing anyone from making a just gain; by abetting thieves; and by receiving, hiding, or buying stolen goods.*
+
+**45.** Is stealing a grave sin?
+
+*It is a grave sin against justice when the matter is grave, since it is a most important thing that the right which each has to his own goods be respected, and this for the good of individuals, of families, and of society.*
+
+**46.** When is the matter of theft grave?
+
+*It is grave when a considerable thing is taken, and also when, although a thing of little moment is taken, one's neighbor suffers grave harm thereby.*
+
+**47.** What does the seventh commandment order us?
+
+*The seventh commandment orders us to respect the goods of others, to give just wages to workmen, and to observe justice in all that concerns the property of others.*
+
+**48.** Does one who has sinned against the seventh commandment need only confess it?
+
+*One who has sinned against the seventh commandment does not need only to confess it, but must do what he can to restore the goods of others and to make good the damages.*
+
+**49.** What is the making good of damages?
+
+*The making good of damages is the compensation that must be given to one's neighbor for the fruits and gains lost on account of the theft and other injustices committed to his harm.*
+
+**50.** To whom must the stolen goods be restored?
+
+*To him from whom they were stolen; to his heirs, if he is dead; and if this is truly impossible, the value must be given out for the benefit of the poor and of pious works.*
+
+**51.** What must one do when one finds something of great value?
+
+*One must use great diligence to find the owner, and faithfully restore it to him.*
+
+## § 5. On the eighth commandment
+
+**52.** What does the eighth commandment — Thou shalt not bear false witness — forbid us?
+
+*The eighth commandment, "Thou shalt not bear false witness," forbids us to testify falsely in court: and it forbids also detraction or back-biting, calumny, flattery, rash judgment and suspicion, and every kind of lie.*
+
+**53.** What is detraction or back-biting?
+
+*Detraction or back-biting is a sin which consists in making known, without just cause, the sins and defects of others.*
+
+**54.** What is calumny?
+
+*Calumny is a sin which consists in maliciously attributing to one's neighbor faults and defects that he does not have.*
+
+**55.** What is flattery?
+
+*Flattery is a sin which consists in deceiving someone by speaking falsely well of him or of others, with the aim of having some advantage from it.*
+
+**56.** What is rash judgment or suspicion?
+
+*Rash judgment or suspicion is a sin which consists in judging or suspecting evil of others without just foundation.*
+
+**57.** What is a lie?
+
+*A lie is a sin which consists in asserting as true or as false, by words or by deeds, what one does not believe to be such.*
+
+**58.** Of how many kinds is a lie?
+
+*A lie is of three kinds: jocose, officious, and harmful.*
+
+**59.** What is the jocose lie?
+
+*The jocose lie is that by which one lies in jest, and without prejudice to anyone.*
+
+**60.** What is the officious lie?
+
+*The officious lie is the assertion of what is false for one's own or another's utility, without prejudice to anyone.*
+
+**61.** What is the harmful lie?
+
+*The harmful lie is the assertion of what is false to the prejudice of one's neighbor.*
+
+**62.** Is it ever lawful to tell a lie?
+
+*It is never lawful to tell a lie, neither in jest, nor for one's own or another's advantage, since it is a thing evil in itself.*
+
+**63.** What sin is a lie?
+
+*The lie, when it is jocose or officious, is a venial sin; when it is harmful, it is a mortal sin, if the harm it causes is grave.*
+
+**64.** Is it always necessary to say everything as one thinks it?
+
+*It is not always necessary, especially when the one who questions has no right to know what he asks.*
+
+**65.** Does one who has sinned against the eighth commandment need only confess it?
+
+*One who has sinned against the eighth commandment does not need only to confess it, but is also obliged to retract whatever he said calumniating his neighbor, and to repair, in the best way he can, the damages he has caused him.*
+
+**66.** What does the eighth commandment order us?
+
+*The eighth commandment orders us to tell the truth in time and place, and to interpret in a good sense, as far as we can, the actions of our neighbor.*
+
+## § 6. On the tenth commandment
+
+**67.** What does the tenth commandment — Thou shalt not desire another's goods — forbid us?
+
+*The tenth commandment, "Thou shalt not desire another's goods," forbids the desire to deprive others of their goods, and the desire to acquire goods by unjust means.*
+
+**68.** Why does God also forbid the desire of another's goods?
+
+*God forbids us the disordered desires of another's goods, because He wills that we be just also inwardly and keep ourselves ever more distant from unjust works.*
+
+**69.** What does the tenth commandment order us?
+
+*The tenth commandment orders us to be content with the state in which God has placed us, and to bear with patience poverty, when God wills us in that state.*
+
+**70.** How can the Christian be content in the state of poverty?
+
+*The Christian can be content even in the state of poverty by considering that the greatest good is a pure and tranquil conscience, that our true country is heaven, and that Jesus Christ made Himself poor for love of us and has promised a special reward to all those who bear poverty with patience.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-terza-capo-iv.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-terza-capo-iv.md
@@ -1,0 +1,179 @@
+# Chapter IV — On the precepts of the Church
+
+## § 1. On the precepts of the Church in general
+
+**1.** Besides the Commandments of God, what else must we observe?
+
+*Besides the Commandments of God we must observe the precepts of the Church.*
+
+**2.** Are we obliged to obey the Church?
+
+*Without doubt we are obliged to obey the Church, because Jesus Christ Himself commands it, and because the precepts of the Church help us to observe the Commandments of God.*
+
+**3.** When does the obligation of observing the precepts of the Church begin?
+
+*The obligation of observing the precepts of the Church generally begins with the use of reason.*
+
+**4.** Is it a sin to violate a precept of the Church?
+
+*Knowingly to violate a precept of the Church in grave matter is a mortal sin.*
+
+**5.** Who can dispense from a precept of the Church?
+
+*Only the Pope, and he who has received the faculties from him, can dispense from a precept of the Church.*
+
+**6.** How many and which are the precepts of the Church?
+
+*The Precepts of the Church are five:*
+
+*1. To hear Mass on all Sundays and other commanded feast days.*
+
+*2. To fast during Lent, on the Ember Days, and on the commanded vigils; not to eat meat on the forbidden days.*
+
+*3. To confess at least once a year, and to receive Communion at Easter, each one in his own parish.*
+
+*4. To pay the tithes due to the Church, according to custom.*
+
+*5. Not to celebrate weddings during the forbidden times, that is, from the first Sunday of Advent until the Epiphany, and from the first day of Lent until the octave of Easter.*
+
+## § 2. On the first precept of the Church
+
+**7.** What does the first precept or commandment of the Church — To hear Mass on all Sundays and other commanded feast days — order us?
+
+*The first precept of the Church, "To hear Mass on all Sundays and other commanded feast days," orders us to assist with devotion at Holy Mass on all Sundays and on the other holy days of obligation.*
+
+**8.** Which is the Mass at which the Church desires us to assist on Sundays and on the other holy days of obligation?
+
+*The Mass at which the Church desires that, if possible, one assist on Sundays and on the other holy days of obligation is the parish Mass.*
+
+**9.** Why does the Church recommend that the faithful assist at the parish Mass?
+
+*The Church recommends that the faithful assist at the parish Mass: 1. that those who belong to the same parish may unite to pray together with the parish priest, who is their head; 2. that the parishioners may share more fully in the holy sacrifice, which is principally applied for them; 3. that they may hear the truths of the Gospel which the parish priests are bound to set forth at Holy Mass; 4. that they may come to know the prescriptions and notices that are published at the said Mass.*
+
+**10.** What does Sunday mean?
+
+*Sunday means the day of the Lord, that is, the day specially consecrated to divine service.*
+
+**11.** Why is special mention made of Sunday in the first commandment of the Church?
+
+*In the first commandment of the Church special mention is made of Sunday because it is the principal feast among Christians, as the sabbath was the principal feast among the Hebrews, instituted by God Himself.*
+
+**12.** What other feasts has the Church instituted?
+
+*The Church has also instituted the feasts of our Lord, of the Most Holy Virgin, of the Angels, and of the Saints.*
+
+**13.** Why has the Church instituted other feasts of our Lord?
+
+*The Church has instituted other feasts of our Lord in memory of His divine mysteries.*
+
+**14.** Why have the feasts of the Most Holy Virgin, of the Angels, and of the Saints been instituted?
+
+*The feasts of the Most Holy Virgin, of the Angels, and of the Saints have been instituted: 1. in memory of the graces God has given them, and to thank the divine goodness for them; 2. that we may honor them, imitate their examples, and be helped by their prayers.*
+
+## § 3. On the second precept of the Church
+
+**15.** What does the second precept of the Church order us with the words: To fast on the commanded days?
+
+*The second precept of the Church, with the words "To fast on the commanded days," orders us to observe the fast: 1. in Lent; 2. on some days of Advent, where this is prescribed; 3. on the Ember Days; 4. on some vigils.*
+
+**16.** In what does the fast consist?
+
+*The fast consists in taking only one meal a day and in abstaining from forbidden foods.*
+
+**17.** On fast days, may a small collation be taken in the evening?
+
+*By the indulgence of the Church, on fast days a small collation may be taken in the evening.*
+
+**18.** What is the use of fasting?
+
+*Fasting serves to better dispose us to prayer, to do penance for sins committed, and to preserve us from committing new ones.*
+
+**19.** Who is obliged to fast?
+
+*To the fast all Christians are obliged who have completed their twenty-first year and who are not either dispensed or excused by lawful impediment.*
+
+**20.** Are those who do not have the obligation of fasting entirely exempt from mortification?
+
+*Those who do not have the obligation of fasting are not entirely exempt from mortification, because we are all obliged to do penance.*
+
+**21.** For what end was Lent instituted?
+
+*Lent was instituted to imitate in some way the rigorous fast of forty days that Jesus Christ made in the desert, and to prepare us, by means of penance, to celebrate Easter in holiness.*
+
+**22.** For what end was the fast of Advent instituted?
+
+*The fast of Advent was instituted to dispose us to celebrate in holiness the Nativity of our Lord Jesus Christ.*
+
+**23.** For what end was the fast of the Ember Days instituted?
+
+*The fast of the Ember Days was instituted to consecrate every season of the year by penance on some days; to ask God for the preservation of the fruits of the earth; to thank Him for the fruits already given; and to pray Him to give His Church good ministers, whose ordination is performed on the Saturdays of the Ember Days.*
+
+**24.** For what end was the fast of the vigils instituted?
+
+*The fast of the vigils was instituted to prepare us to celebrate in holiness the principal feasts.*
+
+**25.** What is forbidden us on Fridays and on Saturdays not dispensed?
+
+*On Fridays and on Saturdays not dispensed, we are forbidden to eat meat, except in case of necessity.*
+
+**26.** Why has the Church willed that we abstain from eating meat on these days?
+
+*That we may do penance every week, and especially on Friday in honor of the Passion, and on Saturday in memory of the burial of Jesus Christ, and in honor of the Most Holy Mary.*
+
+## § 4. On the third precept of the Church
+
+**27.** What does the Church command us with the words of the third precept: To confess at least once a year?
+
+*With the words of the third precept, "To confess at least once a year," the Church obliges all Christians who have reached the use of reason to approach at least once a year the sacrament of Penance.*
+
+**28.** What is the most opportune time to satisfy the precept of annual Confession?
+
+*The most opportune time to satisfy the precept of annual confession is Lent, according to the usage introduced and approved by the whole Church.*
+
+**29.** Why does the Church say that we should confess at least once a year?
+
+*The Church says "at least" to make known her desire that we should approach the holy sacraments more often.*
+
+**30.** Is it then a useful thing to confess often?
+
+*It is most useful to confess often, especially because it is difficult for one who confesses rarely to confess well and to keep himself far from mortal sin.*
+
+**31.** What does the Church prescribe with the other words of the third precept: To receive Communion at least at Easter, each one in his own parish?
+
+*With the other words of the third precept, "To receive Communion at least at Easter, each one in his own parish," the Church obliges all Christians who have reached the age of discretion to receive every year the Most Holy Eucharist in their own parish during the paschal time.*
+
+**32.** Are we obliged at any other time, besides Easter, to receive Communion?
+
+*We are obliged to receive Communion also in danger of death.*
+
+**33.** Why is it said that we receive Communion at least at Easter?
+
+*Because the Church earnestly desires that not only at Easter, but as often as possible, we should approach Holy Communion, which is the divine nourishment of our souls.*
+
+**34.** Is this precept satisfied by a sacrilegious confession or communion?
+
+*One who would make a sacrilegious confession and communion does not satisfy the third precept of the Church, because the intention of the Church is that these sacraments be received for the end for which they were instituted, namely, for our sanctification.*
+
+## § 5. On the fourth precept of the Church
+
+**35.** How is the fourth precept of the Church — To pay the tithes due to the Church — observed?
+
+*The fourth precept, "To pay the tithes due to the Church," is observed by paying those offerings or contributions which have been established to acknowledge the supreme dominion which God has over all things, and to provide for the decent sustenance of His ministers.*
+
+**36.** How must the tithes be paid?
+
+*The tithes must be paid of those things and in that manner which the custom of places requires.*
+
+## § 6. On the fifth precept of the Church
+
+**37.** What does the Church forbid us in the fifth precept: Not to celebrate weddings during the forbidden times?
+
+*In the fifth precept the Church does not forbid the celebration of the sacrament of Matrimony; but only the solemnity of weddings from the first Sunday of Advent until the Epiphany, and from the first day of Lent until the octave of Easter.*
+
+**38.** What is the solemnity of weddings that is forbidden?
+
+*The solemnity forbidden by this precept consists in the Mass proper of the bride and groom, in the nuptial blessing, and in extraordinary wedding pomp.*
+
+**39.** Why are displays of pomp not fitting in Advent and Lent?
+
+*Displays of pomp are not fitting in Advent and Lent, because these are times specially consecrated to penance and prayer.*

--- a/content/books/pius-x-greater-catechism/en-US/parte-terza-capo-v.md
+++ b/content/books/pius-x-greater-catechism/en-US/parte-terza-capo-v.md
@@ -1,0 +1,41 @@
+# Chapter V — On the particular duties of one's state and the evangelical counsels
+
+## § 1. On the duties of one's state
+
+**1.** What are the duties of one's state?
+
+*By the duties of one's state are meant those particular obligations which each has by reason of the state, condition, and office in which he finds himself.*
+
+**2.** Who has imposed on the various states their particular duties?
+
+*God Himself has imposed on the various states their particular duties, because these derive from His divine commandments.*
+
+**3.** Explain to me by some example how the particular duties derive from the ten commandments.
+
+*In the fourth commandment, under the name of father and mother, are understood also all our superiors; and therefore from that commandment derive all the duties of obedience, of love, and of respect of inferiors toward their superiors, and all the duties of vigilance which superiors have toward their inferiors.*
+
+**4.** From which commandments derive the duties of artisans, of merchants, of administrators of another's goods, and the like?
+
+*The duties of fidelity, sincerity, justice, and equity which they have derive from the seventh, the eighth, and the tenth commandments, which forbid every fraud, injustice, negligence, and duplicity.*
+
+**5.** From which commandment derive the duties of persons consecrated to God?
+
+*The duties of persons consecrated to God derive from the second commandment, which orders the fulfillment of vows and promises made to God, since such persons have in this way bound themselves to the observance of all, or some, of the evangelical counsels.*
+
+## § 2. On the evangelical counsels
+
+**6.** What are the evangelical counsels?
+
+*The evangelical counsels are certain means suggested by Jesus Christ in the holy Gospel for attaining to Christian perfection.*
+
+**7.** Which are the evangelical counsels?
+
+*The evangelical counsels are: voluntary poverty, perpetual chastity, and obedience in everything that is not sin.*
+
+**8.** What is the use of the evangelical counsels?
+
+*The evangelical counsels serve to make easier the observance of the commandments and to better assure eternal salvation.*
+
+**9.** Why do the evangelical counsels make easier the observance of the commandments?
+
+*The evangelical counsels make easier the observance of the commandments because they help us to detach the heart from the love of goods, of pleasures, and of honors, and so keep us away from sin.*

--- a/content/books/pius-x-greater-catechism/en-US/prime-nozioni-capo-i.md
+++ b/content/books/pius-x-greater-catechism/en-US/prime-nozioni-capo-i.md
@@ -1,0 +1,101 @@
+# First Notions — Chapter I. On the principal truths of our holy Faith
+
+**1.** Make the Sign of the Cross.
+
+*In the name of the Father and of the Son and of the Holy Spirit. Amen.*
+
+**2.** Say it in Latin.
+
+*In nomine Patris et Filii et Spiritus Sancti. Amen.*
+
+**3.** Who created you?
+
+*God created me.*
+
+**4.** For what end did God create you?
+
+*God created me to know Him, love Him, and serve Him in this life, and then to enjoy Him forever in the next.*
+
+**5.** Who is God?
+
+*God is the most perfect Being, Creator and Lord of heaven and earth.*
+
+**6.** Is there only one God?
+
+*Yes, there is only one God.*
+
+**7.** Where is God?
+
+*God is in heaven, on earth, and in every place.*
+
+**8.** Does God see everything?
+
+*Yes, God sees everything, even our thoughts.*
+
+**9.** Has God always existed?
+
+*God has always existed and always will exist, because He is eternal.*
+
+**10.** Does God have a body like ours?
+
+*God has no body, because He is a most pure spirit.*
+
+**11.** How many Persons are there in God?
+
+*In God there are three Persons really distinct.*
+
+**12.** What are the three divine Persons called?
+
+*The three divine Persons are called the Father, the Son, and the Holy Spirit.*
+
+**13.** Are the Persons of the Most Holy Trinity equal or unequal to one another?
+
+*The Persons of the Most Holy Trinity are perfectly equal, because they have the same divine essence or nature.*
+
+**14.** Which of the three divine Persons became man?
+
+*Of the three divine Persons, the second became man, namely the Son.*
+
+**15.** In what way did the Son of God become man?
+
+*The Son of God became man by taking a body and a soul, like ours, in the most pure womb of the Virgin Mary, by the work of the Holy Spirit.*
+
+**16.** What is the Son of God made man called?
+
+*The Son of God made man is called Jesus Christ.*
+
+**17.** Who, then, is Jesus Christ?
+
+*Jesus Christ is the Son of God made man.*
+
+**18.** Why did the Son of God become man?
+
+*The Son of God became man to save us.*
+
+**19.** What does "to save us" mean?
+
+*To save us means to deliver us from sin and from Hell, and to merit for us the glory of Heaven.*
+
+**20.** What is enjoyed in heaven?
+
+*In heaven one enjoys forever the vision of God and every good, without suffering any kind of evil.*
+
+**21.** To whom does God grant heaven?
+
+*God grants heaven as a reward to those who in this life love and serve Him.*
+
+**22.** What is suffered in hell?
+
+*In hell one suffers forever the privation of the vision of God, eternal fire, and every evil, without ever having any kind of good.*
+
+**23.** Who is condemned to hell?
+
+*To hell are condemned those who in this life would not love or serve God and who die impenitent.*
+
+**24.** What did Jesus Christ do to save us?
+
+*To save us, Jesus Christ suffered and died on the cross.*
+
+**25.** After His death, did Jesus Christ rise again?
+
+*Three days after His death, Jesus Christ rose glorious and triumphant, never to die again.*

--- a/content/books/pius-x-greater-catechism/en-US/prime-nozioni-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/en-US/prime-nozioni-capo-ii.md
@@ -1,0 +1,133 @@
+# First Notions — Chapter II. Principal parts of Christian Doctrine
+
+**1.** What are the principal parts of Christian Doctrine?
+
+*The principal parts of Christian Doctrine are four; namely, the Creed, the Pater Noster, the Commandments, and the Sacraments.*
+
+**2.** Say the Creed.
+
+*1. I believe in God the Father Almighty, Creator of heaven and earth.*
+
+*2. And in Jesus Christ, His only Son, our Lord.*
+
+*3. Who was conceived by the Holy Spirit, born of the Virgin Mary.*
+
+*4. Suffered under Pontius Pilate, was crucified, died, and was buried.*
+
+*5. He descended into hell; on the third day He rose again from the dead.*
+
+*6. He ascended into heaven; and sits at the right hand of God the Father Almighty.*
+
+*7. From thence He shall come to judge the living and the dead.*
+
+*8. I believe in the Holy Spirit.*
+
+*9. The holy Catholic Church; the communion of saints.*
+
+*10. The forgiveness of sins.*
+
+*11. The resurrection of the body.*
+
+*12. Life everlasting. Amen.*
+
+**3.** Say the Pater Noster in Italian.
+
+*Our Father, who art in heaven,*
+
+*1. Hallowed be Thy name.*
+
+*2. Thy kingdom come.*
+
+*3. Thy will be done, on earth as it is in heaven.*
+
+*4. Give us this day our daily bread.*
+
+*5. And forgive us our trespasses, as we forgive those who trespass against us.*
+
+*6. And lead us not into temptation.*
+
+*7. But deliver us from evil. Amen.*
+
+**4.** Say the Pater Noster in Latin.
+
+*Pater noster qui es in coelis,*
+
+*1. Sanctificetur nomen tuum.*
+
+*2. Adveniat regnum tuum.*
+
+*3. Fiat voluntas tua, sicut in coelo et in terra.*
+
+*4. Panem nostrum quotidianum da nobis hodie;*
+
+*5. Et dimitte nobis debita nostra, sicut et nos dimittimus debitoribus nostris;*
+
+*6. Et ne nos inducas in tentationem;*
+
+*7. Sed libera nos a malo. Amen.*
+
+**5.** Say the Ave Maria in Italian.
+
+*Hail Mary, full of grace, the Lord is with thee. Blessed art thou among women, and blessed is the fruit of thy womb, Jesus. Holy Mary, Mother of God, pray for us sinners, now and at the hour of our death. Amen.*
+
+**6.** Say the Ave Maria in Latin.
+
+*Ave, Maria, gratia plena. Dominus tecum. Benedicta tu in mulieribus et benedictus fructus ventris tui, Iesus. Sancta Maria, Mater Dei, ora pro nobis peccatoribus, nunc et in hora mortis nostrae. Amen.*
+
+**7.** Say the Gloria in Italian.
+
+*Glory be to the Father, and to the Son, and to the Holy Spirit, as it was in the beginning, is now, and ever shall be, world without end. Amen.*
+
+**8.** Say the Gloria in Latin.
+
+*Gloria Patri et Filio et Spiritui Sancto, sicut erat in principio et nunc et semper et in saecula saeculorum. Amen.*
+
+**9.** How many and which are the Commandments of God?
+
+*The Commandments of God are ten.*
+
+*I am the Lord thy God:*
+
+*1. Thou shalt not have other gods before Me.*
+
+*2. Thou shalt not take the name of God in vain.*
+
+*3. Remember to keep holy the feast days.*
+
+*4. Honor thy father and thy mother.*
+
+*5. Thou shalt not kill.*
+
+*6. Thou shalt not commit impure acts.*
+
+*7. Thou shalt not steal.*
+
+*8. Thou shalt not bear false witness.*
+
+*9. Thou shalt not desire another's wife.*
+
+*10. Thou shalt not desire another's goods.*
+
+**10.** How many and which are the precepts of the Church?
+
+*The Precepts of the Church are five:*
+
+*1. To hear Mass on all Sundays and other commanded feast days.*
+
+*2. To fast during Lent, on the Ember Days, and on the commanded vigils; not to eat meat on the forbidden days.*
+
+*3. To confess at least once a year, and to receive Communion at Easter, in one's own parish.*
+
+*4. To pay the tithes due to the Church, according to custom.*
+
+*5. Not to celebrate weddings during the forbidden times, that is, from the first Sunday of Advent until the Epiphany, and from the first day of Lent until the octave of Easter.*
+
+**11.** How many and which are the sacraments?
+
+*The Sacraments are seven:*
+
+*1. Baptism; 2. Confirmation; 3. Eucharist; 4. Penance; 5. Extreme Unction; 6. Holy Orders; 7. Matrimony.*
+
+**12.** Who instituted these sacraments?
+
+*Our Lord Jesus Christ instituted them.*

--- a/content/books/pius-x-greater-catechism/en-US/prime-nozioni-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/en-US/prime-nozioni-capo-iii.md
@@ -1,0 +1,21 @@
+# First Notions — Chapter III. Acts of Faith, Hope, Charity and Contrition
+
+**1.** Say the Act of Faith.
+
+*I firmly believe, because God, infallible truth, has so revealed it to the holy Catholic Church, and through her reveals it also to us, that there is one only God in three Divine Persons, equal and distinct, who are called the Father, the Son, and the Holy Spirit; that the Son became man, taking, by the work of the Holy Spirit, human flesh and soul in the womb of the most pure Virgin Mary; died for us on the cross, rose again, ascended into heaven, and from there is to come at the end of the world to judge all the living and the dead, to give forever to the good heaven and to the wicked hell. And further, for the same reason, I believe all that the same holy Church believes and teaches.*
+
+**2.** Say the Act of Hope.
+
+*My God, because You are almighty and infinitely good and merciful, I hope that, through the merits of the passion and death of Jesus Christ our Savior, You will give me eternal life, which You, most faithful, have promised to those who do the works of a good Christian, as I resolve to do with Your holy help.*
+
+**3.** Say the Act of Charity.
+
+*My God, because You are the supreme and most perfect Good, I love You with all my heart and above every other thing, and, rather than offend You, I am ready to lose every other thing; and for love of You I also love and intend to love my neighbor as myself.*
+
+**4.** Say the Act of Contrition.
+
+*My God, because You are supreme Goodness, and because I love You above all things, I repent and grieve with a true heart for having offended You, and I firmly resolve, with Your holy help, never to sin again in the future, and in particular to flee the proximate occasions of sin.*
+
+**5.** Say the Act of Attrition and Contrition.
+
+*O my God, I repent and grieve with a true heart for having offended You. I repent because of the hell I have deserved and the heaven I have lost; but much more do I repent because by sinning I have offended a God so good, so great as You are. I would rather have died than have offended You; and I firmly resolve not to sin again in the future, and to flee the proximate occasions of sin.*

--- a/content/books/pius-x-greater-catechism/en-US/translation-journal.md
+++ b/content/books/pius-x-greater-catechism/en-US/translation-journal.md
@@ -1,0 +1,85 @@
+# Translation Journal — Catechism of St. Pius X (Greater, 1905) — en-US
+
+Source: `it/` — canonical Italian 1905 (Wikisource, *Compendio della dottrina cristiana*).
+Target: `en-US/` — modern, dignified English suitable for adult catechetical reading.
+
+## Key Terms
+
+| Italian | English | Notes |
+|---|---|---|
+| Catechismo | Catechism | |
+| dottrina cristiana | Christian doctrine | |
+| Capo | Chapter | |
+| Parte | Part | |
+| Simbolo apostolico | Apostles' Creed | Symbolic equivalence; "Symbol" only when explicitly referring to the term *Simbolo* |
+| Credo | Creed | Keep italic when quoting the proper noun, as in the Italian source |
+| Pater noster | Pater Noster | Keep Latin form; English "Our Father" only when contextually appropriate |
+| Ave Maria | Hail Mary | English form; "Ave Maria" only as a Latin liturgical reference |
+| Gloria Patri | Glory Be / Gloria Patri | Use "Glory Be" in narrative; keep "Gloria Patri" in Mass-server contexts |
+| Salve Regina | Salve Regina | Keep Latin |
+| Angele Dei | Angele Dei (Guardian Angel prayer) | Keep Latin reference |
+| Spirito Santo | Holy Spirit | Modern usage |
+| Santa Chiesa cattolica | Holy Catholic Church | |
+| comunione dei santi | communion of saints | |
+| risurrezione della carne | resurrection of the body | |
+| vita eterna | life everlasting | |
+| peccato mortale | mortal sin | |
+| peccato veniale | venial sin | |
+| grazia | grace | |
+| paradiso | heaven (or paradise where context demands) | |
+| inferno | hell | |
+| purgatorio | purgatory | |
+| Romano Pontefice | Roman Pontiff | |
+| Papa | Pope | |
+| Vescovi | Bishops | |
+| sacerdote | priest | |
+| chierico | server | In Mass dialogue context ("S. / C."); otherwise "cleric" |
+| comandamenti | Commandments | |
+| precetti | precepts | |
+| Sacramento | Sacrament | |
+| Battesimo | Baptism | |
+| Cresima / Confermazione | Confirmation | |
+| Eucaristia | Eucharist | |
+| Penitenza | Penance | |
+| Estrema Unzione | Extreme Unction | Faithful to the 1905 terminology |
+| Ordine Sacro | Holy Orders | |
+| Matrimonio | Matrimony | |
+| Beatitudini | Beatitudes | |
+| Novissimi | the Last Things (death, judgment, hell, heaven) | |
+| virtù teologali | theological virtues | |
+| virtù cardinali | cardinal virtues | |
+| atto di contrizione | Act of Contrition | |
+| Confiteor | Confiteor | Keep Latin |
+| SS.mo Sacramento | the Most Holy Sacrament | Expand the abbreviation |
+| Maria SS.ma | the Most Holy Mary / the Blessed Virgin Mary | |
+| segno della Croce | Sign of the Cross | |
+
+## Style Rules
+
+- **Q&A format** preserved exactly: `**N.** Question?` then blank line then `*Answer.*` italics. Per-chapter numbering matches the Italian source.
+- **`§` subheadings** rendered as `## § N. Heading` matching the Italian.
+- **Latin liturgical text** is **never translated** — it is the actual liturgical form. Only the rubrics (Italian stage directions like "*Per la mattina*") are translated.
+- **Names of saints**: standard English forms (Saint Peter, Saint John the Baptist).
+- **Tone**: faithful to the 1905 catechetical register — clear, direct, doctrinally precise. Not modernized to colloquial English, but not pseudo-archaic either. "Thou/thee" is avoided.
+- **Use American English** spelling (color, honor, neighbor).
+- **Markdown**: do not introduce extra emphasis, do not add headings beyond what the source has, do not split paragraphs.
+
+## Translation Decisions
+
+- Per-chapter Q&A numbering follows the Italian (which itself was renumbered by Wikisource from the original 1905 sequential numbering of ~993; this is consistent within each chapter).
+- The promulgation letter is rendered in modern formal English; salutations use formal but contemporary phrasing.
+- For *Orazioni quotidiane*, fully translate the Italian rubrics and prayers; keep the Latin Mass-server dialogue in Latin, but translate the Italian section headers.
+- "Limbo dei santi Padri" → "Limbo of the holy Fathers" (technical theological term).
+- "Maestro / sommo Pastore" of Jesus → "supreme priest", "supreme prophet"; treat similar Italian "sommo" as "supreme" or "chief" depending on context.
+- "1.º, 2.º …" enumerations inside answers are rendered as "1., 2., …" — the Italian masculine ordinal markers don't carry over to English.
+- "Limbo / Patriarchi / Profeti" — keep standard English capitalizations as in tradition.
+- "Verbo eterno" = "eternal Word" (capitalized when it names the Person).
+- "decadere" in context of Adam/Eve = "to fall (from)".
+- Generic Italian "uomini" frequently translates as "men" — keep the 1905 register, do not modernize to "people" unless context forces it.
+- "in cielo" rendered as "in heaven" (lowercase) when generic; "Heaven" when referring to the beatific state in distinction from earthly paradise.
+- Italian phrasings like "Sono dunque in Gesù Cristo due nature?" — translate as natural English questions, not literal calques.
+- 1905 register notes: kept "publications" for matrimonial banns (Italian "pubblicazioni"), "tithes" (decime), "civil marriage" (matrimonio civile), "diriment / impedient impediments". Used "endowments" for dotes (gloried bodies). Used "back-biting" for mormorazione (alongside detrazione). Used Italian "domanda" rendered as "petition" only in the seven petitions of the Pater Noster; otherwise "question/request". 
+- Theological terms preserved exact: latria, dulia, hyperdulia, transubstantiation, viaticum, propitiatory/latreutic/eucharistic/impetratory (Mass ends).
+- "Vi adoro/Vi prego/Vi offerisco" rendered with capitalized "You" when addressing God in prayer.
+- Old-rite formula in Confiteor (par. 93): "I confess to Almighty God, to the Blessed Virgin Mary, to all the Saints, and to you, my spiritual father, that I have sinned." Used the older short form to match the Italian rather than the long Tridentine.
+- Section §, question, and answer numbering verified to match Italian source per chapter.

--- a/content/books/pius-x-greater-catechism/it/avvertenza.md
+++ b/content/books/pius-x-greater-catechism/it/avvertenza.md
@@ -1,0 +1,9 @@
+# Avvertenza
+
+L’istruzione pei giovanetti nella Dottrina Cristiana viene divisa in due Classi o Sezioni: alla prima risponde il Catechismo breve destinato principalmente ai fanciulli che non hanno ancora fatta la prima Comunione, alla seconda il Catechismo maggiore pei giovanetti già istruiti di ciò che si insegna nel Catechismo breve. A questo si fanno precedere poche pagine di prime nozioni di Catechismo pei fanciulli di tenera età che sia in casa, sia negli asili infantili, cominciano ad apprendere i primi rudimenti della Fede.
+
+Al Catechismo maggiore fa seguito una Istruzione sulle feste principali della Chiesa ed un brevissimo compendio di Storia della Religione, affinchè nulla manchi ai giovanetti di ciò che conviene alla loro istruzione religiosa.
+
+È interdetta a termini di legge la riproduzione.
+
+Gli editori si riservano di accordare ai singoli Eccellentissimi Vescovi che ne faranno domanda, l’autorizzazione di riprodurre questa edizione.

--- a/content/books/pius-x-greater-catechism/it/lettera-promulgazione.md
+++ b/content/books/pius-x-greater-catechism/it/lettera-promulgazione.md
@@ -1,0 +1,17 @@
+# Lettera di S.S. Papa Pio X al Cardinale Pietro Respighi
+
+AL SIGNOR CARDINALE
+
+PIETRO RESPIGHI
+
+nostro vicario generale
+
+Signor Cardinale,
+
+La necessità di provvedere per quanto è possibile alla religiosa istituzione della tenera gioventù Ci ha consigliato la stampa di un Catechismo, che esponga in modo chiaro i rudimenti della santa fede, e quelle divine verità, alle quali deve informarsi la vita d’ogni cristiano. Pertanto fatti esaminare i molti libri di testo già in uso nelle Diocesi d’Italia, Ci parve opportuno di adottare con lievi ritocchi il testo da vari anni approvato dai Vescovi del Piemonte, della Liguria, della Lombardia, della Emilia e della Toscana. L’uso di questo testo sarà obbligatorio per l’insegnamento pubblico e privato nella Diocesi di Roma e in tutte le altre della Provincia Romana; e confidiamo che anche le altre Diocesi vorranno adottarlo per arrivare così a quel testo unico, almeno per tutta l’Italia, che è nell’universale desiderio.
+
+Con questa dolce speranza impartiamo di tutto cuore a Lei, Signor Cardinale, l’Apostolica Benedizione.
+
+Dal Vaticano, li 14 Giugno 1905.
+
+PIUS PP. X

--- a/content/books/pius-x-greater-catechism/it/lezione-preliminare.md
+++ b/content/books/pius-x-greater-catechism/it/lezione-preliminare.md
@@ -1,0 +1,59 @@
+# Lezione preliminare — Della dottrina cristiana e delle sue parti principali
+
+DELLA DOTTRINA CRISTIANA E DELLE SUE PARTI PRINCIPALI
+
+**1.** Siete voi cristiano?
+
+*Sì, io sono cristiano per grazia di Dio.*
+
+**2.** Perchè dite voi: per grazia di Dio?
+
+*Io dico: per grazia di Dio, perchè l’essere cristiano è un dono tutto gratuito di Dio, che noi non abbiamo potuto meritare.*
+
+**3.** Chi è vero cristiano?
+
+*Vero cristiano è colui che è battezzato, che crede e professa la dottrina cristiana e obbedisce ai legittimi Pastori della Chiesa.*
+
+**4.** Che cosa è la dottrina cristiana?
+
+*La dottrina cristiana è la dottrina che Gesù Cristo nostro Signore ci ha insegnato per mostrarci la strada della salute.*
+
+**5.** È necessario imparare la dottrina insegnata da Gesù Cristo?
+
+*certamente necessario imparare la dottrina insegnata da Gesù Cristo e mancano gravemente quelli che trascurano di farlo.*
+
+**6.** I genitori e i padroni sono obbligati a mandare al catechismo i loro figliuoli e dipendenti?
+
+*I genitori e i padroni sono obbligati a procurare che i loro figliuoli e dipendenti imparino la dottrina cristiana, e si rendono colpevoli dinanzi a Dio se trascurano quest’obbligo.*
+
+**7.** D. chi dobbiamo noi ricevere e imparare la dottrina cristiana?
+
+*Noi dobbiamo ricevere e imparare la dottrina cristiana dalla santa Chiesa cattolica.*
+
+**8.** Come siamo certi che la dottrina cristiana che noi riceviamo dalla santa Chiesa cattolica è proprio vera?
+
+*Siamo certi che la dottrina cristiana che noi riceviamo dalla Chiesa cattolica è vera, perchè Gesù Cristo autore divino di questa dottrina, l’ha affidata per mezzo de’ suoi Apostoli alla Chiesa da sè fondata e costituita maestra infallibile di tutti gli uomini; promettendole la sua divina assistenza fino alla fine dei secoli.*
+
+**9.** Vi sono altre prove della verità della dottrina cristiana?
+
+*La verità della dottrina cristiana è dimostrata pure dalla santità eminente di tanti che la professarono e la professano, dall’eroica fortezza dei martiri, dalla rapida e mirabile sua propagazione nel mondo, e dalla sua piena conservazione attraverso tanti secoli di lotte varie e continue.*
+
+**10.** Quante e quali sono le parti principali e più necessarie della dottrina cristiana?
+
+*Le parti principali e più necessarie della dottrina cristiana sono quattro: il Credo, il Pater noster, i Comandamenti, ei Sacramenti.*
+
+**11.** Che cosa c’insegna il Credo?
+
+*Il Credo c’insegna i principali articoli della nostra santa fede.*
+
+**12.** Che cosa c’insegna il Pater noster?
+
+*Il Pater noster c’insegna tutto quello che dobbiamo sperare da Dio e tutto quello che dobbiamo a Lui domandare.*
+
+**13.** Che cosa c’insegnano i Comandamenti?
+
+*I Comandamenti c’insegnano tutto quello che dobbiamo fare per piacere a Dio: il che tutto si compendia nell’amar Dio sopra ogni cosa e il prossimo come noi stessi, per amor di Dio.*
+
+**14.** Che cosa c’insegna la dottrina dei Sacramenti?
+
+*La dottrina dei Sacramenti ci fa conoscere la natura e il buon uso di quei mezzi che Gesù Cristo ha istituito per rimetterci i peccati, comunicarci la sua grazia, e infondere e accrescere in noi le virtù della fede, della speranza e della carità.*

--- a/content/books/pius-x-greater-catechism/it/orazioni-quotidiane.md
+++ b/content/books/pius-x-greater-catechism/it/orazioni-quotidiane.md
@@ -1,0 +1,349 @@
+# Orazioni quotidiane ed altre preci
+
+## Per la mattina
+
+Fatto il segno della Croce, direte:
+
+*Vi adoro, Dio mio, e vi amo con tutto il cuore: vi ringrazio di avermi creato, fatto cristiano e conservato in questa notte: vi offerisco tutte le mie azioni, vi prego di preservarmi in questo giorno dal peccato e liberarmi da ogni male. Così sia.*
+
+Poi direte il *Pater noster*, l’*Ave Maria*, il *Credo* e gli *Atti di Fede*, *di Speranza* e *di Carità*; la *Salve Regina* e l’*Angele Dei*.
+
+## Durante la giornata
+
+**Prima del lavoro.** — *Signore, vi offerisco questo lavoro, vi prego a benedirlo perchè riesca a vostra gloria.*
+
+**Prima di mangiare.** — *Signore, vi offerisco questo cibo e vi prego a benedirlo.*
+
+**Dopo mangiato.** — *Signore, vi ringrazio del cibo che mi avete dato e fatemi degno di essere ammesso alla vostra mensa celeste.*
+
+**Nelle tentazioni.** — *Gesù mio, aiutatemi e datemi grazia di non offendervi.*
+
+## Preghiere per la sera
+
+*Vi adoro, Dio mio, e vi amo con tutto il cuore; vi ringrazio d’avermi creato, fatto cristiano e conservato in questo giorno: vi offerisco tutto quello che oggi ho fatto di bene e vi prego a liberarmi da ogni male. Così sia.*
+
+Poi direte: *Pater noster*, *Ave Maria*, *Gloria Patri*, *Atto di contrizione*.
+
+*Gesù, Giuseppe e Maria, vi dono il cuore e l’anima mia.*
+
+*Gesù, Giuseppe e Maria, assistetemi nell’ultima agonia.*
+
+*Gesù, Giuseppe e Maria, spiri in pace con voi l’anima mia.*
+
+## Breve preparazione alla confessione
+
+*Amabilissimo mio Salvatore, datemi la grazia di accostarmi a questo sacramento di Penitenza a salute dell’anima mia ed a gloria vostra.*
+
+*Vergine santissima, Madre di Gesù e Madre mia, impetratemi dal vostro benedetto Figliuolo la grazia di conoscere, di detestare e di confessare sinceramente tutti i miei peccati.*
+
+*Pater noster* ed *Ave Maria*. Quindi si faccia con diligenza l’esame, dinanzi a Dio, sopra i peccati commessi in pensieri, in parole, in opere ed in omissioni, contro i comandamenti di Dio e della Chiesa, e contro gli obblighi del proprio stato.
+
+In seguito per eccitare il pentimento dei peccati commessi, si consideri il gran male che si è fatto peccando, cioè che pel peccato mortale si è perduto la grazia di Dio, il paradiso; si sono meritate le pene dell’inferno, e si è offeso Dio nostro Signore e Padre; il quale ci ha fatto tanti benefizi, tanto ci ama, ed ha merito infinito di essere amato sopra ogni cosa e servito fedelmente.
+
+Si reciti l’*Atto di contrizione*.
+
+## Dopo la confessione
+
+Innanzi tutto si rendano grazie al Signore dell’inestimabile beneficio del perdono: si faccia subito la penitenza imposta dal confessore, si rinnovi il proposito di evitare i peccati e le loro occasioni.
+
+Poi si reciti la seguente orazione:
+
+*Quanto siete stato buono con me, o Signore! Invece di punirmi di tanti peccati che ho commesso, me li avete tutti perdonati con infinita misericordia in questa santa confessione. Di nuovo me ne pento con tutto il cuore e prometto, coll’aiuto della vostra grazia, di non offendervi mai più e di compensare con altrettanto amore le offese che vi ho fatte in tutta la mia vita.*
+
+*Vergine santissima, Angeli e Santi del cielo, vi ringrazio della vostra assistenza: e voi pure rendete per me grazie al Signore della sua misericordia ed ottenetemi costanza ed accrescimento nel bene.*
+
+*Pater noster*, *Ave Maria*, *Gloria Patri*, ed *Angele Dei*.
+
+## Breve preparazione alla SS. Comunione
+
+### Atto di fede
+
+*Signor mio Gesù Cristo, io credo fermamente che voi siete realmente presente nel SS.mo Sacramento col vostro Corpo, Sangue, Anima e Divinità.*
+
+### Atto di adorazione
+
+*Signore, io vi adoro in questo Sacramento, e vi riconosco per mio Creatore, Redentore, e sovrano padrone, sommo ed unico mio bene.*
+
+### Atto di umiltà
+
+*Signore, io non son degno che voi veniate dentro di me, ma dite una sola parola e l’anima mia sarà salva.*
+
+### Atto di contrizione
+
+*Signore, detesto tutti i miei peccati, che mi rendono indegno di ricevervi nel mio cuore, e propongo colla vostra grazia di non commetterli più per l’avvenire, di fuggirne le occasioni, e di farne la penitenza.*
+
+### Atto di speranza
+
+*Signore, io spero che dandovi tutto a me in questo divin Sacramento, mi userete misericordia e mi concederete tutte le grazie che sono necessarie per la mia eterna salute.*
+
+### Atto di carità
+
+*Signore, voi siete infinitamente amabile, voi siete il mio padre, il mio Redentore, il mio Dio: e perciò vi amo con tutto il cuore sopra ogni cosa, e per amor vostro amo il mio prossimo come me stesso, e perdono di cuore a chi mi ha offeso.*
+
+### Atto di desiderio
+
+*Signore, desidero ardentemente che veniate nell’anima mia, affinchè io non mi separi più da voi, ma viva sempre nella vostra grazia.*
+
+## Breve ringraziamento dopo la SS. Comunione
+
+### Atto di fede
+
+*Signor mio Gesù Cristo, io credo che voi siete veramente in me col vostro Corpo, Sangue, Anima e Divinità, e lo credo più fermamente che se lo vedessi coi miei propri occhi.*
+
+### Atto di adorazione
+
+*O Gesù mio, io vi adoro presente dentro di me; e mi unisco a Maria SS.ma, agli Angeli ed ai Santi per adorarvi come meritate.*
+
+### Atto di ringraziamento
+
+*Gesù, Signor mio, io vi ringrazio di tutto cuore perchè siete venuto nell’anima mia. SS.ma Vergine Maria, Angelo mio Custode, e voi tutti Angeli e Santi del paradiso, ringraziate Gesù per me.*
+
+### Atto di carità
+
+*O Gesù, mio Dio, io vi amo quanto so e posso, e desidero di amarvi quanto meritate: fate che vi ami sopra di ogni cosa adesso e per tutta l’eternità.*
+
+### Atto di offerta
+
+*O mio Gesù, voi vi siete donato tutto a me, ecco io mi dono tutto a Voi; vi offro il mio cuore e l’anima mia, vi consacro tutta la mia vita, e voglio essere vostro per tutta l’eternità.*
+
+### Atto di speranza
+
+*O mio Gesù, ora che siete venuto nell’anima mia, spero che non vi separerete mai più da me, ma resterete sempre con me colla vostra divina grazia.*
+
+### Atto di domanda
+
+*O mio Gesù datemi, ve ne prego, tutte quelle grazie spirituali e temporali che voi conoscete essere utili all’anima mia; e soccorrete i miei superiori, parenti, amici, benefattori, e le anime sante del purgatorio.*
+
+Poi direte: *Pater Noster*, *Ave Maria*, *Gloria Patri*.
+
+## Misteri del Santo Rosario
+
+### Gaudiosi (lunedì e giovedì)
+
+1. L’annunciazione dell’Angelo a Maria santissima.
+2. La visita di Maria Vergine a S. Elisabetta.
+3. La natività di G. C. nella capanna di Betlemme.
+4. La presentazione di Gesù Bambino al tempio.
+5. Il ritrovamento di Gesù fra i dottori nel tempio.
+
+### Dolorosi (martedì e venerdì)
+
+1. L’orazione di Gesù Cristo nell’orto.
+2. La flagellazione di Gesù Cristo alla colonna.
+3. La coronazione di spine.
+4. Il viaggio al Calvario di Gesù Cristo caricato della croce.
+5. La crocifissione e morte di Gesù Cristo.
+
+### Gloriosi (mercoledì, sabato e domenica)
+
+1. La risurrezione di Gesù Cristo.
+2. L’ascensione di Gesù Cristo al cielo.
+3. La venuta dello Spirito Santo sopra gli Apostoli e sopra Maria santissima.
+4. L’assunzione di Maria Vergine al cielo.
+5. L’incoronazione di Maria Vergine sopra tutti gli Angeli e Santi.
+
+## Litanie della B. Vergine
+
+*Il testo delle Litanie Lauretane non è riportato nella trascrizione Wikisource del 1905.*
+
+## Inni al Santissimo Sacramento
+
+*Dio sia benedetto:*
+
+*Benedetto il suo santo Nome:*
+
+*Benedetto Gesù Cristo vero Dio e vero uomo:*
+
+*Benedetto il nome di Gesù:*
+
+*Benedetto il suo sacratissimo Cuore:*
+
+*Benedetto Gesù nel SS.mo Sacramento dell’altare:*
+
+*Benedetta la gran Madre di Dio Maria SS.ma:*
+
+*Benedetta la sua santa ed immacolata Concezione:*
+
+*Benedetto il nome di Maria Vergine e Madre:*
+
+*Benedetto Dio ne’ suoi Angeli e ne’ suoi Santi.*
+
+## Modo di servire la S. Messa
+
+### Al principio
+
+**S.** In nomine Patris et Filii, et Spiritus Sancti. Amen. Introibo ad altare Dei.
+
+**C.** Ad Deum qui lætificat iuventutem meam.
+
+**S.** Iudica me, Deus, et discerne causam meam de gente non sancta, ab homine iniquo et doloso erue me.
+
+**C.** Quia tu es, Deus, fortitudo mea; quare me repulisti, et quare tristis incedo, dum affligit me inimicus?
+
+**S.** Emitte lucem tuam et veritatem tuam: ipsa me deduxerunt et adduxerunt in montem sanctum tuum et in tabernacula tua.
+
+**C.** Et introibo ad altare Dei; ad Deum qui lætificat iuventutem meam.
+
+**S.** Confitebor tibi in cithara, Deus, Deus meus, quare tristis es anima mea, et quare conturbas me?
+
+**C.** Spera in Deo, quoniam adhuc confitebor illi, salutare vultus mei et Deus meus.
+
+**S.** Gloria Patri et Filio et Spiritui Sancto.
+
+**C.** Sicut erat in principio, et nunc et semper, et in sæcula sæculorum. Amen.
+
+**S.** Introibo ad altare Dei.
+
+**C.** Ad Deum, qui lætificat iuventutem meam.
+
+**S.** Adiutorium nostrum in nomine Domini.
+
+**C.** Qui fecit cœlum et terram.
+
+**S.** Confiteor, ecc.
+
+**C.** Misereatur tui omnipotens Deus, et dimissis peccatis tuis, perducat te ad vitam æternam.
+
+**S.** Amen.
+
+**C.** Confiteor Deo omnipotenti, beatæ Mariæ semper Virgini, beato Michaëli archangelo, beato Ioanni Baptistae, sanctis apostolis Petro et Paulo, omnibus sanctis et tibi, pater; quia peccavi nimis cogitatione, verbo et opere; mea culpa, mea culpa, mea maxima culpa. Ideo precor beatam Mariam semper Virginem, beatum Michaëlem archangelum, beatum Ioannem Baptistam, sanctos apostolos Petrum et Paulum, omnes sanctos et te, pater, orare pro me ad Dominum Deum nostrum.
+
+**S.** Misereatur… vitam aeternam.
+
+**C.** Amen.
+
+**S.** Indulgentiam… misericors Dominus.
+
+**C.** Amen.
+
+**S.** Deus, tu conversus vivificabis nos.
+
+**C.** Et plebs tua lætabitur in te.
+
+**S.** Ostende nobis, Domine, misericordiam tuam.
+
+**C.** Et salutare tuum da nobis.
+
+**S.** Domine, exaudi orationem meam.
+
+**C.** Et clamor meus ad te veniat.
+
+**S.** Dominus vobiscum.
+
+### Al «Kyrie eleison»
+
+**C.** Kyrie, eleison; Christe, eleison; Christe, eleison; Kyrie, eleison.
+
+### Dopo il «Kyrie» o il «Gloria in excelsis»
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+### Al fine degli «Oremus» si risponde
+
+**C.** Amen.
+
+### Finita l’Epistola si risponde
+
+**C.** Deo gratias.
+
+### Prima del Vangelo
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+**S.** Initium o Sequentia sancti Evangelii secundum N.
+
+**C.** Gloria tibi, Domine.
+
+### Finito il Vangelo si risponde
+
+**C.** Laus tibi, Christe.
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+### All’«Orate fratres»
+
+**C.** Suscipiat Dominus sacrificium de manibus tuis ad laudem et gloriam nominis sui; ad utilitatem quoque nostram, totiusque Ecclesiæ suæ sanctæ.
+
+### Al Prefazio
+
+**S.** Per omnia saecula saeculorum.
+
+**C.** Amen.
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+**S.** Sursum corda.
+
+**C.** Habemus ad Dominum.
+
+**S.** Gratias agamus Domino Deo nostro.
+
+**C.** Dignum et iustum est.
+
+### Avanti il «Pater noster»
+
+**S.** Per omnia saecula saeculorum.
+
+**C.** Amen.
+
+### Alla fine del «Pater noster»
+
+**S.** Et ne nos inducas in tentationem.
+
+**C.** Sed libera nos a malo.
+
+### Alla frazione dell’Ostia
+
+**S.** Per omnia saecula saeculorum.
+
+**C.** Amen.
+
+**S.** Pax Domini sit semper vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+### Dopo la Comunione
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+### Al fine degli «Oremus» si risponde
+
+**C.** Amen.
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+**S.** Ite, missa est, o Benedicamus Domino.
+
+**C.** Deo gratias.
+
+### Alla benedizione
+
+**S.** Benedicat vos… Spiritus Sanctus.
+
+**C.** Amen.
+
+### All’ultimo Vangelo
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+**S.** Initium o sequentia sancti Evangelii secundum N.
+
+**C.** Gloria tibi Domine.
+
+### Finito il Vangelo si risponde
+
+**C.** Deo gratias.

--- a/content/books/pius-x-greater-catechism/it/parte-prima-capo-i.md
+++ b/content/books/pius-x-greater-catechism/it/parte-prima-capo-i.md
@@ -1,0 +1,51 @@
+# Capo I — Del «Credo» in generale
+
+**1.** Qual’è la prima parte della dottrina cristiana?
+
+*La prima parte della dottrina cristiana è il simbolo degli Apostoli, detto volgarmente il Credo.*
+
+**2.** Perchè chiamate voi il Credo: Simbolo degli Apostoli?
+
+*Il Credo si chiama simbolo degli Apostoli, perchè è un compendio delle verità della fede insegnate dagli Apostoli.*
+
+**3.** Quanti articoli sono nel Credo?
+
+*Nel Credo vi sono dodici articoli.*
+
+**4.** Recitateli.
+
+*1.º Io credo in Dio Padre onnipotente, Creatore del cielo e della terra.*
+
+*2.º Ed in Gesù Cristo suo Figliuolo unico, Signor nostro.*
+
+*3.º Il quale fu concepito di Spirito Santo: nacque di Maria Vergine.*
+
+*4.º Patì sotto Ponzio Pilato: fu crocifisso, morto e seppellito.*
+
+*5.º Discese all’inferno: il terzo dì risuscitò da morte.*
+
+*6.º Salì al cielo: siede alla destra di Dio Padre onnipotente.*
+
+*7.º Di là ha da venire a giudicare i i vivi ed i morti.*
+
+*8.º Credo nello Spirito Santo.*
+
+*9.º La santa Chiesa cattolica; la comunione dei santi.*
+
+*10.º La remissione dei peccati.*
+
+*11.º La risurrezione della carne.*
+
+*12.º La vita eterna. Amen.*
+
+**5.** Che cosa vuol dire la parola Credo, che dite in principio del Simbolo?
+
+*La parola Credo vuol dire: io tengo per verissimo tutto quello che in questi dodici articoli si contiene: e credo più fermamente queste cose, che se le vedessi cogli occhi miei, perchè le ha rivelate Iddio, che non può ingannarsi, nè ingannare, alla santa Chiesa cattolica e per mezzo di essa le rivela anche a noi.*
+
+**6.** Che cosa contengono gli articoli del Credo?
+
+*Gli articoli del Credo contengono tutto quello che principalmente si ha da credere di Dio, di Gesù Cristo e della Chiesa sua sposa.*
+
+**7.** È cosa molto utile il recitare spesso il Credo?
+
+*È cosa utilissima recitare spesso il Credo per imprimere sempre più nel cuore le verità della fede.*

--- a/content/books/pius-x-greater-catechism/it/parte-prima-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-prima-capo-ii.md
@@ -1,0 +1,195 @@
+# Capo II — Del primo articolo del Simbolo
+
+## § 1. Di Dio Padre e della creazione
+
+**1.** Che cosa c’insegna il primo articolo: Io credo in Dio Padre onnipotente, creatore del cielo e della terra?
+
+*Il primo articolo del Credo c’insegna che vi è un Dio solo, che è onnipotente, e ha creato il cielo, la terra e tutte le cose che nel cielo e nella terra si contengono, cioè l’universo mondo.*
+
+**2.** Come sappiamo noi che vi è Dio?
+
+*Noi sappiamo che vi è Dio, perchè la nostra ragione ce lo dimostra, e la fede ce lo conferma.*
+
+**3.** Perchè si dice che Dio è Padre?
+
+*Si dice che Dio e Padre, 1.º perchè è Padre per natura della seconda Persona della Santissima Trinità, cioè del Figliuolo da lui generato: 2.º perchè Dio ė Padre di tutti gli uomini, che egli ha creato, conserva e governa: 3.º perchè finalmente è Padre per grazia di tutti i buoni cristiani, i quali perciò si chiamano figliuoli di Dio adottivi.*
+
+**4.** Perchè il Padre è la prima Persona della Santissima Trinità?
+
+*Il Padre è la prima Persona della Santis sima Trinità, perchè non procede da altra persona, ma è il principio delle altre due persone, cioè del Figliuolo e dello Spirito Santo.*
+
+**5.** Che vuol dire la parola onnipotente?
+
+*La parola onnipotente vuol dire che Dio può fare tutto quello che vuole.*
+
+**6.** Dio non può peccare nè morire; come dunque si dice ch’egli può far tutto?
+
+*Si dice che Dio può far tutto, quantunque non possa nė peccare nė morire, perchè il poter peccare o morire non è effetto di potenza, ma di debolezza, che non può essere in Dio, il quale è perfettissimo.*
+
+**7.** Che cosa vuol dire; Creatore del cielo e della terra?
+
+*Creare vuol dire fare dal niente; perciò Dio si dice creatore del cielo e della terra per che ha fatto dal niente il cielo e la terra e tutte le cose che nel cielo e nella terra si contengono, cioè l’universo mondo.*
+
+**8.** Il mondo è stato creato solamente dal Padre?
+
+*Il mondo è stato creato ugualmente da tutte e tre le persone divine, perchè tutto ciò che fa una persona riguardo alle creature, lo fanno con uno stesso atto anche le altre.*
+
+**9.** Perchè dunque la creazione si attribuisce particolarmente al Padre?
+
+*La creazione si attribuisce particolarmente al Padre, perchè la creazione è effetto della divina onnipotenza, la quale si attribuisce specialmente al Padre, come si attribuisce la sapienza al Figliuolo, e la bontà allo Spirito Santo, benchè tutte e tre le persone abbiano la stessa onnipotenza, sapienza e bontà.*
+
+**10.** Dio ha egli cura del mondo e delle cose tutte che ha create?
+
+*Sì, Iddio ha cura del mondo e delle cose tutte che ha create, le conserva e le governa con la sua infinita bontà e sapienza, e nulla succede quaggiù, senza che Dio lo voglia o lo permetta.*
+
+**11.** Perchè dite che nulla succede senza che Dio lo voglia o lo permetta?
+
+*Si dice che nulla succede quaggiù senza che Dio lo voglia o lo permetta, perchè vi sono delle cose che Dio vuole e comanda, altre poi che egli non impedisce, come il peccato.*
+
+**12.** Perchè Iddio non impedisce il peccato?
+
+*Dio non impedisce il peccato, perchè anche dall’abuso che l’uomo fa della libertà che gli ha concesso, sa cavare un bene e far sempre più risplendere la sua misericordia, o la sua giustizia.*
+
+## § 2. Degli Angeli
+
+**13.** Quali sono le creature più nobili che Dio ha creato?
+
+*Le creature più nobili create da Dio sono gli Angeli.*
+
+**14.** Chi sono gli Angeli?
+
+*Gli Angeli sono creature intelligenti e puramente spirituali.*
+
+**15.** Per qual fine Iddio ha creato gli Angeli?
+
+*Dio ha creato gli Angeli per essere da essi onorato e servito e per renderli eternamente felici.*
+
+**16.** Quale forma e figura hanno gli Angeli?
+
+*Gli Angeli non hanno nè forma, nè figura alcuna sensibile, perchè sono puri spiriti, creati da Dio per sussistere senza dover essere uniti a corpo alcuno.*
+
+**17.** Perchè dunque gli Angeli si rappresentano sotto forme sensibili?
+
+*Gli Angeli si rappresentano sotto forme sensibili: 1.º per aiuto della nostra imaginazione; 2.º perchè sono così apparsi molte volte agli uomini, come leggiamo nella Sacra Scrittura.*
+
+**18.** Gli Angeli furono tutti fedeli a Dio?
+
+*No, gli Angeli non furono tutti fedeli a Dio, ma molti di essi per superbia pretesero essere uguali a Lui e da Lui indipendenti; e per questo peccato, furono esclusi per sempre dal paradiso e condannati all’inferno.*
+
+**19.** Come si chiamano gli Angeli esclusi per sempre dal paradiso e condannati all’inferno?
+
+*Gli Angeli esclusi per sempre dal paradiso e condannati all’inferno si chiamano demoni, e il loro capo si chiama Lucifero o Satana.*
+
+**20.** I demoni possono farci alcun male?
+
+*Sì, i demoni possono farci molto male e nell’anima e nel corpo, se però Dio ne dà loro il permesso, massime col tentarci a peccare.*
+
+**21.** Perchè ci tentano?
+
+*I demoni ci tentano per l’invidia che ci portano, la quale fa loro desiderare la nostra eterna dannazione, e per odio a Dio, la cui imagine risplende in noi. Iddio poi permette le tentazioni, affinchè noi, vincendole con la sua grazia, esercitiamo le virtù ed acquistiamo meriti pel paradiso.*
+
+**22.** Come possiamo vincere le tentazioni?
+
+*Le tentazioni si vincono colla vigilanza, colla preghiera, e colla mortificazione cristiana.*
+
+**23.** Gli Angeli rimasti fedeli a Dio come si chiamano?
+
+*Gli Angeli rimasti fedeli a Dio si chiamano Angeli buoni, Spiriti celesti, o semplicemente Angeli.*
+
+**24.** Che cosa avvenne degli Angeli rimasti fedeli a Dio?
+
+*Gli Angeli rimasti fedeli a Dio furono confermati in grazia, godono per sempre la vista di Dio, lo amano, lo benedicono, e lo lodano eternamente.*
+
+**25.** Dio si serve degli Angeli come suoi ministri?
+
+*Sì, Dio si serve degli Angeli come suoi ministri, e specialmente affida a molti di essi l’ufficio di nostri custodi e protettori.*
+
+**26.** Dobbiamo noi avere particolare devozione verso l’Angelo nostro custode?
+
+*Sì, noi dobbiamo avere particolare devozione verso l’Angelo nostro custode, onorarlo, invocarne l’aiuto, seguirne le inspirazioni ed essergli riconoscenti per l’assistenza continua ch’egli ci presta.*
+
+## § 3. Dell’uomo
+
+**27.** Qual è la creatura più nobile che Dio ha posto sulla terra?
+
+*La creatura più nobile che Dio ha posto sulla terra è l’uomo.*
+
+**28.** Che cosa è l’uomo?
+
+*L’uomo è una creatura ragionevole composta d’anima e di corpo.*
+
+**29.** Che cosa è l’anima?
+
+*L’anima è la parte più nobile dell’uomo, perchè è sostanza spirituale, dotata d’intelletto e di volontà, capace di conoscere Dio e di possederlo eternamente.*
+
+**30.** L’anima umana si può vedere e toccare?
+
+*L’anima nostra non si può nè vedere nè toccare perchè è spirito.*
+
+**31.** L’anima umana muore col corpo?
+
+*L’anima umana non muore mai: la fede e la stessa ragione provano che essa è immortale.*
+
+**32.** L’uomo è libero nelle sue azioni?
+
+*Sì, l’uomo è libero nelle sue azioni; e ciascuno sente dentro se stesso che può fare una cosa e non farla, o farne una piuttosto che un’altra.*
+
+**33.** Spiegate con un esempio la libertà umana.
+
+*Se io dico volontariamente una bugia, sento che potrei non dirla e tacere, e che potrei anche parlare diversamente, dicendo la verità.*
+
+**34.** Perchè si dice che l’uomo fu creato ad imagine e somiglianza di Dio?
+
+*Si dice che l’uomo fu creato ad imagine e somiglianza di Dio, perchè l’anima umana è spirituale e ragionevole, libera nel suo operare, capace di conoscere e di amare Dio e di goderlo eternamente: perfezioni che rispecchiano in noi un raggio dell’infinita grandezza del Signore.*
+
+**35.** In quale stato pose Dio i nostri primi progenitori Adamo ed Eva?
+
+*Dio pose Adamo ed Eva nello stato di innocenza e di grazia; ma presto ne decaddero per il peccato.*
+
+**36.** Oltre l’innocenza e la grazia santificante conferì Dio altri doni ai nostri progenitori?
+
+*Oltre l’innocenza e la grazia santificante Iddio conferì altri doni ai nostri progenitori, che essi dovevano trasmettere insieme con la grazia santificante ai loro discendenti ed erano: l’ integrità, cioè la perfetta soggezione del senso alla ragione; l’ immortalità; l’ immunità da ogni dolore e miseria; e la scienza proporzionata al loro stato.*
+
+**37.** Quale fu il peccato di Adamo?
+
+*Il peccato di Adamo fu un peccato di superbia e di grave disobbedienza.*
+
+**38.** Quale fu il castigo del peccato di Adamo ed Eva?
+
+*Adamo ed Eva perdettero la grazia di Dio e il diritto che avevano al cielo, furono cacciati dal paradiso terrestre, sottoposti a molte miserie nell’anima e nel corpo, e condannati a morire.*
+
+**39.** Se Adamo ed Eva non avessero peccato, sarebbero stati esenti dalla morte?
+
+*Se Adamo ed Eva non avessero peccato, ma si fossero mantenuti fedeli a Dio, dopo una dimora felice e tranquilla su questa terra, senza morire sarebbero stati trasferiti da Dio nel Cielo a godere una vita eterna e gloriosa.*
+
+**40.** Erano questi doni dovuti all’uomo?
+
+*Questi doni non erano dovuti in verun modo all’uomo, ma erano assolutamente gratuiti e soprannaturali; e perciò, disubbidendo Adamo al divino precetto, potè Iddio senza ingiustizia privarne Adamo e tutta la sua posterità.*
+
+**41.** Questo peccato è proprio solamente di Adamo?
+
+*Questo peccato non è solo di Adamo, ma è anche nostro, sebbene diversamente. È proprio di Adamo, perchè questi lo commise con atto di sua volontà e perciò in lui fu personale. È proprio nostro, perchè, avendo Adamo peccato come capo e fonte di tutto il genere umano, viene trasfuso per naturale generazione in tutti i suoi discendenti, e perciò per noi è peccato originale.*
+
+**42.** Com’è possibile che il peccato originale si trasfonda in tutti gli uomini?
+
+*Il peccato originale si trasfonde in tutti gli uomini, perchè avendo Iddio conferito all’uman genere in Adamo la grazia santificante e gli altri doni soprannaturali, a condizione che Adamo non disobbedisse; avendo questi disobbedito nella sua qualità di capo e padre del genere umano, rese l’umana natura ribelle a Dio. Perciò la natura umana viene trasfusa a tutti i discendenti di Adamo in uno stato di ribellione a Dio, priva della divina grazia e degli altri doni.*
+
+**43.** Quali danni ci ha dunque cagionato il peccato originale?
+
+*I danni del peccato originale sono: la privazione della grazia, la perdita del paradiso, l’ignoranza, l’inclinazione al male, tutte le miserie di questa vita, e infine la morte.*
+
+**44.** Tutti gli uomini contraggono il peccato originale?
+
+*Sì, tutti gli uomini contraggono il peccato originale, eccetto la santissima Vergine, che ne fu preservata da Dio per singolare privilegio, in previsione dei meriti di Gesù Cristo nostro Salvatore.*
+
+**45.** Dopo il peccato di Adamo gli uomini non avrebbero più potuto salvarsi?
+
+*Dopo il peccato di Adamo gli uomini non avrebbero più potuto salvarsi, se Dio non avesse loro usato misericordia.*
+
+**46.** Quale fu la misericordia usata da Dio al genere umano?
+
+*La misericordia usata da Dio al genere umano fu di promettere subito ad Adamo il Redentore divino, o Messia, e di mandarlo poi a suo tempo, per liberare gli uomini dalla schiavitù del demonio, e del peccato.*
+
+**47.** Chi è il Messia promesso?
+
+*Il Messia promesso è Gesù Cristo, come c’insegna il secondo articolo del Credo.*

--- a/content/books/pius-x-greater-catechism/it/parte-prima-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-prima-capo-iii.md
@@ -1,0 +1,57 @@
+# Capo III — Del secondo articolo
+
+**1.** Che cosa c’insegna il secondo articolo: E in Gesù Cristo suo figliuolo unico, Signor nostro?
+
+*Il secondo articolo del Credo c’insegna che il Figliuolo di Dio è la seconda persona della santissima Trinità: che egli è Dio eterno, onnipotente, Creatore e Signore, come il Padre: che egli si è fatto uomo per salvarci: e che il Figliuolo di Dio fatto uomo si chiama Gesù Cristo.*
+
+**2.** Perchè la seconda persona chiamasi Figliuolo?
+
+*La seconda persona chiamasi Figliuolo perchè è generata dal Padre per via d’intelletto da tutta l’eternità; e per questo si chiama anche Verbo eterno del Padre.*
+
+**3.** Essendo anche noi figliuoli di Dio, perchè Gesù Cristo si chiama Figliuolo unico di Dio Padre?
+
+*Gesù Cristo si chiama Figliuolo unico di Dio Padre, perchè Egli solo è per natura suo Figliuolo e noi siamo suoi figliuoli per creazione e per adozione.*
+
+**4.** Perchè Gesù Cristo si chiama Signor nostro?
+
+*Gesù Cristo si chiama Signor nostro perchè oltre l’averci creati insieme al Padre e allo Spirito Santo in quanto è Dio, ci ha pure redenti in quanto Dio ed uomo.*
+
+**5.** Perchè il Figliuolo di Dio fatto uomo si chiama Gesù?
+
+*Il Figliuolo di Dio fatto uomo si chiama Gesù che vuol dire Salvatore, perchè ci ha sal vati dalla morte eterna meritata per i nostri peccati.*
+
+**6.** Chi ha dato il nome di Gesù al Figliuolo di Dio fatto uomo?
+
+*Il nome di Gesù al Figliuolo di Dio fatto uomo l’ha dato lo stesso eterno Padre per mezzo dell’arcangelo Gabriele, quando questi annunzio alla Vergine il mistero dell’Incarnazione.*
+
+**7.** Perchè il Figliuolo di Dio fatto uomo si chiama anche Cristo?
+
+*Il Figliuolo di Dio fatto uomo si chiama anche Cristo, che vuol dire unto e consacrato, perchè anticamente si ungevano i re, i sacer doti, e i profeti; e Gesù è re dei re, sommo sacerdote e sommo profeta.*
+
+**8.** Gesù Cristo fu veramente unto e consacrato con unzione corporale?
+
+*L’unzione di Gesù Cristo non fu corporale, come quella degli antichi re, sacerdoti e profeti, ma tutta spirituale e divina perchè la pienezza della divinità abita in lui sostanzialmente.*
+
+**9.** Di Gesù Cristo prima della sua venuta, ebbero gli uomini cognizione alcuna?
+
+*Sì, gli uomini ebbero cognizione di Gesù Cristo prima della sua venuta, per la promessa del Messia che Iddio fece ai nostri progenitori Adamo ed Eva, e che rinnovò ai santi Patriarchi; e per le profezie e le molte figure che lo designavano.*
+
+**10.** Donde sappiamo noi che Gesù Cristo è veramente il Messia e Redentore promesso?
+
+*Noi sappiamo che Gesù Cristo è veramente il Messia e Redentore promesso dall’essersi adempito in lui, 1.º tutto ciò che annunziavano le profezie; 2.º tutto ciò che rappresentavano le figure dell’antico Testamento.*
+
+**11.** Le profezie che cosa predicevano del Redentore?
+
+*Le profezie predicevano del Redentore la tribù e la famiglia, dalla quale doveva uscire; il luogo e il tempo della nascita; i suoi miracoli e le più minute circostanze della sua passione e morte; la sua risurrezione ed ascensione al cielo; il suo regno spirituale, universale e perpetuo, che è la santa Chiesa cattolica.*
+
+**12.** Quali sono le principali figure del Redentore nell’antico Testamento?
+
+*Le principali figure del Redentore nell’antico Testamento sono l’innocente Abele, il sommo sacerdote Melchisedecco, il sacrificio d’Isacco; Giuseppe venduto dai fratelli, il profeta Giona, l’agnello pasquale, e il serpente di bronzo innalzato da Mosè nel deserto.*
+
+**13.** Donde sappiamo noi che Gesù Cristo è vero Dio?
+
+*Noi sappiamo che Gesù Cristo è vero Dio: 1.º dalla testimonianza del Padre allorchè disse: Questo è il mio Figlio diletto, nel quale mi sono compiaciuto; ascoltatelo: 2.º dell’attestazione di Gesù Cristo stesso, confermata coi più stupendi miracoli; 3.º dalla dottrina degli Apostoli: 4.º dalla tradizione costante della Chiesa cattolica.*
+
+**14.** Quali sono i principali miracoli operati da Gesù Cristo?
+
+*I principali miracoli operati da Gesù Cristo sono, oltre la sua risurrezione, la sanità resa agli infermi, la vista ai ciechi, l’udito ai sordi, la vita ai morti.*

--- a/content/books/pius-x-greater-catechism/it/parte-prima-capo-iv.md
+++ b/content/books/pius-x-greater-catechism/it/parte-prima-capo-iv.md
@@ -1,0 +1,53 @@
+# Capo IV — Del terzo articolo
+
+**1.** Che cosa c’insegna il terzo articolo: Il quale fu concepito di Spirito Santo; nacque di Maria Vergine.
+
+*Il terzo articolo del Credo c’insegna che il Figliuolo di Dio ha preso un corpo e un’anima, come abbiamo noi, nel seno purissimo di Maria Vergine per opera dello Spirito Santo, e che è nato da questa Vergine.*
+
+**2.** Il Padre e il Figliuolo concorsero anche essi a formare il corpo e a creare l’anima di Gesù Cristo?
+
+*Sì, a formare il corpo e a creare l’anima di Gesù Cristo concorsero tutte le tre Persone divine.*
+
+**3.** Perchè si dice solo: fu concepito di Spirito Santo?
+
+*Si dice solo: fu concepito di Spirito Santo, perchè l’incarnazione del Figliuolo di Dio è opera di bontà e di amore, e le opere di bontà e amore si attribuiscono allo Spirito Santo.*
+
+**4.** Il Figlio di Dio facendosi uomo cessò di esser Dio?
+
+*No, il Figlio di Dio si fece uomo, senza cessare di esser Dio.*
+
+**5.** Dunque Gesù Cristo è Dio e uomo insieme?
+
+*Sì, il Figlio di Dio incarnato, cioè Gesù Cristo, è Dio e uomo insieme, perfetto Dio e perfetto uomo.*
+
+**6.** Sono dunque in Gesù Cristo due nature?
+
+*Sì, in Gesù Cristo, che è Dio e uomo, sono due nature: la divina e l’umana.*
+
+**7.** Sono in Gesù Cristo anche due persone, la divina e l’umana?
+
+*No, nel Figlio di Dio fatto uomo non vi ha che una sola persona, cioè la divina.*
+
+**8.** Quante volontà sono in Gesù Cristo?
+
+*In Gesù Cristo sono due volontà: l’una divina, l’altra umana.*
+
+**9.** Gesù Cristo aveva volontà libera?
+
+*Sì, Gesù Cristo aveva volontà libera, ma non poteva fare il male, perchè poter fare il male è difetto, non perfezione della libertà.*
+
+**10.** Il Figliuolo di Dio e il Figliuolo di Maria, sono la medesima persona?
+
+*Il Figliuolo di Dio e il Figliuolo di Maria sono la medesima persona, cioè Gesù Cristo, vero Dio e vero uomo.*
+
+**11.** Maria Vergine è Madre di Dio?
+
+*Sì, Maria Vergine è Madre di Dio, perchè è Madre di Gesù Cristo, che è vero Dio.*
+
+**12.** In qual modo Maria divenne Madre di Gesù Cristo?
+
+*Maria divenne Madre di Gesù Cristo unicamente per opera e virtù dello Spirito Santo.*
+
+**13.** È di fede che Maria fu sempre Vergine?
+
+*Sì, è di fede che Maria Santissima fu sempre Vergine, ed è chiamata la Vergine per eccellenza.*

--- a/content/books/pius-x-greater-catechism/it/parte-prima-capo-ix.md
+++ b/content/books/pius-x-greater-catechism/it/parte-prima-capo-ix.md
@@ -1,0 +1,49 @@
+# Capo IX — Dell’ottavo articolo
+
+**1.** Che cosa c’insegna l’ottavo articolo: Io credo nello Spirito Santo?
+
+*L’ottavo articolo del Credo c’insegna che vi è lo Spirito Santo, terza Persona della santissima Trinità, che Egli è Dio eterno, infinito, onnipotente, Creatore e Signore di tutte le cose, come il Padre e il Figliuolo.*
+
+**2.** Da chi procede lo Spirito Santo?
+
+*Lo Spirito Santo procede dal Padre e dal Figliuolo per via di volontà e di amore, come da un solo principio.*
+
+**3.** Se il Figliuolo procede dal Padre, e lo Spirito Santo procede dal Padre e dal Figliuolo, pare che il Padre e il Figliuolo siano prima dello Spirito Santo: come dunque si dice che sono eterne tutte e tre le Persone?
+
+*Si dice che sono eterne tutte e tre le Persone, perchè il Padre ab eterno ha generato il Figliuolo; e dal Padre e dal Figliuolo ab eterno procede lo Spirito Santo.*
+
+**4.** Perchè la terza Persona della santissima Trinità si chiama particolarmente col nome di Spirito Santo?
+
+*La terza Persona della santissima Trinità si chiama particolarmente col nome di Spirito Santo perchè Essa procede dal Padre e dal Figliuolo per modo di spirazione e d’amore.*
+
+**5.** Quale opera viene attribuita specialmente allo Spirito Santo?
+
+*Allo Spirito Santo viene attribuita specialmente la santificazione delle anime.*
+
+**6.** Il Padre e il Figliuolo ci santificano egualmente che lo Spirito Santo?
+
+*Sì, tutte e tre le divine Persone ci santificano egualmente.*
+
+**7.** Se così è, perchè la santificazione delle anime si attribuisce in particolare allo Spirito Santo?
+
+*La santificazione delle anime si attribuisce in particolare allo Spirito Santo perchè essa è opera d’amore, e le opere d’amore si attribuiscono allo Spirito Santo.*
+
+**8.** Quando discese lo Spirito Santo sopra gli Apostoli?
+
+*Lo Spirito Santo discese sopra gli Apostoli nel giorno della Pentecoste, cioè cinquanta giorni dopo la Risurrezione di Gesù Cristo, e dieci dopo la sua Ascensione.*
+
+**9.** Dov’erano gli Apostoli nei dieci giorni prima della Pentecoste?
+
+*Gli Apostoli erano riuniti nel cenacolo in compagnia di Maria Vergine e degli altri discepoli, e perseveravano nell’orazione, aspettando lo Spirito Santo, che Gesù Cristo aveva loro promesso.*
+
+**10.** Quali effetti produsse lo Spirito Santo negli Apostoli?
+
+*Lo Spirito Santo confermò nella fede gli Apostoli, li riempì di lumi, di forza, di carità e dell’abbondanza di tutti i suoi doni.*
+
+**11.** Lo Spirito Santo è egli stato mandato per i soli Apostoli?
+
+*Lo Spirito Santo è stato mandato per tutta la Chiesa, e per ogni anima fedele.*
+
+**12.** Che cosa opera lo Spirito Santo nella Chiesa?
+
+*Lo Spirito Santo, come l’anima nel corpo, vivifica la Chiesa con la sua grazia e coi suoi doni; vi stabilisce il regno della verità e dell’amore; e l’assiste perchè conduca sicuramente i suoi figliuoli per la via del cielo.*

--- a/content/books/pius-x-greater-catechism/it/parte-prima-capo-v.md
+++ b/content/books/pius-x-greater-catechism/it/parte-prima-capo-v.md
@@ -1,0 +1,77 @@
+# Capo V — Del quarto articolo
+
+**1.** Che cosa c’insegna il quarto articolo: Patì sotto Ponzio Pilato, fu crocifisso, morto e sepolto?
+
+*Il quarto articolo del Credo c’insegna che Gesù Cristo per redimere il mondo col suo Sangue prezioso, patì sotto Ponzio Pilato governatore della Giudea, e morì sul legno della croce, dalla quale deposto, fu seppellito.*
+
+**2.** Che cosa vuol dire la parola patì?
+
+*La parola patì esprime tutte le pene sofferte da Gesù Cristo nella sua passione.*
+
+**3.** Gesù Cristo patì come Dio, o come uomo?
+
+*Gesù Cristo patì come uomo solamente, perchè come Dio non poteva nè patire nè morire.*
+
+**4.** Qual sorta di supplizio era quello della croce?
+
+*Il supplizio della croce era in quei tempi il più crudele e ignominioso di tutti i supplizi.*
+
+**5.** Chi fu che condannò Gesù Cristo ad essere crocifisso?
+
+*Colui che condanno Gesù Cristo ad essere crocifisso fu Ponzio Pilato governatore della Giudea, il quale aveva riconosciuta la innocenza di Lui; ma cedette vilmente alla minacciosa insistenza del popolo di Gerusalemme.*
+
+**6.** Non avrebbe potuto Gesù Cristo liberarsi dalle mani dei giudei e di Pilato?
+
+*Sì, Gesù Cristo avrebbe potuto liberarsi dalle mani dei giudei e di Pilato, ma conoscendo che la volontà del suo Eterno Padre era che Egli patisse e morisse per la nostra salute, vi si sottomise volontariamente, anzi andò Egli stesso incontro a’ suoi nemici, e si lasciò spontaneamente prendere e condurre alla morte.*
+
+**7.** Dove fu crocifisso Gesù Cristo?
+
+*Gesù Cristo fu crocifisso sul monte Calvario.*
+
+**8.** Che cosa operò Gesù Cristo sopra la croce?
+
+*Gesù Cristo sopra la croce pregò per i suoi nemici; diede per madre al discepolo san Giovanni e in persona di lui a noi tutti, la sua stessa madre Maria santissima: offrì la sua morte in sacrificio, e soddisfece alla giustizia di Dio per i peccati degli uomini.*
+
+**9.** Non sarebbe bastato che venisse un Angelo a soddisfare per noi?
+
+*No, non sarebbe bastato che venisse un Angelo a soddisfare per noi, perchè l’offesa fatta a Dio per il peccato era, sotto un certo aspetto, infinita, e per soddisfarla si richiedeva una persona che avesse un merito infinito.*
+
+**10.** Per soddisfare alla divina Giustizia era necessario che Gesù Cristo fosse Dio e uomo insieme?
+
+*Sì, bisognava che Gesù Cristo fosse uomo per poter patire e morire, e bisognava che fosse Dio perchè i suoi patimenti fossero d’un valore infinito.*
+
+**11.** Perchè era necessario che i meriti di Gesù Cristo fossero di un valore infinito?
+
+*Era necessario che i meriti di Gesù Cristo fossero di un valore infinito, perchè la maestà di Dio, offesa col peccato, è infinita.*
+
+**12.** Era necessario che Gesù patisse tanto?
+
+*No, non era assolutamente necessario che Gesù patisse tanto, perchè il minimo dei suoi patimenti sarebbe stato sufficiente alla nostra redenzione, essendo ciascun suo atto di infinito valore.*
+
+**13.** Perchè dunque volle Gesù patir tanto?
+
+*Gesù volle patir tanto per soddisfare più abbondantemente alla divina giustizia, per dimostrarci maggiormente il suo amore, e per ispirarci il più grande orrore al peccato.*
+
+**14.** Accaddero prodigi alla morte di Gesù?
+
+*Sì, alla morte di Gesù si oscurò il sole, tremò la terra, si aprirono i sepolcri e molti morti risuscitarono.*
+
+**15.** Dove fu sepolto il corpo di Gesù Cristo?
+
+*Il corpo di Gesù Cristo fu sepolto in un sepolcro nuovo, scavato nella pietra del monte, poco lontano dal luogo dove era stato crocifisso.*
+
+**16.** Nella morte di Gesù Cristo si separò la divinità dal corpo e dall’anima?
+
+*Nella morte di Gesù Cristo la divinità non si separò nè dal corpo nè dall’anima, ma solamente si separò l’anima dal corpo.*
+
+**17.** Per chi è morto Gesù Cristo?
+
+*Gesù Cristo è morto per la salute di tutti gli uomini ed ha soddisfatto per tutti.*
+
+**18.** Se Gesù Cristo è morto per la salute di tutti, perchè non tutti si salvano?
+
+*Gesù Cristo è morto per tutti, ma non tutti si salvano, perchè non tutti lo vogliono riconoscere, non tutti osservano la sua legge, non tutti si valgono dei mezzi di santificazione che ci ha lasciati.*
+
+**19.** Per essere salvi basta che Gesù Cristo sia morto per noi?
+
+*Per essere salvi non basta che Gesù Cristo sia morto per noi, ma è necessario che siano applicati a ciascun di noi il frutto e i meriti della sua passione e morte, il che avviene sopratutto per mezzo dei sacramenti istituiti a questo fine dal medesimo Gesù Cristo; e siccome molti o non ricevono i sacramenti o non li ricevono bene, perciò rendono a se stessi inutile la morte di Gesù Cristo.*

--- a/content/books/pius-x-greater-catechism/it/parte-prima-capo-vi.md
+++ b/content/books/pius-x-greater-catechism/it/parte-prima-capo-vi.md
@@ -1,0 +1,21 @@
+# Capo VI — Del quinto articolo
+
+**1.** Che cosa c’insegna il quinto articolo: Discese all’inferno, il terzo dì risuscitò da morte?
+
+*Il quinto articolo del Credo c’insegna: che l’anima di Gesù Cristo, separata che fu dal corpo, andò al Limbo dei santi Padri, e che nel terzo giorno si unì di nuovo al corpo suo, per non separarsene mai più.*
+
+**2.** Che cosa s’intende qui per inferno?
+
+*Per inferno s’intende qui il Limbo dei santi Padri cioè quel luogo dove erano trattenute le anime dei giusti aspettando la redenzione di Gesù Cristo.*
+
+**3.** Perchè le anime dei santi Padri non furono introdotte nel paradiso prima della morte di Gesù Cristo?
+
+*Le anime dei santi Padri non furono introdotte nel paradiso prima della morte di Gesù Cristo, perchè pel peccato di Adamo il paradiso era chiuso, e conveniva che Gesù Cristo, il quale con la sua morte lo riaprì, fosse il primo ad entrarvi.*
+
+**4.** Perchè Gesù Cristo volle differire sino al terzo giorno la propria risurrezione?
+
+*Gesù Cristo volle differire sino al terzo giorno la propria risurrezione per manifestare ad evidenza che era veramente morto.*
+
+**5.** La risurrezione di Gesù Cristo fu simile alla risurrezione degli altri uomini risuscitati?
+
+*No, la risurrezione di Gesù Cristo non fu simile alla risurrezione degli altri uomini risuscitati, perchè Gesù Cristo risuscitò per virtù propria, e gli altri furono risuscitati per virtù di Dio.*

--- a/content/books/pius-x-greater-catechism/it/parte-prima-capo-vii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-prima-capo-vii.md
@@ -1,0 +1,21 @@
+# Capo VII — Del sesto articolo
+
+**1.** Che cosa c’insegna il sesto articolo: Salì al cielo, siede alla destra di Dio Padre onnipotente?
+
+*Il sesto articolo del Credo c’insegna che Gesù Cristo, quaranta giorni dopo la sua risurrezione, alla presenza de’ suoi discepoli, ascese da se stesso al cielo, e che essendo, come Dio, eguale al Padre nella gloria, come uomo è stato innalzato sopra tutti gli Angeli e tutti i Santi, e costituito Signore di tutte le cose.*
+
+**2.** Perchè Gesù Cristo dopo la sua risurrezione stette quaranta giorni sulle terra prima di salire al cielo?
+
+*Gesù Cristo dopo la sua risurrezione stette quaranta giorni sulla terra, prima di salire al cielo, per provare con varie apparizioni che era veramente risorto, e per istruire sempre più e confermare gli Apostoli nelle verità della fede.*
+
+**3.** Perchè Gesù Cristo è salito al cielo?
+
+*Gesù Cristo è salito al cielo: 1.º per prendere possesso del suo regno meritato colla sua morte; 2.º per preparare il nostro posto di gloria e per essere nostro Mediatore ed Avvocato appresso il Padre; 3.º per mandare lo Spirito Santo a’ suoi Apostoli.*
+
+**4.** Perchè si dice di Gesù Cristo che salì al cielo, e della Madre sua santissima che fu assunta?
+
+*Si dice di Gesù Cristo che salì al cielo, e della Madre sua santissima che fu assunta, perchè Gesù Cristo, essendo Uomo-Dio, per virtù propria salì al cielo, ma la Madre che era creatura, sebbene la più degna di tutte, salì al cielo per virtù di Dio.*
+
+**5.** Spiegatemi le parole; siede alla destra di Dio Padre onnipotente.
+
+*La parola: siede significa il pacifico possesso, che Gesù Cristo ha della sua gloria, e le parole: alla destra di Dio Padre onnipotente esprimono che Egli ha il posto d’onore sopra tutte le creature.*

--- a/content/books/pius-x-greater-catechism/it/parte-prima-capo-viii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-prima-capo-viii.md
@@ -1,0 +1,25 @@
+# Capo VIII — Del settimo articolo
+
+**1.** Che cosa c’insegna il settimo articolo: Di là ha da venire a giudicare i vivi e i morti?
+
+*Il settimo articolo del Credo c’insegna che alla fine del mondo Gesù Cristo pieno di gloria e maestà verrà dal cielo per giudicare tutti gli uomini, buoni e cattivi, e per dare a ciascuno il premio o la pena che avrà meritato.*
+
+**2.** Se ciascuno, subito dopo morte, dovrà essere giudicato da Gesù Cristo nel giudizio particolare, perchè dovremo essere giudicati tutti nel giudizio universale?
+
+*Dovremo essere giudicati tutti nel giudizio universale per più ragioni: 1.º per gloria di Dio; 2.º per gloria di Gesù Cristo; 3.º per gloria dei Santi; 4.º per confusione dei cattivi; 5.º finalmente affinchè il corpo abbia con l’anima la sua sentenza di premio o di pena.*
+
+**3.** Nel giudizio universale come si manifesterà la gloria di Dio?
+
+*Nel giudizio universale si manifesterà la gloria di Dio, perchè tutti conosceranno con quanta giustizia Dio governi il mondo, sebbene ora si vedano qualche volta i buoni in afflizione e i cattivi in prosperità.*
+
+**4.** Nel giudizio universale come si manifesterà la gloria di Gesù Cristo?
+
+*Nel giudizio universale si manifesterà la gloria di Gesù Cristo, perchè essendo Egli stato dagli uomini ingiustamente condannato, comparirà allora in faccia a tutto il mondo giudice supremo di tutti.*
+
+**5.** Nel giudizio universale come si manifesterà la gloria dei Santi?
+
+*Nel giudizio universale si manifesterà la gloria dei Santi, perchè molti di essi, che sono morti disprezzati dai cattivi, saranno glorificati in presenza di tutto il mondo.*
+
+**6.** Nel giudizio universale quale sarà la confusione dei cattivi?
+
+*Nel giudizio universale la confusione dei cattivi sarà grandissima, massime per quelli che oppressero i giusti e per quelli che si studiarono in vita di essere stimati per uomini di virtù e bontà, vedendo manifestati a tutto il mondo i peccati da loro commessi, anche i più segreti.*

--- a/content/books/pius-x-greater-catechism/it/parte-prima-capo-x.md
+++ b/content/books/pius-x-greater-catechism/it/parte-prima-capo-x.md
@@ -1,0 +1,381 @@
+# Capo X — Del nono articolo
+
+## § 1. Della Chiesa in generale
+
+**1.** Che cosa c’insegna il nono articolo: la santa Chiesa cattolica, la comunione dei santi?
+
+*Il nono articolo del Credo c’insegna che Gesù Cristo ha fondato sulla terra una società visibile che si chiama Chiesa cattolica e che tutte le persone che fanno parte di questa Chiesa sono in comunione tra loro.*
+
+**2.** Perchè dopo l’articolo che tratta dello Spirito Santo si parla subito della Chiesa cattolica?
+
+*Dopo l’articolo che tratta dello Spirito Santo si parla subito della Chiesa cattolica per indicare che tutta la santità della Chiesa medesima deriva dallo Spirito Santo, il quale è l’autore di ogni santità.*
+
+**3.** Che cosa vuol dire questa parola Chiesa?
+
+*La parola Chiesa vuol dire convocazione o adunanza di molte persone.*
+
+**4.** Chi ci ha convocati o chiamati alla Chiesa di Gesù Cristo?
+
+*Noi siamo stati chiamati alla Chiesa di Gesù Cristo da una grazia particolare di Dio, affinchè col lume della fede e l’osservanza della divina legge gli rendiamo il debito culto e per veniamo alla vita eterna.*
+
+**5.** Dove si trovano i membri della Chiesa?
+
+*I membri della Chiesa si trovano parte in cielo, e formano la Chiesa trionfante; parte nel purgatorio, e formano la Chiesa purgante; parte sulla terra e formano la Chiesa militante.*
+
+**6.** Queste diverse parti della Chiesa costituiscono una sola Chiesa?
+
+*Sì, queste diverse parti della Chiesa costituiscono una sola Chiesa ed un solo corpo, perchè hanno il medesimo capo che è Gesù Cristo, il medesimo spirito che le anima e le unisce, e il medesimo fine che è la felicità eterna, la quale si gode già dagli uni e si aspetta dagli altri.*
+
+**7.** A qual parte della Chiesa si riferisce principalmente questo nono articolo?
+
+*Questo nono articolo del Credo si rife risce principalmente alla Chiesa militante, che è la Chiesa nella quale noi siamo attualmente.*
+
+## § 2. Della Chiesa in particolare
+
+**8.** Che cosa è la Chiesa cattolica?
+
+*La Chiesa cattolica è la società o congregazione di tutti i battezzati che, vivendo sulla terra, professano la stessa fede e legge di Cristo, partecipano agli stessi sacramenti, e obbediscono ai legittimi Pastori, principalmente al Romano Pontefice.*
+
+**9.** Dite distintamente che cosa è necessario per esser membro della Chiesa?
+
+*Per esser membro della Chiesa è necessario esser battezzato, credere e professare la dottrina di Gesù Cristo, partecipare ai medesimi sacramenti, riconoscere il Papa e gli altri legittimi Pastori della Chiesa.*
+
+**10.** Chi sono i legittimi Pastori della Chiesa?
+
+*I legittimi Pastori della Chiesa, sono il Romano Pontefice, cioè il Papa, che è il Pastore universale, ed i Vescovi. Inoltre, sotto la dipendenza dei Vescovi e del Papa, hanno parte nell’officio di pastori gli altri sacerdoti e specialmente i parrochi.*
+
+**11.** Perchè dite che il Romano Pontefice è il Pastore universale della Chiesa?
+
+*Perchè Gesù Cristo disse a san Pietro, primo Papa: «Tu sei Pietro e sopra questa pietra edificherò la mia Chiesa, e darò a te le chiavi del regno de’ cieli, e tutto ciò che legherai sulla terra sarà legato anche in cielo, e tutto ciò che scioglierai sulla terra sarà sciolto anche in cielo». E gli disse ancora: «Pasci i miei agnelli, pasci le mie pecorelle».*
+
+**12.** Non appartengono dunque alla Chiesa di Gesù Cristo tante società di uomini battezzati che non riconoscono il Romano Pontefice per loro capo?
+
+*No, tutti coloro che non riconoscono il Romano Pontefice per loro capo, non appartengono alla Chiesa di Gesù Cristo.*
+
+**13.** Come si può distinguere la Chiesa di Gesù Cristo da tante società o sette fondate dagli uomini e che si dicono cristiane?
+
+*Da tante società o sette fondate dagli uomini, che si dicono cristiane, si può facilmente distinguere la vera Chiesa di Gesù Cristo per quattro contrassegni. Essa è Una, Santa, Cattolica e Apostolica.*
+
+**14.** Perchè la Chiesa si dice Una?
+
+*La vera Chiesa si dice Una, perchè i suoi figli, di qualunque tempo e luogo, sono uniti fra loro nella medesima fede, nel medesimo culto, nella medesima legge e nella partecipazione dei medesimi sacramenti, sotto un medesimo capo visibile, il Romano Pontefice.*
+
+**15.** Non vi potrebbero essere più Chiese?
+
+*No, non vi possono essere più Chiese, perchè siccome vi è un solo Dio, una sola Fede e un solo Battesimo, così non vi è, e non vi può essere che una sola vera Chiesa.*
+
+**16.** Ma non si chiamano Chiese anche i fedeli uniti insieme di una nazione, o di una diocesi?
+
+*Si chiamano Chiese anche i fedeli uniti insieme di una nazione o di una diocesi, ma sono sempre porzioni della Chiesa universale e formano con essa una Chiesa sola.*
+
+**17.** Perchè la vera Chiesa si dice Santa?
+
+*La vera Chiesa si dice Santa, perchè santo è il suo capo invisibile, che è Gesù Cristo, santi sono molti suoi membri, santi sono la sua fede, la sua legge, i suoi sacramenti, e fuori di essa non vi è nè vi può essere vera santità.*
+
+**18.** Perchè la Chiesa si chiama Cattolica?
+
+*La vera Chiesa si chiama Cattolica, che vuol dire universale, perchè abbraccia i fedeli di tutti i tempi, di tutti i luoghi, di ogni età e condizione, e tutti gli uomini del mondo sono chiamati a farne parte.*
+
+**19.** Perchè la Chiesa si chiama inoltre Apostolica?
+
+*La vera Chiesa si chiama inoltre Apostolica, perchè rimonta senza interruzione fino agli Apostoli; perchè crede ed insegna tutto ciò che hanno creduto e insegnato gli Apostoli; e perchè è guidata e governata dai loro legittimi successori.*
+
+**20.** E perchè la vera Chiesa si chiama anche Romana?
+
+*La vera Chiesa si chiama anche Romana, perchè i quattro caratteri dell’unità, santità, cattolicità, e apostolicità si riscontrano solo nella Chiesa che riconosce per capo il Vescovo di Roma, successore di san Pietro.*
+
+**21.** Come è costituita la Chiesa di Gesù Cristo?
+
+*La Chiesa di Gesù Cristo è costituita come una vera e perfetta società; ed in essa, come in una persona morale possiamo distinguere l’anima e il corpo.*
+
+**22.** In che consiste l’anima della Chiesa?
+
+*L’anima della Chiesa consiste in ciò che essa ha d’interno e spirituale, cioè la fede, la speranza, la carità, i doni della grazia e dello Spirito Santo e tutti i celesti tesori che le sono derivati pei meriti di Cristo Redentore e dei Santi.*
+
+**23.** Il corpo della Chiesa in che consiste?
+
+*Il corpo della Chiesa consiste in ciò che essa ha di visibile e di esterno, sia nella associazione dei congregati, sia nel culto e nel ministero d’insegnamento, sia nel suo esterno ordine e governo.*
+
+**24.** Per salvarsi basta l’essere comunque membro della Chiesa cattolica?
+
+*No, non basta per salvarsi l’essere comunque membro della Chiesa cattolica, ma bisogna esserne membro vivo.*
+
+**25.** Quali sono i membri vivi della Chiesa?
+
+*I membri vivi della Chiesa sono tutti e solamente i giusti, quelli cioè, che sono attualmente in grazia di Dio.*
+
+**26.** E quali ne sono i membri morti?
+
+*Membri morti della Chiesa sono i fedeli che trovansi in peccato mortale.*
+
+**27.** Può alcuno salvarsi fuori della Chiesa Cattolica, Apostolica, Romana?
+
+*No, fuori della Chiesa Cattolica, Apostolica, Romana nessuno può salvarsi, come niuno potè salvarsi dal diluvio fuori dell’Arca di Noè, che era figura di questa Chiesa.*
+
+**28.** Come dunque si sono salvati gli antichi Patriarchi, i Profeti e tutti gli altri giusti dell’antico Testamento?
+
+*Tutti i giusti dell’antico Testamento si sono salvati in virtù della fede che avevano in Cristo venturo, per mezzo della quale essi già appartenevano spiritualmente a questa Chiesa.*
+
+**29.** Ma chi si trovasse, senza sua colpa, fuori della Chiesa, potrebbe salvarsi?
+
+*Chi, trovandosi senza sua colpa, ossia in buona fede, fuori della Chiesa, avesse ricevuto il Battesimo, o ne avesse il desiderio almeno implicito; cercasse inoltre sinceramente la verità e compisse la volontà di Dio come meglio può; benchè separato dal corpo della Chiesa, sarebbe unito all’anima di lei e quindi in via di salute.*
+
+**30.** E chi essendo pur membro della Chiesa cattolica non mettesse in pratica gl’insegnamenti di essa, si salverebbe?
+
+*Chi, essendo pur membro della Chiesa cattolica, non mettesse in pratica gli insegnamenti di essa, ne sarebbe membro morto e perciò non si salverebbe, perchè per la salute di un adulto si richiede non solo il battesimo e la fede, ma le opere altresì conformi alla fede.*
+
+**31.** Siamo noi obbligati a credere tutte le verità che la Chiesa c’insegna?
+
+*Sì, noi siamo obbligati a credere tutte le verità che la Chiesa c’insegna, e Gesù Cristo dichiara che chi non crede è già condannato.*
+
+**32.** Siamo altresì obbligati a fare tutto quello che la Chiesa comanda?
+
+*Sì, siamo obbligati a fare tutto quello che la Chiesa comanda, perchè Gesù Cristo ha detto ai Pastori della Chiesa: «Chi ascolta voi, ascolta me, e chi disprezza voi, disprezza me».*
+
+**33.** Può sbagliare la Chiesa nelle cose che ci propone a credere?
+
+*No, nelle cose che ci propone a credere, la Chiesa non può sbagliare, perchè secondo la promessa di Gesù Cristo ella è perennemente assistita dallo Spirito Santo.*
+
+**34.** La Chiesa cattolica è dunque infallibile?
+
+*Sì, la Chiesa cattolica è infallibile, epperò quelli che rifiutano le sue definizioni perdono la fede e diventano eretici.*
+
+**35.** La Chiesa cattolica può essere distrutta o perire?
+
+*No; la Chiesa cattolica può essere perseguitata, ma non può essere distrutta, nè perire. Ella durerà sino alla fine del mondo, perchè sino alla fine del mondo Gesù Cristo sarà con lei, come ha promesso.*
+
+**36.** Perchè è tanto perseguitata la Chiesa cattolica?
+
+*La Chiesa cattolica è tanto perseguitata perchè fu così perseguitato anche il suo divin Fondatore e, perchè riprova i vizi, combatte le passioni e condanna tutte le ingiustizie e tutti gli errori.*
+
+**37.** Vi sono altri doveri dei cattolici verso la Chiesa?
+
+*Ogni cattolico deve avere per la Chiesa un amore illimitato, riputarsi infinitamente onorato e felice di appartenerle, e adoprarsi alla gloria e all’incremento di lei con tutti quei mezzi che sono in suo potere.*
+
+## § 3. Della Chiesa docente e della Chiesa discente
+
+**38.** Vi è distinzione alcuna fra i membri che compongono la Chiesa?
+
+*Fra i membri che compongono la Chiesa vi è distinzione notevolissima, perchè vi è chi comanda e chi obbedisce, chi ammaestra e chi è ammaestrato.*
+
+**39.** Come si chiama quella parte della Chiesa che ammaestra?
+
+*La parte della Chiesa che ammaestra si chiama docente ossia insegnante.*
+
+**40.** La parte della Chiesa che viene ammaestrata come si chiama?
+
+*La parte della Chiesa che viene ammaestrata si chiama discente.*
+
+**41.** Chi ha stabilito questa distinzione nella Chiesa?
+
+*Questa distinzione nella Chiesa l’ha stabilita Gesù Cristo medesimo.*
+
+**42.** La Chiesa docente e la Chiesa discente sono dunque due Chiese distinte?
+
+*La Chiesa docente e la Chiesa discente sono due parti distinte di una sola e medesima Chiesa come nel corpo umano il capo è distinto dalle altre membra e tuttavia forma con esse un corpo solo.*
+
+**43.** Da chi si compone la Chiesa docente?
+
+*La Chiesa docente si compone di tutti i Vescovi con a capo il Romano Pontefice, sia che si trovino dispersi, sia che si trovino congregati in Concilio.*
+
+**44.** E la Chiesa discente di chi è composta?
+
+*La Chiesa discente è composta di tutti i fedeli.*
+
+**45.** Quali persone adunque hanno nella Chiesa l’autorità d’insegnare?
+
+*L’autorità d’insegnare nella Chiesa l’hanno il Papa e i Vescovi, e sotto la loro dipendenza, gli altri sacri ministri.*
+
+**46.** Siamo noi obbligati ad ascoltare la Chiesa docente?
+
+*Sì, senza dubbio, siamo tutti obbligati ad ascoltare la Chiesa docente sotto pena di eterna condanna, perchè Gesù Cristo disse ai Pastori della Chiesa, nella persona degli Apostoli: «Chi ascolta voi, ascolta me, e chi disprezza voi disprezza me».*
+
+**47.** Oltre l’autorità d’insegnare, ha la Chiesa qualche altro potere?
+
+*Sì, oltre l’autorità d’insegnare, la Chiesa ha specialmente il potere di amministrare le cose sante, di far leggi e di esigerne l’osservanza.*
+
+**48.** Il potere che hanno i membri della gerarchia ecclesiastica viene dal popolo?
+
+*Il potere che hanno i membri della gerarchia ecclesiastica non viene dal popolo, e sarebbe eresia il dirlo, ma viene unicamente da Dio.*
+
+**49.** A chi spetta l’esercizio di questi poteri?
+
+*L’esercizio di questi poteri spetta unicamente al ceto gerarchico, vale a dire al Papa e ai Vescovi a lui subordinati.*
+
+## § 4. Del Papa e dei Vescovi
+
+**50.** Chi è il Papa?
+
+*Il Papa, che noi chiamiamo pure il Sommo Pontefice, o anche il Romano Pontefice, è il successore di san Pietro nella Cattedra di Roma, il Vicario di Gesù Cristo sulla terra e il capo visibile della Chiesa.*
+
+**51.** Perchè il Romano Pontefice è successore di san Pietro?
+
+*Il Romano Pontefice è successore di S. Pietro, perchè S. Pietro nella sua persona riunì la dignità di Vescovo di Roma e di capo della Chiesa; stabilì in Roma per divina disposizione la sua sede e ivi morì, perciò chi viene eletto vescovo di Roma è anche l’erede di tutta la sua autorità.*
+
+**52.** Perchè il Romano Pontefice è il Vicario di Gesù Cristo?
+
+*Il Romano Pontefice è il Vicario di Gesù Cristo, perchè lo rappresenta sopra la terra e ne fa le veci nel governo della Chiesa.*
+
+**53.** Perchè il Romano Pontefice è capo visibile della Chiesa?
+
+*Il Romano Pontefice è il capo visibile della Chiesa, perchè egli la regge visibilmente coll’autorità medesima di Gesù Cristo, che ne è il capo invisibile.*
+
+**54.** Qual’è dunque la dignità del Papa?
+
+*La dignità del Papa è la massima fra tutte le dignità della terra, e gli dà potere supremo ed immediato sopra tutti e singoli i Pastori e i fedeli.*
+
+**55.** Può errare il Papa nell’ammaestrare la Chiesa?
+
+*Il Papa non può errare, ossia è infallibile nelle definizioni che riguardano la fede e i costumi.*
+
+**56.** Per qual motivo il Papa è infallibile?
+
+*Il Papa è infallibile per la promessa di Gesù Cristo e per la continua assistenza dello Spirito Santo.*
+
+**57.** Quando è che il Papa è infallibile?
+
+*Il Papa è infallibile allora soltanto che nella sua qualità di Pastore e Maestro di tutti i cristiani, in virtù della suprema sua apostolica autorità, definisce una dottrina intorno alla fede o ai costumi da tenersi da tutta la Chiesa.*
+
+**58.** Chi non credesse alle solenni definizioni del Papa, quale peccato commetterebbe?
+
+*Chi non credesse alle definizioni solenni del Papa, o anche solo ne dubitasse, peccherebbe contro la fede, e se rimanesse ostinato in questa incredulità, non sarebbe più cattolico, ma eretico.*
+
+**59.** Per qual fine Dio ha concesso al Papa il dono della infallibilità?
+
+*Dio ha concesso al Papa il dono della infallibilità affinchè tutti siamo certi e sicuri della verità che la Chiesa insegna.*
+
+**60.** Quando fu definito che il Papa è infallibile?
+
+*Che il Papa è infallibile fu definito dalla Chiesa nel Concilio Vaticano, e se alcuno presumesse di contraddire a questa definizione sarebbe eretico e scomunicato.*
+
+**61.** La Chiesa nel definire che il Papa è infallibile ha forse stabilito una nuova verità di fede?
+
+*No, la Chiesa nel definire che il Papa è infallibile non ha stabilito una nuova verità di fede, ma solo, per opporsi a nuovi errori, ha definito che l’infallibilità del Papa, contenuta già nella Sacra Scrittura e nella Tradizione, è una verità rivelata da Dio, e quindi da credersi come dogma o articolo di fede.*
+
+**62.** Come deve comportarsi ogni cattolico verso il Papa?
+
+*Ogni cattolico deve riconoscere il Papa, qual Padre, Pastore e Maestro universale e stare a lui unito di mente e di cuore.*
+
+**63.** Dopo il Papa, quali sono per divina istituzione i personaggi più venerandi nella Chiesa?
+
+*Dopo il Papa, per divina istituzione i personaggi più venerandi della Chiesa sono i Vescovi.*
+
+**64.** Chi sono i Vescovi?
+
+*I Vescovi sono i pastori dei fedeli, posti dallo Spirito Santo a reggere la Chiesa di Dio nelle sedi a loro affidate, sotto la dipendenza del Romano Pontefice.*
+
+**65.** Che cosa è il Vescovo nella propria diocesi?
+
+*Il Vescovo nella propria diocesi è il Pastore legittimo, il Padre, il Maestro, il superiore di tutti i fedeli, ecclesiastici e laici, che appartengono alla diocesi stessa.*
+
+**66.** Perchè il Vescovo si chiama Pastore legittimo?
+
+*Il Vescovo si chiama Pastore legittimo perchè la giurisdizione, ossia il potere che ha di governare i fedeli della propria diocesi, gli è stato conferito secondo le norme e le leggi della Chiesa.*
+
+**67.** Di chi sono successori il Papa e i Vescovi?
+
+*Il Papa è il successore di S. Pietro principe degli Apostoli, e i Vescovi sono i successori degli Apostoli, in ciò che riguarda il governo ordinario della Chiesa.*
+
+**68.** Deve il fedele stare unito al proprio Vescovo?
+
+*Sì, ogni fedele, ecclesiastico e laico, deve stare unito di mente e di cuore al proprio Vescovo in grazia e comunione con la Sede Apostolica.*
+
+**69.** Come deve comportarsi il fedele col proprio Vescovo?
+
+*Ogni fedele, ecclesiastico e laico, deve riverire, amare e onorare il proprio Vescovo, e prestargli obbedienza in tutto ciò che si riferisce alla cura delle anime è al governo spirituale della diocesi.*
+
+**70.** Da chi è aiutato il Vescovo nella cura delle anime?
+
+*Il Vescovo nella cura delle anime è aiutato dai sacerdoti, e principalmente dai parrochi.*
+
+**71.** Chi è il Parroco?
+
+*Il Parroco è un sacerdote deputato a presiedere e dirigere, sotto la dipendenza del Vescovo, una porzione della diocesi che chiamasi parrocchia.*
+
+**72.** Quali doveri hanno i fedeli verso il loro parroco?
+
+*I fedeli devono tenersi uniti al loro parroco, ascoltarlo docilmente e professargli rispetto e sommissione in tutto ciò che riguarda la cura della parrocchia.*
+
+## § 5. Della comunione dei santi
+
+**73.** Che cosa c’insegna il nono articolo del Credo con quelle parole: la comunione dei santi?
+
+*Con le parole: la comunione dei santi, il nono articolo del Credo c’insegna che nella Chiesa, per l’intima unione che esiste tra tutti i suoi membri, sono comuni i beni spirituali, così interni come esterni, che le appartengono.*
+
+**74.** Quali sono nella Chiesa i beni comuni interni?
+
+*I beni comuni interni nella Chiesa sono: la grazia che si riceve nei sacramenti, la fede, la speranza, la carità, i meriti infiniti di Gesù Cristo, i meriti sovrabbondanti della Vergine e dei Santi, e il frutto di tutte le opere buone che in essa Chiesa si fanno.*
+
+**75.** Quali sono i beni esterni comuni nella Chiesa?
+
+*I beni esterni comuni nella Chiesa sono: i sacramenti, il sacrificio della santa Messa, le pubbliche preghiere, le funzioni religiose e tutte le altre pratiche esteriori che uniscono insieme i fedeli.*
+
+**76.** In questa comunione di beni entrano tutti i figli della Chiesa?
+
+*Nella comunione dei beni interni entrano i cristiani, i quali sono in grazia di Dio; quelli poi che sono in peccato mortale non partecipano di questi beni.*
+
+**77.** Perchè non partecipano di questi beni quelli che sono in peccato mortale?
+
+*Perchè la grazia di Dio è quella che unisce i fedeli con Dio e tra loro: e perciò quelli che sono in peccato mortale, essendo senza la grazia di Dio, sono esclusi dalla comunione dei beni spirituali.*
+
+**78.** Dunque i cristiani che sono in peccato mortale non hanno alcun vantaggio dai beni interni e spirituali della Chiesa?
+
+*I cristiani che sono in peccato mortale hanno ancora qualche vantaggio dai beni interni e spirituali della Chiesa de’ quali son privi, in quanto essi conservano il carattere del cristiano che è indelebile, e sono aiutati dalle orazioni e dalle buone opere dei fedeli ad ottenere la grazia di convertirsi a Dio.*
+
+**79.** Quelli che sono in peccato mortale possono partecipare dei beni esterni della Chiesa?
+
+R, Quelli che sono in peccato mortale possono partecipare dei beni esterni della Chiesa, se pure non siano separati dalla Chiesa con la scomunica.
+
+**80.** Perchè i membri di questa comunione presi insieme, si chiamano santi?
+
+*I membri di questa comunione si chiamano santi perchè tutti sono chiamati alla santità e furono santificati per mezzo del Battesimo, e molti di essi sono già pervenuti alla perfetta santità.*
+
+**81.** La comunione dei santi si estende ella anche al cielo e al purgatorio?
+
+*Sì, la comunione dei santi si estende anche al cielo e al purgatorio, perchè la carità unisce le tre Chiese: trionfante, purgante e militante; e i Santi pregano Iddio per noi e per le anime del purgatorio, e noi diamo onore e gloria ai Santi e possiamo sollevare le anime del purgatorio, applicando in loro suffragio Messe, elemosine, indulgenze e altre opere buone.*
+
+## § 6. Di coloro che sono fuori della Chiesa
+
+**82.** Chi sono quelli che non appartengono alla comunione dei santi?
+
+*Non appartengono alla comunione dei santi nell’altra vita i dannati ed in questa coloro che si trovano fuori della vera Chiesa.*
+
+**83.** Chi sono quelli che si trovano fuori della vera Chiesa?
+
+*Si trovano fuori della vera Chiesa gli infedeli, gli ebrei, gli eretici, gli apostati, gli scismatici e gli scomunicati.*
+
+**84.** Chi sono gl’infedeli?
+
+*Gl’infedeli sono quelli che non hanno il Battesimo e non credono in Gesù Cristo; sia perchè credono e adorano false divinità, come gl’idolatri; sia perchè pure ammettendo l’unico vero Dio, non credono in Cristo Messia, nè come venuto nella persona di Gesù Cristo, nè come venturo, tali sono i maomettani ed altri somiglianti.*
+
+**85.** Chi sono gli ebrei?
+
+*Gli ebrei sono quelli che professano la legge di Mosè; non hanno ricevuto il battesimo e non credono in Gesù Cristo.*
+
+**86.** Chi sono gli eretici?
+
+*Gli eretici sono i battezzati che ricusano con pertinacia di credere qualche verità rivelata da Dio e insegnata come di fede dalla Chiesa cattolica, per esempio gli ariani, i nestoriani, e le varie sette dei protestanti.*
+
+**87.** Chi sono gli apostati?
+
+*Gli apostati sono coloro che abiurano, ossia rinnegano con atto esterno la fede cattolica, che prima professavano.*
+
+**88.** Chi sono gli scismatici?
+
+*Gli scismatici sono i cristiani che, non negando esplicitamente alcun domma, si separano volontariamente dalla Chiesa di Gesù Cristo, ossia dai legittimi pastori.*
+
+**89.** Chi sono gli scomunicati?
+
+*Gli scomunicati sono quelli che per mancanze gravissime vengono colpiti di scomunica dal Papa, o dal Vescovo, e sono quindi, siccome indegni, separati dal corpo della Chiesa, la quale aspetta e desidera la loro conversione.*
+
+**90.** Si deve temere la scomunica?
+
+*La scomunica si deve temere grandemente, perchè è la pena più grave e più terribile che la Chiesa possa infliggere a’ suoi figli ribelli ed ostinati.*
+
+**91.** Di quali beni rimangono privi gli scomunicati?
+
+*Gli scomunicati rimangono privi delle preghiere pubbliche, dei sacramenti, delle indulgenze e della sepoltura ecclesiastica.*
+
+**92.** Possiamo noi giovare in qualche modo agli scomunicati?
+
+*Noi possiamo giovare in qualche modo agli scomunicati e a tutti gli altri che sono fuori della vera Chiesa, con salutari avvisi, colle orazioni e colle buone opere, supplicando Iddio che per sua misericordia conceda loro la grazia di convertirsi alla fede e di entrare nella comunione dei Santi.*

--- a/content/books/pius-x-greater-catechism/it/parte-prima-capo-xi.md
+++ b/content/books/pius-x-greater-catechism/it/parte-prima-capo-xi.md
@@ -1,0 +1,17 @@
+# Capo XI — Del decimo articolo
+
+**1.** Che cosa c’insegna il decimo articolo: La remissione dei peccati?
+
+*Il decimo articolo del Credo c’insegna che Gesù Cristo ha lasciato alla sua Chiesa la potestà di rimettere i peccati.*
+
+**2.** La Chiesa può rimettere ogni sorta di peccati?
+
+*Sì, la Chiesa può rimettere tutti i peccati per quanto siano molti e gravi, perchè Gesù Cristo le ha data piena potestà di sciogliere e legare.*
+
+**3.** Chi sono coloro che nella Chiesa esercitano questa potestà di rimettere i peccati?
+
+*Coloro che nella Chiesa esercitano la potestà di rimettere i peccati sono in primo luogo il Papa, il quale solo possiede la pienezza di tale potestà; poi i Vescovi, e, sotto la dipendenza dei Vescovi, i sacerdoti.*
+
+**4.** Come rimette la Chiesa i peccati?
+
+*La Chiesa rimette i peccati pei meriti di Gesù Cristo, conferendo i sacramenti da esso istituiti a questo fine, principalmente il Battesimo e la Penitenza.*

--- a/content/books/pius-x-greater-catechism/it/parte-prima-capo-xii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-prima-capo-xii.md
@@ -1,0 +1,29 @@
+# Capo XII — Dell’undecimo articolo
+
+**1.** Che cosa c’insegna l’undecimo articolo: La risurrezione della carne?
+
+*L’undecimo articolo del Credo c’insegna che tutti gli uomini risusciteranno, ripigliando ogni anima il corpo che ebbe in questa vita.*
+
+**2.** Come avverrà la risurrezione dei morti?
+
+*La risurrezione dei morti avverrà per virtù di Dio onnipotente, a cui nulla è impossibile.*
+
+**3.** Quando avverrà la risurrezione dei morti?
+
+*La risurrezione di tutti i morti avverrà alla fine del mondo, e allora seguirà il giudizio universale.*
+
+**4.** Perchè vuole Iddio la risurrezione dei corpi?
+
+*Dio vuole la risurrezione dei corpi, perchè, avendo l’anima operato il bene o il male unita al corpo, sia ancora insieme con esso premiata o punita.*
+
+**5.** Gli uomini risorgeranno tutti alla stessa maniera?
+
+*No, vi sarà grandissima differenza tra i corpi degli eletti e i corpi dei dannati, perchè i soli corpi degli eletti, avranno a somiglianza di Gesù Cristo risorto le doti dei corpi gloriosi.*
+
+**6.** Quali sono queste doti che adorneranno i corpi degli eletti?
+
+*Le doti che adorneranno i corpi gloriosi degli eletti sono: 1.º la impassibilità, per cui non potranno più essere soggetti a mali, a dolori di veruna sorta, nè a bisogno di cibo, di riposo o d’altro; 2.º la chiarezza, per cui risplenderanno a guisa del sole e d’altrettante stelle; 3.º l’ agilità per cui potranno passare in un momento e senza fatica da un luogo all’altro e dalla terra al cielo; 4.º la sottigliezza, per cui senza ostacolo potranno penetrare qualunque corpo, come fece Gesù Cristo risorto.*
+
+**7.** I corpi dei dannati come saranno?
+
+*I corpi dei dannati saranno privi delle doti dei corpi gloriosi dei Beati, e porteranno l’orribile marchio dell’eterna riprovazione.*

--- a/content/books/pius-x-greater-catechism/it/parte-prima-capo-xiii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-prima-capo-xiii.md
@@ -1,0 +1,29 @@
+# Capo XIII — Del dodicesimo articolo
+
+**1.** Che cosa c’insegna l’ultimo articolo: La vita eterna?
+
+*L’ultimo articolo del Credo c’insegna che dopo la vita presente vi è un’altra vita o eternamente beata per gli eletti in paradiso, o eternamente infelice pei dannati all’inferno.*
+
+**2.** Possiamo noi comprendere la felicità del paradiso?
+
+*No, noi non possiamo comprendere la felicità del paradiso, perchè supera le cognizioni della nostra mente limitata, e perchè i beni del cielo non possono paragonarsi ai beni di questo mondo.*
+
+**3.** In che consiste la felicità degli eletti?
+
+*La felicità degli eletti consiste nel vedere, amare e possedere per sempre Dio, fonte di ogni bene.*
+
+**4.** In che consiste la infelicità dei dannati?
+
+*L’infelicità dei dannati consiste nell’essere sempre privi della vista di Dio e puniti da eterni tormenti nell’inferno.*
+
+**5.** I beni del paradiso e i mali dell’inferno sono solamente per le anime?
+
+*I beni del paradiso e i mali dell’inferno sono adesso solamente per le anime, perchè solo le anime sono adesso in paradiso o nell’inferno; ma dopo la risurrezione della carne, gli uomini, nella pienezza di loro natura, cioè in anima e in corpo, saranno o felici o tormentati per sempre.*
+
+**6.** Saranno uguali per i beati i beni del paradiso, e per i dannati i mali dell’inferno?
+
+*I beni del paradiso per i beati, e i mali dell’inferno per i dannati, saranno uguali nella sostanza e nella eterna durata; ma nella misura, ossia nei gradi, saranno maggiori o minori, secondo i meriti, o demeriti di ciascuno.*
+
+**7.** Che vuol dire la parola Amen in fine del Credo?
+
+*La parola Amen in fine delle preghiere significa: Così sia; in fine del Credo significa: Così è; vale a dire: credo essere verissimo tutto quello che in questi dodici articoli si contiene, ed io ne sono più certo che se lo vedessi cogli occhi miei.*

--- a/content/books/pius-x-greater-catechism/it/parte-quarta-capo-i.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quarta-capo-i.md
@@ -1,0 +1,143 @@
+# Capo I — Dei sacramenti in generale
+
+## § 1. Natura dei sacramenti
+
+**1.** Di che cosa si tratta nella quarta parte della Dottrina cristiana?
+
+*Nella quarta parte della Dottrina cristiana si tratta dei sacramenti.*
+
+**2.** Che cosa s’intende con la parola sacramento?
+
+*Con la parola sacramento s’intende un segno sensibile ed efficace della grazia, istituito da Gesù Cristo per santificare le anime nostre.*
+
+**3.** Perchè chiamate voi i sacramenti segni sensibili ed efficaci della grazia?
+
+*Chiamo i sacramenti segni sensibili ed efficaci della grazia, perchè tutti i sacramenti significano, per mezzo di cose sensibili, la grazia divina che essi producono nell’anima nostra.*
+
+**4.** Spiegate con un esempio come i sacramenti siano segni sensibili ed efficaci della grazia?
+
+*Nel Battesimo, il versar l’acqua sul capo della persona, e le parole: io ti battezzo, cioè ti lavo, nel nome del Padre, del Figliuolo, e dello Spirito Santo, sono un segno sensibile di quello che il Battesimo opera nell’anima; perchè siccome l’acqua lava il corpo, così la grazia data dal Battesimo monda l’anima dal peccato.*
+
+**5.** Quanti e quali sono i sacramenti?
+
+*I sacramenti sono sette, cioè: Battesimo, Cresima, Eucaristia, Penitenza, Estrema Unzione, Ordine Sacro, Matrimonio.*
+
+**6.** Quante cose si richiedono per fare un sacramento?
+
+*Per fare un sacramento si richiedono la materia, la forma ed il ministro, il quale abbia l’intenzione di fare ciò che fa la Chiesa.*
+
+**7.** Che cosa è la materia dei sacramenti?
+
+*La materia dei sacramenti e la cosa sensibile che si adopera per farlo: come per esempio l’acqua naturale nel Battesimo; l’olio ed il balsamo nella Cresima.*
+
+**8.** Che cosa è la forma dei sacramenti?
+
+*La forma dei sacramenti sono le parole che si proferiscono per farlo.*
+
+**9.** Chi è il ministro dei sacramenti?
+
+*Il ministro dei sacramenti è la persona che fa o conferisce il sacramento.*
+
+## § 2. Dell’effetto principale dei sacramenti, che è la grazia
+
+**10.** Che cosa è la grazia?
+
+*La grazia di Dio è un dono interno, soprannaturale, che ci vien dato senza alcun me rito nostro, ma per i meriti di Gesù Cristo in ordine alla vita eterna.*
+
+**11.** Come si distingue la grazia?
+
+*La grazia si distingue in grazia santificante, che si chiama anche abituale, e in grazia attuale.*
+
+**12.** Che cosa è la grazia santificante?
+
+*La grazia santificante è un dono soprannaturale inerente all’anima nostra, che ci rende giusti, figliuoli adottivi di Dio ed eredi del Paradiso.*
+
+**13.** Di quante sorta è la grazia santificante?
+
+*La grazia santificante è di due sorta: grazia prima e grazia seconda.*
+
+**14.** Qual’è la grazia prima?
+
+*La grazia prima è quella per cui l’uomo passa dallo stato di peccato mortale allo stato di giustizia.*
+
+**15.** E la grazia seconda qual’è?
+
+*La grazia seconda è un accrescimento della grazia prima.*
+
+**16.** Che cosa è la grazia attuale?
+
+*La grazia attuale è un dono soprannaturale, che illumina la nostra mente e muove e conforta la nostra volontà, affinchè noi operiamo il bene e ci asteniamo dal male.*
+
+**17.** Possiamo noi resistere alla grazia di Dio?
+
+*Sì, noi possiamo resistere alla grazia di Dio, perchè essa non distrugge il nostro libero arbitrio.*
+
+**18.** Con le sole nostre forze possiamo noi fare alcuna cosa che ci giovi per la vita eterna?
+
+*Senza il soccorso della grazia di Dio, con le sole nostre forze, noi non possiamo fare alcuna cosa che ci giovi per la vita eterna.*
+
+**19.** Come ci viene da Dio comunicata la grazia?
+
+*La grazia ci viene comunicata da Dio principalmente per mezzo dei santi sacramenti.*
+
+**20.** I sacramenti, oltre la grazia santificante ci conferiscono altra grazia?
+
+*I sacramenti, oltre la grazia santificante, conferiscono anche la grazia sacramentale.*
+
+**21.** Che cos’è la grazia sacramentale?
+
+*La grazia sacramentale consiste nel diritto che si acquista ricevendo un sacramento qualunque, di aver a tempo opportuno le grazie attuali necessarie per adempiere gli obblighi che derivano dal sacramento ricevuto. Così noi quando fummo battezzati, ricevemmo il diritto di avere le grazie per vivere cristianamente.*
+
+**22.** I sacramenti dànno sempre la grazia a chi li riceve?
+
+*I sacramenti dànno sempre la grazia, purchè si ricevano con le necessarie disposizioni.*
+
+**23.** Chi ha dato ai sacramenti la virtù di conferire la grazia?
+
+*La virtù di conferire la grazia l’ha data ai sacramenti Gesù Cristo con la sua passione e morte.*
+
+**24.** Quali sono i sacramenti che conferiscono la prima grazia santificante?
+
+*I sacramenti che conferiscono la prima grazia santificante, che ci rende amici di Dio, sono due: il Battesimo e la Penitenza.*
+
+**25.** Come si chiamano perciò questi due sacramenti?
+
+*Questi due sacramenti, cioè il Battesimo e la Penitenza, si chiamano perciò sacramenti dei morti, perchè sono istituiti principalmente per ridare alle anime morte per il peccato, la vita della grazia.*
+
+**26.** Quali sono i sacramenti che accrescono la grazia in chi la possiede?
+
+*I sacramenti che accrescono la grazia in chi la possiede, sono gli altri cinque, cioè la Cresima, l’Eucaristia, l’Estrema Unzione, l’Ordine Sacro ed il Matrimonio, i quali conferiscono la grazia seconda.*
+
+**27.** Come si chiamano perciò questi cinque sacramenti?
+
+*Questi cinque sacramenti, cioè la Cresima, l’Eucaristia, l’Estrema Unzione, l’Ordine Sacro ed il Matrimonio si chiamano sacramenti dei vivi, perchè quelli che li ricevono, devono essere senza peccato mortale, cioè già vivi alla grazia santificante.*
+
+**28.** Qual peccato commette chi riceve uno dei sacramenti dei vivi sapendo di non essere in grazia di Dio?
+
+*Chi riceve uno dei sacramenti dei vivi, sapendo di non essere in grazia di Dio, commette un grave sacrilegio.*
+
+**29.** Quali sono i sacramenti più necessari per salvarci?
+
+*I sacramenti più necessari per salvarci sono due: il Battesimo e la Penitenza: il Battesimo è necessario a tutti, e la Penitenza e necessaria a tutti quelli che hanno peccato mortalmente dopo il Battesimo.*
+
+**30.** Qual’è il più grande di tutti i sacramenti?
+
+*Il più grande di tutti i sacramenti è quello della Eucaristia, perchè contiene non solo la grazia, ma anche Gesù Cristo, autore della grazia e dei sacramenti.*
+
+## § 3. Del carattere che imprimono alcuni Sacramenti
+
+**31.** Quali sacramenti si possono ricevere una volta sola?
+
+*I sacramenti che si possono ricevere una volta sola, sono tre: il Battesimo, la Cresima e l’Ordine Sacro.*
+
+**32.** Perchè i tre sacramenti, Battesimo, Cresima e Ordine Sacro si possono ricevere una volta sola?
+
+*I tre sacramenti, Battesimo, Cresima e Ordine Sacro, si possono ricevere una volta sola, perchè ciascuno di essi imprime il carattere.*
+
+**33.** Che cosa è il carattere che ciascuno dei tre sacramenti, Battesimo, Cresima e Ordine Sacro imprime nell’anima?
+
+*Il carattere che ciascuno dei tre sacra menti, Battesimo, Cresima, e Ordine Sacro imprime nell’anima è un segno spirituale, che non si cancella mai più.*
+
+**34.** A che serve il carattere che imprimono nell’anima questi tre sacramenti?
+
+*Il carattere che imprimono nell’anima questi tre Sacramenti, serve per contrassegnarci nel Battesimo come membri di Gesù Cristo, nella Cresima come suoi soldati, nell’Ordine Sacro come suoi ministri.*

--- a/content/books/pius-x-greater-catechism/it/parte-quarta-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quarta-capo-ii.md
@@ -1,0 +1,115 @@
+# Capo II — Del Battesimo
+
+## § 1. Natura ed effetti del Battesimo
+
+**1.** Che cosa è il sacramento del Battesimo?
+
+*Il Battesimo è il sacramento, pel quale rinasciamo alla grazia di Dio e diventiamo cristiani.*
+
+**2.** Quali sono gli effetti del sacramento del Battesimo?
+
+*Il sacramento del Battesimo conferisce la prima grazia santificante per la quale si cancella il peccato originale, ed anche l’attuale se vi è; rimette tutta la pena per essi dovuta; imprime il carattere di cristiani; ci fa figliuoli di Dio; membri della Chiesa ed eredi del paradiso, e ci rende capaci di ricevere gli altri sacramenti.*
+
+**3.** Qual’è la materia del Battesimo?
+
+*La materia del Battesimo è l’acqua turale che si versa sul capo di chi viene battezzato in tanta quantità che scorra.*
+
+**4.** Qual’è la forma del Battesimo?
+
+*La forma del Battesimo è questa: Io ti battezzo nel nome del Padre e del Figliuolo e dello Spirito Santo.*
+
+## § 2. Ministro del Battesimo
+
+**5.** A chi spetta dare il Battesimo?
+
+*Il dare il Battesimo spetta per diritto ai Vescovi ed ai parrochi; ma, in caso di necessità, qualunque persona può darlo, sia uomo, sia donna, anche un eretico od un infedele, purchè eseguisca il rito del Battesimo ed abbia l’intenzione di fare quello che fa la Chiesa.*
+
+**6.** Se vi fosse necessità di battezzare una persona, che è in pericolo di morire, e molti si trovassero presenti, chi dovrebbe dare il Battesimo?
+
+*Se vi fosse necessità di battezzare una persona in pericolo di morte, e molti si trovassero presenti, dovrebbe battezzarla il sacerdote, se vi fosse, e in sua assenza un ecclesiastico di ordine inferiore, e in assenza di questo, l’uomo secolare a preferenza della donna, se pure la maggior perizia della donna, o la decenza, non richiedessero altrimenti.*
+
+**7.** Quale intenzione deve avere chi battezza?
+
+*Chi battezza deve avere l’intenzione di fare quello che fa la santa Chiesa nel battezzare.*
+
+## § 3. Rito del Battesimo e disposizioni di chi lo riceve adulto
+
+**8.** Come si fa a dare il Battesimo?
+
+*Si dà il Battesimo versando dell’acqua sul capo del battezzando, e se non si può sul capo, su qualche altra parte principale del corpo, e dicendo nello stesso tempo: Io ti battezzo nel nome del Padre e del Figliuolo e dello Spirito Santo.*
+
+**9.** Se uno versasse l’acqua e un altro proferisse le parole, la persona resterebbe battezzata?
+
+*Se uno versasse l’acqua, e un altro proferisse le parole, la persona non resterebbe battezzata; ma è necessario che sia la stessa persona che versi l’acqua e pronunci le parole.*
+
+**10.** Quando si dubita se la persona sia morta, si deve tralasciare di battezzarla?
+
+*Quando si dubita se la persona sia morta, si deve battezzarla sotto condizione, dicendo: Se tu sei vivo, io ti battezzo nel nome del Padre e del Figliuolo e dello Spirito Santo.*
+
+**11.** Quando si devono portare alla chiesa i bambini perchè siano battezzati?
+
+*I bambini si devono portare alla chiesa perchè siano battezzati, il più presto possibile.*
+
+**12.** Perchè si deve avere tanta premura per far ricevere il Battesimo ai bambini?
+
+*Si deve avere somma premura per far battezzare i bambini, perchè essi per la loro tenera età sono esposti a molti pericoli di morire, e non possono salvarsi senza il Battesimo.*
+
+**13.** Peccano adunque i padri e le madri che per la loro negligenza lasciano morire i loro figliuoli senza Battesimo, o lo differiscono?
+
+*Sì, i padri e le madri che per la loro negligenza, lasciano morire i figliuoli senza battesimo, peccano gravemente, perchè privano i loro figliuoli dell’eterna vita; e peccano pure gravemente col differirne a lungo il Battesimo, perchè li espongono al pericolo di morire, senza averlo ricevuto.*
+
+**14.** Quando chi si battezza è adulto quali disposizioni deve avere?
+
+*L’adulto che si battezza, deve oltre la fede avere il dolore almeno imperfetto dei peccati mortali, che avesse commessi.*
+
+**15.** Se un adulto si battezzasse in peccato mortale senza questo dolore che cosa riceverebbe?
+
+*Se un adulto si battezzasse in peccato mortale senza questo dolore riceverebbe il carattere del Battesimo, ma non la remissione dei peccati, nè la grazia santificante. E questi effetti rimarrebbero sospesi, finchè non fosse tolto l’impedimento col dolore perfetto de’ peccati o col sacramento della Penitenza.*
+
+## § 4. Necessità del Battesimo e doveri dei battezzati
+
+**16.** Il Battesimo è necessario per salvarsi?
+
+*Il Battesimo è assolutamente necessario per salvarsi, avendo detto espressamente il Signore: Chi non rinascerà nell’acqua e nello Spirito Santo non potrà entrare nel regno dei cieli.*
+
+**17.** Si può supplire in qualche modo alla mancanza del Battesimo?
+
+*Alla mancanza del sacramento del Battesimo può supplire il martirio, che chiamasi Battesimo di sangue, o un atto di perfetto amor di Dio o di contrizione, che sia congiunto col desiderio almeno implicito del Battesimo, e questo si chiama Battesimo di desiderio.*
+
+**18.** Chi riceve il Battesimo a che cosa resta obbligato?
+
+*Chi riceve il Battesimo resta obbligato a professare sempre la fede, e ad osservare la legge di Gesù Cristo e della sua Chiesa.*
+
+**19.** A che cosa si rinuncia nel ricevere il santo Battesimo?
+
+*Nel ricevere il santo Battesimo, si rinuncia per sempre al demonio, alle sue opere, ed alle sue pompe.*
+
+**20.** Che cosa s’intende per le opere o per le pompe del demonio?
+
+*Per opere e pompe del demonio si intendono i peccati, e le massime del mondo contrarie alle massime del santo Vangelo.*
+
+## § 5. Nome e Padrini
+
+**21.** Perchè s’impone il nome di un Santo a colui che si battezza?
+
+*A colui che si battezza s’impone il nome di un Santo per porlo sotto la speciale prote zione di un celeste patrono ed animarlo ad imitarne gli esempi.*
+
+**22.** Chi sono i padrini e le madrine del Battesimo?
+
+*I padrini e le madrine del Battesimo sono quelle persone, che per disposizione della Chiesa tengono al sacro fonte i bambini, rispondono in vece loro e si rendono garanti in faccia a Dio della loro cristiana educazione, specialmente se vi mancassero i genitori.*
+
+**23.** Siamo noi obbligati a stare a quelle promesse e rinunzie che hanno fatto per noi i nostri padrini?
+
+*Siamo obbligati senza dubbio a stare alle promesse e alle rinunzie che hanno fatto per noi i nostri padrini, perchè Dio non ci ha ricevuti nella sua grazia che a queste condizioni.*
+
+**24.** Quali persone si debbono eleggere per padrini e madrine?
+
+*Si debbono eleggere per padrini e madrine persone cattoliche, di buoni costumi e ossequenti alle leggi della Chiesa.*
+
+**25.** Quali sono le obbligazioni dei padrini e delle madrine?
+
+*I padrini e le madrine sono obbligati a procurare che i loro figli spirituali siano istruiti nelle verità della fede, e vivano da buoni cri stiani, edificandoli col buon esempio.*
+
+**26.** Quale vincolo contraggono i padrini del Battesimo?
+
+*I padrini contraggono una parentela spirituale col battezzato e coi suoi genitori, la quale cagiona impedimento di matrimonio coi medesimi.*

--- a/content/books/pius-x-greater-catechism/it/parte-quarta-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quarta-capo-iii.md
@@ -1,0 +1,77 @@
+# Capo III — Della Cresima o Confermazione
+
+**1.** Che cosa è il sacramento della Cresima?
+
+*La Cresima è un sacramento che ci dà lo Spirito Santo, imprime nell’anima nostra il carattere di soldato di Gesù Cristo, e ci fa perfetti cristiani.*
+
+**2.** In qual maniera il sacramento della Cresima ci fa perfetti cristiani?
+
+*La Cresima ci fa perfetti cristiani, perchè ci conferma nella fede e perfeziona le altre virtù e i doni che abbiamo ricevuti nel santo Battesimo; e perciò si chiama Confermazione.*
+
+**3.** Quali sono i doni dello Spirito Santo, che si ricevono nella Cresima?
+
+*I doni dello Spirito Santo, che si ricevono nella Cresima sono questi sette: Sapienza, Intelletto, Consiglio, Fortezza, Scienza, Pietà e Timor di Dio.*
+
+**4.** Qual’è la materia di questo sacramento?
+
+*La materia di questo sacramento oltre l’imposizione delle mani del Vescovo, è la unzione fatta sulla fronte del battezzato col sacro Crisma; epperciò si chiama anche Cresima, cioè Unzione.*
+
+**5.** Che cosa è il sacro Crisma?
+
+*Il sacro Crisma e olio mischiato con balsamo, che il Vescovo ha consacrato il giovedi santo.*
+
+**6.** Che cosa significano l’olio e il balsamo in questo sacramento?
+
+*In questo sacramento, l’olio che si espande e fortifica, significa la grazia abbondante, che si sparge nell’anima del cristiano per confermarlo nella fede: e il balsamo, che è odoroso e difende dalla corruzione, significa che il cristiano fortificato da questa grazia, è atto a dare buon odore di cristiane virtù e a preservarsi dalla corruzione dei vizi.*
+
+**7.** Qual’è la forma del sacramento della Cresima?
+
+*La forma del sacramento della Cresima è questa: Io ti segno col segno della Croce e ti confermo col crisma della salute in nome del Padre e del Figliuolo e dello Spirito Santo, così sia.*
+
+**8.** Chi è il ministro del sacramento della Cresima?
+
+*Il ministro ordinario del sacramento della Cresima è il solo Vescovo.*
+
+**9.** Con qual rito il Vescovo amministra la Cresima?
+
+*Il Vescovo per amministrare il sacramento della Cresima, prima stende le mani sopra i cresimandi, invocando sopra di loro lo Spirito Santo; poi fa un’unzione in forma di croce col sacro Crisma sulla fronte di ciascheduno, dicendo le parole della forma; indi con la sua destra dà un leggiero schiaffo sulla guancia del cresimato dicendogli: la pace sia teco; finalmente benedice solennemente tutti i cresimati.*
+
+**10.** Perchè si fa l’unzione sulla fronte?
+
+*Si fa l’unzione sulla fronte, dove appariscono i segni del timore e del rossore, affinchè il cresimato intenda che non deve arrossire del nome e della professione di cristiano, nè aver paura dei nemici della fede.*
+
+**11.** Perchè si dà un leggiero schiaffo al cresimato?
+
+*Si dà un leggiero schiaffo al cresimato perchè sappia che deve esser pronto a soffrire ogni affronto e ogni pena per la fede di Gesù Cristo.*
+
+**12.** Devono tutti procurare di ricevere il sacramento della Cresima?
+
+*Sì, tutti devono procurare di ricevere il sacramento della Cresima e di farlo ricevere ai loro dipendenti.*
+
+**13.** In quale età è bene ricevere il sacramento della Cresima?
+
+*L’età, in cui è bene ricevere il sacramento della Cresima, è quella di anni sette circa; perchè allora sogliono cominciare le tentazioni, e si può abbastanza conoscere la grazia di questo sacramento, e ricordarsi d’averlo ricevuto.*
+
+**14.** Quali disposizioni si ricercano per ricevere degnamente il sacramento della Cresima?
+
+*Per ricevere degnamente il sacramento della Cresima, bisogna essere in grazia di Dio, sapere i misteri principali di nostra santa fede e accostarvisi con riverenza e divozione.*
+
+**15.** Peccherebbe chi ricevesse la Cresima una seconda volta?
+
+*Commetterebbe un sacrilegio, perchè la Cresima è uno di quei sacramenti, che imprimono il carattere nell’anima, e che perciò si possono ricevere una volta sola.*
+
+**16.** Che cosa deve fare il cristiano per conservare la grazia della Cresima?
+
+*Per conservare la grazia della Cresima, il cristiano deve spesso pregare, fare buone opere, e vivere secondo la legge di Gesù Cristo, senza rispetti umani.*
+
+**17.** Perchè anche nella Cresima vi sono i padrini e le madrine?
+
+*Affinchè questi indirizzino con le parole e con gli esempi il cresimato nella via della salute e lo aiutino nella milizia spirituale.*
+
+**18.** Quali condizioni si richiedono nel padrino?
+
+*Il padrino deve essere di età conveniente; cattolico, cresimato, istruito nelle cose più necessarie della religione, e di buoni costumi.*
+
+**19.** Il padrino della Cresima contrae alcuna parentela col cresimato e con i suoi genitori?
+
+*Il padrino della Cresima contrae la medesima parentela spirituale di chi tiene a battesimo.*

--- a/content/books/pius-x-greater-catechism/it/parte-quarta-capo-iv.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quarta-capo-iv.md
@@ -1,0 +1,237 @@
+# Capo IV — Dell’Eucaristia
+
+## § 1. Della natura di questo sacramento e della presenza reale di Gesù Cristo nel medesimo
+
+**1.** Che cosa è il sacramento dell’Eucaristia?
+
+*L’Eucaristia è un sacramento nel quale per l’ammirabile conversione di tutta la sostanza del pane nel Corpo di Gesù Cristo e di quella del vino nel suo prezioso Sangue, si contiene veramente, realmente e sostanzialmente il Corpo, il Sangue, l’Anima e la Divinità del medesimo Gesù Cristo Signor Nostro sotto le specie del pane e del vino per essere nostro nutrimento spirituale.*
+
+**2.** Vi è nell’Eucaristia lo stesso Gesù Cristo che è nel cielo e che nacque in terra dalla santissima Vergine?
+
+*Sì, nell’Eucaristia vi è veramente lo stesso Gesù Cristo che è nel cielo e che nacque in terra dalla santissima Vergine.*
+
+**3.** Perchè credete voi che nel sacramento della Eucaristia è veramente Gesù Cristo?
+
+*Io credo che nel sacramento dell’Eucaristia è veramente presente Gesù Cristo, perchè lo ha detto Egli stesso, e me lo insegna la santa Chiesa.*
+
+**4.** Qual è la materia del sacramento dell’Eucaristia?
+
+*La materia del sacramento dell’Eucari stia è quella adoperata da Gesù Cristo, cioè il pane di frumento ed il vino di vite.*
+
+**5.** Qual è la forma del sacramento dell’Eucaristia?
+
+*La forma del sacramento dell’Eucaristia consiste nelle parole usate da Gesù Cristo: questo è il mio Corpo; questo è il mio Sangue.*
+
+**6.** Che cosa è dunque l’ostia prima della consacrazione?
+
+*L’ostia prima della consacrazione è pane.*
+
+**7.** Dopo la consacrazione che cosa è l’ostia?
+
+*Dopo la consacrazione l’ostia è il vero Corpo di Nostro Signor Gesù Cristo sotto le specie del pane.*
+
+**8.** Nel calice prima della consacrazione che cosa vi è?
+
+*Nel calice prima della consacrazione vi e del vino con alcune gocce d’acqua.*
+
+**9.** Dopo la consacrazione che cosa è nel calice?
+
+*Dopo la consacrazione nel calice è il vero Sangue di Nostro Signore Gesù Cristo sotto le specie del vino.*
+
+**10.** Quando si fa la conversione del pane nel Corpo, e del vino nel Sangue di Gesù Cristo?
+
+*La conversione del pane nel Corpo, e del vino nel Sangue di Gesù Cristo si fa nell’atto stesso in cui il sacerdote, nella santa Messa, pronuncia le parole della consacrazione.*
+
+**11.** Che cosa è la consacrazione?
+
+*La consacrazione è la rinnovazione, per mezzo del sacerdote, del miracolo operato da Gesù Cristo nell’ultima cena di mutare il pane ed il vino nel suo Corpo e nel suo Sangue adorabile, dicendo: questo è il mio corpo, questo è il mio sangue.*
+
+**12.** Come è chiamata dalla Chiesa la miracolosa conversione del pane e del vino nel Corpo e nel Sangue di Gesù Cristo?
+
+*La miracolosa conversione, che ogni giorno si opera sui nostri altari, è chiamata dalla Chiesa transustanziazione.*
+
+**13.** Chi ha dato tanta virtù alle parole della consacrazione?
+
+*Ha dato tanta virtù alle parole della consacrazione lo stesso Signor nostro Gesù Cristo, il quale è Dio onnipotente.*
+
+**14.** Dopo la consacrazione non resta niente del pane e del vino?
+
+*Dopo la consacrazione restano soltanto le specie del pane e del vino.*
+
+**15.** Che cosa sono le specie del pane e del vino?
+
+*Le specie sono la quantità e le qualità sensibili del pane e del vino, come la figura, il colore, il sapore.*
+
+**16.** In che maniera possono restare le specie del pane e del vino senza la loro sostanza?
+
+*Le specie del pane e del vino restano mirabilmente senza la loro sostanza, per virtù di Dio onnipotente.*
+
+**17.** Sotto le specie del pane vi è solo il Corpo di Gesù Cristo, e sotto le specie del vino vi è solo il suo Sangue?
+
+*Tanto sotto le specie del pane, quanto sotto le specie del vino vi è tutto Gesù Cristo vivente, in Corpo, Sangue, Anima e Divinità.*
+
+**18.** Mi sapreste dire perchè tanto nell’ostia, quanto nel calice, vi è tutto Gesù Cristo?
+
+*Tanto nell’ostia, quanto nel calice, vi è tutto Gesù Cristo, perchè egli è nell’Eucaristia vivo ed immortale come nel cielo; perciò dove è il suo Corpo vi è anche il Sangue, l’Anima e la Divinità, e dove è il Sangue, vi è ancora il Corpo, l’Anima e la Divinità, essendo tutto questo inseparabile in Gesù Cristo.*
+
+**19.** Quando Gesù è nell’ostia, cessa di essere in cielo?
+
+*Quando Gesù è nell’ostia, non cessa di essere in cielo, ma si trova nel medesimo tempo in cielo e nel santissimo Sacramento.*
+
+**20.** Gesù Cristo si trova in tutte le ostie consacrate del mondo?
+
+*Sì, Gesù Cristo si trova in tutte le ostie consacrate.*
+
+**21.** Come può essere che Gesù Cristo si trovi in tutte le ostie consacrate?
+
+*Gesù Cristo si trova in tutte le ostie consacrate, per onnipotenza di Dio, al quale niente è impossibile.*
+
+**22.** Quando si rompe l’ostia, si rompe il Corpo di Gesù Cristo?
+
+*Quando si rompe l’ostia, non si rompe il Corpo di Gesù Cristo, ma si rompono solamente le specie del pane.*
+
+**23.** In quale parte dell’ostia resta il Corpo di Gesù Cristo?
+
+*Il Corpo di Gesù Cristo, resta intiero in tutte le parti, nelle quali l’ostia è stata divisa.*
+
+**24.** Gesù Cristo è tanto in un’ostia grande, quanto nella particella di un’ostia?
+
+*Tanto in un’ostia grande, quanto nella particella di un’ostia, vi è il medesimo Gesù Cristo.*
+
+**25.** Per qual motivo si conserva nelle chiese la santissima Eucaristia?
+
+*La santissima Eucaristia si conserva nelle chiese affinchè sia adorata dai fedeli, e portata agli infermi secondo il bisogno.*
+
+**26.** Si deve adorare l’Eucaristia?
+
+*L’Eucaristia si deve adorare da tutti, perchè contiene veramente, realmente e sostanzialmente lo stesso N. S. Gesù Cristo.*
+
+## § 2. Della istituzione e degli effetti del sacramento dell’Eucaristia
+
+**27.** In qual tempo Gesù Cristo ha istituito il sacramento dell’Eucaristia?
+
+*Gesù Cristo ha istituito il sacramento della Eucaristia nell’ultima cena, che fece co’ suoi discepoli la sera avanti la sua passione.*
+
+**28.** Perchè Gesù Cristo ha istituito la santissima Eucaristia?
+
+*Gesù Cristo ha istituito la santissima Eucaristia per tre principali ragioni:*
+
+*1.º Perchè sia sacrificio della nuova legge.*
+
+*2.º Perchè sia cibo dell’anima nostra.*
+
+*3.º Perchè sia un perpetuo memoriale di sua passione e morte, ed un pegno prezioso dell’amor suo verso di noi, e della vita eterna.*
+
+**29.** Perchè Gesù Cristo istituì questo sacramento sotto le specie del pane e del vino?
+
+*Gesù Cristo istituì questo sacramento sotto le specie del pane e del vino, perchè l’Eucaristia doveva essere nostro nutrimento spirituale, ed era perciò conveniente che ci venisse data in forma di cibo e di bevanda.*
+
+**30.** Quali effetti produce in noi la santissima Eucaristia?
+
+*Gli effetti principali che la santissima Eucaristia produce in chi la riceve degnamente sono questi: 1.º conserva ed accresce la vita dell’anima che è la grazia, come il cibo materiale sostiene ed accresce la vita del corpo; 2.º rimette i peccati veniali e preserva dai mortali; 3.º produce spirituale consolazione.*
+
+**31.** La santissima Eucaristia non produce in noi altri effetti?
+
+*Sì, la santissima Eucaristia produce in noi altri tre effetti, cioè: 1.º indebolisce le nostre passioni, ed in ispecie ammorza in noi le fiamme della concupiscenza; 2.º accresce in noi il fervore della carità verso Dio e verso il prossimo e ci aiuta ad operare in uniformità ai desiderî di Gesù Cristo; 3.º ci dà un pegno della gloria futura e della stessa risurrezione del nostro corpo.*
+
+## § 3. Delle disposizioni necessarie per ben comunicarsi
+
+**32.** Il sacramento dell’Eucaristia produce sempre in noi i suoi meravigliosi effetti?
+
+*Il sacramento dell’Eucaristia produce in noi i suoi meravigliosi effetti, quando si riceve con le dovute disposizioni.*
+
+**33.** Quante cose sono necessarie per fare una buona Comunione?
+
+*Per fare una buona Comunione sono necessarie tre cose; 1.º essere in grazia di Dio; 2.º essere digiuno dalla mezzanotte fino all’atto della Comunione; 3.º sapere che cosa si va a ricevere e accostarsi alla santa Comunione con divozione.*
+
+**34.** Che cosa vuol dire essere in grazia di Dio?
+
+*Essere in grazia di Dio vuol dire: avere la coscienza pura e monda da ogni peccato mortale.*
+
+**35.** Chi sa di essere in peccato mortale, che cosa deve fare prima di comunicarsi?
+
+*Chi sa di essere in peccato mortale, deve prima di comunicarsi fare una buona confessione; non bastando l’atto di contrizione perfetta, senza la confessione, a chi è in peccato mortale per comunicarsi come conviene.*
+
+**36.** Perchè non basta neppure l’atto di contrizione perfetta a chi sa di essere in peccato mortale, per potersi comunicare?
+
+*Perchè la Chiesa ha stabilito, per ri spetto a questo sacramento, che chi è colpevole di peccato mortale non ardisca di fare la Comunione se prima non si è confessato.*
+
+**37.** Chi si comunicasse in peccato mortale riceverebbe Gesù Cristo?
+
+*Chi si comunicasse in peccato mortale, riceverebbe Gesù Cristo, ma non la sua grazia, anzi commetterebbe sacrilegio e si farebbe meritevole della sentenza di dannazione.*
+
+**38.** Qual’è il digiuno che si richiede prima della Comunione?
+
+*Prima della Comunione si richiede il digiuno naturale, il quale si rompe per ogni piccola cosa che si prenda per modo di cibo o di bevanda.*
+
+**39.** Se uno inghiottisce qualche cosa rimasta fra i denti o qualche goccia d’acqua entratagli in bocca, si può ancora comunicare?
+
+*Chi inghiottisse qualche cosa rimasta fra i denti, o qualche goccia d’acqua nel lavarsi, si può ancora comunicare; perchè allora queste cose o non si prendono per modo di cibo o di bevanda, o ne hanno già perduta la natura.*
+
+**40.** È mai permesso fare la Comunione senza essere digiuno?
+
+*Il fare la Comunione senza essere digiuno, è permesso agli infermi che sono in pericolo di morte e a chi ne ha ottenuta speciale facoltà dal Papa a cagione di prolungata infermità. La Comunione poi fatta dagli infermi in pericolo di morte, si chiama Viatico perchè li sostenta nel viaggio che fanno da questa vita all’eternità.*
+
+**41.** Che cosa vuol dire: sapere ciò che si va a ricevere?
+
+*Sapere ciò che si va a ricevere, vuol dire: conoscere quelle cose che s’insegnano intorno a questo sacramento nella Dottrina cristiana, e crederle fermamente.*
+
+**42.** Che cosa vuol dire: comunicarsi con divozione?
+
+*Comunicarsi con divozione, vuol dire accostarsi alla santa Comunione con umiltà e modestia, sì nella persona, come nel vestito; e fare la preparazione prima e il ringraziamento dopo la santa Comunione.*
+
+**43.** In che consiste la preparazione prima della Comunione?
+
+*La preparazione prima della Comunione consiste in trattenersi per qualche tempo a considerare chi andiamo a ricevere e chi siamo noi; e in fare atti di fede, di speranza, di carità, di contrizione, di adorazione, di umiltà e di desiderio di ricevere Gesù Cristo.*
+
+**44.** In che consiste il ringraziamento dopo la Comunione?
+
+*Il ringraziamento dopo la Comunione consiste nel trattenerci raccolti ad onorare dentro di noi stessi il Signore; rinnovando gli atti di fede, di speranza, di carità, di adorazione, di ringraziamento, di offerta e di domanda, sopratutto di quelle grazie che maggiormente sono necessarie per noi e per coloro pei quali siamo obbligati a pregare.*
+
+**45.** Che cosa si deve fare nel giorno della Comunione?
+
+*Nel giorno della Comunione si deve stare raccolti per quanto è possibile, occuparsi in opere di pietà e adempiere con maggiore diligenza i doveri del proprio stato.*
+
+**46.** Dopo la santa Comunione quanto tempo resta in noi Gesù Cristo?
+
+*Dopo la santa Comunione Gesù Cristo resta in noi con la sua grazia finchè non si pecca mortalmente; e con la sua reale presenza resta in noi finchè non si sono consumate le specie sacramentali.*
+
+## § 4. Della maniera di comunicarsi
+
+**47.** Come bisogna presentarsi nell’atto di ricevere la santa Comunione?
+
+*Nell’atto di ricevere la santa Comunione bisogna essere inginocchiati, tenere la testa mediocremente alzata, gli occhi modesti e rivolti alla sacra particola, la bocca sufficientemente aperta e la lingua un poco avanzata sulle labbra.*
+
+**48.** Come bisogna tenere la tovaglia o la tavoletta della Comunione?
+
+*La tovaglia o la tavoletta della Comunione bisogna tenerla in modo che raccolga la sacra particola qualora essa venisse a cadere.*
+
+**49.** Quando si deve inghiottire la sacra particola?
+
+*Dobbiamo procurare d’inghiottire la sacra particola più presto che si può, e per qualche tempo astenerci dallo sputare.*
+
+**50.** Se la sacra particola si attaccasse al palato, che cosa si dovrebbe fare?
+
+*Se la sacra particola si attaccasse al palato, la si dovrebbe distaccare con la lingua, e non mai col dito.*
+
+## § 5. Del precetto della Comunione
+
+**51.** Quando vi è l’obbligo di comunicarsi?
+
+*Vi è l’obbligo di comunicarsi in ogni anno, alla Pasqua di Risurrezione, ciascuno alla propria parrocchia; e inoltre in pericolo di morte.*
+
+**52.** In quale età comincia ad obbligare il comandamento della Comunione pasquale?
+
+*Il comandamento della Comunione pasquale comincia ad obbligare nell’età in cui il fanciullo è capace di accostarvisi con le dovute disposizioni.*
+
+**53.** Peccano coloro che hanno l’età capace per essere ammessi alla Comunione e non si comunicano?
+
+*Coloro che, avendo l’etả capace per essere ammessi alla Comunione, non si comunicano, o perchè non vogliono, o perchè non sono per loro colpa istruiti, peccano senza dubbio. Peccano altresì i loro genitori, o chi ne fa le veci, se la dilazione della Comunione avviene per loro colpa, e ne dovranno rendere gran conto a Dio.*
+
+**54.** È cosa buona ed utile comunicarsi spesso?
+
+*È cosa ottima il comunicarsi spesso, pur che si faccia con le disposizioni dovute.*
+
+**55.** Con quale frequenza si può andare alla Comunione?
+
+*Ciascuno può andare alla Comunione con quella maggior frequenza che gli sia consigliata da un pio e dotto confessore.*

--- a/content/books/pius-x-greater-catechism/it/parte-quarta-capo-ix.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quarta-capo-ix.md
@@ -1,0 +1,111 @@
+# Capo IX — Del Matrimonio
+
+## § 1. Natura del sacramento del Matrimonio
+
+**1.** Che cosa è il sacramento del Matrimonio?
+
+*Il Matrimonio è un sacramento, istituito da nostro Signore Gesù Cristo, che stabilisce una santa ed indissolubile unione tra l’uomo e la donna, e dà loro la grazia di amarsi l’un l’altro santamente e di allevare cristianamente i figliuoli.*
+
+**2.** Da chi fu istituito il Matrimonio?
+
+*Il Matrimonio fu istituito da Dio stesso nel paradiso terrestre, e nel nuovo Testamento fu elevato da Gesù Cristo alla dignità di sacramento.*
+
+**3.** Il sacramento del Matrimonio ha qualche speciale significato?
+
+*Il sacramento del Matrimonio significa l’indissolubile unione di Gesù Cristo con la santa Chiesa sua sposa e nostra amantissima madre.*
+
+**4.** Perchè si dice che il vincolo del matrimonio è indissolubile?
+
+*Si dice che il vincolo del matrimonio è indissolubile ossia che non si può sciogliere se non per la morte di uno dei coniugi, perchè così ha stabilito Dio fin da principio, e così ha solennemente proclamato Gesù Cristo Signor nostro.*
+
+**5.** Nel matrimonio cristiano si potrebbe dividere il contratto dal sacramento?
+
+*No, nel matrimonio fra i cristiani non si può dividere il contratto dal sacramento, perchè per essi il matrimonio non è altro che lo stesso contratto naturale elevato da Gesù Cristo alla dignità di sacramento.*
+
+**6.** Fra i cristiani dunque non vi può essere vero matrimonio che non sia sacramento?
+
+*Fra i cristiani non vi può essere vero matrimonio, che non sia sacramento.*
+
+**7.** Quali effetti produce il sacramento del Matrimonio?
+
+*Il sacramento del Matrimonio: 1.º dà l’aumento della grazia santificante: 2.º conferisce la grazia speciale per adempiere fedelmente tutti i doveri matrimoniali.*
+
+## § 2. Ministri, rito e disposizioni
+
+**8.** Quali sono i ministri di questo sacramento?
+
+*I ministri di questo sacramento sono gli stessi sposi, che vicendevolmente conferiscono e ricevono il sacramento.*
+
+**9.** In qual modo si amministra questo sacramento?
+
+*Questo sacramento, conservando la natura di contratto, si amministra dagli stessi contraenti col dichiarare alla presenza del loro parroco, o di un suo delegato, e di due testimoni di unirsi in matrimonio.*
+
+**10.** A che serve dunque la benedizione che il parroco dà agli sposi?
+
+*La benedizione che il parroco dà agli sposi non è necessaria per costituire il sacramento, ma si dà per sanzionare a nome della Chiesa la loro unione, e per chiamare sempre più sopra di essi le benedizioni di Dio.*
+
+**11.** Che intenzione deve avere chi contrae matrimonio?
+
+*Chi contrae matrimonio deve avere l’intenzione: 1.º di fare la volontà di Dio, che lo chiama a tale stato: 2.º di operare in esso la salute dell’anima propria: 3.º di allevare cristianamente i figliuoli, se Dio concede di averne.*
+
+**12.** In qual maniera gli sposi devono disporsi per ricevere con frutto il sacramento del Matrimonio?
+
+*Gli sposi, per ricevere con frutto il sacramento del Matrimonio devono: 1.º raccomandarsi di cuore a Dio per conoscere la sua volontà, e per ottenere da lui quelle grazie, che sono necessarie in tale stato; 2.º consultarsi coi propri genitori prima di farne la promessa, come lo esige l’ubbidienza e il rispetto dovuto ai medesimi; 3.º prepararsi con una buona confessione, anche generale, se fa bisogno, di tutta la vita; 4. schivare ogni pericolosa familiarità di tratto e di parola nel conversare insieme.*
+
+**13.** Quali sono le principali obbligazioni delle persone congiunte in matrimonio?
+
+*Le persone congiunte in matrimonio devono: 1.º custodire inviolata la fedeltà coniugale e diportarsi sempre cristianamente in tutto; 2.º amarsi scambievolmente, sopportandosi a vicenda con pazienza, e vivere in pace e concordia; 3.º se hanno dei figliuoli, pensare seriamente a provvederli secondo il bisogno; dar loro una cristiana educazione; e lasciare ad essi la libertà di scegliere quello stato a cui da Dio sono chiamati.*
+
+## § 3. Condizioni e impedimenti
+
+**14.** Che cosa è necessario per contrarre validamente il matrimonio cristiano?
+
+*Per contrarre validamente il matrimonio cristiano è necessario esser libero da ogni impedimento matrimoniale dirimente, e prestare liberamente il proprio consenso al contratto del matrimonio dinanzi al proprio parroco o ad un sacerdote da lui delegato, e a due testimoni.*
+
+**15.** Che cosa è necessario per contrarre lecitamente il matrimonio cristiano?
+
+*Per contrarre lecitamente il matrimonio cristiano è necessario esser libero dagli impedimenti matrimoniali impedienti, essere istruito nelle cose principali della religione, ed essere in istato di grazia, altrimenti si commetterebbe un sacrilegio.*
+
+**16.** Che cosa sono gli impedimenti matrimoniali?
+
+*Gli impedimenti matrimoniali sono tali circostanze che rendono il matrimonio o invalido, o illecito. Nel primo caso si dicono impedimenti dirimenti, nel secondo impedimenti impedienti.*
+
+**17.** Datemi qualche esempio di impedimento dirimente.
+
+*Impedimenti dirimenti sono, per esempio, la consanguineità fino al quarto grado, la parentela spirituale, il voto solenne di castità, la diversità di culto tra battezzati e non battezzati, ecc.*
+
+**18.** Datemi qualche esempio di impedimento impediente.
+
+*Impedimenti impedienti sono, per esempio, il tempo proibito, il voto semplice di castità, ecc.*
+
+**19.** I fedeli sono obbligati a manifestare all’autorità ecclesiastica gl’impedimenti matrimoniali che conoscono?
+
+*I fedeli sono obbligati a manifestare all’autorità ecclesiastica gl’impedimenti matrimoniali che conoscono; ed è perciò che dai parroci si fanno le pubblicazioni.*
+
+**20.** Chi ha la podestà di stabilire impedimenti matrimoniali, di dispensare da essi e di giudicare della validità del matrimonio cristiano?
+
+*Solamente la Chiesa ha la podestà di stabilire impedimenti e di giudicare della validità del matrimonio fra i cristiani, come la Chiesa sola può dispensare da quelli impedimenti che essa ha stabiliti.*
+
+**21.** Perchè solamente la Chiesa ha la podestà di stabilire impedimenti e di giudicare della validità del matrimonio?
+
+*Solamente la Chiesa ha la podestà di stabilire impedimenti, di giudicare della validità del matrimonio, e dispensare dagli impedimenti che essa ha posti, perchè nel matrimonio cristiano non potendosi dividere il contratto dal sacramento, anche il contratto cade sotto la podestà della Chiesa, alla quale sola Gesù Cristo conferì il diritto di far leggi e decisioni nelle cose sacre.*
+
+**22.** Può l’autorità civile sciogliere col divorzio il vincolo del matrimonio cristiano?
+
+*No, il vincolo del matrimonio cristiano non può essere sciolto dall’autorità civile, perchè questa non può ingerirsi in materia di sacramenti, e separare ciò che Dio ha congiunto.*
+
+**23.** Che cosa è il matrimonio civile?
+
+*Il matrimonio civile non è altro che una formalità prescritta dalla legge al fine di dare e di assicurare gli effetti civili ai coniugati e alla loro prole.*
+
+**24.** Basta per un cristiano fare il solo matrimonio ossia contratto civile?
+
+*Per un cristiano, non basta fare il solo contratto civile, perchè questo non è sacramento, e quindi non è vero matrimonio.*
+
+**25.** Se gli sposi convivessero tra loro col solo matrimonio civile, in che condizione si troverebbero?
+
+*Se gli sposi convivessero tra loro col solo matrimonio civile sarebbero in istato di continuo peccato mortale, e la loro unione resterebbe sempre illegittima innanzi a Dio e alla Chiesa.*
+
+**26.** Si deve fare anche il matrimonio civile?
+
+*Si deve fare anche il matrimonio civile, perchè sebbene questo non sia sacramento, pur tuttavia serve per garantire ai contraenti e ai loro figliuoli gli effetti civili della società coniugale; e però di regola generale dall’autorità ecclesiastica non si permette il matrimonio religioso se non quando siano iniziati gli atti prescritti dalla legge civile.*

--- a/content/books/pius-x-greater-catechism/it/parte-quarta-capo-v.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quarta-capo-v.md
@@ -1,0 +1,97 @@
+# Capo V — Del santo sacrificio della Messa
+
+## § 1. Della essenza, della istituzione e dei fini del santo sacrificio della Messa
+
+**1.** L’Eucaristia si deve considerare solamente come sacramento?
+
+*L’Eucaristia, oltre essere sacramento, è anche il sacrificio permanente della nuova legge, che Gesù Cristo lasciò alla sua Chiesa, da offrirsi a Dio per mano de’ suoi sacerdoti.*
+
+**2.** In che consiste, in generale, il sacrificio?
+
+*Il sacrificio, in generale, consiste nell’offerire una cosa sensibile a Dio, e distruggerla in qualche maniera per riconoscere il supremo dominio di lui sopra di noi e sopra tutte le cose.*
+
+**3.** Come si chiama questo sacrificio della nuova legge?
+
+*Questo sacrificio della nuova legge si chiama la santa Messa.*
+
+**4.** Che cosa è dunque la santa Messa?
+
+*La santa Messa è il sacrificio del Corpo e del Sangue di Gesù Cristo offerto sui nostri altari sotto le specie del pane e del vino, in memoria del sacrificio della Croce.*
+
+**5.** Il sacrificio della Messa è il medesimo della Croce?
+
+*Il sacrificio della Messa è sostanzialmente il medesimo della Croce in quanto lo stesso Gesù Cristo, che si è offerto sopra la Croce, è quello che si offerisce per mano dei sacerdoti, suoi ministri, sui nostri altari; ma in quanto al modo con cui viene offerto il sacrificio della Messa differisce dal sacrificio della Croce, pur ritenendo con questo la più intima ed essenziale relazione.*
+
+**6.** Quale differenza dunque e relazione vi è tra il sacrificio della Messa e quello della Croce?
+
+*Tra il sacrificio della Messa è quello della Croce vi è questa differenza e relazione; che Gesù Cristo sulla Croce si offrì spargendo il suo sangue e meritando per noi; invece sugli altari Egli si sacrifica senza spargimento di sangue e ci applica i frutti della sua Passione e Morte.*
+
+**7.** Quale altra relazione ha il sacrificio della Messa con quello della Croce?
+
+*Un’altra relazione del sacrificio della Messa con quello della Croce è che il sacrificio della Messa rappresenta in modo sensibile lo spargimento del sangue di Gesù Cristo sulla Croce; perchè in virtù delle parole della consacrazione si rende presente sotto le specie del pane il solo Corpo, e sotto le specie del vino il solo Sangue del nostro Salvatore; sebbene per naturale concomitanza e per l’unione ipostatica sia presente sotto ciascuna delle specie Gesù Cristo vivo e vero.*
+
+**8.** Non è forse il sacrificio della Croce l’unico sacrificio della nuova legge?
+
+*Il sacrificio della Croce è l’unico sacrificio della nuova legge, inquantochè per esso il Signore placò la Divina Giustizia, acquistò tutti i meriti necessari a salvarci, e così compiè da parte sua la nostra redenzione. Questi meriti però Egli ci applica pei mezzi da lui istituiti nella sua Chiesa, tra i quali è il santo sacrificio della Messa.*
+
+**9.** Per quali fini dunque si offre il sacrificio della santa Messa?
+
+*Il sacrificio della santa Messa si offerisce a Dio per quattro fini: 1.º per onorarlo come si conviene, e per questo si chiama latreutico; 2.º per ringraziarlo dei suoi benefizi, e per questo si chiama eucaristico; 3.º per placarlo, per dargli la dovuta soddisfazione dei nostri peccati e per suffragare le anime del purgatorio; e per questo si chiama propiziatorio; 4.º per ottenere tutte le grazie che ci sono necessarie, e per questo si chiama impetratorio.*
+
+**10.** Chi è che offre a Dio il sacrificio della santa Messa?
+
+*Il primo e principale offerente del sacri ficio della santa Messa è Gesù Cristo, e il sacerdote e il ministro che in nome di Gesù Cristo offre lo stesso sacrificio all’Eterno Padre.*
+
+**11.** Chi ha istituito il sacrificio della santa Messa?
+
+*Il sacrificio della santa Messa lo istituì Gesù Cristo medesimo quando istituì il sacramento dell’Eucaristia; e disse che si facesse in memoria della sua Passione.*
+
+**12.** A chi si offre la santa Messa?
+
+*La santa Messa si offre a Dio solo.*
+
+**13.** Se la santa Messa si offre a Dio solo, perchè si celebrano tante Messe in onore della santissima Vergine e dei Santi?
+
+*La Messa celebrata in onore della Vergine e dei Santi è sempre un sacrificio offerto a Dio solo: si dice però celebrata in onore della santissima Vergine e dei Santi per ringraziare Dio dei doni che loro ha fatti e ottenere da Lui con la loro intercessione più abbondantemente le grazie di cui abbiamo bisogno.*
+
+**14.** Chi è partecipe dei frutti della Messa?
+
+*Tutta la Chiesa partecipa dei frutti della Messa, ma particolarmente: 1.º il sacerdote e quelli che assistono alla Messa, i quali si considerano uniti al sacerdote; 2.º quelli per cui si applica la Messa, che possono essere sì vivi che defunti.*
+
+## § 2. Del modo di assistere alla santa Messa
+
+**15.** Quali cose sono necessarie per ascoltare bene e con frutto la santa Messa?
+
+*Per ascoltare bene e con frutto la santa Messa sono necessarie due cose: 1.º la modestia della persona; 2.º la divozione del cuore.*
+
+**16.** In che consiste la modestia della persona?
+
+*La modestia della persona consiste in modo speciale nell’essere modestamente vestito; nell’osservare silenzio e raccoglimento, e nello stare, per quanto si può, ginocchioni, eccettuato il tempo dei due vangeli, che si ascoltano stando in piedi.*
+
+**17.** Nell’ascoltare la santa Messa qual è il miglior modo di praticare la divozione del cuore?
+
+*Il miglior modo di praticare la divozione del cuore nell’ascoltare la santa Messa è il seguente:*
+
+*1.º Unire da principio la propria intenzione a quella del sacerdote, offerendo a Dio il santo sacrificio per i fini pei quali è stato istituito.*
+
+*2.º Accompagnare il sacerdote in ciascuna preghiera e azione del sacrificio.*
+
+*3.º Meditare la passione e morte di Gesù Cristo e detestare di cuore i peccati che ne sono stati la cagione.*
+
+*4.º Fare la Comunione sacramentale, o almeno la spirituale, nel tempo che si comunica il sacerdote.*
+
+**18.** Che cosa è la Comunione spirituale?
+
+*La Comunione spirituale è un gran desiderio di unirsi sacramentalmente a Gesù Cristo dicendo, per esempio: Signore mio Gesù Cristo, io desidero con tutto il cuore di unirmi a Voi adesso e per tutta l’eternità; e facendo i medesimi atti che si fanno avanti, e dopo la Comunione sacramentale.*
+
+**19.** La recita del Rosario o di altre orazioni durante la Messa impedisce di ascoltarla con frutto?
+
+*La recita di queste preghiere non impedisce di ascoltare con frutto la Messa, purchè si procuri per quanto si può di seguire l’azione del santo sacrificio.*
+
+**20.** È cosa ben fatta il pregare anche per gli altri nell’assistere alla santa Messa?
+
+*È cosa ben fatta il pregare anche per gli altri nell’assistere alla santa Messa: anzi il tempo della santa Messa è il più opportuno per pregar Dio per i vivi e per i morti.*
+
+**21.** Finita la Messa che cosa si dovrebbe fare?
+
+*Finita la Messa, si dovrebbe ringraziar Dio della grazia d’averci fatto assistere a questo grande sacrificio, e domandargli perdono delle mancanze che abbiamo commesso nell’assistervi.*

--- a/content/books/pius-x-greater-catechism/it/parte-quarta-capo-vi.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quarta-capo-vi.md
@@ -1,0 +1,581 @@
+# Capo VI — Della Penitenza
+
+## § 1. Della Penitenza in generale
+
+**1.** Che cosa è il sacramento della Penitenza?
+
+*La Penitenza detta anche Confessione, è il sacramento istituito da Gesù Cristo per rimettere i peccati commessi dopo il Battesimo.*
+
+**2.** Perchè a questo sacramento si dà il nome di Penitenza?
+
+*A questo sacramento si dà il nome di Penitenza, perchè ad ottenere il perdono dei peccati è necessario detestarli con pentimento, e perchè chi ha commesso una colpa, deve sottoporsi alla pena che il sacerdote impone.*
+
+**3.** Perchè questo sacramento si chiama anche Confessione?
+
+*Questo sacramento si chiama anche Confessione, perchè ad ottenere il perdono dei peccati non basta detestarli, ma è necessario accusarli al sacerdote, cioè farne la confessione.*
+
+**4.** Quando Gesù Cristo ha istituito il sacramento della Penitenza?
+
+*Gesù Cristo ha istituito il sacramento della Penitenza il giorno della sua risurrezione, quando entrato nel cenacolo solennemente diede ai suoi Apostoli la facoltà di rimettere i peccati.*
+
+**5.** Come Gesù Cristo diede ai suoi Apostoli la facoltà di rimettere i peccati?
+
+*Gesù Cristo diede ai suoi Apostoli la facoltà di rimettere i peccati, soffiando sopra di loro, e dicendo: Ricevete lo Spirito Santo: i peccati di coloro ai quali voi li rimetterete, saranno rimessi; ed i peccati di coloro ai quali voi li riterrete, saranno ritenuti.*
+
+**6.** Qual’è la materia del sacramento della Penitenza?
+
+*La materia del sacramento della Penitenza si distingue in remota e prossima. La materia remota è costituita dai peccati commessi dal penitente dopo il Battesimo, e la materia prossima sono gli atti del penitente stesso, cioè la contrizione, l’accusa e la soddisfazione.*
+
+**7.** Qual’è la forma del sacramento della Penitenza?
+
+*La forma del sacramento della Penitenza è questa: Io ti assolvo dai tuoi peccati.*
+
+**8.** Chi è il ministro del sacramento della Penitenza?
+
+*Il ministro del sacramento della Penitenza è il sacerdote approvato dal Vescovo per ascoltare le confessioni.*
+
+**9.** Perchè avete detto che il sacerdote deve essere approvato dal Vescovo?
+
+*Il sacerdote deve essere approvato dal Vescovo ad ascoltare le confessioni, perchè ad amministrare validamente questo sacramento non basta la potestà dell’ordine, ma è necessaria anche la potestà di giurisdizione, cioè la facoltà di giudicare, che deve essere data dal Vescovo.*
+
+**10.** Quante sono le parti del sacramento della Penitenza?
+
+*Le parti del sacramento della Penitenza sono: la contrizione, la confessione e la soddisfazione del penitente, e l’assoluzione del sacerdote.*
+
+**11.** Che cosa è la contrizione, ossia il dolore dei peccati?
+
+*La contrizione ossia il dolore dei peccati, è un dispiacere dell’animo, pel quale si detestano i peccati commessi e si propone di non farne più in avvenire.*
+
+**12.** Che cosa vuol dire questa parola contrizione?
+
+*La parola contrizione, vuol dire rottura o spezzamento, come quando una pietra è pestata e ridotta in polvere.*
+
+**13.** Perchè si dà il nome di contrizione al dolore dei peccati?
+
+*Si dà il nome di contrizione al dolore dei peccati, per significare che il cuor duro del peccatore in certo modo si spezza per dolore di avere offeso Dio.*
+
+**14.** In che consiste la confessione dei peccati?
+
+*La confessione consiste in un’accusa distinta dei nostri peccati fatta al confessore per averne l’assoluzione e la penitenza.*
+
+**15.** Perchè la confessione si chiama accusa?
+
+*La confessione si chiama accusa, perchè non dev’essere un indifferente racconto, ma una vera e dolorosa manifestazione de’ propri peccati.*
+
+**16.** Che cosa è la soddisfazione o penitenza?
+
+*La soddisfazione o penitenza è quella preghiera o altra opera buona, che il confessore ingiunge al penitente in espiazione de’ suoi peccati.*
+
+**17.** Che cosa è l’assoluzione?
+
+*L’assoluzione è la sentenza, che il sacerdote pronunzia in nome di Gesù Cristo, per rimettere i peccati al penitente.*
+
+**18.** Delle parti del sacramento della Penitenza qual è la più necessaria?
+
+*Delle parti del sacramento della Penitenza la più necessaria è la contrizione, perchè senza di essa non si può mai ottenere il perdono dei peccati, e con essa sola, quando sia perfetta, si può ottenere il perdono, purchè sia congiunta col desiderio, almeno implicito, di confessarsi.*
+
+## § 2. Degli effetti e della necessità del sacramento della Penitenza e delle disposizioni per ben riceverlo
+
+**19.** Quanti sono gli effetti del sacramento della Penitenza?
+
+*Il sacramento della Penitenza conferisce la grazia santificante con la quale sono rimessi i peccati mortali e anche i veniali che si sono confessati e dei quali si ha dolore; commuta la pena eterna nella temporale, della quale pure vien rimesso più o meno secondo le disposizioni; restituisce i meriti delle buone opere fatte prima di commettere il peccato mortale; dà al l’anima aiuti opportuni per non ricadere nella colpa, e ridona la pace alla coscienza.*
+
+**20.** Il sacramento della Penitenza è necessario a tutti per salvarsi?
+
+*Il sacramento della Penitenza è necessario per salvarsi a tutti quelli che dopo il Battesimo hanno commesso qualche peccato mortale.*
+
+**21.** È cosa buona confessarsi spesso?
+
+*Il confessarsi spesso è cosa ottima, perchè il sacramento della Penitenza, oltre al cancellare i peccati dà le grazie opportune per evitarli in avvenire.*
+
+**22.** Il sacramento della Penitenza ha virtù di rimettere tutti i peccati per molti e grandi che siano?
+
+*Il sacramento della Penitenza ha virtù di rimettere tutti i peccati per molti e grandi che siano, purchè si riceva con le dovute disposizioni.*
+
+**23.** Quante cose si richiedono per fare una buona confessione?
+
+*Per fare una buona confessione si richiedono cinque cose: 1.º esame di coscienza; 2.º dolore di avere offeso Iddio; 3.º proponimento di non più peccare, 4.º accusa dei propri peccati; 5.º soddisfazione o penitenza.*
+
+**24.** Che cosa dobbiamo noi fare prima di tutto per confessarci bene?
+
+*Per confessarci bene dobbiamo prima di tutto pregare di cuore il Signore a darci lume per conoscere tutti i nostri peccati e forza per detestarli.*
+
+## § 3. Dell’esame
+
+**25.** Che cos’è l’esame di coscienza?
+
+*L’esame di coscienza è una diligente ricerca dei peccati che si sono commessi, dopo l’ultima confessione ben fatta.*
+
+**26.** Come si fa l’esame di coscienza?
+
+*L’esame di coscienza si fa col richiamare diligentemente alla memoria, innanzi a Dio, tutti i peccati commessi, non mai confessati, in pensieri, parole, opere ed omissioni, contro i comandamenti di Dio e della Chiesa, e gli obblighi del proprio stato.*
+
+**27.** Sopra quali altre cose dobbiamo esaminarci?
+
+*Dobbiamo esaminarci ancora sopra le abitudini cattive e sopra le occasioni del peccato.*
+
+**28.** Nell’esame dobbiamo ricercare anche il numero dei peccati?
+
+*Nell’esame dobbiamo ricercare anche il numero dei peccati mortali.*
+
+**29.** Che cosa si richiede perchè un peccato sia mortale?
+
+*Perchè un peccato sia mortale si richiedono tre cose: materia grave, piena avvertenza, e perfetto consenso della volontà.*
+
+**30.** Quand’è che vi ha materia grave?
+
+*Vi ha materia grave quando si tratta di una cosa notabilmente contraria alla legge di Dio e della Chiesa.*
+
+**31.** Quand’è che vi ha piena conoscenza nel peccare?
+
+*Vi ha piena conoscenza nel peccare, quando si conosca perfettamente di fare un grave male.*
+
+**32.** Quand’è che, nel peccato, si ha il perfetto consenso della volontà?
+
+*Si ha, nel peccato, il perfetto consenso della volontà, quando si vuol fare deliberatamente una cosa, sebbene si conosca peccaminosa.*
+
+**33.** Qual diligenza si deve usare nell’esame di coscienza?
+
+*Nell’esame di coscienza si deve usare quella diligenza che si userebbe in un affare di grande importanza.*
+
+**34.** Quanto tempo si deve impiegare nell’esame?
+
+*Si deve impiegare nell’esame di coscienza più o meno tempo, secondo il bisogno, cioè secondo il numero e la qualità dei peccati che aggravano la coscienza e secondo il tempo scorso dalla ultima confessione ben fatta.*
+
+**35.** Come si può facilitare l’esame per la confessione?
+
+## § 4. Del dolore
+
+**36.** Che cosa è il dolore dei peccati?
+
+*Il dolore dei peccati consiste in un dispiacere ed in una sincera detestazione dell’offesa fatta a Dio.*
+
+**37.** Di quante sorta è il dolore?
+
+*Il dolore è di due sorta: perfetto, ossia di contrizione; imperfetto, ossia di attrizione.*
+
+**38.** Qual è il dolore perfetto, o di contrizione?
+
+*Il dolore perfetto è il dispiacere di avere offeso Dio, perchè infinitamente buono e degno per se stesso di essere amato.*
+
+**39.** Perchè chiamate voi perfetto il dolore di contrizione?
+
+*Chiamo perfetto il dolore di contrizione per due ragioni: 1.º perchè riguarda esclusivamente la bontà di Dio, e non il nostro vantaggio o danno; 2.º perchè ci fa subito ottenere il perdono dei peccati, restandoci però l’obbligo di confessarci.*
+
+**40.** Dunque il dolore perfetto ci ottiene il perdono dei peccati indipendentemente dalla confessione?
+
+*Il dolore perfetto non ci ottiene il perdono dei peccati indipendentemente dalla confessione, perchè sempre include la volontà di confessarsi.*
+
+**41.** Perchè il dolore perfetto, o contrizione, produce questo effetto di rimetterci in grazia di Dio?
+
+*Il dolore perfetto, o contrizione produce questo effetto, perchè nasce dalla carità la quale non può trovarsi nell’anima insieme col peccato mortale.*
+
+**42.** Qual’è il dolore imperfetto o di attrizione?
+
+*Il dolore imperfetto o di attrizione e quello per cui ci pentiamo di avere offeso Dio, come sommo Giudice, cioè per timore dei castighi meritati in questa o nell’altra vita o per la stessa bruttezza del peccato.*
+
+**43.** Quali condizioni deve avere il dolore, per essere buono?
+
+*Il dolore per essere buono, deve avere quattro condizioni: deve essere interno, soprannaturale, sommo e universale.*
+
+**44.** Che cosa vuol dire che il dolore deve essere interno?
+
+*Vuol dire che deve essere nel cuore e nella volontà e non nelle sole parole.*
+
+**45.** Perchè il dolore dev’essere interno?
+
+*Il dolore deve essere interno, perchè la volontà che si è allontanata da Dio col peccato, deve ritornare a Dio detestando il peccato commesso.*
+
+**46.** Che cosa vuol dire che il dolore deve essere soprannaturale?
+
+*Vuol dire che deve essere eccitato in noi dalla grazia del Signore e concepito per motivi di fede.*
+
+**47.** Perchè il dolore dev’essere soprannaturale?
+
+*Il dolore deve essere soprannaturale, per chè è soprannaturale il fine a cui si dirige, cioè il perdono di Dio, l’acquisto della grazia santificante ed il diritto alla gloria eterna.*
+
+**48.** Spiegate meglio la differenza tra il dolore soprannaturale e il naturale?
+
+*Chi si pente per avere offeso Dio infinitamente buono e degno per se stesso di essere amato, per aver perduto il paradiso e meritato l’inferno, ovvero per la malizia intrinseca del peccato, ha un dolore soprannaturale perchè questi sono motivi di fede: chi invece si pentisse solo pel disonore, o castigo che gli viene dagli uomini, o per qualche danno puramente temporale, avrebbe un dolore naturale, perchè si pentirebbe solo per motivi umani.*
+
+**49.** Perchè il dolore deve essere sommo?
+
+*Il dolore deve essere sommo, perchè dobbiamo riguardare e odiare il peccato come sommo di tutti i mali, essendo offesa di Dio sommo Bene.*
+
+**50.** Pel dolore dei peccati è forse necessario piangere, come alle volte si piange per le disgrazie di questa vita?
+
+*Non è necessario che materialmente si pianga pel dolore dei peccati; ma basta che nel cuore si faccia più gran caso di avere offeso Dio, che di qualunque altra disgrazia.*
+
+**51.** Che vuol dire che il dolore deve essere universale?
+
+*Vuol dire che deve estendersi a tutti i peccati mortali commessi.*
+
+**52.** Perchè il dolore deve estendersi a tutti i peccati mortali commessi?
+
+*Perchè chi non si pente anche di un solo peccato mortale, rimane nemico di Dio.*
+
+**53.** Che cosa dobbiamo fare per avere il dolore dei nostri peccati?
+
+*Per avere il dolore dei nostri peccati dobbiamo dimandarlo di cuore a Dio, ed eccitarlo in noi con la considerazione del gran male che abbiamo fatto peccando.*
+
+**54.** Come farete per eccitarvi a detestare i peccati?
+
+*Per eccitarmi a detestare i peccati: 1.º considererò il rigore della infinita giustizia di Dio e la deformità del peccato che ha deturpato l’anima mia e mi ha reso meritevole delle pene eterne dell’inferno; 2.º considererò che ho perduta la grazia, l’amicizia, la figliuolanza di Dio e l’eredità del paradiso; 3.º che ho offeso il mio Redentore che è morto per me, e che i miei peccati sono stati la cagione della sua morte; 4.º che ho disprezzato il mio Creatore, il mio Dio; che ho voltato le spalle a lui, mio sommo bene degno di essere amato sopra ogni cosa e servito fedelmente.*
+
+**55.** Dobbiamo noi essere grandemente solleciti, quando andiamo a confessarci, d’avere un vero dolore de’ nostri peccati?
+
+*Quando noi andiamo a confessarci, dobbiamo essere certamente molto solleciti di avere un vero dolore de’ nostri peccati, perchè questa è la cosa più importante di tutte: e se manca il dolore, la confessione non vale.*
+
+**56.** Chi si confessa di soli peccati veniali deve avere il dolore di tutti?
+
+*Chi si confessa di soli peccati veniali, per confessarsi validamente basta che sia pentito di alcuno di essi; ma per ottenere il perdono di tutti è necessario che si penta di tutti quelli che riconosce di aver commesso.*
+
+**57.** Chi si confessa di soli peccati veniali, e non è pentito neppure di un solo, fa una buona confessione?
+
+*Chi si confessa di soli peccati veniali e non è pentito neppure di un solo, fa una confessione di nessun valore; la quale è inoltre sacrilega, se la mancanza del dolore è avvertita.*
+
+**58.** Che cosa convien fare per rendere più sicura la confessione di soli peccati veniali?
+
+*Per rendere più sicura la confessione di soli peccati veniali, è cosa prudente accusare, con vero dolore, anche qualche peccato più grave della vita passata, benchè già confessato altre volte.*
+
+**59.** È cosa buona fare spesso l’atto di contrizione?
+
+R: È cosa buona ed utilissima il fare spesso l’atto di contrizione, massime prima di andare a dormire, e quando uno si accorge o dubita di essere caduto in peccato mortale, per rimettersi più presto in grazia di Dio; e giova sopratutto per ottenere più facilmente da Dio la grazia di fare simile atto nel maggior bisogno, cioè nel pericolo di morte.
+
+## § 5. Del proponimento
+
+**60.** In che consiste il proponimento?
+
+*Il proponimento consiste in una volontà risoluta di non commettere mai più il peccato e di usare tutti i mezzi necessari per fuggirlo.*
+
+**61.** Quali condizioni deve avere il proponimento per essere buono?
+
+*Il proponimento, affinchè sia buono, deve avere principalmente tre condizioni: deve essere assoluto, universale ed efficace.*
+
+**62.** Che cosa vuol dire: proponimento assoluto?
+
+*Vuol dire che il proponimento deve essere senza alcuna condizione di tempo, di luogo, o di persona.*
+
+**63.** Che cosa vuol dire: il proponimento deve essere universale?
+
+*Il proponimento deve essere universale, vuol dire che dobbiamo voler fuggire tutti i peccati mortali, tanto quelli già altre volte commessi, quanto altri che potremmo commettere.*
+
+**64.** Che cosa vuol dire: il proponimento deve essere efficace?
+
+*Il proponimento deve essere efficace, vuol dire che bisogna avere una volontà risoluta di perdere prima ogni cosa che commettere un nuovo peccato, di fuggire le occasioni pericolose di peccare, di distruggere gli abiti cattivi, e di adempiere gli obblighi contratti in conseguenza dei nostri peccati.*
+
+**65.** Che s’intende per abito cattivo?
+
+*Per abito cattivo s’intende la disposizione acquistata a cadere con facilità in quei peccati ai quali ci siamo assuefatti.*
+
+**66.** Che cosa si deve fare per correggere gli abiti cattivi?
+
+*Per correggere gli abiti cattivi dobbiamo stare vigilanti sopra di noi, fare molta orazione, frequentare la confessione, avere un buon direttore stabile, e mettere in pratica i consigli e i rimedi che egli ci propone.*
+
+**67.** Che cosa s’intende per occasioni pericolose di peccare?
+
+*Per occasioni pericolose di tendono tutte quelle circostanze di tempo, di luogo, di persone, o di cose che per propria natura, o per la nostra fragilità ci inducono a commettere il peccato.*
+
+**68.** Siamo noi gravemente obbligati a schivare tutte le occasioni pericolose?
+
+*Noi siamo gravemente obbligati a schivare quelle occasioni pericolose che d’ordinario ci inducono a commettere peccato mortale, le quali si chiamano le occasioni prossime del peccato.*
+
+**69.** Che cosa deve fare chi non può fuggire qualche occasione di peccato?
+
+*Chi non può fuggire qualche occasione di peccato, lo dica al confessore e stia ai consigli di lui.*
+
+**70.** Quali considerazioni servono per fare il proponimento?
+
+*Per fare il proponimento servono le stesse considerazioni, che valgono ad eccitare il dolore; cioè la considerazione dei motivi che abbiamo di temere la giustizia di Dio e di amare la sua infinità bontà.*
+
+## § 6. Dell’accusa dei peccati al confessore
+
+**71.** Dopo di esservi ben disposto alla confessione con l’esame, col dolore e col proponimento, che cosa farete?
+
+*Dopo di essermi ben disposto coll’esame, col dolore e col proponimento, andrò a fare al confessore l’accusa de’ miei peccati per averne l’assoluzione.*
+
+**72.** Di quali peccati siamo obbligati a confessarci?
+
+*Siamo obbligati a confessarci di tutti i peccati mortali; è bene però confessare anche i veniali.*
+
+**73.** Quali sono le condizioni che deve avere l’accusa dei peccati o confessione?
+
+*Le condizioni principali che deve avere l’accusa dei peccati sono cinque: deve essere umile, intiera, sincera, prudente e breve.*
+
+**74.** Che vuol dire: l’accusa deve esser umile?
+
+*L’accusa deve esser umile, vuol dire che il penitente deve accusarsi dinanzi al suo confessore, senza alterigia di animo o di parole, ma coi sentimenti di un reo, che riconosce la sua colpa e comparisce davanti al giudice.*
+
+**75.** Che vuol dire: l’accusa dev’essere intiera?
+
+*L’accusa dev’essere intiera, vuol dire che si debbono manifestare con le loro circostanze e nel loro numero tutti i peccati mortali commessi dopo l’ultima confessione ben fatta e dei quali si ha coscienza.*
+
+**76.** Quali circostanze si devono manifestare, perchè l’accusa sia intiera?
+
+*Perchè l’accusa sia intiera, si devono manifestare le circostanze che mutano la specie del peccato.*
+
+**77.** Quali sono le circostanze che mutano la specie del peccato?
+
+*Le circostanze che mutano la specie del peccato, sono: 1.º quelle per le quali un’azione peccaminosa da veniale diventa mortale; 2.º quelle per le quali un’azione peccaminosa contiene la malizia di due o più peccati mortali.*
+
+**78.** Datemi l’esempio di una circostanza che faccia diventar mortale un peccato veniale?
+
+*Chi per iscusarsi dicesse una bugia dalla quale venisse grave danno al prossimo, dovrebbe manifestare questa circostanza che cambia la bugia da officiosa in gravemente dannosa.*
+
+**79.** Datemi ora l’esempio di una circostanza per la quale una stessa azione peccaminosa contiene la malizia di due o più peccati.
+
+*Chi avesse rubato una cosa sacra do vrebbe accusare questa circostanza che aggiunge al furto la malizia del sacrilegio.*
+
+**80.** Se taluno non fosse certo di aver commesso un peccato, deve confessarsene?
+
+*Se taluno non fosse certo di aver commesso un peccato, non è obbligato a confessarsene; se però volesse accusarlo, dovrà aggiungere che non è certo di averlo commesso.*
+
+**81.** Chi non ricorda precisamente il numero de’ suoi peccati, che cosa deve fare?
+
+*Chi non ricorda precisamente il numero dei suoi peccati, deve accusarne il numero approssimativo.*
+
+**82.** Chi ha taciuto per pura dimenticanza un peccato mortale, o una circostanza necessaria, ha fatto una buona confessione?
+
+*Chi ha taciuto per pura dimenticanza un peccato mortale, o una circostanza necessaria, ha fatto una buona confessione purchè abbia usata la debita diligenza per ricordarsene.*
+
+**83.** Se un peccato mortale dimenticato nella confessione torna poi in mente, siamo obbligati ad accusarcene in un’altra confessione?
+
+*Se un peccato mortale dimenticato nella confessione torna poi in mente, siamo obbligati senza dubbio ad accusarlo la prima volta che di nuovo ci confessiamo.*
+
+**84.** Chi per vergogna, o per qualche altro motivo tace colpevolmente nella confessione qualche peccato mortale, che cosa commette?
+
+*Colui che per vergogna o per qualche altro motivo tace colpevolmente qualche peccato mortale in confessione, profana il sacramento e perciò si fa reo di un gravissimo sacrilegio.*
+
+**85.** Chi ha taciuto colpevolmente qualche peccato mortale nella confessione, come deve provvedere alla propria coscienza?
+
+*Chi ha taciuto colpevolmente qualche peccato mortale nella confessione, deve esporre al confessore il peccato taciuto, dire in quante confessioni l’abbia taciuto e rifare tutte le confessioni dall’ultima ben fatta.*
+
+**86.** Che cosa deve considerare chi fosse tentato a tacere qualche peccato in confessione?
+
+*Chi fosse tentato a tacere un peccato grave in confessione deve considerare:*
+
+*1.º che non ha avuto rossore di peccare alla presenza di Dio, che tutto vede;*
+
+*2.º che è meglio manifestare i propri peccati al confessore in segreto, che vivere in quieto nel peccato, fare una morte infelice ed essere perciò svergognato nel dì del giudizio universale in faccia a tutto il mondo;*
+
+*3.º che il confessore è obbligato al sigillo sacramentale sotto gravissimo peccato e con la minaccia di severissime pene temporali ed eterne.*
+
+**87.** Che cosa vuol dire: l’accusa deve essere sincera?
+
+*L’accusa deve essere sincera, vuol dire che bisogna dichiarare i propri peccati quali sono, senza scusarli, diminuirli o accrescerli.*
+
+**88.** Che vuol dire: la confessione deve essere prudente?
+
+*La confessione deve essere prudente, vuol dire che nel confessare i peccati dobbiamo servirci dei termini più modesti, e che dobbiamo guardarci dallo scoprire i peccati degli altri.*
+
+**89.** Che cosa significa: la confessione deve essere breve?
+
+*La confessione deve essere breve, significa che non dobbiamo dire niente d’inutile al confessore.*
+
+**90.** Non è egli gravoso il dover confessare ad un altro i propri peccati, massimamente se sono assai vergognosi?
+
+*Sebbene il confessare ad un altro i propri peccati possa essere gravoso, bisogna farlo, perchè è di precetto divino e altrimenti non si può ottenere il perdono dei peccati commessi, e inoltre perchè la difficoltà di confessarsi è compensata da molti vantaggi e da grandi consolazioni.*
+
+## § 7. Del modo di confessarsi
+
+**91.** Come vi presenterete al confessore?
+
+*Mi inginocchierò ai piedi del confessore e dirò: beneditemi, padre, perchè ho peccato.*
+
+**92.** Che cosa farete mentre il confessore vi darà la benedizione?
+
+*Mi inchinerò umilmente a ricevere la benedizione, e farò il segno della Croce.*
+
+**93.** Fatto il segno della Croce, che cosa deve dirsi?
+
+*Fatto il segno della Croce, si deve dire: mi confesso a Dio onnipotente, alla beata Vergine Maria, a tutti i Santi, ed a voi, padre mio spirituale, perchè ho peccato.*
+
+**94.** E poi che cosa bisogna dire?
+
+*Poi bisogna dire: mi sono confessato nel tal tempo; per grazia di Dio ho ricevuto l’assoluzione, ho fatto la penitenza, e sono andato alla Comunione. Quindi si fa l’accusa dei peccati.*
+
+**95.** Finita l’accusa dei peccati che cosa farete?
+
+*Finita l’accusa dei peccati dirò: mi accuso ancora di tutti i peccati della vita passata, specialmente contro la tale, o tale virtù – p. es. contro la purità, contro il quarto comandamento, ecc.*
+
+**96.** Dopo questa accusa che cosa si deve dire?
+
+*Si deve dire: di tutti questi peccati e di quelli che non ricordo, domando perdono a Dio con tutto il cuore; ed a voi, mio padre spirituale, domando la penitenza e l’assoluzione.*
+
+**97.** Compita così l’accusa dei peccati che cosa resta a farsi?
+
+*Compita l’accusa dei peccati, bisogna ascoltare con rispetto quello che dirà il confessore; accettare la penitenza con sincera volontà di farla; e mentre egli darà l’assoluzione, rinnovare di cuore l’atto di contrizione.*
+
+**98.** Ricevuta l’assoluzione, che resta a fare?
+
+*Ricevuta l’assoluzione, bisogna ringraziare il Signore; fare al più presto la penitenza; e mettere in pratica gli avvisi del confessore.*
+
+## § 8. Dell’assoluzione
+
+**99.** Debbono i confessori dar sempre l’assoluzione a quelli che si confessano?
+
+*I confessori debbono dare l’assoluzione solamente a quelli che essi giudicano ben disposti a riceverla.*
+
+**100.** Possono i confessori differire o negare qualche volta l’assoluzione?
+
+*I confessori non solamente possono, nè debbono differire o negare l’assoluzione in certi casi, per non profanare il sacramento.*
+
+**101.** Quali sono i penitenti che debbono ritenersi mal disposti, e ai quali si deve d’ordinario negare o differire l’assoluzione?
+
+*I penitenti che debbono ritenersi mal disposti sono questi principalmente:*
+
+*1.º coloro che non sanno i misteri principali della fede o trascurano d’imparare le altre cose della Dottrina cristiana, che sono obbligati a sapere secondo il loro stato;*
+
+*2.º coloro che sono gravemente negligenti nel fare l’esame di coscienza o non dànno segni di dolore e di pentimento;*
+
+*3.º coloro che non vogliono restituire, potendo, la roba altrui, o la riputazione tolta;*
+
+*4.º coloro che non perdonano di cuore ai loro nemici.*
+
+*5.º coloro che non vogliono praticare i mezzi necessari per emendarsi dei loro abiti cattivi;*
+
+*6.º coloro che non vogliono lasciare le occasioni prossime del peccato.*
+
+**102.** Non è egli troppo rigoroso il confessore che differisce l’assoluzione al penitente, perchè non lo crede ancora ben disposto?
+
+*Il confessore che differisce l’assoluzione al penitente, perchè non lo crede ancora ben disposto, non è troppo rigoroso, ma anzi molto caritatevole, regolandosi come un buon medico, che tenta tutti i rimedi, anche disgustosi e dolorosi, per salvare la vita all’ammalato.*
+
+**103.** Il peccatore al quale si differisce o si nega l’assoluzione, dovrà disperarsi, o affatto ritirarsi dalla confessione?
+
+*Il peccatore, al quale si differisce, o si nega l’assoluzione, non deve disperarsi, o ritirarsi affatto dalla confessione; ma deve umiliarsi, riconoscere il suo deplorabile stato, profittare dei buoni consigli che il confessore gli dà, e così mettersi al più presto possibile in istato di meritare l’assoluzione.*
+
+**104.** Che cosa deve fare il penitente, quanto alla scelta del confessore?
+
+*Il vero penitente deve raccomandarsi molto a Dio per la scelta di un confessore pio, dotto e prudente, poi mettersi nelle sue mani, e sottomettersi a lui, come a suo giudice e medico.*
+
+## § 9. Della soddisfazione ossia penitenza
+
+**105.** Che cosa è la soddisfazione?
+
+*La soddisfazione, che chiamasi anche pe nitenza sacramentale, è uno degli atti del penitente, col quale egli dà un qualche risarcimento alla giustizia di Dio per i peccati commessi, eseguendo quelle opere che il confessore gli impone.*
+
+**106.** Il penitente è obbligato ad accettare la penitenza ingiuntagli dal confessore?
+
+*Il penitente è obbligato ad accettare la penitenza ingiuntagli dal confessore, se può farla; e se non può farla, deve dirlo umilmente al confessore stesso, e domandarne un’altra.*
+
+**107.** Quando si deve fare la penitenza?
+
+*Se il confessore non ha prescritto verun tempo, la penitenza si deve fare al più presto, e procurare di farla in istato di grazia.*
+
+**108.** Come si deve fare la penitenza?
+
+*La penitenza si deve fare intiera e con divozione.*
+
+**109.** Perchè nella confessione s’ingiunge la penitenza?
+
+*La penitenza s’ingiunge perchè d’ordinario, dopo l’assoluzione sacramentale che rimette la colpa e la pena eterna, resta una pena temporale da scontarsi in questo mondo o nel purgatorio.*
+
+**110.** Per qual ragione ha voluto il Signore nel sacramento del Battesimo rimettere tutta la pena dovuta ai peccati e non nel sacramento della Penitenza?
+
+*Il Signore ha voluto nel sacramento del Battesimo rimettere tutta la pena dovuta ai peccati, e non nel sacramento della Penitenza, perchè i peccati dopo il Battesimo sono assai più gravi, essendo commessi con maggior cognizione e ingratitudine ai beneficî di Dio, e anche perchè l’obbligo di soddisfarli sia freno a non ricadere nel peccato.*
+
+**111.** Possiamo noi soddisfare da noi stessi a Dio?
+
+*Noi, da noi stessi, non possiamo soddisfare a Dio; ma ben lo possiamo con l’unirci a Gesù Cristo, che col merito della sua passione e morte dà valore alle nostre azioni.*
+
+**112.** La penitenza che dà il confessore basta essa sempre a cancellare la pena che rimane dovuta ai peccati?
+
+*La penitenza che dà il confessore d’ordinario non basta per scontare la pena che rimane dovuta ai peccati; perciò bisogna procurare di supplire con altre penitenze volontarie.*
+
+**113.** Quali sono le opere di penitenza?
+
+*Le opere di penitenza si possono ridurre a tre specie: alla preghiera, al digiuno, alla limosina.*
+
+**114.** Che cosa intendete per preghiera?
+
+*Per la preghiera s’intende ogni sorta di esercizi di pietà.*
+
+**115.** Che cosa s’intende per digiuno?
+
+*Per digiuno s’intende ogni sorta di mortificazione.*
+
+**116.** Che s’intende per limosina?
+
+*Per limosina s’intende qualunque opera di misericordia spirituale e corporale.*
+
+**117.** Quale penitenza è più meritoria, quella che dà il confessore, o quella che facciamo di nostra elezione?
+
+*La penitenza che ci dà il confessore è la più meritoria, perchè, essendo parte del sacramento, riceve maggior virtù dai meriti della passione di Gesù Cristo.*
+
+**118.** Quelli che muoiono dopo d’avere ricevuta l’assoluzione, ma prima d’avere pienamente soddisfatto alla giustizia di Dio, vanno subito in paradiso?
+
+*No; vanno in purgatorio per ivi soddisfare alla giustizia di Dio, e purificarsi interamente.*
+
+**119.** Le anime che sono nel purgatorio possono essere da noi sollevate nelle loro pene?
+
+*Sì, le anime, che sono nel purgatorio, possono essere sollevate con le preghiere, con le limosine, con tutte le altre buone opere e con le indulgenze, ma sopratutto col santo sacrificio della Messa.*
+
+**120.** Oltre la penitenza, che altro deve fare il penitente dopo la confessione?
+
+*Il penitente, dopo la confessione, oltre la penitenza, se ha danneggiato ingiustamente il prossimo nella roba o nell’onore, o se gli ha dato scandalo, deve per quanto gli è possibile al più presto restituirgli la roba, ripararne l’onore e rimediare allo scandalo.*
+
+**121.** Come si può rimediare allo scandalo che si è cagionato?
+
+*Si può rimediare allo scandalo che si è cagionato, facendone cessare l’occasione, ed edificando con le parole e col buon esempio quelli che abbiamo scandalizzati.*
+
+**122.** In qual maniera si dovrà soddisfare al prossimo, quando è stato da noi offeso?
+
+*Si dovrà soddisfare al prossimo, quando è stato da noi offeso, con domandargli perdono o con dargli qualche altra conveniente riparazione.*
+
+**123.** Quali frutti produce in noi una buona confessione?
+
+*Una buona confessione: 1.º ci rimette i peccati commessi, e ci dà la grazia di Dio; 2.º ci restituisce la pace e la quiete della coscienza; 3.º ci riapre le porte del paradiso, e cambia la pena eterna dell’inferno in pena temporale; 4.º ci preserva dalle ricadute e ci rende capaci del tesoro delle indulgenze.*
+
+## § 10. Delle indulgenze
+
+**124.** Che cosa è l’indulgenza?
+
+*L’indulgenza è la remissione della pena temporale dovuta per i nostri peccati, già rimessi quanto alla colpa; remissione che la Chiesa accorda fuori del sacramento della Penitenza.*
+
+**125.** Da chi ha ricevuto la Chiesa la facoltà di dare le indulgenze?
+
+*La Chiesa ha ricevuto la facoltà di dare le indulgenze da Gesù Cristo.*
+
+**126.** In qual modo la Chiesa ci rimette la pena temporale per mezzo delle indulgenze?
+
+*La Chiesa ci rimette la pena temporale per mezzo delle indulgenze, applicandoci le soddisfazioni sovrabbondanti di Gesù Cristo, di Maria SSm̃a, e dei Santi, le quali formano ciò che dicesi il tesoro della Chiesa.*
+
+**127.** Chi ha il potere di concedere le indulgenze?
+
+*Il potere di concedere le indulgenze lo ha solo il Papa in tutta la Chiesa, e il Vescovo nella sua diocesi, secondo la facoltà concessagli dal Papa.*
+
+**128.** Di quante specie sono le indulgenze?
+
+*Le indulgenze sono di due specie: l’indulgenza plenaria e l’indulgenza parziale.*
+
+**129.** Qual’è l’indulgenza plenaria?
+
+*L’indulgenza plenaria è quella con cui ci viene rimessa tutta la pena temporale dovuta per i nostri peccati. Perciò se taluno morisse dopo aver ricevuto tale Indulgenza, andrebbe subito in Paradiso, esente affatto dalle pene del purgatorio.*
+
+**130.** Qual’è l’indulgenza parziale?
+
+*L’indulgenza parziale è quella con la quale ci viene rimessa soltanto una parte della pena temporale dovuta per i nostri peccati.*
+
+**131.** Che cosa intende di fare la Chiesa nel concedere le indulgenze?
+
+*Nel concedere le indulgenze la Chiesa intende venire in aiuto alla nostra incapacità di espiare in questo mondo tutta la pena temporale, facendoci conseguire per mezzo di opere di pietà e di carità cristiana quello che nei primi secoli procurava che si ottenesse col rigore dei canoni penitenziali.*
+
+**132.** Che cosa s’intende per indulgenza di quaranta o cento giorni, ovvero di sette anni, e simili?
+
+*Per indulgenza di quaranta o cento giorni ovvero di sette anni e simili, s’intende la remissione di tanta pena temporale, quanta se ne sconterebbe con quaranta o cento giorni ovvero sette anni della penitenza anticamente stabilita dalla Chiesa.*
+
+**133.** Che conto dobbiamo fare delle indulgenze?
+
+*Delle indulgenze dobbiamo fare grandissimo conto, perchè con esse si soddisfa alla giustizia di Dio e più presto e più facilmente si ottiene il possesso del cielo.*
+
+**134.** Che cosa si ricerca per acquistare le indulgenze?
+
+*Per acquistare le indulgenze si ricerca: 1.º lo stato di grazia (almeno nell’ultima opera che si compie) e la mondezza anche da quelle colpe veniali, di cui vuolsi cancellare la pena; 2.º l’adempimento delle opere che la Chiesa prescrive per acquistare l’indulgenza; 3.º l’intenzione di acquistarla.*
+
+**135.** Le indulgenze possono applicarsi anche alle anime del purgatorio?
+
+*Sì, le indulgenze possono applicarsi anche alle anime del purgatorio, quando chi le accorda dichiari che si possono ad esse applicare.*
+
+**136.** Che cosa è il Giubileo?
+
+*Il Giubileo, che ordinariamente si concede ogni venticinque anni, è un’indulgenza plenaria a cui sono annessi molti privilegi e particolari concessioni, come di poter ottenere l’assoluzione di alcuni peccati riservati e delle censure, e la commutazione di alcuni voti.*

--- a/content/books/pius-x-greater-catechism/it/parte-quarta-capo-vii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quarta-capo-vii.md
@@ -1,0 +1,25 @@
+# Capo VII — Dell’Estrema Unzione
+
+**1.** Che cosa è il sacramento dell’Estrema Unzione detto pure Olio Santo?
+
+*L’Estrema Unzione detta pure Olio Santo, è il sacramento istituito per sollievo spirituale ed anche temporale degli infermi, in pericolo di morte.*
+
+**2.** Quali effetti produce il sacramento dell’Estrema Unzione?
+
+*Il sacramento dell’Estrema Unzione produce i seguenti effetti: 1.º accresce la grazia santificante; 2.º cancella i peccati veniali, e anche i mortali che l’infermo pentito non potesse più confessare; 3.º toglie quella debolezza e languidezza pel bene, la quale rimane anche dopo di aver ottenuto il perdono dei peccati; 4.º dà la forza di sopportare pazientemente il male, di resistere alle tentazioni e di morire santamente; 5.º aiuta a ricuperare la sanità del corpo, se sia utile alla salute dell’anima.*
+
+**3.** In qual tempo si deve ricevere l’Olio Santo?
+
+*L’Olio Santo si deve ricevere quando la malattia è pericolosa, e dopo che l’infermo ha ricevuto, se può, i sacramenti della Penitenza e dell’Eucaristia; anzi è bene riceverlo quando si è ancora sano di mente e con qualche speranza di vita.*
+
+**4.** Perchè è bene ricevere l’Olio Santo, quando si è ancora di mente sana e con qualche speranza di vita?
+
+*È bene ricevere l’Olio Santo, quando si è ancora di mente sana e con qualche speranza di vita, perchè ricevendolo con miglior disposizione si può riceverne maggior frutto, e ancora perchè, dando questo sacramento la sanità del corpo, se è espediente all’anima, con aiutare le forze della natura, non si deve aspettare che la salute sia disperata.*
+
+**5.** Con quali disposizioni si deve ricevere l’Olio Santo?
+
+*Le principali disposizioni per ricevere l’Olio Santo sono: essere in grazia di Dio, confidare nella virtù del sacramento e nella divina misericordia, e rassegnarsi alla volontà del Signore.*
+
+**6.** Quali sentimenti deve provare l’infermo alla vista del sacerdote?
+
+*Alla vista del sacerdote l’infermo deve provare sentimento di gratitudine a Dio per averglielo mandato, deve ricevere volentieri e chiedere, se può da sè stesso, i conforti della religione.*

--- a/content/books/pius-x-greater-catechism/it/parte-quarta-capo-viii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quarta-capo-viii.md
@@ -1,0 +1,71 @@
+# Capo VIII — Dell’Ordine Sacro
+
+**1.** Che cosa è il sacramento dell’Ordine Sacro?
+
+*L’Ordine Sacro è il sacramento che dà la potestà di esercitare i sacri ministeri che riguardano il culto di Dio e la salute delle anime, e che imprime nell’anima di chi lo riceve il carattere di ministro di Dio.*
+
+**2.** Perchè si chiama Ordine?
+
+*Si chiama Ordine perchè consiste in vari gradi, l’uno subordinato all’altro, dai quali risulta la sacra Gerarchia.*
+
+**3.** Quali sono questi gradi?
+
+*Supremo tra essi è l’ Episcopato, che con tiene la pienezza del sacerdozio; quindi il Presbiterato o Sacerdozio semplice; poi il Diaconato, e gli Ordini che diconsi minori.*
+
+**4.** Ha Gesù Cristo istituito immediatamente tutti i gradi dell’Ordine Sacro?
+
+*Gesù Cristo ha istituito immediatamente i due gradi superiori dell’Ordine Sacro, che sono l’ Episcopato e il Sacerdozio semplice; per mezzo degli Apostoli poi istituì il Diaconato, dal quale derivano gli altri Ordini inferiori.*
+
+**5.** Quando Gesù Cristo ha istituito l’Ordine Sacerdotale?
+
+*Gesù Cristo ha istituito l’Ordine Sacerdotale nell’ultima Cena, quando conferì agli Apostoli e ai loro successori la potestà di consa crare la SSm̃a Eucaristia. Il giorno poi della sua resurrezione conferì ai medesimi il potere di rimettere e di ritenere i peccati, costituendoli così i primi sacerdoti della nuova legge in tutta la pienezza della loro potestả.*
+
+**6.** Chi è il ministro di questo sacramento?
+
+*Il ministro di questo sacramento è il solo Vescovo.*
+
+**7.** È dunque grande la dignità del Sacerdozio cristiano?
+
+*La dignità del Sacerdozio cristiano è grandissima per la doppia potestà che ad esso ha conferito Gesù Cristo sul suo Corpo reale e sul suo Corpo mistico, che è la Chiesa; e per la divina missione affidata ai sacerdoti di condurre tutti gli uomini alla vita eterna.*
+
+**8.** Il Sacerdozio cattolico è necessario nella Chiesa?
+
+*Il Sacerdozio cattolico è necessario nella Chiesa; perchè senza di esso i fedeli sarebbero privi del santo sacrificio della Messa e della maggior parte dei sacramenti, non avrebbero chi li ammaestrasse nella fede, e resterebbero come pecore senza pastore in balia dei lupi, a dir breve non esisterebbe più la Chiesa come Gesù Cristo l’ha istituita.*
+
+**9.** Dunque il Sacerdozio cattolico non cesserà mai sulla terra?
+
+*Il Sacerdozio cattolico, non ostante la guerra che gli muove contro l’inferno, durerà fino alla fine dei secoli; avendo Gesù Cristo promesso che le potestà dell’inferno non prevarranno giammai contro la sua Chiesa.*
+
+**10.** È peccato disprezzare i sacerdoti?
+
+*È peccato gravissimo, perchè il disprezzo e le ingiurie che si rivolgono contro i sacerdoti, ricadono sopra Gesù Cristo stesso, il quale ha detto ai suoi Apostoli: chi disprezza voi, disprezza me.*
+
+**11.** Quale deve essere il fine di chi abbraccia lo stato ecclesiastico?
+
+*Il fine di chi abbraccia lo stato ecclesiastico deve essere unicamente la gloria di Dio e la salute delle anime.*
+
+**12.** Che cosa è necessario per entrare nello stato ecclesiastico?
+
+*Per entrare nello stato ecclesiastico è necessaria, prima di tutto, la vocazione divina.*
+
+**13.** Che cosa si deve fare per conoscere se Dio chiama allo stato ecclesiastico?
+
+*Per conoscere se Dio chiama allo stato ecclesiastico si deve: 1.º pregare con fervore il Signore che manifesti qual’è la sua volontà; 2.º prendere consiglio dal proprio Vescovo o da un savio e prudente direttore; 3.º esaminare con diligenza se si abbia l’abilità necessaria agli studi, ai ministeri, ed agli obblighi di questo stato.*
+
+**14.** Chi entrasse nello stato ecclesiastico senza vocazione divina farebbe male?
+
+*Chi entrasse nello stato ecclesiastico senza vocazione divina farebbe un grave male e si metterebbe in pericolo di perdizione.*
+
+**15.** Fanno male i genitori che per motivi temporali inducono i figliuoli ad abbracciare senza vocazione lo stato ecclesiastico?
+
+*I genitori che per motivi temporali, inducono i figliuoli ad abbracciare senza vocazione lo stato ecclesiastico, commettono essi pure gravissima colpa, perchè con ciò usurpano il diritto che Dio ha riservato a sè solo di scegliere i suoi ministri, e mettono i figliuoli in pericolo di eterna dannazione.*
+
+**16.** Quali sono i doveri dei fedeli verso coloro che sono chiamati agli Ordini sacri?
+
+*I fedeli devono:*
+
+*1.º lasciare ai loro figliuoli e dipendenti piena libertà di seguire la vocazione di Dio;*
+
+*2.º pregar Iddio che si degni di concedere alla sua Chiesa buoni pastori e zelanti ministri, essendo anche a tal fine istituiti i digiuni delle quattro tempora;*
+
+*3.º avere un singolare rispetto verso tutti quelli che sono, per mezzo degli Ordini, consacrati al servizio di Dio.*

--- a/content/books/pius-x-greater-catechism/it/parte-quinta-capo-i.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quinta-capo-i.md
@@ -1,0 +1,261 @@
+# Capo I — Delle virtù principali
+
+## § 1. Delle virtù teologali
+
+**1.** Che cosa è la virtù?
+
+*La virtù è una qualità dell’anima, per la quale si ha propensione, facilità e prontezza a conoscere ed operare il bene.*
+
+**2.** Quante sono le principali virtù soprannaturali?
+
+*Le principali virtù soprannaturali sono sette: cioè tre teologali e quattro cardinali.*
+
+**3.** Quali sono le virtù teologali?
+
+*Le virtù teologali sono: la Fede, la Speranza e la Carità.*
+
+**4.** Perchè la Fede, la Speranza e la Carità si chiamano virtù teologali?
+
+*La Fede, la Speranza e la Carità si chiamano virtù teologali, perchè hanno Dio per oggetto immediato e principale, e ci sono infuse da Lui.*
+
+**5.** In qual modo le virtù teologali hanno Dio per oggetto immediato?
+
+*Le virtù teologali hanno Dio per oggetto immediato, perchè con la Fede noi crediamo in Dio, e crediamo tutto ciò che Egli ha rivelato; con la Speranza speriamo di possedere Dio; con la Carità amiamo Dio e in Lui amiamo noi stessi e il prossimo.*
+
+**6.** Quando è che Dio ci infonde nell’anima le virtù teologali?
+
+*Iddio per sua bontà ci infonde nell’anima le virtù teologali quando ci adorna della sua grazia santificante, e perciò quando ricevemmo il Battesimo fummo arricchiti di queste virtù, e con esse, dei doni dello Spirito Santo.*
+
+**7.** Basta per salvarsi, aver ricevuto nel Battesimo le virtù teologali?
+
+*Per chi ha l’uso della ragione, non basta aver ricevuto nel Battesimo le virtù teologali; ma è necessario farne spesso gli atti.*
+
+**8.** Quando siamo obbligati di fare gli atti di Fede, di Speranza e di Carità?
+
+*Siamo obbligati di fare gli atti di Fede, di Speranza e di Carità: 1.º giunti all’uso della ragione: 2.º spesse volte nel decorso della vita; 3.º in pericolo di morte.*
+
+## § 2. Della Fede
+
+**9.** Che cosa è la Fede?
+
+*La Fede è una virtù soprannaturale, infusa da Dio nell’anima nostra, per la quale noi, appoggiati all’autorità di Dio stesso, crediamo esser vero tutto quello che Egli ha rivelato, e che per mezzo della Chiesa ci propone a credere.*
+
+**10.** In quale maniera sappiamo noi le verità rivelate da Dio?
+
+*Noi sappiamo le verità rivelate da Dio per mezzo della santa Chiesa che è infallibile; cioè, per mezzo del Papa, successore di san Pietro e per mezzo dei Vescovi successori degli Apostoli, i quali furono ammaestrati da Gesù Cristo medesimo.*
+
+**11.** Siamo noi sicuri di quelle cose che la santa Chiesa c’insegna?
+
+*Di quelle cose che la santa Chiesa c’insegna, noi siamo sicurissimi, perchè Gesù Cristo ha impegnato la sua parola, che la Chiesa non si sarebbe mai ingannata.*
+
+**12.** Con qual peccato si perde la Fede?
+
+*La Fede si perde con negare o dubitare volontariamente anche di un solo articolo propostoci a credere.*
+
+**13.** Come si riacquista la Fede perduta?
+
+*La Fede perduta si riacquista con pentirsi del peccato commesso e con credere di nuovo tutto quello che crede la santa Chiesa.*
+
+## § 3. Dei misteri
+
+**14.** Possiamo noi capire tutte le verità della Fede?
+
+*No, noi non possiamo capire tutte le verità della Fede, perchè alcune di queste verità sono misteri.*
+
+**15.** Che cosa sono i misteri?
+
+*I misteri sono verità superiori alla ragione, che noi dobbiamo credere quantunque non le possiamo comprendere.*
+
+**16.** Perchè dobbiamo credere i misteri?
+
+*Dobbiamo credere i misteri, perchè li ha rivelati Iddio, il quale essendo Verità e Bontà infinita, non può nè ingannarsi nè ingannare.*
+
+**17.** I misteri sono essi contrari alla ragione?
+
+*I misteri sono superiori, ma non contrari alla ragione; è anzi la stessa ragione che ci persuade ad ammettere i misteri.*
+
+**18.** Perchè i misteri non possono essere contrari alla ragione?
+
+*I misteri non possono essere contrari alla ragione, perchè è lo stesso Dio che ci ha dato il lume della ragione e rivelato i misteri, nè Egli può contraddire a se stesso.*
+
+## § 4. Della Sacra Scrittura
+
+**19.** Dove si contengono le verità che Dio ha rivelato?
+
+*Le verità che Dio ha rivelato si con tengono nella Sacra Scrittura e nella Tradizione.*
+
+**20.** Che cosa è la Sacra Scrittura?
+
+*La Sacra Scrittura è la collezione dei libri scritti dai Profeti ed Agiografi, dagli Apostoli, e dagli Evangelisti per ispirazione dello Spirito Santo, e ricevuti dalla Chiesa come ispirati.*
+
+**21.** In quante parti si divide la Sacra Scrittura?
+
+*La Sacra Scrittura si divide in due parti: nell’antico e nel nuovo Testamento.*
+
+**22.** Che cosa contiene l’antico Testamento?
+
+*L’antico Testamento contiene i libri ispirati, scritti innanzi alla venuta di Gesù Cristo.*
+
+**23.** Che cosa contiene il nuovo Testamento?
+
+*Il nuovo Testamento contiene i libri ispirati, scritti dopo la venuta di Gesù Cristo.*
+
+**24.** Con qual nome si chiama comunemente la Sacra Scrittura?
+
+*La Sacra Scrittura chiamasi comunemente col nome di Sacra Bibbia.*
+
+**25.** Che cosa vuol dire la parola Bibbia?
+
+*La parola Bibbia vuol dire la collezione dei libri santi, il libro per eccellenza, il libro dei libri, il libro ispirato da Dio.*
+
+**26.** Perchè la Sacra Scrittura dicesi il libro per eccellenza?
+
+*La Sacra Scrittura dicesi il libro per eccellenza, a motivo dell’eccellenza della materia di cui tratta e dell’Autore della medesima.*
+
+**27.** Non vi può essere errore nella Sacra Scrittura?
+
+*Nella Sacra Scrittura non vi può essere errore alcuno, perchè, essendo tutta ispirata, autore di tutte le sue parti è Dio medesimo. Ciò non toglie che nelle copie e traduzioni della stessa possa essere occorso qualche sbaglio o dei copisti o dei traduttori. Però nelle edizioni rivedute ed approvate dalla Chiesa cattolica non vi può essere errore in ciò che riguarda la fede o la morale.*
+
+**28.** È necessaria a tutti i cristiani la lettura della Bibbia?
+
+*La lettura della Bibbia non è necessaria a tutti i cristiani, ammaestrati come sono dalla Chiesa, ma però è molto utile e raccomandata a tutti.*
+
+**29.** Si può leggere qualunque traduzione volgare della Bibbia?
+
+*Si possono leggere quelle traduzioni volgari della Bibbia, che sono riconosciute fedeli dalla Chiesa cattolica, e sono accompagnate da spiegazioni approvate dalla Chiesa medesima.*
+
+**30.** Perchè si possono leggere le sole traduzioni della Bibbia, che sono approvate dalla Chiesa?
+
+*Si possono leggere le sole traduzioni della Bibbia che sono approvate dalla Chiesa, perchè essa sola è legittima custode della Bibbia.*
+
+**31.** Per mezzo di chi possiamo noi conoscere il vero senso delle Sacre Scritture?
+
+*Il vero senso delle Sacre Scritture noi possiamo conoscerlo solo per mezzo della Chiesa, perchè solo la Chiesa non può errare nell’interpretarle.*
+
+**32.** Che dovrebbe fare il cristiano se gli venisse offerta la Bibbia da un protestante o da qualche emissario dei protestanti?
+
+*Se ad un cristiano venisse offerta la Bibbia da un protestante, o da qualche emissario dei protestanti, egli dovrebbe rigettarla con orrore, perchè proibita dalla Chiesa; che se l’avesse ricevuta senza badarvi, dovrebbe tosto gettarla alle fiamme, o consegnarla al proprio parroco.*
+
+**33.** Perchè la Chiesa proibisce le Bibbie protestanti?
+
+*La Chiesa proibisce la Bibbie protestanti perchè o sono alterate e contengono errori, oppure, mancando della sua approvazione e delle note dichiarative dei sensi oscuri, possono nuocere alla Fede. Per questo, la Chiesa proibisce eziandio le traduzioni della Sacra Scrittura già approvate da essa, ma ristampate senza le spiegazioni dalla medesima approvate.*
+
+## § 5. Della Tradizione
+
+**34.** Ditemi: che cosa è la Tradizione?
+
+*La Tradizione e la parola di Dio non scritta, ma comunicata a viva voce da Gesù Cristo e dagli Apostoli, e giunta inalterata, di secolo in secolo per mezzo della Chiesa fino a noi.*
+
+**35.** Dove si contengono gl’insegnamenti della Tradizione?
+
+*Gl’insegnamenti della Tradizione si contengono principalmente nei decreti dei Concilî, negli scritti dei santi Padri, negli atti della Santa Sede, nelle parole e negli usi della sacra Liturgia.*
+
+**36.** In qual conto si deve tenere la Tradizione?
+
+*La Tradizione si deve tenere in quel medesimo conto in che si tiene la parola di Dio rivelata, contenuta nella Sacra Scrittura.*
+
+## § 6. Della Speranza
+
+**37.** Che cosa è la Speranza?
+
+*La Speranza è una virtù soprannaturale, infusa da Dio nell’anima nostra, per la quale desideriamo ed aspettiamo la vita eterna che Dio ha promesso ai suoi servi, e gli aiuti necessari per ottenerla.*
+
+**38.** Per qual motivo dobbiamo noi sperare da Dio il paradiso e gli aiuti necessari per con seguirlo?
+
+*Noi dobbiamo sperare da Dio il paradiso e gli aiuti necessari per conseguirlo, perchè Dio misericordiosissimo, pei meriti di N. S. Gesù Cristo, lo ha promesso a chi lo serve di cuore; ed essendo fedelissimo ed onnipotente, mantiene sempre la sua promessa.*
+
+**39.** Quali sono le condizioni necessarie per ottenere il paradiso?
+
+*Le condizioni necessarie per ottenere il paradiso, sono la grazia di Dio, l’esercizio delle buone opere e la perseveranza nel santo amore di Lui fino alla morte.*
+
+**40.** Come si perde la Speranza?
+
+*Si perde la Speranza ogni qual volta si perde la Fede: si perde ancora per il peccato di disperazione o di presunzione.*
+
+**41.** Come si riacquista la Speranza perduta?
+
+*La Speranza perduta si riacquista con pentirsi del peccato commesso, eccitando di nuovo la fiducia nella bontà divina.*
+
+## § 7. Della Carità
+
+**42.** Che cosa è la Carità?
+
+*La Carità è una virtù soprannaturale, infusa da Dio nell’anima nostra, per la quale amiamo Dio per se stesso sopra ogni cosa, e il prossimo come noi stessi per amor di Dio.*
+
+**43.** Per quali motivi dobbiamo noi amare Dio?
+
+*Noi dobbiamo amare Iddio perchè Egli è il sommo bene, infinitamente buono e perfetto; e inoltre per il comando che Egli ce ne fa, e per i tanti beneficî che da Lui riceviamo.*
+
+**44.** Come si deve amare Iddio?
+
+*Dio si deve amare sopra tutte le cose, con tutto il cuore, con tutta la mente, con tutta l’anima e con tutte le forze.*
+
+**45.** Che vuol dire amare Iddio sopra tutte le cose?
+
+*Amare Iddio sopra tutte le cose vuol dire preferirlo a tutte le creature più care e più perfette, ed essere disposti a perdere tutto piuttosto che offenderlo e cessare di amarlo.*
+
+**46.** Che vuol dire amare Iddio con tutto il cuore?
+
+*Amare Iddio con tutto il cuore vuol dire consacrare a Lui tutti i nostri affetti.*
+
+**47.** Che vuol dire amare Iddio con tutta la mente?
+
+*Amare Iddio con tutta la mente vuol dire indirizzare a Lui tutti i nostri pensieri.*
+
+**48.** Che vuol dire amare Iddio con tutta l’anima?
+
+*Amare Iddio con tutta l’anima vuol dire consacrare a Lui l’uso di tutte le potenze dell’anima nostra.*
+
+**49.** Che vuol dire amare Iddio con tutte le nostre forze?
+
+*Amare Iddio con tutte le nostre forze vuol dire procurare di crescere sempre più nell’amore di Lui e fare in modo che tutte le nostre azioni abbiano per motivo e per fine l’amore di Lui, ed il desiderio di piacergli.*
+
+**50.** Perchè dobbiamo noi amare il prossimo?
+
+*Noi dobbiamo amare il prossimo per amor di Dio, perchè Egli ce lo comanda, e perchè ogni uomo è immagine di Lui.*
+
+**51.** Siamo obbligati ad amare anche i nemici?
+
+*Sì, siamo obbligati ad amare anche i nemici, perchè sono anch’essi nostro prossimo, e perchè Gesù Cristo ce ne ha fatto un espresso comando.*
+
+**52.** Che vuol dire amare il prossimo come se stesso?
+
+*Amare il prossimo come se stesso vuol dire desiderargli e fargli, per quanto si può, quel bene che dobbiamo desiderare a noi stessi, e non desiderargli nè fargli alcun male.*
+
+**53.** Quando è che noi amiamo noi stessi come si deve?
+
+*Noi amiamo noi stessi come si deve, quando cerchiamo di servir Dio e mettere in Lui ogni nostra felicità.*
+
+**54.** Come si perde la Carità?
+
+*La Carità si perde con qualunque peccato mortale.*
+
+**55.** Come si riacquista la Carità?
+
+*La Carità si riacquista facendo atti di amor di Dio, pentendosi e confessandosi come si deve.*
+
+## § 8. Delle virtù cardinali
+
+**56.** Quali sono le virtù cardinali?
+
+*Le virtù cardinali sono la Prudenza, la Giustizia, la Fortezza e la Temperanza.*
+
+**57.** Perchè la Prudenza, la Giustizia, la Fortezza, e la Temperanza si chiamano virtù cardinali?
+
+*La Prudenza, la Giustizia, la Fortezza, e la Temperanza si chiamano virtù cardinali, perchè sono il cardine, e il fondamento delle virtù morali.*
+
+**58.** Che cosa è la Prudenza?
+
+*La Prudenza e la virtù che dirige ogni azione al debito fine, e però cerca i mezzi convenienti affinchè l’opera riesca in tutto ben fatta, e quindi accetta al Signore.*
+
+**59.** Che cosa è la Giustizia?
+
+*La Giustizia è la virtù per cui diamo a ciascuno quello che gli si deve.*
+
+**60.** Che cosa è la Fortezza?
+
+*La Fortezza è la virtù che ci rende coraggiosi a non temere alcun pericolo, neppure l’istessa morte, per servizio di Dio.*
+
+**61.** Che cosa è la Temperanza?
+
+*La Temperanza è la virtù per la quale raffreniamo i desideri disordinati dei piaceri sensibili, e usiamo con moderazione dei beni temporali.*

--- a/content/books/pius-x-greater-catechism/it/parte-quinta-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quinta-capo-ii.md
@@ -1,0 +1,37 @@
+# Capo II — Dei doni dello Spirito Santo
+
+**1.** Quanti e quali sono i doni dello Spirito Santo?
+
+*I doni dello Spirito Santo sono sette: 1.º il dono della Sapienza; 2.º dell’Intelletto; 3.º del Consiglio; 4.º della Fortezza; 5.º della Scienza; 6.º della Pietà; 7.º del Timor di Dio.*
+
+**2.** A che servono i doni dello Spirito Santo?
+
+*I doni dello Spirito Santo servono a stabilirci nella Fede, nella Speranza e nella Carità; e a renderci pronti agli atti delle virtù necessarie per conseguire la perfezione della vita cristiana.*
+
+**3.** Che cosa è la Sapienza?
+
+*La Sapienza è un dono col quale noi alzando la mente da queste cose terrene e fragili, contempliamo le eterne, cioè l’eterna Verità che è Dio, gustando ed amando Lui, nel quale consiste ogni nostro bene.*
+
+**4.** Che cosa è l’Intelletto?
+
+*L’Intelletto è un dono col quale ci viene facilitata, per quanto si può da uomo mortale, l’intelligenza delle verità della Fede e dei divini misteri, i quali col lume naturale dell’intelletto nostro non possiamo conoscere.*
+
+**5.** Che cosa è il Consiglio?
+
+*Il Consiglio è un dono col quale nei dubbi ed incertezze dell’umana vita conosciamo ciò che torna più alla gloria di Dio, alla salute nostra e del prossimo.*
+
+**6.** Che cosa è la Fortezza?
+
+*La Fortezza è un dono che c’inspira valore e coraggio per osservare fedelmente la santa legge di Dio e della Chiesa, superando tutti gli ostacoli e gli assalti dei nostri nemici.*
+
+**7.** Che cosa è la Scienza?
+
+*La Scienza è un dono col quale giudichiamo rettamente delle cose create, è conosciamo il modo di ben usarle e indirizzarle all’ultimo fine che è Dio.*
+
+**8.** Che cosa è la Pietà?
+
+*La Pietà è un dono col quale veneriamo ed amiamo Dio e i Santi, e conserviamo un animo pio e benevolo verso il prossimo per amor di Dio.*
+
+**9.** Che cosa è il Timor di Dio?
+
+*Il Timor di Dio è un dono che ci fa riverire Dio e temere di offendere la sua divina Maestà, e ci distoglie dal male incitandoci al bene.*

--- a/content/books/pius-x-greater-catechism/it/parte-quinta-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quinta-capo-iii.md
@@ -1,0 +1,77 @@
+# Capo III — Delle Beatitudini evangeliche
+
+**1.** Quante e quali sono le Beatitudini evangeliche?
+
+*Le Beatitudini evangeliche sono otto:*
+
+*1.ª Beati i poveri di spirito, perchè di questi è il regno de’ cieli.*
+
+*2.ª Beati i mansueti, perchè questi possederanno la terra.*
+
+*3.ª Beati quelli che piangono, perchè saranno consolati.*
+
+*4.ª Beati quelli che hanno fame e sete della giustizia, perchè saranno saziati.*
+
+*5.ª Beati i misericordiosi, perchè troveranno misericordia.*
+
+*6.ª Beati i mondi di cuore, perchè vedranno Dio.*
+
+*7.ª Beati i pacifici, perchè saranno chiamati figli di Dio.*
+
+*8.ª Beati quelli che soffrono persecuzioni per amor della giustizia, perchè di essi è il regno de’ cieli.*
+
+**2.** Perchè Gesù Cristo ci ha proposto le Beatitudini?
+
+*Gesù Cristo ci ha proposto le Beatitudini per farci detestare le massime del mondo, e per invitarci ad amare e praticare le massime del suo Vangelo.*
+
+**3.** Chi sono quelli che il mondo chiama beati?
+
+*Il mondo chiama beati quelli che abbondano di ricchezze e di onori, che vivono allegramente, e che non hanno alcuna occasione di patire.*
+
+**4.** Chi sono i poveri di spirito, che Gesù Cristo chiama beati?
+
+*I poveri di spirito, secondo il Vangelo, sono quelli che hanno il cuore distaccato dalle ricchezze; ne fanno buon uso, se le posseggono; non le cercano con sollecitudine, se ne sono privi; ne soffrono con rassegnazione la perdita, se loro vengono tolte.*
+
+**5.** Chi sono i mansueti?
+
+*I mansueti sono quelli che trattano il prossimo con dolcezza, e ne soffrono con pazienza i difetti e i torti che da essi ricevono, senza querele, risentimenti o vendette.*
+
+**6.** Chi sono quelli che piangono, eppure sono detti beati?
+
+*Quelli che piangono, eppure sono detti beati, sono coloro che soffrono rassegnati le tribolazioni, e che si affliggono per i peccati commessi, pei mali e per gli scandali che si vedono nel mondo, per la lontananza dal paradiso e pel pericolo di perderlo.*
+
+**7.** Chi sono quelli che hanno fame e sete della giustizia?
+
+*Quelli che hanno fame e sete della giustizia sono coloro che desiderano ardentemente di crescere sempre più nella divina grazia e nell’esercizio delle opere buone e virtuose.*
+
+**8.** Chi sono i misericordiosi?
+
+*I misericordiosi, sono quelli che amano in Dio e per amor di Dio il loro prossimo, ne compassionano le miserie si spirituali, che corporali, e procurano di sollevarlo secondo le loro forze e il loro stato.*
+
+**9.** Chi sono i mondi di cuore?
+
+*I mondi di cuore sono quelli che non hanno veruno affetto al peccato e ne stanno lontani, e schivano sopratutto ogni sorta d’impurità.*
+
+**10.** Chi sono i pacifici?
+
+*I pacifici sono quelli che conservano la pace col prossimo e con se stessi, e procurano di mettere la pace tra quelli che sono in discordia.*
+
+**11.** Chi sono quelli che soffrono persecuzione per amore della giustizia?
+
+*Quelli che soffrono persecuzione per amore della giustizia sono coloro che sopportano con pazienza le derisioni, i rimproveri e le persecuzioni per causa della fede e della legge di Gesù Cristo.*
+
+**12.** Che cosa significano i diversi premi promessi da Gesù Cristo nelle Beatitudini?
+
+*I diversi premi promessi da Gesù Cristo nelle Beatitudini significano tutti, sotto diversi nomi, la gloria eterna del cielo.*
+
+**13.** Le Beatitudini ci procurano solo l’eterna gloria del paradiso?
+
+*Le Beatitudini non ci procurano solo l’eterna gloria del paradiso, ma sono anche i mezzi per condurre una vita felice, per quanto è possibile, in questo mondo.*
+
+**14.** Coloro che seguono le Beatitudini, ne ricevono già qualche ricompensa in questa vita?
+
+*Sì, certamente, coloro che seguono le Beatitudini, ne ricevono già qualche ricompensa anche in questa vita, perchè già godono un’interna pace e contentezza, che è principio, benchè imperfetto, della eterna felicità.*
+
+**15.** Quelli che seguono le massime del mondo potranno dirsi felici?
+
+*No, quelli che seguono le massime del mondo, non sono felici, perchè non hanno la vera pace dell’anima, e corrono pericolo di dannarsi.*

--- a/content/books/pius-x-greater-catechism/it/parte-quinta-capo-iv.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quinta-capo-iv.md
@@ -1,0 +1,45 @@
+# Capo IV — Delle opere di misericordia
+
+**1.** Quali sono le opere buone delle quali ci sarà domandato conto particolare nel dì del Giudizio?
+
+*Le opere buone delle quali ci sarà domandato conto particolare nel dì del Giudizio sono le opere di misericordia.*
+
+**2.** Che cosa s’intende per opera di misericordia?
+
+*Opera di misericordia è quella con la quale si soccorre ai bisogni corporali o spirituali del nostro prossimo.*
+
+**3.** Quali sono le opere di misericordia corporali?
+
+*Le opere di misericordia corporali sono:*
+
+*1.ª Dar da mangiare agli affamati.*
+
+*2.ª Dar da bere agli assetati.*
+
+*3.ª Vestire gl’ignudi.*
+
+*4.ª Alloggiare i pellegrini.*
+
+*5.ª Visitare gli infermi.*
+
+*6.ª Visitare i carcerati.*
+
+*7.ª Seppellire i morti.*
+
+**4.** Quali sono le opere di misericordia spirituali?
+
+*Le opere di misericordia spirituali sono:*
+
+*1.ª Consigliare i dubbiosi.*
+
+*2.ª Istruire gli ignoranti.*
+
+*3.ª Ammonire i peccatori.*
+
+*4.ª Consolare gli afflitti.*
+
+*5.ª Perdonare le offese.*
+
+*6.ª Sopportare pazientemente le persone moleste.*
+
+*7.ª Pregare Dio per i vivi e per i morti.*

--- a/content/books/pius-x-greater-catechism/it/parte-quinta-capo-v.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quinta-capo-v.md
@@ -1,0 +1,57 @@
+# Capo V — Dei peccati e delle loro specie principali
+
+**1.** Quante sorta di peccati vi sono?
+
+*Vi sono due sorta di peccati: il peccato originale ed il peccato attuale.*
+
+**2.** Qual’è il peccato originale?
+
+*Il peccato originale è quello col quale tutti nasciamo, e che abbiamo contratto per la disubbidienza del nostro primo padre Adamo.*
+
+**3.** Quali danni ci ha cagionati il peccato di Adamo?
+
+*I danni del peccato di Adamo sono: la privazione della grazia, la perdita del paradiso, l’ignoranza, l’inclinazione al male, la morte e tutte le altre miserie.*
+
+**4.** Come si cancella il peccato originale?
+
+*Il peccato originale si cancella col santo Battesimo.*
+
+**5.** Qual’è il peccato attuale?
+
+*Il peccato attuale è quello che l’uomo, arrivato all’uso della ragione, commette con la sua libera volontà.*
+
+**6.** Quante sorta di peccato attuale vi sono?
+
+*Vi sono due sorta di peccato attuale: il mortale ed il veniale.*
+
+**7.** Qual’è il peccato mortale?
+
+*Il peccato mortale è una trasgressione della divina legge, per la quale si manca gravemente ai doveri verso Dio, verso il prossimo, verso noi stessi.*
+
+**8.** Perchè si dice mortale?
+
+*Si dice mortale perchè dà morte all’anima, col far perdere la grazia santificante, che è la vita dell’anima, come l’anima è la vita dal corpo.*
+
+**9.** Quali danni fa all’anima il peccato mortale?
+
+*1.º Il peccato mortale priva l’anima della grazia e dell’amicizia di Dio; 2.º le fa perdere il paradiso; 3.º la priva dei meriti acquistati, e la rende incapace di acquistarne dei nuovi; 4.º la fa schiava del demonio; 5.º le fa meritare l’inferno, ed anche i castighi di questa vita.*
+
+**10.** Oltre la gravità della materia che cosa si richiede per costituire un peccato mortale?
+
+*Oltre la gravità della materia per costituire un peccato mortale si richiede la piena avvertenza di tale gravità e la deliberata volontà di commettere il peccato.*
+
+**11.** Qual è il peccato veniale?
+
+*Il peccato veniale è una lieve trasgressione della divina legge, per la quale si manca solo leggermente a qualche dovere verso Dio, verso il prossimo e verso noi stessi.*
+
+**12.** Perchè si chiama veniale?
+
+*Perchè è leggiero rispetto al peccato mortale, non ci fa perdere la divina grazia; e perchè Dio più facilmente lo perdona.*
+
+**13.** Dunque non è da fare gran caso del peccato veniale?
+
+*Ciò sarebbe un inganno grandissimo, sia perchè il peccato veniale contiene sempre una qualche offesa di Dio, sia perchè reca danni non piccoli all’anima.*
+
+**14.** Quali danni reca il peccato veniale?
+
+*Il peccato veniale: 1.º indebolisce e raffredda in noi la carità; 2.º ci dispone al peccato mortale; 3.º ci rende meritevoli di grandi pene temporali in questo mondo o nell’altro.*

--- a/content/books/pius-x-greater-catechism/it/parte-quinta-capo-vi.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quinta-capo-vi.md
@@ -1,0 +1,37 @@
+# Capo VI — Dei vizi capitali e di altri peccati più gravi
+
+**1.** Che cosa è il vizio?
+
+*Il vizio è una cattiva disposizione dell’animo a fuggire il bene e a fare il male, causata dal frequente ripetersi degli atti cattivi.*
+
+**2.** Che differenza v’è tra peccato e vizio?
+
+*Tra peccato e vizio v’è questa differenza, che il peccato è un atto che passa, mentre il vizio è la cattiva abitudine contratta di cadere in qualche peccato.*
+
+**3.** Quali sono i vizi che si chiamano capitali?
+
+*I vizi che si chiamano capitali sono sette: 1.º Superbia; 2.º Avarizia; 3.º Lussuria; 4.º Ira; 5.º Gola; 6.º Invidia; 7.º Accidia.*
+
+**4.** I vizi capitali come si vincono?
+
+*I vizi capitali si vincono con l’esercizio delle virtù opposte. Così la superbia si vince con l’umiltà; l’avarizia con la liberalità; la lussuria con la castità; l’ira con la pazienza; la gola con l’astinenza; l’invidia con l’amor fraterno; l’accidia con la diligenza e col fervore nel servizio di Dio.*
+
+**5.** Perchè questi vizi si chiamano capitali?
+
+*Questi vizi si chiamano capitali, perchè sono la sorgente e la cagione di molti altri vizi e peccati.*
+
+**6.** Quanti sono i peccati contro lo Spirito Santo?
+
+*I peccati contro lo Spirito Santo sono sei: 1.º disperazione delle salute; 2.º presunzione di salvarsi senza merito; 3.º impugnare la verità conosciuta; 4.º invidia della altrui grazia; 5.º ostinazione nei peccati; 6.º impenitenza finale.*
+
+**7.** Perchè questi peccati si dicono in particolare contro lo Spirito Santo?
+
+*Questi peccati si dicono in particolare contro lo Spirito Santo, perchè si commettono per pura malizia, la quale è contraria alla bontà, che si attribuisce allo Spirito Santo.*
+
+**8.** Quali sono i peccati che si dicono gridare vendetta nel cospetto di Dio?
+
+*I peccati che diconsi gridar vendetta nel cospetto di Dio sono quattro: 1.º omicidio volontario; 2.º peccato impuro contro l’ordine della natura; 3.º oppressione dei poveri; 4.º fraudare la mercede agli operai.*
+
+**9.** Perchè si dice che questi peccati gridano vendetta al cospetto di Dio?
+
+*Questi peccati diconsi gridare vendetta al cospetto di Dio, perchè lo dice lo Spirito Santo e perchè la loro iniquità è così grave e manifesta che provoca Dio a punirli con più severi castighi.*

--- a/content/books/pius-x-greater-catechism/it/parte-quinta-capo-vii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quinta-capo-vii.md
@@ -1,0 +1,17 @@
+# Capo VII — Dei Novissimi e di altri mezzi principali per evitare il peccato
+
+**1.** Che cosa intendete per Novissimi?
+
+*Novissimi sono chiamate nei Libri santi le cose ultime che accadranno all’uomo.*
+
+**2.** Quanti sono i Novissimi, o cose ultime dell’uomo?
+
+*I Novissimi, o cose ultime dell’uomo, sono quattro: Morte, Giudizio, Inferno e Paradiso.*
+
+**3.** Perchè i Novissimi si dicono cose ultime dell’uomo?
+
+*I Novissimi si dicono cose ultime dell’uomo, perchè la Morte è l’ultima cosa che ci accade in questo mondo; il Giudizio di Dio è l’ultimo fra i giudizi che dobbiamo sostenere; l’Inferno è l’estremo male che avranno i cattivi; il Paradiso il sommo bene che avranno i buoni.*
+
+**4.** Quando dobbiamo noi pensare ai Novissimi?
+
+*È bene pensare ai Novissimi ogni giorno, e massimamente nel fare orazione alla mattina subito svegliati, alla sera prima di andare a riposo e tutte le volte che siamo tentati a far male, perchè questo pensiero è validissimo a farci evitare il peccato.*

--- a/content/books/pius-x-greater-catechism/it/parte-quinta-capo-viii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-quinta-capo-viii.md
@@ -1,0 +1,89 @@
+# Capo VIII — Degli esercizi divoti che si consigliano al cristiano per ogni giorno
+
+**1.** Che cosa deve fare un buon cristiano la mattina subito svegliato?
+
+*Un buon cristiano, la mattina appena svegliato, deve fare il segno della santa Croce ed offrire il cuore a Dio, dicendo queste o altre simili parole: Mio Dio, io vi dono il mio cuore e l’anima mia.*
+
+**2.** A che cosa si dovrebbe pensare levandosi dal letto e vestendosi?
+
+*Levandosi dal letto e vestendosi, si dovrebbe pensare che Dio è presente, che quel giorno può esser l’ultimo della nostra vita; e levarsi e vestirsi con ogni possibile modestia.*
+
+**3.** Levato e vestito, che cosa deve fare un buon cristiano?
+
+*Un buon cristiano, appena levato e vestito, deve mettersi alla presenza di Dio, e ing nocchiarsi, se può, innanzi a qualche divota immagine, dicendo con divozione: «Vi adoro, mio Dio, e vi amo con tutto il cuore; vi ringrazio di avermi creato, fatto cristiano e conservato in questa notte; vi offerisco tutte le mie azioni, e vi prego di preservarmi in questo giorno dal peccato, e di liberarmi da ogni male. Così sia». Reciti quindi il Pater Noster, l’ Ave Maria, il Credo e gli atti di Fede, di Speranza e di Carità, accompagnandoli con vivo affetto del cuore.*
+
+**4.** Quali pratiche di pietà dovrebbe ogni giorno compiere il cristiano?
+
+*Il cristiano, potendolo, dovrebbe ogni giorno: 1.º assistere con divozione alla santa Messa; 2.º fare una visita, anche brevissima, al SS. Sacramento; 3.º recitare la terza parte del santo Rosario.*
+
+**5.** Che cosa si deve fare prima di lavorare?
+
+*Prima di lavorare, si deve offrire il lavoro a Dio, dicendo di cuore: «Signore vi offerisco questo lavoro: datemi la vostra benedizione».*
+
+**6.** Per qual fine si deve lavorare?
+
+*Si deve lavorare per la gloria di Dio e per fare la sua volontà.*
+
+**7.** Che cosa convien fare prima di prender cibo?
+
+*Prima di prender cibo, stando in piedi, conviene fare il segno della santa Croce e poi dire con divozione: «Signore Iddio, date la vostra benedizione a noi e al cibo che ora prenderemo per mantenerci nel vostro servizio».*
+
+**8.** Avendo finito di prender cibo, che cosa convien fare?
+
+*Finito di prender cibo convien fare il segno della santa Croce, e dire; «Signore vi ringrazio del cibo che mi avete dato; fatemi degno di partecipare alla mensa celeste».*
+
+**9.** Quando uno si accorge di qualche tentazione che cosa dovrebbe fare?
+
+*Quando uno si accorge di qualche tentazione dovrebbe invocare con fede il SS. Nome di Gesù, o di Maria, o dire fervorosamente qualche giaculatoria, come p. e. «datemi grazia, o Signore, che non vi offenda giammai», oppure fare il segno della Croce; evitando però che da segni esterni si accorgano gli altri delle sue tentazioni.*
+
+**10.** Quando uno conosce o dubita d’aver commesso qualche peccato, che cosa deve fare?
+
+*Quando alcuno conosce o dubita d’aver peccato, deve fare subito un atto di contrizione, e procurare di confessarsene al più presto.*
+
+**11.** Quando, fuori di chiesa, si sente il segno dell’elevazione dell’ostia alla Messa solenne, o della benedizione del SS. Sacramento, che cosa si deve fare?
+
+*Si deve fare, almeno col cuore, un atto di adorazione dicendo p. e.: «Sia lodato e rin graziato ogni momento il santissimo e divinissimo Sacramento».*
+
+**12.** Che cosa si deve dire quando suona l’ Ave Maria, all’alba, al mezzodì e alla sera?
+
+*Al suono dell’ Ave Maria, il buon cristiano recita l’ Angelus Domini, con tre volte l’ Ave Maria.*
+
+**13.** La sera, prima di andare a riposo che cosa convien fare?
+
+*La sera prima del riposo, convien mettersi, come al mattino, alla presenza di Dio, recitare divotamente le stesse orazioni, fare un breve esame di coscienza e domandare perdono a Dio dei peccati commessi nella giornata.*
+
+**14.** Che cosa farete prima di addormentarvi?
+
+*Prima di addormentarmi farò il segno della santa Croce, penserò che posso morire in quella notte, e darò il cuore a Dio, dicendo: «Signore e Dio mio, io vi dono tutto il mio cuore; Santissima Trinità, datemi grazia di ben vivere e di ben morire; Gesù, Giuseppe e Maria, io raccomando a voi l’anima mia».*
+
+**15.** Oltre alle orazioni della mattina e della sera, in quale altra maniera si può ricorrere a Dio nel corso della giornata?
+
+*Nel corso della giornata si può pregare Iddio frequentemente con altre brevi orazioni che si chiamano giaculatorie.*
+
+**16.** Dite qualche giaculatoria.
+
+*Signore aiutatemi — Signore sia fatta la vostra santissima volontà — Gesù mio, io voglio essere tutto vostro — Gesù mio, misericordia — Dolce Cuor del mio Gesù, fa ch’io t’ami sempre più.*
+
+**17.** È utile dire durante il giorno molte giaculatorie?
+
+*È cosa utilissima dire durante il giorno molte orazioni giaculatorie, e si possono dire anche col cuore senza proferir parola, camminando, lavorando, ecc.*
+
+**18.** Oltre alle orazioni giaculatorie, in quale altra cosa si dovrebbe esercitare sovente il cristiano?
+
+*Oltrechè nelle orazioni giaculatorie il cristiano si dovrebbe esercitare nella cristiana mortificazione.*
+
+**19.** Che cosa vuol dire mortificarsi?
+
+*Mortificarsi, vuol dire lasciare, per amore di Dio, quello che piace, ed accettare quello che dispiace secondo i sensi, o l’amor proprio.*
+
+**20.** Quando si porta il Santissimo Sacramento ad un infermo, che cosa si deve fare?
+
+*Quando si porta il SSm̃o Sacramento a qualche infermo, si deve procurare, potendo, di accompagnarlo con modestia e raccoglimento; e se non si può, fare un atto di adorazione in qualunque luogo uno si trovi, e poi dire: «Consolate, o Signore, questo infermo, e dategli grazia di uniformarsi alla vostra santissima volontà e di conseguire la sua salute».*
+
+**21.** Sentendo suonare l’agonia di qualche moribondo, che cosa farete?
+
+*Sentendo suonare l’agonia di un mori bondo, mi porterò, potendo, alla Chiesa a pregare per lui, e non potendo, raccomanderò al Signore l’anima sua, pensando che fra breve tempo avrò da trovarmi io pure in questo stato.*
+
+**22.** Sentendo il segno della morte di qualcheduno, che cosa farete?
+
+*Sentendo il segno della morte di qualcheduno, procurerò di dire un De profundis o un Requiem per l’anima di quel defunto, e rinnoverò il pensiero della morte.*

--- a/content/books/pius-x-greater-catechism/it/parte-seconda-capo-i.md
+++ b/content/books/pius-x-greater-catechism/it/parte-seconda-capo-i.md
@@ -1,0 +1,105 @@
+# Capo I — Dell’orazione in generale
+
+**1.** Di che cosa si tratta nella seconda parte della Dottrina cristiana?
+
+*Nella seconda parte della Dottrina cristiana si tratta dell’orazione in generale e del Pater Noster in particolare.*
+
+**2.** Che cosa è l’orazione?
+
+*L’orazione e una elevazione della mente a Dio per adorarlo, per ringraziarlo, e per domandargli quello che ci abbisogna.*
+
+**3.** Come si distingue l’orazione?
+
+*L’orazione si distingue in mentale e vocale. L’orazione mentale è quella che si fa con la sola mente; l’orazione vocale è quella che si fa con le parole accompagnate dall’attenzione della mente e dalla divozione del cuore.*
+
+**4.** Si può distinguere in altro modo l’orazione?
+
+*L’orazione si può anche distinguere in privata e pubblica.*
+
+**5.** Qual’è l’orazione privata?
+
+*L’orazione privata è quella che ciascuno fa in particolare per sè o per altri.*
+
+**6.** Qual’è l’orazione pubblica?
+
+*L’orazione pubblica è quella che si fa dai sacri ministri, a nome della Chiesa, e per la salvezza del popolo fedele. Si può chiamar pubblica anche l’orazione fatta in comune e pubblicamente dai fedeli, come nelle processioni, nei pellegrinaggi e nel tempio.*
+
+**7.** Abbiamo noi speranza fondata di ottenere per mezzo della orazione, gli aiuti e le grazie di cui abbiamo bisogno?
+
+*La speranza di ottenere da Dio le grazie, di cui abbiamo bisogno, è fondata nelle promesse di Dio Onnipotente, misericordioso e fedelissimo, e nei meriti di Gesù Cristo.*
+
+**8.** In nome di chi dobbiamo domandare a Dio le grazie che ci sono necessarie?
+
+*Noi dobbiamo domandare a Dio le grazie che ci sono necessarie in nome di Gesù Cristo, come Egli medesimo ci ha insegnato e come pratica la Chiesa la quale termina sempre le sue preghiere con queste parole: per Dominum nostrum Iesum Christum, cioè: per il nostro Signore Gesù Cristo.*
+
+**9.** Perchè dobbiamo domandare a Dio le grazie in nome di Gesù Cristo?
+
+*Noi dobbiamo domandare le grazie in nome di Gesù Cristo, perchè essendo Egli il nostro mediatore, solo per mezzo di lui noi possiamo avvicinarci al trono di Dio.*
+
+**10.** Se l’orazione ha tanta virtù, che vuol dire che molte volte non sono esaudite le nostre preghiere?
+
+*Molte volte le nostre preghiere non sono esaudite, o perchè domandiamo cose che non convengono alla nostra eterna salute, o perchè non preghiamo come si deve.*
+
+**11.** Quali sono le cose che dobbiamo principalmente domandare a Dio?
+
+*Dobbiamo principalmente domandare a Dio la sua gloria, la nostra eterna salute e i mezzi per conseguirla.*
+
+**12.** Non è lecito il domandare anche beni temporali?
+
+*Sì, è lecito domandare a Dio anche i beni temporali, ma sempre con la condizione che siano conformi alla sua santissima volontà, e non siano d’impedimento alla nostra eterna salute.*
+
+**13.** Se Iddio sa tutto ciò che ci è necessario, perchè si deve pregare?
+
+*Sebbene Iddio sappia tutto ciò che ci è necessario, pure vuole che noi lo preghiamo, per riconoscerlo come datore d’ogni bene, per attestargli la nostra umile sommissione e per meritarci i suoi favori.*
+
+**14.** Qual’è la prima e migliore disposizione per rendere efficaci le nostre preghiere?
+
+*La prima e miglior disposizione per ren dere efficaci le nostre preghiere è di essere in istato di grazia, o non essendovi, almeno desiderare di rimettersi in tale stato.*
+
+**15.** Quali altre disposizioni si richiedono per ben pregare?
+
+*Per ben pregare si richiedono specialmente il raccoglimento, l’umiltà, la fiducia, la perseveranza e la rassegnazione.*
+
+**16.** Che vuol dire pregare con raccoglimento?
+
+*Vuol dire pensare che parliamo con Dio, e perciò dobbiamo pregare con tutto il rispetto e la divozione, evitando per quanto è possibile le distrazioni, cioè ogni pensiero estraneo all’orazione.*
+
+**17.** Le distrazioni diminuiscono il merito dell’orazione?
+
+*Sì, quando noi stessi le procuriamo, ovvero non le respingiamo con diligenza. Se poi facciamo quanto è possibile per essere raccolti in Dio, allora le distrazioni non diminuiscono il merito della nostra orazione, ma anzi lo possono accrescere.*
+
+**18.** Che cosa si richiede per fare orazione con raccoglimento?
+
+*Dobbiamo prima della preghiera allontanare tutte le occasioni di distrazione, e dobbiamo durante la preghiera pensare che siamo alla presenza di Dio il quale ci vede e ci ascolta.*
+
+**19.** Che vuol dire pregare con umiltà?
+
+*Vuol dire riconoscere sinceramente la propria indegnità, impotenza e miseria, accom pagnando la preghiera con la compostezza del corpo.*
+
+**20.** Che vuol dire pregare con fiducia?
+
+*Vuol dire che dobbiamo avere ferma speranza di essere esauditi, se da ciò deriva la gloria di Dio ed il nostro vero bene.*
+
+**21.** Che vuol dire pregare con perseveranza?
+
+*Vuol dire che non dobbiamo stancarci di pregare, se Iddio subito non ci esaudisce, ma che dobbiamo seguitare anzi a pregare con più fervore.*
+
+**22.** Che vuol dire pregare con rassegnazione?
+
+*Vuol dire che dobbiamo conformarci al volere di Dio, il quale conosce meglio di noi quanto è necessario alla nostra eterna salute, pur anche nel caso in cui le nostre preghiere non fossero esaudite.*
+
+**23.** Dio esaudisce sempre le orazioni ben fatte?
+
+*Sì, Dio esaudisce sempre le orazioni ben fatte; ma nella maniera che egli sa essere più utile per la nostra eterna salute, e non sempre secondo la nostra volontà.*
+
+**24.** Quali effetti produce in noi l’orazione?
+
+*L’orazione ci fa riconoscere la nostra dipendenza da Dio supremo Signore in tutte le cose, ci fa pensare alle cose celesti, ci fa progredire nella virtù, ci ottiene da Dio misericordia, ci fortifica contro le tentazioni, ci conforta nelle tribolazioni, ci aiuta nei nostri bisogni, e ci ottiene la grazia della perseveranza finale.*
+
+**25.** Quand’è che noi dobbiamo specialmente pregare?
+
+*Noi dobbiamo pregare specialmente nei pericoli, nelle tentazioni e in punto di morte; inoltre dobbiamo pregare frequentemente, ed è bene che ciò si faccia la mattina e la sera e al principio delle azioni importanti della giornata.*
+
+**26.** Per chi dobbiamo pregare?
+
+*Dobbiamo pregare per tutti; cioè per noi stessi, per i nostri parenti, superiori, benefattori, amici e nemici; per la conversione dei poveri peccatori, di quelli che sono fuori della vera Chiesa, e per le anime sante del purgatorio.*

--- a/content/books/pius-x-greater-catechism/it/parte-seconda-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-seconda-capo-ii.md
@@ -1,0 +1,211 @@
+# Capo II — Dell’orazione domenicale
+
+## § 1. Dell’orazione domenicale in genere
+
+**1.** Qual’è l’orazione vocale più eccellente?
+
+*L’orazione vocale più eccellente è quella che Gesù Cristo medesimo ci ha insegnato, cioè il Pater noster.*
+
+**2.** Perchè il Pater noster è l’orazione più eccellente?
+
+*Il Pater noster è l’orazione più eccellente perchè l’ha composta e ce l’ha insegnata Gesù Cristo medesimo; perchè contiene chiaramente in poche parole tutto quello che possiamo sperare da Dio; ed è la regola e il modello di tutte le altre orazioni.*
+
+**3.** Il Pater noster è anche l’orazione più efficace?
+
+*Il Pater noster è anche l’orazione più efficace, perchè è la più accetta a Dio, facendo noi orazione con le stesse parole che ci ha dettate il suo divin Figliuolo.*
+
+**4.** Perchè il Pater noster si chiama orazione domenicale?
+
+*Il Pater noster si chiama orazione domenicale, che vuol dire preghiera del Signore, appunto perchè ce l’ha insegnata Gesù Cristo di propria bocca.*
+
+**5.** Quante domande sono nel Pater noster?
+
+*Nel Pater noster sono sette domande, precedute da un proemio.*
+
+**6.** Recitate il Pater noster.
+
+*Padre nostro, che sei nei cieli:*
+
+*1.ª Sia santificato il nome tuo.*
+
+*2.ª Venga il regno tuo.*
+
+*3.ª Sia fatta la volontà tua, come in cielo, così in terra.*
+
+*4.ª Dacci oggi il nostro pane quotidiano.*
+
+*5.ª E rimetti a noi i nostri debiti, siccome noi li rimettiamo ai nostri debitori.*
+
+*6.ª E non c’indurre in tentazione.*
+
+*7.ª Ma liberaci dal male. Così sia.*
+
+**7.** Perchè, invocando Dio in principio dell’orazione domenicale, lo chiamiamo nostro Padre?
+
+*In principio dell’orazione domenicale chiamiamo Dio nostro Padre per risvegliare la nostra fiducia nella sua infinita bontà, essendo noi suoi figliuoli.*
+
+**8.** Perchè possiamo noi dire che siamo figliuoli di Dio?
+
+*Noi siamo figliuoli di Dio: 1.º Perchè Egli ci ha creato a imagine sua e ci conserva e governa colla sua provvidenza; 2.º Perchè ci ha, per ispeciale benevolenza, adottati nel Battesimo come fratelli di Gesù Cristo e coeredi insieme con lui dell’eterna gloria.*
+
+**9.** Perchè chiamiamo Dio Padre nostro e non Padre mio?
+
+*Chiamiamo Dio Padre nostro e non Padre mio, perchè tutti siamo suoi figliuoli e però dobbiamo riguardarci ed amarci tutti come fratelli, e pregare gli uni per gli altri.*
+
+**10.** Essendo Dio in ogni luogo, perchè gli diciamo: che sei ne’ cieli?
+
+*Dio è in ogni luogo; ma diciamo: Padre nostro, che sei ne’ cieli, per sollevare i nostri cuori al cielo, dove Dio si manifesta nella gloria a’ suoi figliuoli.*
+
+## § 2. Della prima petizione
+
+**11.** Che cosa chiediamo noi nella prima domanda: Sia santificato il nome tuo?
+
+*Nella prima domanda: Sia santificato il nome tuo noi chiediamo che Dio sia conosciuto, amato, onorato e servito da tutto il mondo, e da noi in particolare.*
+
+**12.** Che cosa intendiamo chiedendo che Dio sia conosciuto, amato e servito da tutto il mondo?
+
+*Noi intendiamo di chiedere che gli infedeli giungano alla cognizione del vero Dio, gli eretici riconoscano i loro errori, gli scismatici ritornino all’unità della Chiesa, che i peccatori si ravvedano e che i giusti siano perseveranti nel bene.*
+
+**13.** Perchè prima d’ogni altra cosa domandiamo che sia santificato il nome di Dio?
+
+*Prima d’ogni altra cosa domandiamo che sia santificato il nome di Dio, perchè la gloria di Dio ci deve stare più a cuore che tutti i nostri beni e vantaggi.*
+
+**14.** In qual modo possiamo noi procurare la gloria di Dio?
+
+*Noi possiamo procurare la gloria di Dio con la preghiera, col buon esempio, e con l’indirizzare a Lui tutti i pensieri, gli affetti e le opere nostre.*
+
+## § 3. Della seconda petizione
+
+**15.** Che cosa intendiamo noi per regno di Dio?
+
+*Per regno di Dio intendiamo un triplice regno spirituale; cioè il regno di Dio in noi, ossia il regno della grazia; il regno di Dio in terra, cioè la santa Chiesa cattolica; e il regno di Dio nei cieli, ovvero il paradiso.*
+
+**16.** Che cosa chiediamo noi con le parole: venga il regno tuo, in ordine alla grazia?
+
+*In ordine alla grazia noi chiediamo che Dio regni in noi con la sua grazia santificante per la quale Egli si compiace di risiedere in noi come re nella sua reggia; e di tenerci uniti a Lui con le virtù della fede, della speranza e della carità per le quali regna sul nostro intelletto, sul nostro cuore, e sulla nostra volontà.*
+
+**17.** Che cosa chiediamo con le parole: venga il regno tuo, in ordine alla Chiesa?
+
+*In ordine alla Chiesa chiediamo che questa sempre più si dilati e si propaghi per tutto il mondo a salvezza degli uomini.*
+
+**18.** Che cosa chiediamo con le parole: venga il regno tuo in ordine alla gloria?
+
+*In ordine alla gloria noi chiediamo di potere un giorno essere ammessi nel santo paradiso, per il quale fummo creati, dove saremo pienamente felici.*
+
+## § 4. Della terza petizione
+
+**19.** Che cosa chiediamo nella terza domanda: sia fatta la volontà tua, come in cielo, così in terra?
+
+*Nella terza domanda: sia fatta la volontà tua, come in cielo, così in terra, chiediamo la grazia di fare in ogni cosa la volontà di Dio con ubbidire ai suoi santi comandamenti così prontamente, come gli angeli e i santi gli ubbidiscono in cielo. Chiediamo inoltre la grazia di corrispondere alle divine ispirazioni, e di vivere rassegnati alla volontà di Dio quando Egli ci manda delle tribolazioni.*
+
+**20.** È necessario eseguire la volontà di Dio?
+
+*È necessario eseguire la volontà di Dio quanto è necessario il conseguire l’eterna salute, perchè Gesù Cristo ha detto che entrerà nel regno dei cieli soltanto chi avrà fatto la volontà del Padre suo.*
+
+**21.** In qual modo possiamo conoscere la volontà di Dio?
+
+*Noi possiamo conoscere la volontà di Dio specialmente per mezzo della Chiesa e dei nostri superiori spirituali stabiliti da Dio per guidarci nella via della salute. Possiamo anche conoscere questa santissima volontà dalle divine ispirazioni e dalle stesse circostanze nelle quali il Signore ci ha posti.*
+
+**22.** Dobbiamo sempre riconoscere la volontà di Dio nelle cose prospere od avverse della vita?
+
+*Nelle cose sì prospere che avverse della vita presente dobbiamo sempre riconoscere anche la volontà di Dio, il quale tutto dispone o permette per il nostro bene.*
+
+## § 5. Della quarta petizione
+
+**23.** Che cosa chiediamo nella quarta domanda: dacci oggi il nostro pane quotidiano?
+
+*Nella quarta domanda: dacci oggi il nostro pane quotidiano, chiediamo a Dio ciò che ci è necessario ciascun giorno e per l’anima e pel corpo.*
+
+**24.** Che cosa domandiamo a Dio per l’anima nostra?
+
+*Per l’anima nostra domandiamo a Dio il sostentamento della vita spirituale: cioè preghiamo il Signore che ci doni la sua grazia, di cui abbiamo continuamente bisogno.*
+
+**25.** Come si nutrisce la vita dell’anima nostra?
+
+*La vita dell’anima si nutrisce specialmente col cibo della divina parola e col Santissimo Sacramento dell’altare.*
+
+**26.** Che cosa domandiamo a Dio pel nostro corpo?
+
+*Pel nostro corpo domandiamo ciò che è necessario al sostentamento della vita temporale.*
+
+**27.** Perchè diciamo: dacci oggi il nostro pane, e non piuttosto: dacci oggi il pane?
+
+*Diciamo dacci oggi il nostro pane, e non piuttosto: dacci oggi il pane, per escludere ogni desiderio della roba d’altri; perciò preghiamo il Signore che ci aiuti nei guadagni giusti e leciti, affinchè ci procuriamo il vitto con le nostre fatiche, senza furti ed inganni.*
+
+**28.** Perchè diciamo: dacci il pane, e non dammi?
+
+*Diciamo: dacci invece di dammi per rammentarci che, siccome le sostanze ci vengono da Dio, così se Egli ce ne dà in abbondanza, lo fa a questo fine che ne dispensiamo il superfluo ai poveri.*
+
+**29.** Perchè aggiungiamo quotidiano?
+
+*Aggiungiamo quotidiano, perchè dobbiamo desiderare quello che ci è necessario alla vita, e non l’abbondanza dei cibi e dei beni della terra.*
+
+**30.** Che cosa significa di più la parola oggi nella quarta domanda?
+
+*La parola oggi significa che non dobbiamo essere troppo solleciti dell’avvenire, ma domandare quello che ci è necessario al presente.*
+
+## § 6. Della quinta petizione
+
+**31.** Che cosa chiediamo nella quinta domanda: e rimetti a noi i nostri debiti, siccome noi li rimettiamo ai nostri debitori?
+
+*Nella quinta domanda: e rimetti a noi i nostri debiti, siccome noi li rimettiamo ai nostri debitori, chiediamo a Dio che ci perdoni i nostri peccati, siccome noi perdoniamo ai nostri offensori.*
+
+**32.** Perchè i nostri peccati si chiamano debiti?
+
+*I nostri peccati si chiamano debiti perchè per essi dobbiamo soddisfare alla divina giustizia o in questa vita o nell’altra.*
+
+**33.** Quelli che non perdonano al prossimo, possono sperare che Dio loro perdoni?
+
+*Quelli che non perdonano al prossimo non hanno nessuna ragione di sperare che Dio loro perdoni, tanto più che si condannano da se stessi, dicendo a Dio, che perdoni loro, come essi perdonano al prossimo.*
+
+## § 7. Della sesta petizione
+
+**34.** Che cosa chiediamo nella sesta domanda: e non c’indurre in tentazione?
+
+*Nella sesta domanda: e non c’indurre in tentazione, chiediamo a Dio che ci liberi dalle tentazioni, o non permettendo che siamo tentati, o dandoci grazia di non essere vinti.*
+
+**35.** Che cosa sono le tentazioni?
+
+*Le tentazioni sono un incitamento al peccato che ci viene dal demonio, o dai cattivi, o dalle nostre passioni.*
+
+**36.** È peccato aver tentazioni?
+
+*No, non è peccato aver tentazioni, ma è peccato acconsentirvi, o esporsi volontariamente al pericolo di acconsentirvi.*
+
+**37.** Perchè Iddio permette che siamo tentati?
+
+*Iddio permette che siamo tentati per provare la nostra fedeltà, per far aumentare le nostre virtù e per accrescere i nostri meriti.*
+
+**38.** Che cosa dobbiamo fare per evitare le tentazioni?
+
+*Per evitare le tentazioni dobbiamo fuggire le occasioni pericolose, custodire i nostri sensi, ricevere spesso i santi sacramenti, e far uso della preghiera.*
+
+## § 8. Della settima petizione
+
+**39.** Che cosa chiediamo nella settima domanda: ma liberaci dal male?
+
+*Nella settima domanda, ma liberaci dal male, chiediamo a Dio, che ci liberi dai mali passati, presenti e futuri, e specialmente dal sommo male che è il peccato e dall’eterna dannazione, che ne è la pena.*
+
+**40.** Perchè diciamo: liberaci dal male e non dai mali?
+
+*Diciamo: liberaci dal male e non dai mali, perchè non dobbiamo desiderare di andare esenti da tutti i mali di questa vita, ma solamente da quelli, che non sono espedienti all’anima nostra, e perciò domandiamo la liberazione dal male in genere, cioè da tutto ciò che Dio vede essere per noi male.*
+
+**41.** Non è lecito domandare la liberazione da qualche male in particolare, per esempio da una malattia?
+
+*Sì, è lecito domandare la liberazione da qualche male in particolare, ma sempre rimettendoci alla volontà di Dio, il quale può anche ordinare quella tribolazione a vantaggio dell’anima nostra.*
+
+**42.** A che cosa ci giovano le tribolazioni che Dio ci manda?
+
+*Le tribolazioni ci giovano per fare penitenza delle nostre colpe, per esercitare le virtù, e sopratutto per imitare Gesù Cristo nostro capo, al quale è giusto che ci conformiamo nei patimenti, se vogliamo aver parte nella sua gloria.*
+
+**43.** Che vuol dire Amen in fine del Pater?
+
+*Amen vuol dire: così sia, così desidero, così prego il Signore e così spero.*
+
+**44.** Per ottenere le grazie domandate nel Pater noster basta recitarlo in qualsivoglia maniera?
+
+*Per ottenere le grazie domandate nel Pater noster bisogna recitarlo senza fretta, con attenzione e accompagnarlo col cuore.*
+
+**45.** Quando dobbiamo noi dire il Pater?
+
+*Il Pater dobbiamo dirlo ogni giorno, perchè abbiamo bisogno ogni giorno dell’aiuto di Dio.*

--- a/content/books/pius-x-greater-catechism/it/parte-seconda-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-seconda-capo-iii.md
@@ -1,0 +1,61 @@
+# Capo III — Dell’«Ave Maria»
+
+**1.** Quale orazione siamo noi soliti dire dopo il Pater?
+
+*Dopo il Pater, diciamo la salutazione angelica, cioè l’ Ave Maria, per mezzo della quale ricorriamo alla santissima Vergine.*
+
+**2.** Perchè l’ Ave Maria si chiama salutazione angelica?
+
+*L’ Ave Maria si chiama salutazione angelica perchè comincia col saluto che fece a Maria Vergine l’arcangelo Gabriele.*
+
+**3.** Di chi sono le parole dell’ Ave Maria?
+
+*Le parole dell’ Ave Maria parte sono dell’arcangelo Gabriele, parte di S. Elisabetta, e parte della Chiesa.*
+
+**4.** Quali sono le parole dell’arcangelo Gabriele?
+
+*Le parole dell’arcangelo Gabriele sono: «Dio ti salvi, piena di grazia: il Signore è teco: tu sei benedetta fra le donne».*
+
+**5.** Quando fu che l’Angelo disse a Maria queste parole?
+
+*L’Angelo disse a Maria queste parole, quando andò ad annunziarle da parte di Dio il mistero dell’Incarnazione che in lei doveva operarsi.*
+
+**6.** Che intendiamo noi di fare nel salutare la santissima Vergine con le stesse parole dell’Arcangelo?
+
+*Nel salutare la santissima Vergine con le parole dell’Arcangelo, noi ci rallegriamo con lei, facendo memoria dei singolari privilegi e doni, che Iddio le ha conceduti a preferenza di tutte le altre creature.*
+
+**7.** Quali sono le parole di santa Elisabetta?
+
+*Le parole di santa Elisabetta sono: «Tu sei benedetta fra le donne, e benedetto il frutto del tuo seno».*
+
+**8.** Quando fu che santa Elisabetta disse queste parole?
+
+*Santa Elisabetta disse queste parole, inspirata da Dio, quando tre mesi prima che desse alla luce S. Giovanni Battista, fu visitata dalla santissima Vergine, che già portava nel seno il suo divin Figliuolo.*
+
+**9.** Che cosa facciamo noi nel dire queste parole?
+
+*Nel dire le parole di santa Elisabetta ci rallegriamo con Maria SSm̃a della sua eccelsa dignità di Madre di Dio, e benediciamo Dio e lo ringraziamo di averci dato Gesù Cristo per mezzo di Maria.*
+
+**10.** Di chi sono le altre parole dell’ Ave Maria?
+
+*Tutte le altre parole dell’ Ave Maria sono state aggiunte dalla Chiesa.*
+
+**11.** Che cosa domandiamo noi con le ultime parole dell’ Ave Maria?
+
+*Con le ultime parole dell’ Ave Maria, domandiamo la protezione della santissima Vergine nel corso di questa vita, e specialmente nel l’ora della nostra morte, nella quale ne avremo maggior bisogno.*
+
+**12.** Perchè dopo il Pater diciamo piuttosto l’ Ave Maria, che qualunque altra orazione?
+
+*Perchè la SSm̃a Vergine è l’Avvocata più potente appresso Gesù Cristo, epperciò dopo avere detta l’orazione insegnataci da Gesù Cristo, preghiamo la SSm̃a Vergine che ci ottenga le grazie, che abbiamo domandate.*
+
+**13.** Per qual motivo la Vergine santissima è così potente?
+
+*La santissima Vergine è così potente perchè è Madre di Dio, ed è impossibile che non sia da Lui esaudita.*
+
+**14.** Che c’insegnano i Santi sulla devozione a Maria?
+
+*Sulla devozione a Maria i Santi c’insegnano che i veri suoi devoti sono da Lei amati e protetti con amore di tenerissima Madre e per mezzo di Lei sono certi di trovare Gesù e di ottenere il paradiso.*
+
+**15.** Qual divozione a Maria la Chiesa ci raccomanda in modo speciale?
+
+*La divozione che la Chiesa ci raccomanda in modo speciale verso Maria santissima è la recita del santo Rosario.*

--- a/content/books/pius-x-greater-catechism/it/parte-seconda-capo-iv.md
+++ b/content/books/pius-x-greater-catechism/it/parte-seconda-capo-iv.md
@@ -1,0 +1,13 @@
+# Capo IV — Dell’invocazione dei Santi
+
+**1.** È cosa buona ed utile il ricorrere alla intercessione dei Santi?
+
+*È cosa utilissima pregare i Santi, e deve farsi da ogni cristiano. Dobbiamo pregare particolarmente i nostri Angeli Custodi, S. Giuseppe Patrono della Chiesa, i santi Apostoli, i Santi di cui portiamo il nome, e i Santi Protettori della diocesi e della parrocchia.*
+
+**2.** Che differenza passa tra le preghiere che facciamo a Dio e quelle che facciamo ai Santi?
+
+*Tra le preghiere che facciamo a Dio e quelle che facciamo ai Santi passa questa differenza, che Dio lo preghiamo affinchè, come autore delle grazie, ci dia i beni e ci liberi dai mali, e i Santi li preghiamo perchè, come avvocati presso Dio, intercedano per noi.*
+
+**3.** Quando diciamo che un Santo ha fatto una grazia, che cosa intendiamo dire?
+
+*Quando diciamo che un Santo ha fatto una grazia, intendiamo dire che quel Santo ha ottenuto da Dio quella grazia.*

--- a/content/books/pius-x-greater-catechism/it/parte-terza-capo-i.md
+++ b/content/books/pius-x-greater-catechism/it/parte-terza-capo-i.md
@@ -1,0 +1,55 @@
+# Capo I — Dei comandamenti di Dio in generale
+
+**1.** Di che cosa si tratta nella terza parte della Dottrina cristiana?
+
+*Nella terza parte della Dottrina cristiana si tratta dei comandamenti di Dio e della Chiesa.*
+
+**2.** Quanti sono i comandamenti della legge di Dio?
+
+*I comandamenti della legge di Dio sono dieci:*
+
+*Io sono il Signore Iddio tuo:*
+
+*1.º Non avrai altro Dio avanti di me.*
+
+*2.º Non nominare il nome di Dio invano.*
+
+*3.º Ricordati di santificare le feste.*
+
+*4.º Onora il padre e la madre.*
+
+*5.º Non ammazzare.*
+
+*6.º Non fornicare.*
+
+*7.º Non rubare.*
+
+*8.º Non dire il falso testimonio.*
+
+*9.º Non desiderare la donna d’altri.*
+
+*10.º Non desiderare la roba d’altri.*
+
+**3.** I comandamenti di Dio perchè hanno questo nome?
+
+*I comandamenti di Dio hanno questo nome perchè lo stesso Dio li ha impressi nell’anima di ogni uomo, li ha promulgati sul monte Sinai nell’antica legge scolpiti sopra due tavole di pietra, e Gesù Cristo li ha confermati nella legge nuova.*
+
+**4.** Quali sono i comandamenti della prima tavola?
+
+*I comandamenti della prima tavola sono i primi tre, che riguardano direttamente Dio, e i doveri che abbiamo verso di Lui.*
+
+**5.** Quali sono i comandamenti della seconda tavola?
+
+*I comandamenti della seconda tavola sono i sette ultimi, che riguardano il prossimo e i doveri che abbiamo verso di esso.*
+
+**6.** Siamo noi obbligati ad osservare i comandamenti?
+
+*Sì, siamo tutti obbligati ad osservare i comandamenti, perchè tutti dobbiamo vivere secondo la volontà di Dio che ci ha creati, e basta trasgredirne gravemente uno solo per meritare l’inferno.*
+
+**7.** Possiamo noi osservare i comandamenti?
+
+*Noi possiamo senza dubbio osservare i comandamenti di Dio, perchè Iddio non ci co manda alcuna cosa impossibile e dà la grazia di osservarli a chi la domanda come si deve.*
+
+**8.** Che cosa si deve considerare generalmente in ciascun comandamento?
+
+*In ciascun comandamento si deve considerare la parte positiva e la parte negativa; cioè quello che ci viene comandato e quello che ci viene proibito.*

--- a/content/books/pius-x-greater-catechism/it/parte-terza-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-terza-capo-ii.md
@@ -1,0 +1,203 @@
+# Capo II — Dei comandamenti che riguardano Dio
+
+## § 1. Del primo comandamento
+
+**1.** Perchè si dice in principio: Io sono il Signore Iddio tuo?
+
+*In principio dei comandamenti si dice: Io sono il Signore Iddio tuo, perchè conosciamo che Dio, essendo il nostro Creatore e Signore, può comandare quello che vuole, e noi, sue creature, siamo tenuti ad obbedirgli.*
+
+**2.** Che cosa Iddio ci ordina colle parole del primo comandamento: Non avrai altro Dio avanti di me?
+
+*Con le parole del primo comandamento: Non avrai altro Dio avanti di me, Iddio ci ordina di riconoscere, di adorare, di amare e servire Lui solo, come nostro supremo Signore.*
+
+**3.** Come si adempie il primo comandamento?
+
+*Il primo comandamento si adempie coll’esercizio del culto interno ed esterno.*
+
+**4.** Che cosa è il culto interno?
+
+*Il culto interno è l’onore che si rende a Dio con le sole facoltà dello spirito, ossia con la mente e con la volontà.*
+
+**5.** Che cosa è il culto esterno?
+
+*Il culto esterno è l’omaggio che si rende a Dio per mezzo di atti esteriori e di oggetti sensibili.*
+
+**6.** Non basta adorar Dio solo col cuore internamente?
+
+*No, non basta adorar Dio solo col cuore internamente, ma bisogna adorarlo anche esternamente, collo spirito insieme e col corpo, perchè Egli è Creatore e Signore assoluto dell’uno e dell’altro.*
+
+**7.** Può stare il culto esterno, senza l’interno?
+
+*No, non può stare in verun modo il culto esterno senza l’interno, perchè quello scompagnato da questo rimane privo di vita, di merito e di efficacia, come corpo senz’anima.*
+
+**8.** Che cosa ci proibisce il primo comandamento?
+
+*Il primo comandamento ci proibisce l’idolatria, la superstizione, il sacrilegio, l’eresia ed ogni altro peccato contro la religione.*
+
+**9.** Che cosa è l’idolatria?
+
+*Si chiama idolatria il dare a qualche creatura, per esempio ad una statua, ad un’imagine, ad un uomo, il culto supremo di adorazione dovuto a Dio solo.*
+
+**10.** Come si trova espressa nella Sacra Scrittura questa proibizione?
+
+*Nella Sacra Scrittura si trova espressa questa proibizione con le parole: Tu non ti farai scultura, nè rappresentazione alcuna di quel che è lassù nel cielo e quaggiù in terra. E non adorerai tali cose, nè ad esse presterai culto.*
+
+**11.** Proibiscono queste parole ogni sorta d’imagini?
+
+*No certamente; ma soltanto quelle delle false divinità, fatte a scopo di adorazione, come facevano gl’idolatri. Ciò è tanto vero che Iddio stesso comandò a Mosè di farne alcune, come le due statue di cherubini sull’arca, e il serpente di bronzo nel deserto.*
+
+**12.** Che cosa è la superstizione?
+
+*Si chiama superstizione qualunque devozione contraria alla dottrina e all’uso della Chiesa, come anche l’attribuire ad un’azione o ad una cosa qualunque una virtù soprannaturale che non ha.*
+
+**13.** Che cosa è il sacrilegio?
+
+*Il sacrilegio è la profanazione di un luogo, di una persona o di una cosa consacrata a Dio e destinata al suo culto.*
+
+**14.** Che cosa è l’eresia?
+
+*L’eresia è un errore colpevole dell’intelletto, per cui si nega con pertinacia qualche verità della fede.*
+
+**15.** Quali altre cose proibisce il primo comandamento?
+
+*Il primo comandamento ci proibisce altresì qualunque commercio col demonio e l’aggregarsi alle sette anticristiane.*
+
+**16.** Chi ricorresse al demonio o lo invocasse, commetterebbe grave peccato?
+
+*Chi ricorresse al demonio o lo invocasse commetterebbe un peccato enorme, perchè il demonio è il più perverso nemico di Dio e dell’uomo.*
+
+**17.** È lecito interrogare le tavole così dette parlanti o scriventi, o consultare in qualunque modo le anime dei trapassati mediante lo spiritismo?
+
+*Tutte le pratiche dello spiritismo sono illecite, perchè superstiziose, e spesso non immuni da intervento diabolico, e perciò furono dalla Chiesa giustamente proibite.*
+
+**18.** Il primo comandamento proibisce forse di onorare ed invocare gli Angeli e i Santi?
+
+*No, non è proibito onorare ed invocare gli Angeli e i Santi; anzi dobbiamo farlo, perchè è cosa buona e utile, e dalla Chiesa altamente raccomandata, essendo essi gli amici di Dio e i nostri intercessori presso di Lui.*
+
+**19.** Essendo Gesù Cristo il nostro unico Mediatore presso Dio, perchè ricorriamo anche alla mediazione di Maria santissima e dei Santi?
+
+*Gesù Cristo è il nostro Mediatore presso Dio, inquantochè, essendo vero Dio e vero Uomo, Egli solo in virtù dei proprî meriti ci ha riconciliati con Dio e ce ne ottiene tutte le grazie. La Vergine poi e i Santi in virtù dei meriti di Gesù Cristo e per la carità che li unisce a Dio ed a noi, ci aiutano con la loro intercessione ad ottenere le grazie che domandiamo. E questo è uno dei grandi beni della comunione dei Santi.*
+
+**20.** Possiamo onorare anche le sacre imagini di Gesù Cristo e dei Santi?
+
+*Sì, perchè l’onore che si rende alle sacre imagini di Gesù Cristo e dei Santi si riferisce alle loro stesse persone.*
+
+**21.** E le reliquie dei Santi si possono onorare?
+
+*Sì, anche le reliquie dei Santi si debbono onorare, perchè i loro corpi furono vivi membri di Gesù Cristo, e templi dello Spirito Santo, e debbono risorgere gloriosi all’eterna vita.*
+
+**22.** Che differenza vi è tra il culto che rendiamo a Dio e il culto che rendiamo ai Santi?
+
+*Tra il culto che rendiamo a Dio e il culto che rendiamo ai Santi vi è questa differenza, che Iddio lo adoriamo per la sua infinita eccellenza, e i Santi invece non li adoriamo, ma li onoriamo e veneriamo come amici di Dio e nostri intercessori presso di Lui. Il culto che si rende a Dio si chiama latria cioè di adorazione, ed il culto che si rende ai Santi si chiama dulia cioè di venerazione a’ servi di Dio; il culto poi particolare, che prestiamo a Maria santissima, si chiama iperdulia, cioè di specialissima venerazione, come a Madre di Dio.*
+
+## § 2. Del secondo comandamento
+
+**23.** Che cosa ci proibisce il secondo comandamento: Non nominare il nome di Dio invano?
+
+*Il secondo comandamento: Non nominare il nome di Dio invano, ci proibisce: 1.º di nominare il nome di Dio senza rispetto; 2.º di bestemmiare contro Dio, contro la santissima Vergine e contro i Santi; 3.º di fare giuramenti falsi o non necessari, o in qualunque modo illeciti.*
+
+**24.** Che vuol dire nominare il nome di Dio senza rispetto?
+
+*Nominare il nome di Dio senza rispetto vuol dire pronunziare questo santo nome e tutto ciò che si riferisce in modo speciale a Dio stesso, come il nome di Gesù, di Maria e dei Santi, nella collera, per ischerzo, o in altro modo poco riverente.*
+
+**25.** Che cosa è la bestemmia?
+
+*La bestemmia è un orribile peccato che consiste in parole o atti di disprezzo o di maledizione contro Dio, la Vergine, i Santi, o contro le cose sante.*
+
+**26.** Vi è differenza tra la bestemmia e l’imprecazione?
+
+*V’è differenza perchè con la bestemmia si maledice, o si desidera il male a Dio, alla Madonna, ai Santi: mentre con la imprecazione si maledice o si desidera il male a sè stesso, o al prossimo.*
+
+**27.** Che cosa è il giuramento?
+
+*Il giuramento è il chiamare Dio in testimonio della verità di ciò che si dice, o si promette.*
+
+**28.** È sempre proibito il giurare?
+
+*Non è sempre proibito il giurare, ma è lecito anzi onorevole a Dio quando vi sia necessità e il giuramento sia fatto con verità, con giudizio e con giustizia.*
+
+**29.** Quando non si giura con verità?
+
+*Quando si afferma con giuramento ciò che si sa, o si crede che sia falso, e quando con giuramento si promette di fare ciò che non si ha intenzione di eseguire.*
+
+**30.** Quando non si giura con giudizio?
+
+*Quando si giura senza prudenza e senza matura considerazione, ovvero per cose di poca importanza.*
+
+**31.** Quando non si giura con giustizia?
+
+*Quando si giura di fare una cosa che non sia giusta o lecita, come vendicarsi, rubare ed altre cose simili.*
+
+**32.** Siamo noi obbligati di mantenere il giuramento di fare cose ingiuste od illecite?
+
+*Non solo non siamo obbligati, ma peccheremmo facendole, perchè proibite dalla legge di Dio, o della Chiesa.*
+
+**33.** Chi giura il falso che peccato commette?
+
+*Chi giura il falso commette peccato mortale, perchè disonora gravemente Dio verità infinita, chiamandolo in testimonio del falso.*
+
+**34.** Che cosa ci ordina il secondo comandamento?
+
+*Il secondo comandamento ci ordina di onorare il nome santo di Dio e di adempiere oltre i giuramenti anche i voti.*
+
+**35.** Che cosa è il voto?
+
+*Il voto è una promessa che si fa a Dio di una cosa buona e a noi possibile e migliore della cosa contraria, alla quale ci obblighiamo come se ci fosse comandata.*
+
+**36.** Se la osservanza del voto riuscisse in tutto o in parte molto difficile, che si dovrebbe fare?
+
+*Si può domandare la commutazione o la dispensa al proprio Vescovo, od al Sommo Pontefice, secondo la qualità del voto.*
+
+**37.** È peccato trasgredire i voti?
+
+*Il trasgredire i voti è peccato, e perciò non dobbiamo far voti senza matura riflessione e, ordinariamente, senza il consiglio del confessore, o d’altra persona prudente, per non esporci al pericolo di peccare.*
+
+**38.** Si possono fare i voti alla Madonna ed ai Santi?
+
+*I voti si fanno solamente a Dio: si può però promettere a Dio di far qualche cosa in onore della Madonna, o dei Santi.*
+
+## § 3. Del terzo comandamento
+
+**39.** Che cosa ci ordina il terzo comandamento: Ricordati di santificare le feste?
+
+*Il terzo comandamento: Ricordati di santificare le feste, ci ordina di onorare Dio con opere di culto nei giorni di festa.*
+
+**40.** Quali sono i giorni di festa?
+
+*Nell’antica legge erano i sabati ed altri giorni particolarmente solenni per il popolo ebreo; nella legge nuova sono le domeniche ed altre festività stabilite dalla Chiesa.*
+
+**41.** Perchè nella legge nuova si santifica la domenica invece del sabato?
+
+*La domenica, che significa giorno del Signore, fu sostituita al sabato perchè in tal giorno Gesù Cristo Signor nostro risuscitò.*
+
+**42.** Quale opera di culto ci viene comandata nei giorni di festa?
+
+*Ci viene comandato di assistere divotamente al santo sacrificio della Messa.*
+
+**43.** Con quali altre opere un buon cristiano santifica le feste?
+
+*Il buon cristiano santifica le feste: 1.º coll’intervenire alla Dottrina cristiana, alle prediche ed ai divini uffizî; 2.º col ricevere spesso, con le dovute disposizioni i sacramenti della Penitenza e dell’Eucaristia; 3.º coll’esercitarsi nell’orazione e nelle opere di cristiana carità verso il prossimo.*
+
+**44.** Che cosa ci proibisce il terzo comandamento?
+
+*Il terzo comandamento ci proibisce le opere servili e qualunque opera che ci impedisca il culto di Dio.*
+
+**45.** Quali sono le opere servili proibite nei giorni di festa?
+
+*Le opere servili proibite nei giorni di festa sono le opere dette manuali, cioè quei lavori materiali in cui ha parte più il corpo che lo spirito; come quelle che ordinariamente si fanno dai servi, dagli operai e dagli artieri.*
+
+**46.** Quale peccato si commette lavorando in giorno di festa?
+
+*Lavorando in giorno di festa si commette peccato mortale: scusa però dalla colpa grave la brevità del tempo che si occupa.*
+
+**47.** Non vi è alcuna opera servile che sia permessa nei giorni di festa?
+
+*Nei giorni di festa sono permesse quelle opere che sono necessarie alla vita, o al servizio di Dio; e quelle che si fanno per una causa grave domandando licenza, se si può, al proprio parroco.*
+
+**48.** Per qual fine nelle feste sono proibite le opere servili?
+
+*Sono proibite nelle feste le opere servili, affinchè possiamo meglio attendere al divin culto e alla salute dell’anima nostra; e riposarci dalle fatiche. Per questo non è proibito qualche onesto divertimento.*
+
+**49.** Quali altre cose dobbiamo schivare sovrattutto nelle feste?
+
+*Nelle feste dobbiamo schivare sopra tutto il peccato e tutto ciò che può indurci al peccato, come i divertimenti e i ritrovi pericolosi.*

--- a/content/books/pius-x-greater-catechism/it/parte-terza-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/it/parte-terza-capo-iii.md
@@ -1,0 +1,293 @@
+# Capo III — Dei comandamenti che riguardano il prossimo
+
+## § 1. Del quarto comandamento
+
+**1.** Che cosa ci ordina il quarto comandamento: Onora il padre e la madre?
+
+*Il quarto comandamento: Onora il padre e la madre, ci ordina di rispettare il padre e la madre, di obbedire loro in tutto ciò che non è peccato, e di aiutarli nei loro bisogni spirituali e temporali.*
+
+**2.** Che cosa ci proibisce il quarto comanda mento?
+
+*Il quarto comandamento ci proibisce di offendere i genitori con le parole, con le opere e in qualsiasi altro modo.*
+
+**3.** Sotto il nome di padre e di madre, quali altre persone comprende questo comandamento?
+
+*Questo comandamento, sotto il nome di padre e di madre comprende ancora tutti i superiori, così ecclesiastici, come secolari, ai quali perciò dobbiamo obbedire e portare rispetto.*
+
+**4.** Donde viene ai genitori l’autorità di comandare ai figliuoli, e l’obbligo ai figliuoli di obbedire loro?
+
+*L’autorità che i genitori hanno di comandare ai figliuoli, e l’obbligo ai figliuoli di obbedire, viene da Dio che costituì ed ordinò la famiglia, acciocchè in essa l’uomo trovi i primi mezzi necessari al suo perfezionamento materiale e spirituale.*
+
+**5.** I genitori hanno dei doveri verso i loro figli?
+
+*I genitori hanno il dovere di amare, alimentare e mantenere i loro figliuoli, di provvedere alla loro educazione religiosa e civile, di dar loro buono esempio, di allontanarli dall’occasione di peccato, correggerli delle loro mancanze, ed aiutarli ad abbracciare lo stato al quale sano chiamati da Dio.*
+
+**6.** Ci diede Iddio l’esempio di famiglia perfetta?
+
+*Iddio ci diede l’esempio di famiglia perfetta nella Sacra Famiglia, nella quale Gesù Cristo visse soggetto a Maria santissima e a S. Giuseppe fino ai trent’anni, cioè fino a quando incominciò ad esercitare la missione affidatagli dall’Eterno Padre di predicare il Vangelo.*
+
+**7.** Se le famiglie vivessero da sole, separate una dall’altra, potrebbero provvedere a tutti i propri bisogni materiali e morali?
+
+*Se le famiglie vivessero da sole, separate una dall’altra, non potrebbero provvedere ai propri bisogni, ed è necessario che si siano unite in società civile, a fine di aiutarsi a vicenda per il perfezionamento e la felicità comune.*
+
+**8.** Che cosa è la società civile?
+
+*La società civile è l’unione di molte famiglie dipendenti dall’autorità di un capo, per aiutarsi scambievolmente a conseguire il mutuo perfezionamento e la felicità temporale.*
+
+**9.** Donde viene alla società civile l’autorità che la governa?
+
+*L’autorità che governa la società civile viene da Dio, che la vuole costituita a bene comune.*
+
+**10.** Vi è obbligo di rispettare e di obbedire l’autorità che governa la società civile?
+
+*Sì, tutti quelli che appartengono alla società civile hanno l’obbligo di rispettare e di obbedire l’autorità perchè viene da Dio, e perchè così è richiesto dal bene comune.*
+
+**11.** Si debbono rispettare tutte le leggi che sono imposte dall’autorità civile?
+
+*Si debbono rispettare tutte le leggi che l’autorità civile impone, purchè esse non siano contrarie alla legge di Dio, secondo il comando e l’esempio di nostro Signor Gesù Cristo.*
+
+**12.** Oltre il rispetto e l’obbedienza alle leggi imposte dall’autorità, coloro che fanno parte della società civile hanno altri doveri?
+
+*Coloro che fanno parte della società civile, hanno, oltre l’obbligo del rispetto e dell’obbedienza alle leggi, il dovere di vivere concordi e di adoperarsi ciascuno coi mezzi e con le forze proprie affinchè essa sia virtuosa, pacifica, ordinata e prospera a comune vantaggio.*
+
+## § 2. Del quinto comandamento
+
+**13.** Che cosa proibisce il quinto comandamento: Non ammazzare?
+
+*Il quinto comandamento: Non ammazzare, proibisce di dar morte, battere, ferire o fare qualunque altro danno al prossimo nel corpo, sia per sè, sia per mezzo d’altri; come pure di offenderlo con parole ingiuriose e di volergli male. In questo comandamento Iddio proibisce anche il dar morte a se stesso, ossia il suicidio.*
+
+**14.** Perchè è peccato grave uccidere il prossimo?
+
+*Perchè l’uccisore si usurpa temerariamente il diritto che ha Dio solo sulla vita dell’uomo; perchè distrugge la sicurezza dell’umano consorzio, e perchè perchè toglie al prossimo la vita, che è il più gran bene naturale che ha sulla terra.*
+
+**15.** Vi sono dei casi nei quali sia lecito uccidere il prossimo?
+
+*È lecito uccidere il prossimo quando si combatte in una guerra giusta, quando si eseguisce per ordine dell’autorità suprema la condanna di morte in pena di qualche delitto; e finalmente quando trattasi di necessaria e legittima difesa della vita contro un ingiusto aggressore.*
+
+**16.** Dio, nel quinto comandamento, proibisce anche di nuocere alla vita spirituale del prossimo?
+
+*Sì, Iddio nel quinto comandamento proibisce anche di nuocere alla vita spirituale del prossimo con lo scandalo.*
+
+**17.** Che cosa è lo scandalo?
+
+*Lo scandalo è qualunque detto, fatto o omissione, che è occasione ad altri di commettere peccati.*
+
+**18.** È peccato grave lo scandalo?
+
+*Lo scandalo è un peccato grave, perchè tende a distruggere la più grande opera di Dio, che è la redenzione, con la perdita delle anime; dà al prossimo la morte dell’anima togliendogli la vita della grazia, che è più preziosa della vita del corpo; è causa di una moltitudine di peccati. Perciò Iddio minaccia agli scandalosi i più severi castighi.*
+
+**19.** Perchè nel quinto comandamento, Dio proibisce il dar morte a se stesso, ossia il suicidio?
+
+*Nel quinto comandamento, Dio proibisce il suicidio perchè l’uomo non è padrone della sua vita, come non lo è di quella degli altri. La Chiesa poi punisce il suicida colla privazione della sepoltura ecclesiastica.*
+
+**20.** È proibito nel quinto comandamento anche il duello?
+
+*Sì, nel quinto comandamento è proibito anche il duello, perchè il duello partecipa della malizia del suicidio e dell’omicidio, ed è scomu nicato chiunque volontariamente vi ha parte, anche di semplice spettatore.*
+
+**21.** È anche proibito il duello quando sia escluso il pericolo di morte?
+
+*È anche proibito questo duello perchè non solamente non possiamo uccidere, ma neanche ferire volontariamente noi stessi e gli altri.*
+
+**22.** La difesa dell’onore può scusare il duello?
+
+*No: perchè non è vero, che nel duello si ripara l’offesa; e perchè non si può riparare l’onore con un’azione ingiusta, irragionevole e barbara, quale è il duello.*
+
+**23.** Che cosa ci ordina il quinto comandamento?
+
+*Il quinto comandamento ci ordina di per donare ai nostri nemici, e di voler bene a tutti.*
+
+**24.** Che cosa deve fare chi ha danneggiato il prossimo nella vita del corpo, o in quella dell’anima?
+
+*Chi ha danneggiato il prossimo non basta che si confessi, ma deve anche riparare al male che ha fatto col risarcire al prossimo i danni arrecati, col ritrattare gli errori insegnati, e col dar buoni esempi.*
+
+## § 3. Del sesto e del nono comandamento
+
+**25.** Che cosa ci proibisce il sesto comandamento: Non fornicare?
+
+*Il sesto comandamento: Non fornicare, ci proibisce ogni atto, ogni sguardo, ogni di scorso contrario alla castità, e l’infedeltà nel matrimonio.*
+
+**26.** Che cosa proibisce il nono comandamento?
+
+*Il nono comandamento proibisce espressamente ogni desiderio contrario alla fedeltà che i coniugi si sono giurata nel contrarre matrimonio: e proibisce pure ogni colpevole pensiero o desiderio di azione vietata dal sesto comandamento.*
+
+**27.** È un gran peccato l’impurità?
+
+*È un peccato gravissimo ed abominevole innanzi a Dio ed agli uomini; avvilisce l’uomo alla condizione dei bruti, lo trascina a molti altri peccati e vizi, e provoca i più terribili castighi in questa vita e nell’altra.*
+
+**28.** Sono peccati tutti i pensieri che ci vengono in mente contro la purità?
+
+*I pensieri che ci vengono in mente contro la purità, per se stessi non sono peccati, ma piuttosto tentazioni e incentivi al peccato.*
+
+**29.** Quando è che sono peccati i pensieri cattivi?
+
+*I pensieri cattivi, ancorchè siano inefficaci, sono peccati quando colpevolmente diamo loro motivo, o vi acconsentiamo, o ci esponiamo al pericolo prossimo di acconsentirvi.*
+
+**30.** Che cosa ci ordinano il sesto e nono comandamento?
+
+*Il sesto comandamento ci ordina di essere casti e modesti negli atti, negli sguardi, nel portamento e nelle parole. Il nono comandamento ci ordina di essere casti e puri anche nell’interno, cioè nella mente e nel cuore.*
+
+**31.** Che cosa ci convien fare per osservare il sesto e il nono comandamento?
+
+*Per ben osservare il sesto e il nono comandamento, dobbiamo pregare spesso e di cuore Iddio, essere divoti di Maria Vergine Madre della purità, ricordarci che Dio ci vede, pensare alla morte, ai divini castighi, alla passione di Gesù Cristo, custodire i nostri sensi, praticare la mortificazione cristiana e frequentare colle dovute disposizioni i sacramenti.*
+
+**32.** Che cosa dobbiamo fuggire per mantenerci casti?
+
+*Per mantenerci casti conviene fuggire l’ozio, i cattivi compagni, la lettura dei libri e dei giornali cattivi, l’intemperanza, il guardare le immagini indecenti, gli spettacoli licenziosi, le conversazioni pericolose, e tutte le altre occasioni di peccato.*
+
+## § 4. Del settimo comandamento
+
+**33.** Che cosa ci proibisce il settimo comandamento: Non rubare?
+
+*Il settimo comandamento: Non rubare, proibisce di prendere e di ritenere ingiustamente la roba altrui e di recar danno al prossimo nella roba in qualunque altro modo.*
+
+**34.** Che cosa vuol dire rubare?
+
+*Vuol dire prendere ingiustamente la roba altrui contro la volontà del padrone, quando cioè egli ha tutta la ragione ed il diritto di non volerne essere privato.*
+
+**35.** Perchè si proibisce il rubare?
+
+*Perchè si pecca contro la giustizia, e si fa ingiuria al prossimo, prendendo e ritenendo contro il suo diritto e la sua volontà ciò che gli appartiene.*
+
+**36.** Che cosa è la roba d’altri?
+
+*È tutto ciò che appartiene al prossimo, che ne ha la proprietà o l’uso, o lo tiene in deposito.*
+
+**37.** In quanti modi si prende ingiustamente la roba degli altri?
+
+*In due modi: col furto e con la rapina.*
+
+**38.** Il furto come si commette?
+
+*Il furto si commette prendendo occultamente la roba degli altri.*
+
+**39.** La rapina come si commette?
+
+*La rapina si commette prendendo con violenza e manifestamente la roba degli altri.*
+
+**40.** In quali casi si può prendere la roba de gli altri senza far peccato?
+
+*Quando il padrone non fosse contrario, ovvero quando ingiustamente non volesse, come accadrebbe di uno che avesse estrema necessità, purchè prendesse soltanto quanto gli è strettamente necessario per sovvenire all’urgente ed estremo bisogno.*
+
+**41.** Solamente col furto e con la rapina si danneggia il prossimo nella roba?
+
+*Si danneggia anche con la frode, con l’usura e con qualunque altra ingiustizia contro i suoi beni.*
+
+**42.** Come si commette la frode?
+
+*La frode si commette ingannando il prossimo nel commercio con pesi, misure o monete false e con merci cattive; falsificando scritture e documenti; in somma facendo inganni nelle compre, nelle vendite ed in qualsiasi altro contratto ed anche quando non si vuol dare il giusto ed il convenuto.*
+
+**43.** In qual modo si commette l’usura?
+
+*L’usura si commette con l’esigere senza legittimo titolo un illecito interesse per una somma prestata, abusando del bisogno e dell’ignoranza altrui.*
+
+**44.** Quali altre ingiustizie si commettono contro i beni del prossimo?
+
+*Col fargli perdere ingiustamente ciò che ha, col danneggiarlo nelle possessioni, non lavorare conforme al dovere, non pagare per malizia i debiti e le dovute mercedi, col ferire od uccidere animali che gli appartengono, col mandare a male le cose avute in custodia, con l’impedire ad alcuno di fare un giusto guadagno, col tenere mano ai ladri, col ricevere, nascondere o comprare la roba rubata.*
+
+**45.** È peccato grave rubare?
+
+*È un peccato grave contro la giustizia quando trattasi di materia grave, essendo cosa molto importante che sia rispettato il diritto che ciascuno ha sulla roba propria, e ciò per il bene degli individui, delle famiglie e della società.*
+
+**46.** Quando è grave la materia del furto?
+
+*È grave quando si toglie cosa rilevante, ed anche quando, togliendosi cosa di poco momento, il prossimo ne patisce grave danno.*
+
+**47.** Che cosa ci ordina il settimo comandamento?
+
+*Il settimo comandamento ci ordina di rispettare la roba degli altri, dare la giusta mercede agli operai, ed osservare la giustizia in tutto quello che riguarda la proprietà altrui.*
+
+**48.** Chi ha peccato contro il settimo comandamento basta che se ne confessi?
+
+*Chi ha peccato contro il settimo comandamento non basta che se ne confessi, ma bisogna che faccia quello che può per restituire la roba d’altri e risarcire i danni.*
+
+**49.** Che cosa è il risarcimento dei danni?
+
+*Il risarcimento dei danni è il compenso che si deve dare al prossimo dei frutti e dei guadagni perduti a cagione del furto e delle altre ingiustizie commesse a suo danno.*
+
+**50.** A chi si deve restituire la roba rubata?
+
+*A chi si è rubato; ai suoi eredi, se egli fosse morto; e se ciò fosse veramente impossibile, si deve erogarne il valore a beneficio dei poveri e di pie opere.*
+
+**51.** Che cosa si deve fare quando si trova qualche cosa di grande valore?
+
+*Devesi usare grande diligenza per trovarne il padrone, e restituirgliela fedelmente.*
+
+## § 5. Dell’ottavo comandamento
+
+**52.** Che cosa ci proibisce l’ottavo comandamento: Non dire falso testimonio?
+
+*L’ottavo comandamento: Non dire il falso testimonio, ci proibisce di attestare il falso in giudizio: e proibisce ancora la detrazione o mormorazione, la calunnia, l’adulazione, il giudizio ed il sospetto temerario ed ogni sorta di bugia.*
+
+**53.** Che cos’è la detrazione o mormorazione?
+
+*La detrazione o mormorazione è un peccato che consiste nel manifestare, senza giusto motivo, i peccati e difetti altrui.*
+
+**54.** Che cos’è la calunnia?
+
+*La calunnia è un peccato che consiste nell’attribuire malignamente al prossimo colpe e difetti che non ha.*
+
+**55.** Che cos’è l’adulazione?
+
+*L’adulazione è un peccato che consiste nell’ingannare taluno col dire falsamente bene di lui o di altri, allo scopo di averne vantaggio.*
+
+**56.** Che cos’è il giudizio o sospetto temerario?
+
+*Il giudizio o sospetto temerario è un peccato che consiste nel giudicare o sospettar male degli altri senza un giusto fondamento.*
+
+**57.** Che cos’è la bugia?
+
+*La bugia è un peccato che consiste nell’asserire per vero o per falso, con parole o con fatti, ciò che non si crede tale.*
+
+**58.** Di quante specie è la bugia?
+
+*La bugia è di tre specie: giocosa, officiosa e dannosa.*
+
+**59.** Qual’è la bugia giocosa?
+
+*La bugia giocosa è quella con cui si mentisce per giuoco, e senza pregiudizio di alcuno.*
+
+**60.** Qual’è la bugia officiosa?
+
+*La bugia officiosa è l’asserzione del falso per la propria o per l’altrui utilità, senza pregiudizio di alcuno.*
+
+**61.** Qual’è la bugia dannosa?
+
+*La bugia dannosa è l’asserzione del falso con pregiudizio del prossimo.*
+
+**62.** È mai lecito dir la bugia?
+
+*Non è mai lecito dir la bugia nè per giuoco, nè per proprio, nè per altrui vantaggio, essendo cosa per se stessa cattiva.*
+
+**63.** Che peccato è la bugia?
+
+*La bugia quando è giocosa od officiosa è peccato veniale; quando poi è dannosa è peccato mortale, se il danno che reca è grave.*
+
+**64.** È necessario sempre dir tutto come si pensa?
+
+*Non è sempre necessario, specialmente quando chi interroga non ha il diritto di sapere ciò che domanda.*
+
+**65.** Chi ha peccato contro l’ottavo comandamento, basta che se ne confessi?
+
+*Chi ha peccato contro l’ottavo comandamento, non basta che se ne confessi, ma è obbligato anche a ritrattare quanto disse calun niando il prossimo, e a riparare, nel miglior modo che può, i danni che gli ha cagionato.*
+
+**66.** Che cosa ci ordina l’ottavo comandamento?
+
+*L’ottavo comandamento ci ordina di dire a tempo e luogo la verità, e di interpretare in bene, per quanto possiamo, le azioni del nostro prossimo.*
+
+## § 6. Del decimo comandamento
+
+**67.** Che cosa ci proibisce il decimo comandamento: Non desiderare la roba d’altri?
+
+*Il decimo comandamento: Non desiderare la roba d’altri, proibisce il desiderio di privare altri della sua roba e il desiderio di acquistar roba con mezzi ingiusti.*
+
+**68.** Perchè proibisce Iddio anche il desiderio della roba altrui?
+
+*Dio ci proibisce i desiderî sregolati della roba altrui, perchè Egli vuole che noi anche internamente siamo giusti e ci teniamo sempre più lontani dalle opere ingiuste.*
+
+**69.** Il decimo comandamento che cosa ci ordina?
+
+*Il decimo comandamento ci ordina di contentarci dello stato in cui Dio ci ha posti e di soffrire con pazienza la povertà, quando Iddio ci voglia in tale stato.*
+
+**70.** Come può il cristiano essere contento nello stato di povertà?
+
+*Il cristiano può essere contento anche nello stato di povertà, considerando che mas simo bene è la coscienza pura e tranquilla, che la nostra vera patria è il cielo, e che Gesù Cristo si fece povero per amor nostro e ha promesso un premio speciale a tutti quelli che sopportano con pazienza la povertà.*

--- a/content/books/pius-x-greater-catechism/it/parte-terza-capo-iv.md
+++ b/content/books/pius-x-greater-catechism/it/parte-terza-capo-iv.md
@@ -1,0 +1,179 @@
+# Capo IV — Dei precetti della Chiesa
+
+## § 1. Dei precetti della Chiesa in generale
+
+**1.** Oltre i comandamenti di Dio, che altro dobbiamo noi osservare?
+
+*Oltre i comandamenti di Dio noi dobbiamo osservare i precetti della Chiesa.*
+
+**2.** Siamo noi obbligati ad obbedire alla Chiesa?
+
+*Senza dubbio siamo obbligati ad obbedire alla Chiesa, perchè Gesù Cristo medesimo lo comanda, e perchè i precetti della Chiesa aiutano ad osservare i comandamenti di Dio.*
+
+**3.** Quando comincia l’obbligo di osservare i precetti della Chiesa?
+
+*L’obbligo di osservare i precetti della Chiesa generalmente incomincia dall’uso di ragione.*
+
+**4.** È peccato trasgredire un precetto della Chiesa?
+
+*Il trasgredire avvertitamente un precetto della Chiesa in materia grave è peccato mortale.*
+
+**5.** Chi può dispensare da un precetto della Chiesa?
+
+*Da un precetto della Chiesa può dispensare solamente il Papa, e chi da lui ne ha ricevute le facoltà.*
+
+**6.** Quanti e quali sono i precetti della Chiesa?
+
+*I Precetti della Chiesa sono cinque:*
+
+*1.º Udir la Messa tutte le domeniche e le altre feste comandate.*
+
+*2.º Digiunare la Quaresima, le quattro tempora e le vigilie comandate; non mangiar carne nei giorni proibiti.*
+
+*3.º Confessarsi almeno una volta l’anno, e comunicarsi alla Pasqua di Risurrezione, ciascuno alla propria parrocchia.*
+
+*4.º Pagare le decime dovute alla Chiesa, secondo le usanze.*
+
+*5.º Non celebrare le nozze ne’ tempi vietati, cioè dalla prima domenica dell’Avvento fino all’Epifania, e dal primo giorno di Quaresima fino all’ottava di Pasqua.*
+
+## § 2. Del primo precetto della Chiesa
+
+**7.** Che cosa ci ordina il primo precetto o comandamento della Chiesa: Ascoltare la Messa tutte le domeniche e le altre feste comandate?
+
+*Il primo precetto della Chiesa: Ascoltare la Messa tutte le domeniche e le altre feste comandate, ci ordina di assistere con divozione alla santa Messa in tutte le domeniche e nelle altre feste di precetto.*
+
+**8.** Qual’è la Messa alla quale la Chiesa desidera che si assista nelle domeniche e nelle altre feste di precetto?
+
+*La Messa alla quale la Chiesa desidera che possibilmente si assista nelle domeniche e nelle altre feste di precetto è la Messa parrocchiale.*
+
+**9.** Perchè la Chiesa raccomanda ai fedeli di assistere alla Messa parrocchiale?
+
+*La Chiesa raccomanda ai fedeli di assistere alla Messa parrocchiale: 1.º affinchè quelli che appartengono alla stessa parrocchia si uniscano a pregare insieme col parroco che è loro capo; 2.º affinchè i parrocchiani partecipino maggiormente al santo sacrificio, che è applicato principalmente per loro; 3.º affinchè ascoltino le verità del Vangelo che i parrochi hanno obbligo di esporre nella santa Messa; 4.º affinchè vengano a conoscere le prescrizioni e gli avvisi che si pubblicano in detta Messa.*
+
+**10.** Che cosa vuol dire: domenica?
+
+*Domenica vuol dire giorno del Signore, cioè giorno specialmente consacrato al divino servizio.*
+
+**11.** Perchè nel primo comandamento della Chiesa si fa menzione speciale della domenica?
+
+*Nel primo comandamento della Chiesa si fa menzione speciale della domenica, perchè essa è la festa principale presso i cristiani, come il sabato era la festa principale presso gli ebrei, istituita da Dio stesso.*
+
+**12.** Quali altre feste ha istituito la Chiesa?
+
+*La Chiesa ha istituito anche le feste di nostro Signore, della SSm̃a Vergine, degli Angeli e dei Santi.*
+
+**13.** Perchè la Chiesa ha istituito altre feste di nostro Signore?
+
+*La Chiesa ha istituito altre feste di nostro Signore in memoria de’ suoi divini misteri.*
+
+**14.** Le feste della SSm̃a Vergine, degli Angeli e dei Santi perchè sono state istituite?
+
+*Le feste della santissima Vergine, degli Angeli e dei Santi, sono state istituite 1.º in memoria delle grazie che Dio loro ha fatte, e per ringraziarne la divina bontà; 2.º affinchè noi li onoriamo, imitiamo i loro esempi e siamo aiutati dalle loro preghiere.*
+
+## § 3. Del secondo precetto della Chiesa
+
+**15.** Che cosa ci ordina il secondo precetto della Chiesa con le parole: Digiunare i giorni comandati?
+
+*Il secondo precetto della Chiesa con le parole: Digiunare i giorni comandati, ci ordina di osservare il digiuno: 1.º nella Quaresima; 2.º in alcuni giorni dell’Avvento, dove ciò è prescritto; 3.º nelle quattro tempora; 4.º in alcune vigilie.*
+
+**16.** In che consiste il digiuno?
+
+*Il digiuno consiste nel fare un solo pasto al giorno e nell’astenersi dai cibi vietati.*
+
+**17.** Nei giorni di digiuno, si può fare la sera una piccola refezione?
+
+*Per condiscendenza della Chiesa si può, nei giorni di digiuno, fare un po’ di refezione alla sera.*
+
+**18.** A che serve il digiuno?
+
+*Il digiuno serve a meglio disporci all’orazione, a fare penitenza dei peccati commessi e preservarci dal commetterne dei nuovi.*
+
+**19.** Chi è obbligato al digiuno?
+
+*Al digiuno sono obbligati tutti i cristiani, che hanno compiuto ventun anno e che non sono o dispensati o scusati da legittimo impedimento.*
+
+**20.** Quelli che non hanno l’obbligo del digiuno sono affatto esenti dalla mortificazione?
+
+*Quelli che non hanno l’obbligo del digiuno non sono affatto esenti dalla mortificazione, perchè siamo tutti obbligati a fare penitenza.*
+
+**21.** Per qual fine è stata istituita la Quaresima?
+
+*La Quaresima è stata istituita per imitare in qualche modo il rigoroso digiuno di quaranta giorni che Gesù Cristo fece nel deserto, e per prepararci col mezzo della penitenza a celebrare santamente la Pasqua.*
+
+**22.** Per qual fine è stato istituito il digiuno dell’Avvento?
+
+*Il digiuno dell’Avvento è stato istituito per disporci a celebrare santamente il Natale di N. S. Gesù Cristo.*
+
+**23.** Per qual fine è stato istituito il digiuno delle quattro tempora?
+
+*Il digiuno delle quattro tempora, è stato istituito per consacrare ogni stagione dell’anno con la penitenza di alcuni giorni; per domandare a Dio la conservazione dei frutti della terra; per ringraziarlo dei frutti già dati, e per pregarlo di dare alla sua Chiesa dei buoni ministri, dei quali si fa l’ordinazione nei sabati delle quattro tempora.*
+
+**24.** Per qual fine è stato istituito il digiuno delle vigilie?
+
+*Il digiuno delle vigilie è stato istituito per prepararci a celebrare santamente le feste principali.*
+
+**25.** Che cosa ci è proibito nel venerdì e nel sabato non dispensato?
+
+*Nel venerdì e nel sabato non dispensato, ci è proibito il mangiar carne, eccettuato il caso di necessità.*
+
+**26.** Perchè la Chiesa ha voluto che ci asteniamo dal mangiar carne in questi giorni?
+
+*Acciocchè facciamo penitenza in ogni settimana, e massime il venerdì in onore della Passione, ed il sabato in memoria della sepoltura di Gesù Cristo, e in onore di Maria SSm̃a.*
+
+## § 4. Del terzo precetto della Chiesa
+
+**27.** Che cosa ci comanda la Chiesa colle parole del terzo precetto: Confessarsi almeno una volta l’anno?
+
+*Con le parole del terzo precetto: Confessarsi almeno una volta l’anno, la Chiesa obbliga tutti i cristiani, che sono giunti all’uso di ragione, ad accostarsi almeno una volta l’anno al sacramento della Penitenza.*
+
+**28.** Qual è il tempo più opportuno per soddisfare al precetto della Confessione annuale?
+
+*Il tempo più opportuno per soddisfare al precetto della confessione annuale è la Quaresima secondo l’uso introdotto e approvato da tutta la Chiesa.*
+
+**29.** Perchè la Chiesa dice che ci confessiamo almeno una volta l’anno?
+
+*La Chiesa dice: almeno, per farci conoscere il suo desiderio che ci accostiamo più spesso ai santi sacramenti.*
+
+**30.** È dunque cosa utile confessarsi spesso?
+
+*È cosa utilissima confessarsi spesso, massimamente perchè è difficile che si confessi bene e si tenga lontano dal peccato mortale chi si confessa di rado.*
+
+**31.** Che cosa ci prescrive la Chiesa con le altre parole del terzo precetto: Comunicarsi almeno alla Pasqua di Risurrezione, ciascuno nella propria parrocchia?
+
+*Con le altre parole del terzo precetto: Comunicarsi almeno alla Pasqua di Risurrezione, ciascuno nella propria parrocchia, la Chiesa obbliga tutti i cristiani che sono arrivati all’età della discrezione, a ricevere ogni anno la santissima Eucaristia nella propria parrocchia durante il tempo pasquale.*
+
+**32.** Siamo in altro tempo, fuori di Pasqua, obbligati a comunicarci?
+
+*Siamo obbligati a comunicarci anche in pericolo di morte.*
+
+**33.** Perchè si dice che ci comunichiamo almeno alla Pasqua?
+
+*Perchè la Chiesa desidera vivamente che non solo alla Pasqua di Risurrezione; ma il più spesso possibile ci accostiamo alla santa Comunione, che è il divino nutrimento delle anime nostre.*
+
+**34.** Si soddisfa questo precetto con una confessione, o comunione sacrilega.
+
+*Chi facesse una confessione e comunione sacrilega non soddisfa al terzo precetto della Chiesa, perchè l’intenzione della Chiesa è che si ricevano questi sacramenti pel fine per cui furono istituiti, cioè per la nostra santificazione.*
+
+## § 5. Del quarto precetto della Chiesa
+
+**35.** Come si osserva il quarto precetto della Chiesa: Pagar le decime dovute alla Chiesa?
+
+*Il quarto precetto: ' Pagar le decime dovute alla Chiesa, si osserva col pagare quelle offerte o prestazioni che sono state stabilite per riconoscere il supremo dominio che Iddio ha sopra tutte le cose, e per provvedere all’onesta sussistenza de’ suoi ministri.*
+
+**36.** Come si devono pagare le decime?
+
+*Le decime si devono pagare di quelle cose e in quel modo che porta la consuetudine dei luoghi.*
+
+## § 6. Del quinto precetto della Chiesa
+
+**37.** Che cosa ci proibisce la Chiesa nel quinto precetto: Non celebrare le nozze nei tempi proibiti?
+
+*Nel quinto precetto la Chiesa non vieta la celebrazione del sacramento del Matrimonio; ma soltanto la solennità delle nozze dalla prima domenica dell’Avvento sino all’Epifania, e dal primo giorno di Quaresima sino all’ottava di Pasqua.*
+
+**38.** Quale è la solennità delle nozze proibita?
+
+*La solennità proibita da questo precetto consiste nella Messa propria degli sposi, nella benedizione nuziale, e nella pompa straordinaria delle nozze.*
+
+**39.** Perchè le dimostrazioni di pompa non convengono nell’Avvento e nella Quaresima?
+
+*Le dimostrazioni di pompa non convengono nell’Avvento e nella Quaresima, perchè questi sono tempi specialmente consacrati alla penitenza e all’orazione.*

--- a/content/books/pius-x-greater-catechism/it/parte-terza-capo-v.md
+++ b/content/books/pius-x-greater-catechism/it/parte-terza-capo-v.md
@@ -1,0 +1,41 @@
+# Capo V — Dei doveri particolari del proprio stato e dei consigli evangelici
+
+## § 1. Dei doveri del proprio stato
+
+**1.** Che cosa sono i doveri del proprio stato?
+
+*Per doveri del proprio stato s’intendono quelle particolari obbligazioni che ciascuno ha per causa dello stato, della condizione e dell’officio in cui si trova.*
+
+**2.** Chi ha imposto ai vari stati i particolari loro doveri?
+
+*Dio stesso ha imposto ai vari stati i particolari loro doveri, perchè questi derivano da’ suoi divini comandamenti.*
+
+**3.** Spiegatemi con qualche esempio come i doveri particolari derivino dai dieci comandamenti?
+
+*Nel quarto comandamento sotto il nome di padre e di madre, s’intendono anche tutti i nostri superiori, e perciò da quel comandamento derivano tutti i doveri di obbedienza, di amore e di rispetto degli inferiori verso i loro superiori, e tutti i doveri di vigilanza che hanno i superiori verso i loro inferiori.*
+
+**4.** Da quali comandamenti derivano i doveri degli artigiani, dei commercianti, degli amministratori di roba altrui e simili?
+
+*I doveri di fedeltà, di sincerità, di giustizia, di equità, che essi hanno, derivano dal settimo, dall’ottavo e dal decimo comandamento che proibiscono ogni frode, ingiustizia, negligenza e doppiezza.*
+
+**5.** I doveri delle persone consacrate a Dio, da quale comandamento derivano?
+
+*I doveri delle persone consacrate a Dio derivano dal secondo comandamento che ordina di adempiere i voti e le promesse fatte a Dio, essendosi tali persone obbligate in tal modo alla osservanza di tutti o di alcuni consigli evangelici.*
+
+## § 2. Dei consigli evangelici
+
+**6.** Che cosa sono i consigli evangelici?
+
+*I consigli evangelici sono alcuni mezzi suggeriti da Gesù Cristo nel santo Vangelo per giungere alla cristiana perfezione.*
+
+**7.** Quali sono i consigli evangelici?
+
+*I consigli evangelici sono: la povertà volontaria, la castità perpetua, e l’obbedienza in ogni cosa che non sia peccato.*
+
+**8.** A che servono i consigli evangelici?
+
+*I consigli evangelici servono a facilitare l’osservanza dei comandamenti e ad assicurar meglio la eterna salute.*
+
+**9.** Perchè i consigli evangelici facilitano l’osservanza dei comandamenti?
+
+*I consigli evangelici facilitano l’osservanza dei comandamenti, perchè ci aiutano a distaccare il cuore dall’amor della roba, dai piaceri, e dagli onori, e così ci allontanano dal peccato.*

--- a/content/books/pius-x-greater-catechism/it/prime-nozioni-capo-i.md
+++ b/content/books/pius-x-greater-catechism/it/prime-nozioni-capo-i.md
@@ -1,0 +1,101 @@
+# Prime nozioni — Capo I. Delle verità principali di nostra santa Fede
+
+**1.** Fatevi il segno della Croce.
+
+*Nel nome del Padre e del Figliuolo e dello Spirito Santo. Così sia.*
+
+**2.** Ditelo in latino.
+
+*In nomine Patris et Filii et Spiritus Sancti. Amen.*
+
+**3.** Chi vi ha creato?
+
+*Mi ha creato Iddio.*
+
+**4.** Per qual fine Dio vi ha creato?
+
+*Dio mi ha creato per conoscerlo, amarlo e servirlo in questa vita, e poi goderlo per sempre nell’altra.*
+
+**5.** Chi è Dio?
+
+*Dio è l’Essere perfettissimo, Creatore e Signore del cielo e della terra.*
+
+**6.** Vi è un solo Dio?
+
+*Sì, vi è un solo Dio.*
+
+**7.** Dove è Dio?
+
+*Dio è in cielo, in terra e in ogni luogo.*
+
+**8.** Dio vede tutto?
+
+*Sì, Dio vede tutto, anche i nostri pensieri.*
+
+**9.** Dio è sempre stato?
+
+*Dio è sempre stato e sempre sarà, perchè è eterno.*
+
+**10.** Dio ha il corpo come noi?
+
+*Dio non ha corpo, perchè è un purissimo spirito.*
+
+**11.** Quante Persone sono in Dio?
+
+*In Dio sono tre Persone realmente distinte.*
+
+**12.** Come si chiamano le tre Persone divine?
+
+*Le tre Persone divine si chiamano il Padre, il Figliuolo e lo Spirito Santo.*
+
+**13.** Le Persone della SSm̃a Trinità sono uguali o disuguali fra loro?
+
+*Le Persone della SSm̃a Trinità sono perfettamente uguali, perchè hanno la stessa essenza o natura divina.*
+
+**14.** Delle tre Persone divine quale si è fatta uomo?
+
+*Delle tre Persone divine si è fatta uomo la seconda, cioè il Figliuolo.*
+
+**15.** In qual modo il Figliuolo di Dio si fece uomo?
+
+*Il Figliuolo di Dio si fece uomo prendendo un corpo ed un’anima, come abbiamo noi, nel purissimo seno di Maria Vergine, per opera dello Spirito Santo.*
+
+**16.** Come si chiama il Figliuolo di Dio fatto uomo?
+
+*Il Figliuolo di Dio fatto uomo si chiama Gesù Cristo.*
+
+**17.** Chi è dunque Gesù Cristo?
+
+*Gesù Cristo è il Figliuolo di Dio fatto uomo.*
+
+**18.** Perchè il Figliuolo di Dio si fece uomo?
+
+*Il Figliuolo di Dio si fece uomo per salvarci.*
+
+**19.** Che vuol dire: per salvarci?
+
+*Per salvarci vuol dire per liberarci dal peccato e dall’Inferno e per meritarci la gloria del Paradiso.*
+
+**20.** Che cosa si gode in paradiso?
+
+*In paradiso si gode per sempre la vista di Dio e ogni bene, senza patire alcuna sorta di male.*
+
+**21.** A chi concede Iddio il paradiso?
+
+*Dio concede il paradiso come premio a coloro che in questa vita lo amano e lo servono.*
+
+**22.** Che cosa si soffre nell’inferno?
+
+*Nell’inferno si soffre per sempre la privazione della vista di Dio, il fuoco eterno ed ogni male, senza aver mai alcuna sorta di bene.*
+
+**23.** Chi è condannato all inferno?
+
+*All’inferno sono condannati coloro che in questa vita non vollero amare nè servire Iddio e muoiono impenitenti.*
+
+**24.** Che cosa ha fatto Gesù Cristo per salvarci?
+
+*Gesù Cristo per salvarci ha patito ed è morto in croce.*
+
+**25.** Dopo la sua morte risuscitò Gesù Cristo?
+
+*Gesù Cristo tre giorni dopo la sua morte risuscitò glorioso e trionfante per non mai più morire.*

--- a/content/books/pius-x-greater-catechism/it/prime-nozioni-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/it/prime-nozioni-capo-ii.md
@@ -1,0 +1,133 @@
+# Prime nozioni — Capo II. Parti principali della Dottrina cristiana
+
+**1.** Quali sono le parti principali della Dottrina cristiana?
+
+*Le parti principali della Dottrina cristiana sono quattro; cioè il Credo, il Pater noster, i Comandamenti e i Sacramenti.*
+
+**2.** Dite il Credo.
+
+*1.º Io credo in Dio Padre onnipotente creatore del cielo e della terra.*
+
+*2.º E in Gesù Cristo, suo figliuolo unico, Signor nostro.*
+
+*3.º Il quale fu concepito di Spirito Santo: nacque da Maria Vergine.*
+
+*4.º Patì sotto Ponzio Pilato: fu crocifisso, morto e sepolto.*
+
+*5.º Discese all’inferno: il terzo giorno risuscitò da morte.*
+
+*6.º Salì al Cielo: siede alla destra di Dio Padre onnipotente.*
+
+*7.º Di là ha da venire a giudicare i vivi e i morti.*
+
+*8.º Credo nello Spirito Santo.*
+
+*9.º La santa Chiesa Cattolica: la comunione dei santi.*
+
+*10.º La remissione de’ peccati.*
+
+*11.º La risurrezione della carne.*
+
+*12.º La vita eterna. Amen.*
+
+**3.** Dite il Pater noster in italiano.
+
+*Padre nostro, che sei ne’ cieli,*
+
+*1.º Sia santificato il nome tuo.*
+
+*2.º Venga il regno tuo.*
+
+*3.º Sia fatta la volontà tua, come in cielo, così in terra.*
+
+*4.º Dacci oggi il nostro pane quotidiano.*
+
+*5.º E rimetti a noi i nostri debiti, siccome noi li rimettiamo ai nostri debitori.*
+
+*6.º E non c’indurre in tentazione.*
+
+*7.º Ma liberaci dal male. Così sia.*
+
+**4.** Dite il Pater noster in latino.
+
+*Pater noster qui es in coelis,*
+
+*1.º Sanctificetur nomen tuum.*
+
+*2.º Adveniat regnum tuum.*
+
+*3.º Fiat voluntas tua, sicut in coelo et in terra.*
+
+*4.º Panem nostrum quotidianum da nobis hodie;*
+
+*5.º Et dimitte nobis debita nostra, sicut et nos dimittimus debitoribus nostris;*
+
+*6.º Et ne nos inducas in tentationem;*
+
+*7.º Sed libera nos a malo. Amen.*
+
+**5.** Dite l’ Ave Maria in italiano.
+
+*Dio ti salvi, o Maria, piena di grazia. Il Signore è teco. Tu sei benedetta fra le donne, e benedetto è il frutto del tuo seno Gesù. Santa Maria, Madre di Dio, prega per noi peccatori, adesso e nell’ora della morte nostra. Così sia.*
+
+**6.** Dite l’ Ave Maria in latino.
+
+*Ave, Maria, gratia plena. Dominus tecum. Benedicta tu in mulieribus et benedictus fructus ventris tui, Iesus. Sancta Maria, Mater Dei, ora pro nobis peccatoribus, nunc et in hora mortis nostrae. Amen.*
+
+**7.** Dite il Gloria in italiano.
+
+*Gloria al Padre, al Figlio e allo Spirito Santo, come era nel principio, adesso e sempre e nei secoli dei secoli. Così sia.*
+
+**8.** Dite il Gloria in latino.
+
+*Gloria Patri et Filio et Spiritui Sancto, sicut erat in principio et nunc et semper et in saecula saeculorum. Amen.*
+
+**9.** Quanti e quali sono i comandamenti di Dio?
+
+*I comandamenti di Dio sono dieci.*
+
+*Io sono il Signore Iddio tuo:*
+
+*1.º Non avrai altro Dio avanti di me.*
+
+*2.º Non nominare il nome di Dio invano.*
+
+*3.º Ricordati di santificare le feste.*
+
+*4.º Onora il padre e la madre.*
+
+*5.º Non ammazzare.*
+
+*6.º Non fornicare.*
+
+*7.º Non rubare.*
+
+*8.º Non dire il falso testimonio.*
+
+*9.º Non desiderare la donna d’altri.*
+
+*10.º Non desiderare la roba d’altri.*
+
+**10.** Quanti e quali sono i precetti della Chiesa?
+
+*I Precetti della Chiesa sono cinque:*
+
+*1.º Udir la Messa tutte le domeniche e le altre feste comandate.*
+
+*2.º Digiunare la quaresima, le quattro tempora e le vigilie comandate: non mangiar carne nei giorni proibiti.*
+
+*3.º Confessarsi almeno una volta l’anno, e comunicarsi nella Pasqua di Risurrezione, alla propria parrocchia.*
+
+*4.º Pagare le decime dovute alla Chiesa, secondo le usanze.*
+
+*5.º Non celebrare le nozze ne’ tempi vietati, cioè dalla prima domenica dell’Avvento fino all’Epifania, e dal primo giorno di Quaresima fino all’ottava di Pasqua.*
+
+**11.** Quanti e quali sono i sacramenti?
+
+*I Sacramenti sono sette:*
+
+*1.º Battesimo; 2.º Cresima; 3.º Eucaristia; 4.º Penitenza; 5.º Estrema unzione; 6.º Ordine sacro; 7.º Matrimonio.*
+
+**12.** Chi ha istituito questi sacramenti?
+
+*Li ha istituiti il nostro Signor Gesù Cristo.*

--- a/content/books/pius-x-greater-catechism/it/prime-nozioni-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/it/prime-nozioni-capo-iii.md
@@ -1,0 +1,21 @@
+# Prime nozioni — Capo III. Atti di Fede, di Speranza, di Carità e di Contrizione
+
+**1.** Dite l’Atto di Fede.
+
+*Io credo fermamente, perchè così ha rivelato Dio, infallibile verità, alla santa Chiesa cattolica, e per mezzo di essa lo rivela anche a noi, che vi è un solo Dio in tre Persone Divine, uguali e distinte, che si chiamano Padre, Figliuolo e Spirito Santo; che il Figliuolo si fece uomo, prendendo, per opera dello Spirito Santo, carne ed anima umana nel seno della purissima Vergine Maria: morì per noi in croce, risuscitò, salì al cielo, e di là ha da venire alla fine del mondo a giudicare tutti i vivi ed i morti, per dare per sempre ai buoni il paradiso ed ai cattivi l’inferno. E di più per l’istesso motivo credo tutto quello che crede ed insegna la medesima santa Chiesa.*
+
+**2.** Dite l’Atto di Speranza.
+
+*Dio mio, perchè siete onnipotente ed infinitamente buono e misericordioso, io spero che, per i meriti della passione e morte di Gesù Cristo nostro Salvatore, mi darete la vita eterna, la quale Voi fedelissimo avete promessa a chi farà opere da buon cristiano, come propongo di fare col vostro santo aiuto.*
+
+**3.** Dite l’Atto di Carità.
+
+*Dio mio, perchè siete sommo e perfettissimo Bene, vi amo con tutto il cuore e sopra ogni altra cosa, e, piuttosto che offendervi, sono disposto a perdere ogni altra cosa e per amor vostro amo ancora e voglio amare il prossimo mio come me medesimo.*
+
+**4.** Dite l’Atto di Contrizione.
+
+*Dio mio, per esser Voi somma Bontà, e perchè vi amo sopra ogni cosa, mi pento e mi dolgo di vero cuore di avervi offeso, e propongo fermamente, col vostro santo aiuto, di non peccare mai più nell’avvenire, ed in particolare di fuggire le occasioni prossime del peccato.*
+
+**5.** Dite l’Atto di Attrizione e Contrizione?
+
+*O mio Dio, mi pento e mi dolgo di vero cuore di avervi offeso. Me ne pento per l’inferno che ho meritato e per il paradiso che ho perduto; ma molto più mi pento perchè peccando ho offeso un Dio così buono, così grande come siete Voi. Vorrei prima esser morto che avervi offeso; e propongo fermamente di non peccare più per l’avvenire e di fuggire le occasioni prossime del peccato.*

--- a/content/books/pius-x-greater-catechism/pt-BR/avvertenza.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/avvertenza.md
@@ -1,0 +1,9 @@
+# Advertência
+
+A instrução das crianças e jovens na Doutrina Cristã divide-se em duas Classes ou Seções: à primeira responde o Catecismo Breve, destinado principalmente às crianças que ainda não fizeram a primeira Comunhão; à segunda, o Catecismo Maior, para os jovens já instruídos no que se ensina no Catecismo Breve. A este precedem algumas poucas páginas de primeiras noções de Catecismo para as crianças de tenra idade que, seja em casa, seja nas creches e jardins de infância, começam a aprender os primeiros rudimentos da Fé.
+
+Ao Catecismo Maior segue-se uma Instrução sobre as festas principais da Igreja e um brevíssimo compêndio de História da Religião, a fim de que nada falte aos jovens daquilo que convém à sua instrução religiosa.
+
+É proibida, nos termos da lei, a reprodução.
+
+Os editores reservam-se o direito de conceder aos Excelentíssimos Bispos que o solicitarem a autorização para reproduzir esta edição.

--- a/content/books/pius-x-greater-catechism/pt-BR/lettera-promulgazione.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/lettera-promulgazione.md
@@ -1,0 +1,17 @@
+# Carta de S.S. o Papa Pio X ao Cardeal Pietro Respighi
+
+AO SENHOR CARDEAL
+
+PIETRO RESPIGHI
+
+nosso vigário geral
+
+Senhor Cardeal,
+
+A necessidade de prover, quanto possível, à instrução religiosa da tenra juventude aconselhou-Nos a impressão de um Catecismo que exponha de modo claro os rudimentos da santa fé e aquelas verdades divinas pelas quais se deve pautar a vida de todo cristão. Por isso, depois de mandarmos examinar os muitos livros de texto já em uso nas Dioceses da Itália, pareceu-Nos oportuno adotar, com leves retoques, o texto há vários anos aprovado pelos Bispos do Piemonte, da Ligúria, da Lombardia, da Emília e da Toscana. O uso deste texto será obrigatório para o ensino público e privado na Diocese de Roma e em todas as outras da Província Romana; e confiamos em que também as outras Dioceses queiram adotá-lo, chegando-se assim àquele texto único, ao menos para toda a Itália, que é o desejo universal.
+
+Com esta doce esperança, concedemos de todo o coração a Vós, Senhor Cardeal, a Bênção Apostólica.
+
+Do Vaticano, aos 14 de junho de 1905.
+
+PIUS PP. X

--- a/content/books/pius-x-greater-catechism/pt-BR/lezione-preliminare.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/lezione-preliminare.md
@@ -1,0 +1,59 @@
+# Lição preliminar — Da doutrina cristã e de suas partes principais
+
+DA DOUTRINA CRISTÃ E DE SUAS PARTES PRINCIPAIS
+
+**1.** Sois cristão?
+
+*Sim, sou cristão por graça de Deus.*
+
+**2.** Por que dizeis: por graça de Deus?
+
+*Eu digo: por graça de Deus, porque o ser cristão é um dom totalmente gratuito de Deus, que nós não pudemos merecer.*
+
+**3.** Quem é verdadeiro cristão?
+
+*Verdadeiro cristão é aquele que é batizado, que crê e professa a doutrina cristã e obedece aos legítimos Pastores da Igreja.*
+
+**4.** O que é a doutrina cristã?
+
+*A doutrina cristã é a doutrina que Jesus Cristo, Nosso Senhor, nos ensinou para mostrar-nos o caminho da salvação.*
+
+**5.** É necessário aprender a doutrina ensinada por Jesus Cristo?
+
+*É certamente necessário aprender a doutrina ensinada por Jesus Cristo, e faltam gravemente aqueles que negligenciam fazê-lo.*
+
+**6.** Os pais e patrões são obrigados a mandar seus filhos e subordinados ao catecismo?
+
+*Os pais e patrões são obrigados a procurar que os seus filhos e subordinados aprendam a doutrina cristã, e tornam-se culpados diante de Deus se negligenciarem este dever.*
+
+**7.** De quem devemos nós receber e aprender a doutrina cristã?
+
+*Nós devemos receber e aprender a doutrina cristã da santa Igreja católica.*
+
+**8.** Como estamos certos de que a doutrina cristã que recebemos da santa Igreja católica é verdadeira?
+
+*Estamos certos de que a doutrina cristã que recebemos da Igreja católica é verdadeira, porque Jesus Cristo, autor divino dessa doutrina, a confiou, por meio dos seus Apóstolos, à Igreja por Ele mesmo fundada e constituída mestra infalível de todos os homens, prometendo-lhe a sua divina assistência até o fim dos séculos.*
+
+**9.** Há outras provas da verdade da doutrina cristã?
+
+*A verdade da doutrina cristã é demonstrada também pela eminente santidade de tantos que a professaram e a professam, pela heroica fortaleza dos mártires, pela sua rápida e admirável propagação no mundo e pela sua plena conservação através de tantos séculos de lutas variadas e contínuas.*
+
+**10.** Quantas e quais são as partes principais e mais necessárias da doutrina cristã?
+
+*As partes principais e mais necessárias da doutrina cristã são quatro: o Credo, o Pater Noster, os Mandamentos e os Sacramentos.*
+
+**11.** O que nos ensina o Credo?
+
+*O Credo nos ensina os principais artigos de nossa santa fé.*
+
+**12.** O que nos ensina o Pater Noster?
+
+*O Pater Noster nos ensina tudo o que devemos esperar de Deus e tudo o que devemos pedir-Lhe.*
+
+**13.** O que nos ensinam os Mandamentos?
+
+*Os Mandamentos nos ensinam tudo o que devemos fazer para agradar a Deus; o que tudo se resume em amar a Deus sobre todas as coisas e ao próximo como a nós mesmos, por amor de Deus.*
+
+**14.** O que nos ensina a doutrina dos Sacramentos?
+
+*A doutrina dos Sacramentos nos faz conhecer a natureza e o bom uso daqueles meios que Jesus Cristo instituiu para perdoar-nos os pecados, comunicar-nos a sua graça e infundir e aumentar em nós as virtudes da fé, da esperança e da caridade.*

--- a/content/books/pius-x-greater-catechism/pt-BR/orazioni-quotidiane.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/orazioni-quotidiane.md
@@ -1,0 +1,349 @@
+# Orações cotidianas e outras preces
+
+## Pela manhã
+
+Feito o sinal da Cruz, direis:
+
+*Eu Vos adoro, meu Deus, e Vos amo de todo o coração: agradeço-Vos por me haverdes criado, feito cristão e conservado nesta noite; ofereço-Vos todas as minhas ações, peço-Vos que me preserveis neste dia do pecado e me livreis de todo mal. Assim seja.*
+
+Depois direis o *Pater Noster*, a *Ave Maria*, o *Credo* e os *Atos de Fé*, *de Esperança* e *de Caridade*; a *Salve Rainha* e o *Angele Dei*.
+
+## Durante o dia
+
+**Antes do trabalho.** — *Senhor, ofereço-Vos este trabalho, peço-Vos que o abençoeis, para que seja para Vossa glória.*
+
+**Antes das refeições.** — *Senhor, ofereço-Vos este alimento e peço-Vos que o abençoeis.*
+
+**Depois das refeições.** — *Senhor, agradeço-Vos pelo alimento que me destes e fazei-me digno de ser admitido à Vossa mesa celeste.*
+
+**Nas tentações.** — *Jesus meu, ajudai-me e dai-me a graça de não Vos ofender.*
+
+## Orações para a noite
+
+*Eu Vos adoro, meu Deus, e Vos amo de todo o coração; agradeço-Vos por me haverdes criado, feito cristão e conservado neste dia; ofereço-Vos tudo o que de bem fiz hoje e peço-Vos que me livreis de todo mal. Assim seja.*
+
+Depois direis: *Pater Noster*, *Ave Maria*, *Gloria Patri*, *Ato de contrição*.
+
+*Jesus, José e Maria, eu Vos dou o coração e a alma minha.*
+
+*Jesus, José e Maria, assisti-me na última agonia.*
+
+*Jesus, José e Maria, expire em paz convosco a alma minha.*
+
+## Breve preparação para a confissão
+
+*Amabilíssimo Salvador meu, dai-me a graça de aproximar-me deste sacramento da Penitência para a salvação da minha alma e para a Vossa glória.*
+
+*Virgem santíssima, Mãe de Jesus e Mãe minha, alcançai-me de Vosso bendito Filho a graça de conhecer, detestar e confessar sinceramente todos os meus pecados.*
+
+*Pater Noster* e *Ave Maria*. Em seguida faça-se diligentemente o exame, diante de Deus, sobre os pecados cometidos em pensamentos, palavras, obras e omissões, contra os mandamentos de Deus e da Igreja, e contra os deveres do próprio estado.
+
+A seguir, para excitar o arrependimento dos pecados cometidos, considere-se o grande mal que se fez ao pecar, isto é, que pelo pecado mortal se perdeu a graça de Deus e o paraíso, mereceram-se as penas do inferno, e ofendeu-se Deus, nosso Senhor e Pai, o qual nos fez tantos benefícios, tanto nos ama e tem mérito infinito para ser amado sobre todas as coisas e servido fielmente.
+
+Recite-se o *Ato de contrição*.
+
+## Depois da confissão
+
+Antes de tudo, dêem-se graças ao Senhor pelo inestimável benefício do perdão; cumpra-se logo a penitência imposta pelo confessor; renove-se o propósito de evitar os pecados e suas ocasiões.
+
+Em seguida recite-se a seguinte oração:
+
+*Quão bom fostes comigo, ó Senhor! Em vez de me punirdes pelos muitos pecados que cometi, todos mos perdoastes com infinita misericórdia nesta santa confissão. De novo me arrependo deles de todo o coração e prometo, com o auxílio da Vossa graça, não Vos ofender nunca mais e compensar com igual amor as ofensas que Vos fiz em toda a minha vida.*
+
+*Virgem santíssima, Anjos e Santos do céu, agradeço-Vos a vossa assistência; e vós também rendei por mim graças ao Senhor por Sua misericórdia, e obtende-me constância e progresso no bem.*
+
+*Pater Noster*, *Ave Maria*, *Gloria Patri* e *Angele Dei*.
+
+## Breve preparação para a Santíssima Comunhão
+
+### Ato de fé
+
+*Senhor meu Jesus Cristo, creio firmemente que estais realmente presente no Santíssimo Sacramento com o Vosso Corpo, Sangue, Alma e Divindade.*
+
+### Ato de adoração
+
+*Senhor, eu Vos adoro neste Sacramento e Vos reconheço por meu Criador, Redentor e soberano Senhor, sumo e único bem meu.*
+
+### Ato de humildade
+
+*Senhor, eu não sou digno de que entreis em mim, mas dizei uma só palavra e a minha alma será salva.*
+
+### Ato de contrição
+
+*Senhor, detesto todos os meus pecados, que me tornam indigno de Vos receber em meu coração, e proponho, com a Vossa graça, não os cometer mais para o futuro, fugir das suas ocasiões e fazer deles a penitência.*
+
+### Ato de esperança
+
+*Senhor, espero que, dando-Vos todo a mim neste divino Sacramento, useis comigo de misericórdia e me concedais todas as graças necessárias para a minha eterna salvação.*
+
+### Ato de caridade
+
+*Senhor, Vós sois infinitamente amável, sois meu pai, meu Redentor, meu Deus; por isso Vos amo de todo o coração sobre todas as coisas, e por Vosso amor amo o meu próximo como a mim mesmo, e perdoo de coração a quem me ofendeu.*
+
+### Ato de desejo
+
+*Senhor, desejo ardentemente que venhais à minha alma, para que eu não me separe nunca mais de Vós, mas viva sempre na Vossa graça.*
+
+## Breve ação de graças depois da Santíssima Comunhão
+
+### Ato de fé
+
+*Senhor meu Jesus Cristo, creio que estais verdadeiramente em mim com o Vosso Corpo, Sangue, Alma e Divindade, e o creio mais firmemente do que se o visse com os meus próprios olhos.*
+
+### Ato de adoração
+
+*Ó Jesus meu, eu Vos adoro presente dentro de mim; e me uno a Maria Santíssima, aos Anjos e aos Santos para Vos adorar como mereceis.*
+
+### Ato de agradecimento
+
+*Jesus, Senhor meu, eu Vos agradeço de todo o coração, porque viestes à minha alma. Santíssima Virgem Maria, Anjo meu da Guarda, e vós todos Anjos e Santos do paraíso, agradecei a Jesus por mim.*
+
+### Ato de caridade
+
+*Ó Jesus, meu Deus, eu Vos amo quanto sei e posso, e desejo amar-Vos quanto mereceis: fazei que Vos ame sobre todas as coisas agora e por toda a eternidade.*
+
+### Ato de oferecimento
+
+*Ó meu Jesus, Vós Vos destes todo a mim, eis que eu me dou todo a Vós; ofereço-Vos o meu coração e a minha alma, consagro-Vos toda a minha vida e quero ser Vosso por toda a eternidade.*
+
+### Ato de esperança
+
+*Ó meu Jesus, agora que viestes à minha alma, espero que não Vos separeis nunca mais de mim, mas permaneçais sempre comigo com a Vossa divina graça.*
+
+### Ato de petição
+
+*Ó meu Jesus, dai-me, por favor, todas aquelas graças espirituais e temporais que Vós conheceis serem úteis à minha alma; e socorrei os meus superiores, parentes, amigos, benfeitores e as santas almas do purgatório.*
+
+Depois direis: *Pater Noster*, *Ave Maria*, *Gloria Patri*.
+
+## Mistérios do Santo Rosário
+
+### Gozosos (segunda e quinta-feira)
+
+1. A anunciação do Anjo a Maria Santíssima.
+2. A visita de Maria Virgem a Santa Isabel.
+3. A natividade de Jesus Cristo na gruta de Belém.
+4. A apresentação do Menino Jesus no templo.
+5. A perda e o reencontro de Jesus entre os doutores no templo.
+
+### Dolorosos (terça e sexta-feira)
+
+1. A oração de Jesus Cristo no horto.
+2. A flagelação de Jesus Cristo na coluna.
+3. A coroação de espinhos.
+4. O caminho do Calvário de Jesus Cristo carregando a cruz.
+5. A crucificação e morte de Jesus Cristo.
+
+### Gloriosos (quarta-feira, sábado e domingo)
+
+1. A ressurreição de Jesus Cristo.
+2. A ascensão de Jesus Cristo ao céu.
+3. A vinda do Espírito Santo sobre os Apóstolos e sobre Maria Santíssima.
+4. A assunção de Maria Virgem ao céu.
+5. A coroação de Maria Virgem sobre todos os Anjos e Santos.
+
+## Ladainha da Bem-aventurada Virgem
+
+*O texto da Ladainha Lauretana não consta da transcrição Wikisource de 1905.*
+
+## Hinos ao Santíssimo Sacramento
+
+*Bendito seja Deus:*
+
+*Bendito seja o seu santo Nome:*
+
+*Bendito seja Jesus Cristo verdadeiro Deus e verdadeiro homem:*
+
+*Bendito seja o nome de Jesus:*
+
+*Bendito seja o seu sacratíssimo Coração:*
+
+*Bendito seja Jesus no Santíssimo Sacramento do altar:*
+
+*Bendita seja a grande Mãe de Deus Maria Santíssima:*
+
+*Bendita seja a sua santa e imaculada Conceição:*
+
+*Bendito seja o nome de Maria Virgem e Mãe:*
+
+*Bendito seja Deus em seus Anjos e em seus Santos.*
+
+## Modo de servir à Santa Missa
+
+### Ao início
+
+**S.** In nomine Patris et Filii, et Spiritus Sancti. Amen. Introibo ad altare Dei.
+
+**C.** Ad Deum qui lætificat iuventutem meam.
+
+**S.** Iudica me, Deus, et discerne causam meam de gente non sancta, ab homine iniquo et doloso erue me.
+
+**C.** Quia tu es, Deus, fortitudo mea; quare me repulisti, et quare tristis incedo, dum affligit me inimicus?
+
+**S.** Emitte lucem tuam et veritatem tuam: ipsa me deduxerunt et adduxerunt in montem sanctum tuum et in tabernacula tua.
+
+**C.** Et introibo ad altare Dei; ad Deum qui lætificat iuventutem meam.
+
+**S.** Confitebor tibi in cithara, Deus, Deus meus, quare tristis es anima mea, et quare conturbas me?
+
+**C.** Spera in Deo, quoniam adhuc confitebor illi, salutare vultus mei et Deus meus.
+
+**S.** Gloria Patri et Filio et Spiritui Sancto.
+
+**C.** Sicut erat in principio, et nunc et semper, et in sæcula sæculorum. Amen.
+
+**S.** Introibo ad altare Dei.
+
+**C.** Ad Deum, qui lætificat iuventutem meam.
+
+**S.** Adiutorium nostrum in nomine Domini.
+
+**C.** Qui fecit cœlum et terram.
+
+**S.** Confiteor, etc.
+
+**C.** Misereatur tui omnipotens Deus, et dimissis peccatis tuis, perducat te ad vitam æternam.
+
+**S.** Amen.
+
+**C.** Confiteor Deo omnipotenti, beatæ Mariæ semper Virgini, beato Michaëli archangelo, beato Ioanni Baptistae, sanctis apostolis Petro et Paulo, omnibus sanctis et tibi, pater; quia peccavi nimis cogitatione, verbo et opere; mea culpa, mea culpa, mea maxima culpa. Ideo precor beatam Mariam semper Virginem, beatum Michaëlem archangelum, beatum Ioannem Baptistam, sanctos apostolos Petrum et Paulum, omnes sanctos et te, pater, orare pro me ad Dominum Deum nostrum.
+
+**S.** Misereatur… vitam aeternam.
+
+**C.** Amen.
+
+**S.** Indulgentiam… misericors Dominus.
+
+**C.** Amen.
+
+**S.** Deus, tu conversus vivificabis nos.
+
+**C.** Et plebs tua lætabitur in te.
+
+**S.** Ostende nobis, Domine, misericordiam tuam.
+
+**C.** Et salutare tuum da nobis.
+
+**S.** Domine, exaudi orationem meam.
+
+**C.** Et clamor meus ad te veniat.
+
+**S.** Dominus vobiscum.
+
+### Ao «Kyrie eleison»
+
+**C.** Kyrie, eleison; Christe, eleison; Christe, eleison; Kyrie, eleison.
+
+### Depois do «Kyrie» ou do «Gloria in excelsis»
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+### Ao final dos «Oremus» responde-se
+
+**C.** Amen.
+
+### Terminada a Epístola responde-se
+
+**C.** Deo gratias.
+
+### Antes do Evangelho
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+**S.** Initium o Sequentia sancti Evangelii secundum N.
+
+**C.** Gloria tibi, Domine.
+
+### Terminado o Evangelho responde-se
+
+**C.** Laus tibi, Christe.
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+### Ao «Orate fratres»
+
+**C.** Suscipiat Dominus sacrificium de manibus tuis ad laudem et gloriam nominis sui; ad utilitatem quoque nostram, totiusque Ecclesiæ suæ sanctæ.
+
+### Ao Prefácio
+
+**S.** Per omnia saecula saeculorum.
+
+**C.** Amen.
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+**S.** Sursum corda.
+
+**C.** Habemus ad Dominum.
+
+**S.** Gratias agamus Domino Deo nostro.
+
+**C.** Dignum et iustum est.
+
+### Antes do «Pater Noster»
+
+**S.** Per omnia saecula saeculorum.
+
+**C.** Amen.
+
+### Ao final do «Pater Noster»
+
+**S.** Et ne nos inducas in tentationem.
+
+**C.** Sed libera nos a malo.
+
+### À fração da Hóstia
+
+**S.** Per omnia saecula saeculorum.
+
+**C.** Amen.
+
+**S.** Pax Domini sit semper vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+### Depois da Comunhão
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+### Ao final dos «Oremus» responde-se
+
+**C.** Amen.
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+**S.** Ite, missa est, o Benedicamus Domino.
+
+**C.** Deo gratias.
+
+### À bênção
+
+**S.** Benedicat vos… Spiritus Sanctus.
+
+**C.** Amen.
+
+### Ao último Evangelho
+
+**S.** Dominus vobiscum.
+
+**C.** Et cum spiritu tuo.
+
+**S.** Initium o sequentia sancti Evangelii secundum N.
+
+**C.** Gloria tibi Domine.
+
+### Terminado o Evangelho responde-se
+
+**C.** Deo gratias.

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-i.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-i.md
@@ -1,0 +1,51 @@
+# Capítulo I — Do «Credo» em geral
+
+**1.** Qual é a primeira parte da doutrina cristã?
+
+*A primeira parte da doutrina cristã é o símbolo dos Apóstolos, comumente chamado Credo.*
+
+**2.** Por que chamais o Credo de Símbolo dos Apóstolos?
+
+*O Credo chama-se símbolo dos Apóstolos porque é um compêndio das verdades da fé ensinadas pelos Apóstolos.*
+
+**3.** Quantos artigos há no Credo?
+
+*No Credo há doze artigos.*
+
+**4.** Recitai-os.
+
+*1.º Creio em Deus Pai todo-poderoso, Criador do céu e da terra.*
+
+*2.º E em Jesus Cristo, seu único Filho, Nosso Senhor.*
+
+*3.º O qual foi concebido pelo poder do Espírito Santo; nasceu da Virgem Maria.*
+
+*4.º Padeceu sob Pôncio Pilatos; foi crucificado, morto e sepultado.*
+
+*5.º Desceu à mansão dos mortos; ressuscitou ao terceiro dia.*
+
+*6.º Subiu ao céu; está sentado à direita de Deus Pai todo-poderoso.*
+
+*7.º Donde há de vir a julgar os vivos e os mortos.*
+
+*8.º Creio no Espírito Santo.*
+
+*9.º Na santa Igreja católica; na comunhão dos santos.*
+
+*10.º Na remissão dos pecados.*
+
+*11.º Na ressurreição da carne.*
+
+*12.º Na vida eterna. Amém.*
+
+**5.** O que quer dizer a palavra Credo, que dizeis no princípio do Símbolo?
+
+*A palavra Credo quer dizer: tenho por veríssimo tudo o que nestes doze artigos se contém; e creio mais firmemente nestas coisas do que se as visse com meus próprios olhos, porque as revelou Deus, que não pode enganar-se nem enganar, à santa Igreja católica e, por meio dela, as revela também a nós.*
+
+**6.** O que contêm os artigos do Credo?
+
+*Os artigos do Credo contêm tudo aquilo que principalmente se deve crer acerca de Deus, de Jesus Cristo e da Igreja, sua esposa.*
+
+**7.** É muito útil recitar amiúde o Credo?
+
+*É utilíssimo recitar amiúde o Credo, para imprimir cada vez mais no coração as verdades da fé.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-ii.md
@@ -1,0 +1,195 @@
+# Capítulo II — Do primeiro artigo do Símbolo
+
+## § 1. De Deus Pai e da criação
+
+**1.** Que nos ensina o primeiro artigo: Creio em Deus Pai todo-poderoso, Criador do céu e da terra?
+
+*O primeiro artigo do Credo nos ensina que existe um só Deus, que é onipotente e criou o céu, a terra e todas as coisas que no céu e na terra se contêm, isto é, o universo inteiro.*
+
+**2.** Como sabemos nós que existe Deus?
+
+*Sabemos que existe Deus porque a nossa razão no-lo demonstra e a fé no-lo confirma.*
+
+**3.** Por que se diz que Deus é Pai?
+
+*Diz-se que Deus é Pai: 1.º porque é Pai por natureza da segunda Pessoa da Santíssima Trindade, isto é, do Filho por Ele gerado; 2.º porque Deus é Pai de todos os homens, que Ele criou, conserva e governa; 3.º porque, enfim, é Pai por graça de todos os bons cristãos, os quais por isso se chamam filhos adotivos de Deus.*
+
+**4.** Por que o Pai é a primeira Pessoa da Santíssima Trindade?
+
+*O Pai é a primeira Pessoa da Santíssima Trindade porque não procede de outra pessoa, mas é o princípio das outras duas pessoas, isto é, do Filho e do Espírito Santo.*
+
+**5.** O que quer dizer a palavra onipotente?
+
+*A palavra onipotente quer dizer que Deus pode fazer tudo o que quer.*
+
+**6.** Deus não pode pecar nem morrer; como, então, se diz que Ele pode fazer tudo?
+
+*Diz-se que Deus pode fazer tudo, ainda que não possa pecar nem morrer, porque o poder pecar ou morrer não é efeito de potência, mas de fraqueza, a qual não pode haver em Deus, que é perfeitíssimo.*
+
+**7.** O que quer dizer: Criador do céu e da terra?
+
+*Criar quer dizer fazer do nada; por isso Deus se diz Criador do céu e da terra, porque do nada fez o céu e a terra e todas as coisas que no céu e na terra se contêm, isto é, o universo inteiro.*
+
+**8.** O mundo foi criado somente pelo Pai?
+
+*O mundo foi criado igualmente pelas três pessoas divinas, porque tudo aquilo que faz uma pessoa em relação às criaturas, o fazem com um só e mesmo ato também as outras.*
+
+**9.** Por que, então, a criação se atribui particularmente ao Pai?
+
+*A criação se atribui particularmente ao Pai porque a criação é efeito da divina onipotência, a qual se atribui especialmente ao Pai, como se atribui a sabedoria ao Filho e a bondade ao Espírito Santo, embora as três pessoas tenham a mesma onipotência, sabedoria e bondade.*
+
+**10.** Deus tem cuidado do mundo e de todas as coisas que criou?
+
+*Sim, Deus tem cuidado do mundo e de todas as coisas que criou; conserva-as e governa-as com sua infinita bondade e sabedoria, e nada acontece aqui na terra sem que Deus o queira ou o permita.*
+
+**11.** Por que dizeis que nada acontece sem que Deus o queira ou o permita?
+
+*Diz-se que nada acontece aqui na terra sem que Deus o queira ou o permita, porque há coisas que Deus quer e ordena, e outras que Ele não impede, como o pecado.*
+
+**12.** Por que Deus não impede o pecado?
+
+*Deus não impede o pecado porque também do abuso que o homem faz da liberdade que lhe concedeu, sabe tirar um bem e fazer resplandecer cada vez mais a sua misericórdia ou a sua justiça.*
+
+## § 2. Dos Anjos
+
+**13.** Quais são as criaturas mais nobres que Deus criou?
+
+*As criaturas mais nobres criadas por Deus são os Anjos.*
+
+**14.** Quem são os Anjos?
+
+*Os Anjos são criaturas inteligentes e puramente espirituais.*
+
+**15.** Para que fim Deus criou os Anjos?
+
+*Deus criou os Anjos para ser por eles honrado e servido, e para torná-los eternamente felizes.*
+
+**16.** Que forma e figura têm os Anjos?
+
+*Os Anjos não têm forma alguma nem figura sensível, porque são puros espíritos, criados por Deus para subsistir sem precisar estar unidos a corpo algum.*
+
+**17.** Por que, então, os Anjos são representados sob formas sensíveis?
+
+*Os Anjos são representados sob formas sensíveis: 1.º como auxílio à nossa imaginação; 2.º porque assim apareceram muitas vezes aos homens, como lemos na Sagrada Escritura.*
+
+**18.** Foram todos os Anjos fiéis a Deus?
+
+*Não, nem todos os Anjos foram fiéis a Deus; muitos deles, por soberba, pretenderam ser iguais a Ele e dele independentes; e, por esse pecado, foram para sempre excluídos do paraíso e condenados ao inferno.*
+
+**19.** Como se chamam os Anjos para sempre excluídos do paraíso e condenados ao inferno?
+
+*Os Anjos para sempre excluídos do paraíso e condenados ao inferno chamam-se demônios, e seu chefe chama-se Lúcifer ou Satanás.*
+
+**20.** Os demônios podem fazer-nos algum mal?
+
+*Sim, os demônios podem fazer-nos muito mal, tanto na alma como no corpo, se Deus lhes der permissão, sobretudo tentando-nos a pecar.*
+
+**21.** Por que nos tentam?
+
+*Os demônios nos tentam pela inveja que nos têm, a qual lhes faz desejar a nossa eterna danação, e pelo ódio a Deus, cuja imagem resplandece em nós. Deus, por sua vez, permite as tentações para que nós, vencendo-as com a sua graça, exercitemos as virtudes e adquiramos méritos para o paraíso.*
+
+**22.** Como podemos vencer as tentações?
+
+*As tentações se vencem com a vigilância, com a oração e com a mortificação cristã.*
+
+**23.** Como se chamam os Anjos que permaneceram fiéis a Deus?
+
+*Os Anjos que permaneceram fiéis a Deus chamam-se Anjos bons, Espíritos celestes ou simplesmente Anjos.*
+
+**24.** Que aconteceu aos Anjos que permaneceram fiéis a Deus?
+
+*Os Anjos que permaneceram fiéis a Deus foram confirmados em graça, gozam para sempre da visão de Deus, amam-nO, bendizem-nO e louvam-nO eternamente.*
+
+**25.** Deus serve-se dos Anjos como seus ministros?
+
+*Sim, Deus serve-se dos Anjos como seus ministros, e especialmente confia a muitos deles o ofício de nossos guardiães e protetores.*
+
+**26.** Devemos ter particular devoção ao Anjo da Guarda?
+
+*Sim, devemos ter particular devoção ao Anjo da Guarda, honrá-lo, invocar o seu auxílio, seguir as suas inspirações e ser-lhe gratos pela assistência contínua que ele nos presta.*
+
+## § 3. Do homem
+
+**27.** Qual é a criatura mais nobre que Deus colocou sobre a terra?
+
+*A criatura mais nobre que Deus colocou sobre a terra é o homem.*
+
+**28.** O que é o homem?
+
+*O homem é uma criatura racional composta de alma e corpo.*
+
+**29.** O que é a alma?
+
+*A alma é a parte mais nobre do homem, porque é substância espiritual, dotada de inteligência e de vontade, capaz de conhecer a Deus e de possuí-Lo eternamente.*
+
+**30.** A alma humana pode ser vista e tocada?
+
+*A nossa alma não pode ser vista nem tocada, porque é espírito.*
+
+**31.** A alma humana morre com o corpo?
+
+*A alma humana não morre jamais: a fé e a própria razão provam que ela é imortal.*
+
+**32.** O homem é livre em suas ações?
+
+*Sim, o homem é livre em suas ações; e cada um sente dentro de si que pode fazer uma coisa ou não fazê-la, ou fazer uma em vez de outra.*
+
+**33.** Explicai com um exemplo a liberdade humana.
+
+*Se eu digo voluntariamente uma mentira, sinto que poderia não dizê-la e calar-me, e que poderia também falar diferentemente, dizendo a verdade.*
+
+**34.** Por que se diz que o homem foi criado à imagem e semelhança de Deus?
+
+*Diz-se que o homem foi criado à imagem e semelhança de Deus, porque a alma humana é espiritual e racional, livre em seu agir, capaz de conhecer e amar a Deus e de gozá-Lo eternamente — perfeições que refletem em nós um raio da infinita grandeza do Senhor.*
+
+**35.** Em que estado pôs Deus nossos primeiros progenitores, Adão e Eva?
+
+*Deus pôs Adão e Eva no estado de inocência e de graça; mas logo decaíram dele pelo pecado.*
+
+**36.** Além da inocência e da graça santificante, Deus conferiu outros dons aos nossos progenitores?
+
+*Além da inocência e da graça santificante, Deus conferiu outros dons aos nossos progenitores, que eles deviam transmitir, juntamente com a graça santificante, aos seus descendentes; e eram: a integridade, isto é, a perfeita sujeição do sentido à razão; a imortalidade; a imunidade de toda dor e miséria; e a ciência proporcionada ao seu estado.*
+
+**37.** Qual foi o pecado de Adão?
+
+*O pecado de Adão foi um pecado de soberba e de grave desobediência.*
+
+**38.** Qual foi o castigo do pecado de Adão e Eva?
+
+*Adão e Eva perderam a graça de Deus e o direito que tinham ao céu, foram expulsos do paraíso terrestre, sujeitos a muitas misérias na alma e no corpo, e condenados a morrer.*
+
+**39.** Se Adão e Eva não tivessem pecado, teriam ficado isentos da morte?
+
+*Se Adão e Eva não tivessem pecado, mas se houvessem mantido fiéis a Deus, depois de uma estada feliz e tranquila sobre esta terra, sem morrer teriam sido transferidos por Deus para o Céu, para gozar uma vida eterna e gloriosa.*
+
+**40.** Eram esses dons devidos ao homem?
+
+*Esses dons não eram devidos de modo algum ao homem, mas eram absolutamente gratuitos e sobrenaturais; e por isso, tendo Adão desobedecido ao preceito divino, pôde Deus, sem injustiça, privar deles Adão e toda a sua posteridade.*
+
+**41.** Este pecado pertence somente a Adão?
+
+*Este pecado não é só de Adão, mas é também nosso, embora de modo diverso. É próprio de Adão, porque ele o cometeu por ato de sua vontade, e por isso nele foi pessoal. É próprio nosso, porque, tendo Adão pecado como cabeça e fonte de todo o gênero humano, transmite-se por geração natural a todos os seus descendentes, e por isso para nós é pecado original.*
+
+**42.** Como é possível que o pecado original se transmita a todos os homens?
+
+*O pecado original se transmite a todos os homens porque, tendo Deus conferido ao gênero humano em Adão a graça santificante e os demais dons sobrenaturais, com a condição de que Adão não desobedecesse; tendo este desobedecido em sua qualidade de cabeça e pai do gênero humano, tornou a natureza humana rebelde a Deus. Por isso a natureza humana se transmite a todos os descendentes de Adão num estado de rebelião contra Deus, privada da divina graça e dos demais dons.*
+
+**43.** Que danos, então, nos causou o pecado original?
+
+*Os danos do pecado original são: a privação da graça, a perda do paraíso, a ignorância, a inclinação ao mal, todas as misérias desta vida e, enfim, a morte.*
+
+**44.** Todos os homens contraem o pecado original?
+
+*Sim, todos os homens contraem o pecado original, exceto a santíssima Virgem, que dele foi preservada por Deus, por singular privilégio, em previsão dos méritos de Jesus Cristo, nosso Salvador.*
+
+**45.** Depois do pecado de Adão, os homens não teriam mais podido salvar-se?
+
+*Depois do pecado de Adão, os homens não teriam mais podido salvar-se, se Deus não lhes tivesse usado de misericórdia.*
+
+**46.** Qual foi a misericórdia que Deus usou com o gênero humano?
+
+*A misericórdia que Deus usou com o gênero humano foi prometer logo a Adão o Redentor divino, ou Messias, e enviá-lo depois, a seu tempo, para libertar os homens da escravidão do demônio e do pecado.*
+
+**47.** Quem é o Messias prometido?
+
+*O Messias prometido é Jesus Cristo, como nos ensina o segundo artigo do Credo.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-iii.md
@@ -1,0 +1,57 @@
+# Capítulo III — Do segundo artigo
+
+**1.** Que nos ensina o segundo artigo: E em Jesus Cristo, seu único Filho, Nosso Senhor?
+
+*O segundo artigo do Credo nos ensina que o Filho de Deus é a segunda pessoa da santíssima Trindade; que Ele é Deus eterno, onipotente, Criador e Senhor, como o Pai; que Ele se fez homem para nos salvar; e que o Filho de Deus feito homem se chama Jesus Cristo.*
+
+**2.** Por que a segunda pessoa se chama Filho?
+
+*A segunda pessoa chama-se Filho porque é gerada pelo Pai por via de inteligência desde toda a eternidade; e por isso chama-se também Verbo eterno do Pai.*
+
+**3.** Sendo também nós filhos de Deus, por que Jesus Cristo se chama Filho único de Deus Pai?
+
+*Jesus Cristo chama-se Filho único de Deus Pai porque só Ele é por natureza seu Filho, e nós somos filhos seus por criação e por adoção.*
+
+**4.** Por que Jesus Cristo se chama Senhor nosso?
+
+*Jesus Cristo chama-se Senhor nosso porque, além de nos ter criado, juntamente com o Pai e o Espírito Santo, enquanto Deus, nos redimiu também enquanto Deus e homem.*
+
+**5.** Por que o Filho de Deus feito homem se chama Jesus?
+
+*O Filho de Deus feito homem chama-se Jesus, que quer dizer Salvador, porque nos salvou da morte eterna merecida por nossos pecados.*
+
+**6.** Quem deu o nome de Jesus ao Filho de Deus feito homem?
+
+*O nome de Jesus ao Filho de Deus feito homem foi dado pelo próprio Pai eterno, por meio do arcanjo Gabriel, quando este anunciou à Virgem o mistério da Encarnação.*
+
+**7.** Por que o Filho de Deus feito homem se chama também Cristo?
+
+*O Filho de Deus feito homem chama-se também Cristo, que quer dizer ungido e consagrado, porque antigamente se ungiam os reis, os sacerdotes e os profetas; e Jesus é rei dos reis, sumo sacerdote e sumo profeta.*
+
+**8.** Jesus Cristo foi verdadeiramente ungido e consagrado com unção corporal?
+
+*A unção de Jesus Cristo não foi corporal, como a dos antigos reis, sacerdotes e profetas, mas inteiramente espiritual e divina, porque a plenitude da divindade habita nele substancialmente.*
+
+**9.** De Jesus Cristo, antes da sua vinda, tiveram os homens algum conhecimento?
+
+*Sim, os homens tiveram conhecimento de Jesus Cristo antes da sua vinda, pela promessa do Messias que Deus fez a nossos progenitores Adão e Eva, e que renovou aos santos Patriarcas, e pelas profecias e as muitas figuras que o designavam.*
+
+**10.** Donde sabemos nós que Jesus Cristo é verdadeiramente o Messias e Redentor prometido?
+
+*Sabemos que Jesus Cristo é verdadeiramente o Messias e Redentor prometido por se ter cumprido nele: 1.º tudo o que anunciavam as profecias; 2.º tudo o que representavam as figuras do Antigo Testamento.*
+
+**11.** As profecias que prediziam acerca do Redentor?
+
+*As profecias prediziam acerca do Redentor a tribo e a família da qual deveria sair; o lugar e o tempo do nascimento; os seus milagres e as mais minuciosas circunstâncias da sua paixão e morte; a sua ressurreição e ascensão ao céu; o seu reino espiritual, universal e perpétuo, que é a santa Igreja católica.*
+
+**12.** Quais são as principais figuras do Redentor no Antigo Testamento?
+
+*As principais figuras do Redentor no Antigo Testamento são o inocente Abel, o sumo sacerdote Melquisedeque, o sacrifício de Isaac, José vendido pelos irmãos, o profeta Jonas, o cordeiro pascal e a serpente de bronze erguida por Moisés no deserto.*
+
+**13.** Donde sabemos nós que Jesus Cristo é verdadeiro Deus?
+
+*Nós sabemos que Jesus Cristo é verdadeiro Deus: 1.º pelo testemunho do Pai, quando disse: Este é o meu Filho amado, em quem me comprazi; ouvi-O; 2.º pela atestação do próprio Jesus Cristo, confirmada pelos mais estupendos milagres; 3.º pela doutrina dos Apóstolos; 4.º pela tradição constante da Igreja católica.*
+
+**14.** Quais são os principais milagres operados por Jesus Cristo?
+
+*Os principais milagres operados por Jesus Cristo são, além da sua ressurreição, a saúde restituída aos enfermos, a vista aos cegos, o ouvido aos surdos, a vida aos mortos.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-iv.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-iv.md
@@ -1,0 +1,53 @@
+# Capítulo IV — Do terceiro artigo
+
+**1.** Que nos ensina o terceiro artigo: O qual foi concebido pelo poder do Espírito Santo; nasceu da Virgem Maria?
+
+*O terceiro artigo do Credo nos ensina que o Filho de Deus tomou um corpo e uma alma, como nós temos, no puríssimo seio de Maria Virgem, por obra do Espírito Santo, e que nasceu desta Virgem.*
+
+**2.** O Pai e o Filho também concorreram para formar o corpo e criar a alma de Jesus Cristo?
+
+*Sim, para formar o corpo e criar a alma de Jesus Cristo concorreram todas as três Pessoas divinas.*
+
+**3.** Por que se diz apenas: foi concebido pelo poder do Espírito Santo?
+
+*Diz-se apenas: foi concebido pelo poder do Espírito Santo, porque a encarnação do Filho de Deus é obra de bondade e de amor, e as obras de bondade e de amor atribuem-se ao Espírito Santo.*
+
+**4.** O Filho de Deus, fazendo-se homem, deixou de ser Deus?
+
+*Não, o Filho de Deus fez-se homem sem deixar de ser Deus.*
+
+**5.** Então Jesus Cristo é Deus e homem ao mesmo tempo?
+
+*Sim, o Filho de Deus encarnado, isto é, Jesus Cristo, é Deus e homem ao mesmo tempo, perfeito Deus e perfeito homem.*
+
+**6.** Há, portanto, em Jesus Cristo duas naturezas?
+
+*Sim, em Jesus Cristo, que é Deus e homem, há duas naturezas: a divina e a humana.*
+
+**7.** Há em Jesus Cristo também duas pessoas, a divina e a humana?
+
+*Não, no Filho de Deus feito homem há uma só pessoa, isto é, a divina.*
+
+**8.** Quantas vontades há em Jesus Cristo?
+
+*Em Jesus Cristo há duas vontades: uma divina, outra humana.*
+
+**9.** Jesus Cristo tinha vontade livre?
+
+*Sim, Jesus Cristo tinha vontade livre, mas não podia fazer o mal, porque poder fazer o mal é defeito, não perfeição da liberdade.*
+
+**10.** O Filho de Deus e o Filho de Maria são a mesma pessoa?
+
+*O Filho de Deus e o Filho de Maria são a mesma pessoa, isto é, Jesus Cristo, verdadeiro Deus e verdadeiro homem.*
+
+**11.** Maria Virgem é Mãe de Deus?
+
+*Sim, Maria Virgem é Mãe de Deus, porque é Mãe de Jesus Cristo, que é verdadeiro Deus.*
+
+**12.** De que modo Maria se tornou Mãe de Jesus Cristo?
+
+*Maria se tornou Mãe de Jesus Cristo unicamente por obra e virtude do Espírito Santo.*
+
+**13.** É de fé que Maria foi sempre Virgem?
+
+*Sim, é de fé que Maria Santíssima foi sempre Virgem, e é chamada a Virgem por excelência.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-ix.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-ix.md
@@ -1,0 +1,49 @@
+# Capítulo IX — Do oitavo artigo
+
+**1.** Que nos ensina o oitavo artigo: Creio no Espírito Santo?
+
+*O oitavo artigo do Credo nos ensina que existe o Espírito Santo, terceira Pessoa da santíssima Trindade, e que Ele é Deus eterno, infinito, onipotente, Criador e Senhor de todas as coisas, como o Pai e o Filho.*
+
+**2.** De quem procede o Espírito Santo?
+
+*O Espírito Santo procede do Pai e do Filho por via de vontade e de amor, como de um só princípio.*
+
+**3.** Se o Filho procede do Pai, e o Espírito Santo procede do Pai e do Filho, parece que o Pai e o Filho são anteriores ao Espírito Santo: como, então, se diz que as três Pessoas são eternas?
+
+*Diz-se que as três Pessoas são eternas, porque o Pai desde a eternidade gerou o Filho; e do Pai e do Filho desde a eternidade procede o Espírito Santo.*
+
+**4.** Por que a terceira Pessoa da santíssima Trindade se chama particularmente com o nome de Espírito Santo?
+
+*A terceira Pessoa da santíssima Trindade chama-se particularmente com o nome de Espírito Santo porque Ela procede do Pai e do Filho por modo de espiração e de amor.*
+
+**5.** Que obra é especialmente atribuída ao Espírito Santo?
+
+*Ao Espírito Santo é especialmente atribuída a santificação das almas.*
+
+**6.** O Pai e o Filho nos santificam igualmente como o Espírito Santo?
+
+*Sim, as três divinas Pessoas nos santificam igualmente.*
+
+**7.** Se assim é, por que a santificação das almas se atribui em particular ao Espírito Santo?
+
+*A santificação das almas atribui-se em particular ao Espírito Santo, porque ela é obra de amor, e as obras de amor atribuem-se ao Espírito Santo.*
+
+**8.** Quando desceu o Espírito Santo sobre os Apóstolos?
+
+*O Espírito Santo desceu sobre os Apóstolos no dia de Pentecostes, isto é, cinquenta dias depois da Ressurreição de Jesus Cristo e dez depois de sua Ascensão.*
+
+**9.** Onde estavam os Apóstolos nos dez dias anteriores ao Pentecostes?
+
+*Os Apóstolos estavam reunidos no cenáculo, na companhia de Maria Virgem e dos demais discípulos, e perseveravam em oração, aguardando o Espírito Santo que Jesus Cristo lhes havia prometido.*
+
+**10.** Que efeitos produziu o Espírito Santo nos Apóstolos?
+
+*O Espírito Santo confirmou os Apóstolos na fé, encheu-os de luzes, de força, de caridade e da abundância de todos os seus dons.*
+
+**11.** O Espírito Santo foi enviado somente para os Apóstolos?
+
+*O Espírito Santo foi enviado para toda a Igreja e para cada alma fiel.*
+
+**12.** Que faz o Espírito Santo na Igreja?
+
+*O Espírito Santo, como a alma no corpo, vivifica a Igreja com sua graça e com seus dons; nela estabelece o reino da verdade e do amor; e a assiste para que conduza com segurança seus filhos pelo caminho do céu.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-v.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-v.md
@@ -1,0 +1,77 @@
+# Capítulo V — Do quarto artigo
+
+**1.** Que nos ensina o quarto artigo: Padeceu sob Pôncio Pilatos, foi crucificado, morto e sepultado?
+
+*O quarto artigo do Credo nos ensina que Jesus Cristo, para redimir o mundo com seu precioso Sangue, padeceu sob Pôncio Pilatos, governador da Judeia, e morreu no lenho da cruz, do qual deposto, foi sepultado.*
+
+**2.** Que quer dizer a palavra padeceu?
+
+*A palavra padeceu exprime todas as penas sofridas por Jesus Cristo em sua paixão.*
+
+**3.** Jesus Cristo padeceu como Deus ou como homem?
+
+*Jesus Cristo padeceu somente como homem, porque como Deus não podia nem padecer nem morrer.*
+
+**4.** Que espécie de suplício era o da cruz?
+
+*O suplício da cruz era, naqueles tempos, o mais cruel e ignominioso de todos os suplícios.*
+
+**5.** Quem foi que condenou Jesus Cristo a ser crucificado?
+
+*Quem condenou Jesus Cristo a ser crucificado foi Pôncio Pilatos, governador da Judeia, o qual havia reconhecido a sua inocência, mas cedeu covardemente à ameaçadora insistência do povo de Jerusalém.*
+
+**6.** Não teria podido Jesus Cristo livrar-se das mãos dos judeus e de Pilatos?
+
+*Sim, Jesus Cristo teria podido livrar-se das mãos dos judeus e de Pilatos, mas, conhecendo que a vontade de seu Eterno Pai era que Ele padecesse e morresse pela nossa salvação, a ela se submeteu voluntariamente; mais ainda, Ele mesmo foi ao encontro dos seus inimigos e deixou-se espontaneamente prender e conduzir à morte.*
+
+**7.** Onde foi crucificado Jesus Cristo?
+
+*Jesus Cristo foi crucificado no monte Calvário.*
+
+**8.** Que fez Jesus Cristo sobre a cruz?
+
+*Jesus Cristo sobre a cruz orou por seus inimigos; deu por mãe ao discípulo São João, e na pessoa dele a todos nós, a sua própria mãe Maria santíssima; ofereceu a sua morte em sacrifício e satisfez à justiça de Deus pelos pecados dos homens.*
+
+**9.** Não teria bastado que um Anjo viesse satisfazer por nós?
+
+*Não, não teria bastado que um Anjo viesse satisfazer por nós, porque a ofensa feita a Deus pelo pecado era, sob certo aspecto, infinita, e para satisfazê-la requeria-se uma pessoa que tivesse um mérito infinito.*
+
+**10.** Para satisfazer à divina Justiça, era necessário que Jesus Cristo fosse Deus e homem ao mesmo tempo?
+
+*Sim, era preciso que Jesus Cristo fosse homem para poder padecer e morrer, e era preciso que fosse Deus para que os seus padecimentos fossem de valor infinito.*
+
+**11.** Por que era necessário que os méritos de Jesus Cristo fossem de valor infinito?
+
+*Era necessário que os méritos de Jesus Cristo fossem de valor infinito porque a majestade de Deus, ofendida pelo pecado, é infinita.*
+
+**12.** Era necessário que Jesus padecesse tanto?
+
+*Não, não era absolutamente necessário que Jesus padecesse tanto, porque o menor de seus padecimentos teria bastado para nossa redenção, sendo cada ato seu de valor infinito.*
+
+**13.** Por que, então, quis Jesus padecer tanto?
+
+*Jesus quis padecer tanto para satisfazer mais abundantemente à divina justiça, para nos demonstrar ainda mais o seu amor, e para nos inspirar o maior horror ao pecado.*
+
+**14.** Sucederam prodígios na morte de Jesus?
+
+*Sim, na morte de Jesus o sol se escureceu, a terra tremeu, os sepulcros se abriram e muitos mortos ressuscitaram.*
+
+**15.** Onde foi sepultado o corpo de Jesus Cristo?
+
+*O corpo de Jesus Cristo foi sepultado em um sepulcro novo, cavado na pedra do monte, pouco distante do lugar onde fora crucificado.*
+
+**16.** Na morte de Jesus Cristo, separou-se a divindade do corpo e da alma?
+
+*Na morte de Jesus Cristo, a divindade não se separou nem do corpo nem da alma, mas somente a alma se separou do corpo.*
+
+**17.** Por quem morreu Jesus Cristo?
+
+*Jesus Cristo morreu pela salvação de todos os homens e satisfez por todos.*
+
+**18.** Se Jesus Cristo morreu pela salvação de todos, por que nem todos se salvam?
+
+*Jesus Cristo morreu por todos, mas nem todos se salvam, porque nem todos o querem reconhecer, nem todos observam a sua lei, nem todos se valem dos meios de santificação que nos deixou.*
+
+**19.** Para sermos salvos, basta que Jesus Cristo tenha morrido por nós?
+
+*Para sermos salvos, não basta que Jesus Cristo tenha morrido por nós, mas é necessário que sejam aplicados a cada um de nós o fruto e os méritos de sua paixão e morte, o que sucede sobretudo por meio dos sacramentos, instituídos para esse fim pelo próprio Jesus Cristo; e, como muitos ou não recebem os sacramentos, ou não os recebem bem, por isso tornam para si inútil a morte de Jesus Cristo.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-vi.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-vi.md
@@ -1,0 +1,21 @@
+# Capítulo VI — Do quinto artigo
+
+**1.** Que nos ensina o quinto artigo: Desceu à mansão dos mortos; ressuscitou ao terceiro dia?
+
+*O quinto artigo do Credo nos ensina que a alma de Jesus Cristo, depois de separada do corpo, foi ao Limbo dos santos Padres, e que ao terceiro dia uniu-se de novo ao seu corpo, para nunca mais separar-se dele.*
+
+**2.** O que se entende aqui por inferno?
+
+*Por inferno entende-se aqui o Limbo dos santos Padres, isto é, aquele lugar onde estavam detidas as almas dos justos, aguardando a redenção de Jesus Cristo.*
+
+**3.** Por que as almas dos santos Padres não foram introduzidas no paraíso antes da morte de Jesus Cristo?
+
+*As almas dos santos Padres não foram introduzidas no paraíso antes da morte de Jesus Cristo porque, pelo pecado de Adão, o paraíso estava fechado, e convinha que Jesus Cristo, o qual com a sua morte o reabriu, fosse o primeiro a entrar nele.*
+
+**4.** Por que Jesus Cristo quis adiar até o terceiro dia a sua ressurreição?
+
+*Jesus Cristo quis adiar até o terceiro dia a sua ressurreição para manifestar com toda evidência que estava verdadeiramente morto.*
+
+**5.** A ressurreição de Jesus Cristo foi semelhante à ressurreição dos outros homens ressuscitados?
+
+*Não, a ressurreição de Jesus Cristo não foi semelhante à ressurreição dos outros homens ressuscitados, porque Jesus Cristo ressuscitou por virtude própria, e os outros foram ressuscitados pela virtude de Deus.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-vii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-vii.md
@@ -1,0 +1,21 @@
+# Capítulo VII — Do sexto artigo
+
+**1.** Que nos ensina o sexto artigo: Subiu ao céu; está sentado à direita de Deus Pai todo-poderoso?
+
+*O sexto artigo do Credo nos ensina que Jesus Cristo, quarenta dias depois de sua ressurreição, na presença de seus discípulos, subiu por si mesmo ao céu, e que, sendo, como Deus, igual ao Pai na glória, como homem foi elevado acima de todos os Anjos e de todos os Santos, e constituído Senhor de todas as coisas.*
+
+**2.** Por que Jesus Cristo, depois de sua ressurreição, permaneceu quarenta dias na terra, antes de subir ao céu?
+
+*Jesus Cristo, depois de sua ressurreição, permaneceu quarenta dias na terra, antes de subir ao céu, para provar, por meio de várias aparições, que estava verdadeiramente ressuscitado, e para instruir cada vez mais e confirmar os Apóstolos nas verdades da fé.*
+
+**3.** Por que Jesus Cristo subiu ao céu?
+
+*Jesus Cristo subiu ao céu: 1.º para tomar posse do seu reino, merecido com sua morte; 2.º para preparar o nosso lugar de glória e para ser nosso Mediador e Advogado junto ao Pai; 3.º para enviar o Espírito Santo aos seus Apóstolos.*
+
+**4.** Por que se diz de Jesus Cristo que subiu ao céu, e de sua Mãe santíssima que foi assunta?
+
+*Diz-se de Jesus Cristo que subiu ao céu, e de sua Mãe santíssima que foi assunta, porque Jesus Cristo, sendo Homem-Deus, por virtude própria subiu ao céu; mas a Mãe, que era criatura — embora a mais digna de todas — subiu ao céu pela virtude de Deus.*
+
+**5.** Explicai-me as palavras: está sentado à direita de Deus Pai todo-poderoso.
+
+*A palavra está sentado significa a pacífica posse que Jesus Cristo tem de sua glória; e as palavras à direita de Deus Pai todo-poderoso exprimem que Ele ocupa o lugar de honra sobre todas as criaturas.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-viii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-viii.md
@@ -1,0 +1,25 @@
+# Capítulo VIII — Do sétimo artigo
+
+**1.** Que nos ensina o sétimo artigo: Donde há de vir a julgar os vivos e os mortos?
+
+*O sétimo artigo do Credo nos ensina que, no fim do mundo, Jesus Cristo, cheio de glória e majestade, virá do céu para julgar todos os homens, bons e maus, e para dar a cada um o prêmio ou a pena que houver merecido.*
+
+**2.** Se cada um, logo após a morte, deverá ser julgado por Jesus Cristo no juízo particular, por que deveremos ser todos julgados no juízo universal?
+
+*Deveremos ser todos julgados no juízo universal por várias razões: 1.º para glória de Deus; 2.º para glória de Jesus Cristo; 3.º para glória dos Santos; 4.º para confusão dos maus; 5.º enfim, para que o corpo receba juntamente com a alma a sua sentença de prêmio ou de pena.*
+
+**3.** No juízo universal, como se manifestará a glória de Deus?
+
+*No juízo universal manifestar-se-á a glória de Deus, porque todos conhecerão com quanta justiça Deus governa o mundo, ainda que agora se vejam algumas vezes os bons em aflição e os maus em prosperidade.*
+
+**4.** No juízo universal, como se manifestará a glória de Jesus Cristo?
+
+*No juízo universal manifestar-se-á a glória de Jesus Cristo, porque, tendo sido Ele injustamente condenado pelos homens, aparecerá então, diante de todo o mundo, juiz supremo de todos.*
+
+**5.** No juízo universal, como se manifestará a glória dos Santos?
+
+*No juízo universal manifestar-se-á a glória dos Santos, porque muitos deles, que morreram desprezados pelos maus, serão glorificados na presença de todo o mundo.*
+
+**6.** No juízo universal, qual será a confusão dos maus?
+
+*No juízo universal, a confusão dos maus será grandíssima, sobretudo para aqueles que oprimiram os justos e para aqueles que se esforçaram em vida por ser estimados como homens de virtude e bondade, vendo manifestados a todo o mundo os pecados que cometeram, mesmo os mais secretos.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-x.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-x.md
@@ -1,0 +1,381 @@
+# Capítulo X — Do nono artigo
+
+## § 1. Da Igreja em geral
+
+**1.** Que nos ensina o nono artigo: na santa Igreja católica, na comunhão dos santos?
+
+*O nono artigo do Credo nos ensina que Jesus Cristo fundou na terra uma sociedade visível, que se chama Igreja católica, e que todas as pessoas que fazem parte desta Igreja estão em comunhão entre si.*
+
+**2.** Por que, depois do artigo que trata do Espírito Santo, se fala logo da Igreja católica?
+
+*Depois do artigo que trata do Espírito Santo, fala-se logo da Igreja católica para indicar que toda a santidade da própria Igreja deriva do Espírito Santo, o qual é o autor de toda santidade.*
+
+**3.** O que quer dizer esta palavra Igreja?
+
+*A palavra Igreja quer dizer convocação ou ajuntamento de muitas pessoas.*
+
+**4.** Quem nos convocou ou chamou à Igreja de Jesus Cristo?
+
+*Nós fomos chamados à Igreja de Jesus Cristo por uma graça particular de Deus, a fim de que, com a luz da fé e a observância da divina lei, lhe prestemos o culto devido e cheguemos à vida eterna.*
+
+**5.** Onde se encontram os membros da Igreja?
+
+*Os membros da Igreja encontram-se: parte no céu, e formam a Igreja triunfante; parte no purgatório, e formam a Igreja purgante; parte na terra, e formam a Igreja militante.*
+
+**6.** Estas diversas partes da Igreja constituem uma só Igreja?
+
+*Sim, estas diversas partes da Igreja constituem uma só Igreja e um só corpo, porque têm a mesma cabeça, que é Jesus Cristo, o mesmo espírito que as anima e as une, e o mesmo fim, que é a felicidade eterna, a qual já é gozada por uns e esperada pelos outros.*
+
+**7.** A que parte da Igreja se refere principalmente este nono artigo?
+
+*Este nono artigo do Credo refere-se principalmente à Igreja militante, que é a Igreja na qual nós nos encontramos atualmente.*
+
+## § 2. Da Igreja em particular
+
+**8.** O que é a Igreja católica?
+
+*A Igreja católica é a sociedade ou congregação de todos os batizados que, vivendo sobre a terra, professam a mesma fé e lei de Cristo, participam dos mesmos sacramentos e obedecem aos legítimos Pastores, principalmente ao Romano Pontífice.*
+
+**9.** Dizei distintamente o que é necessário para ser membro da Igreja.
+
+*Para ser membro da Igreja é necessário ser batizado, crer e professar a doutrina de Jesus Cristo, participar dos mesmos sacramentos e reconhecer o Papa e os demais legítimos Pastores da Igreja.*
+
+**10.** Quem são os legítimos Pastores da Igreja?
+
+*Os legítimos Pastores da Igreja são o Romano Pontífice, isto é, o Papa, que é o Pastor universal, e os Bispos. Ademais, sob a dependência dos Bispos e do Papa, têm parte no ofício de pastores os demais sacerdotes, e especialmente os párocos.*
+
+**11.** Por que dizeis que o Romano Pontífice é o Pastor universal da Igreja?
+
+*Porque Jesus Cristo disse a São Pedro, primeiro Papa: «Tu és Pedro, e sobre esta pedra edificarei a minha Igreja, e te darei as chaves do reino dos céus; tudo o que ligares na terra será ligado também no céu, e tudo o que desatares na terra será desatado também no céu.» E disse-lhe ainda: «Apascenta os meus cordeiros, apascenta as minhas ovelhas.»*
+
+**12.** Não pertencem, então, à Igreja de Jesus Cristo tantas sociedades de homens batizados que não reconhecem o Romano Pontífice por sua cabeça?
+
+*Não, todos aqueles que não reconhecem o Romano Pontífice por sua cabeça não pertencem à Igreja de Jesus Cristo.*
+
+**13.** Como se pode distinguir a Igreja de Jesus Cristo de tantas sociedades ou seitas fundadas pelos homens, e que se dizem cristãs?
+
+*De tantas sociedades ou seitas fundadas pelos homens, que se dizem cristãs, pode-se facilmente distinguir a verdadeira Igreja de Jesus Cristo por quatro sinais. Ela é Una, Santa, Católica e Apostólica.*
+
+**14.** Por que a Igreja se diz Una?
+
+*A verdadeira Igreja se diz Una porque os seus filhos, de qualquer tempo e lugar, estão unidos entre si na mesma fé, no mesmo culto, na mesma lei e na participação dos mesmos sacramentos, sob uma mesma cabeça visível, o Romano Pontífice.*
+
+**15.** Não poderia haver várias Igrejas?
+
+*Não, não pode haver várias Igrejas, porque, assim como há um só Deus, uma só Fé e um só Batismo, assim também não há, nem pode haver, senão uma só verdadeira Igreja.*
+
+**16.** Mas não se chamam Igrejas também os fiéis unidos de uma nação, ou de uma diocese?
+
+*Chamam-se Igrejas também os fiéis unidos de uma nação ou de uma diocese, mas são sempre porções da Igreja universal e formam com ela uma só Igreja.*
+
+**17.** Por que a verdadeira Igreja se diz Santa?
+
+*A verdadeira Igreja se diz Santa porque santa é a sua cabeça invisível, que é Jesus Cristo; santos são muitos dos seus membros; santas são a sua fé, a sua lei e os seus sacramentos; e fora dela não há, nem pode haver, verdadeira santidade.*
+
+**18.** Por que a Igreja se chama Católica?
+
+*A verdadeira Igreja chama-se Católica, que quer dizer universal, porque abrange os fiéis de todos os tempos, de todos os lugares, de toda idade e condição, e todos os homens do mundo são chamados a dela fazer parte.*
+
+**19.** Por que a Igreja se chama, ademais, Apostólica?
+
+*A verdadeira Igreja chama-se, ademais, Apostólica, porque remonta sem interrupção até os Apóstolos; porque crê e ensina tudo o que creram e ensinaram os Apóstolos; e porque é guiada e governada pelos seus legítimos sucessores.*
+
+**20.** E por que a verdadeira Igreja se chama também Romana?
+
+*A verdadeira Igreja chama-se também Romana, porque os quatro caracteres de unidade, santidade, catolicidade e apostolicidade encontram-se somente na Igreja que reconhece por cabeça o Bispo de Roma, sucessor de São Pedro.*
+
+**21.** Como é constituída a Igreja de Jesus Cristo?
+
+*A Igreja de Jesus Cristo é constituída como uma verdadeira e perfeita sociedade; e nela, como em uma pessoa moral, podemos distinguir a alma e o corpo.*
+
+**22.** Em que consiste a alma da Igreja?
+
+*A alma da Igreja consiste naquilo que ela tem de interno e espiritual, isto é, a fé, a esperança, a caridade, os dons da graça e do Espírito Santo e todos os tesouros celestes que dela derivam pelos méritos de Cristo Redentor e dos Santos.*
+
+**23.** Em que consiste o corpo da Igreja?
+
+*O corpo da Igreja consiste naquilo que ela tem de visível e externo, seja na associação dos congregados, seja no culto e no ministério do ensino, seja em sua ordem e governo exteriores.*
+
+**24.** Para salvar-se, basta ser, de qualquer modo, membro da Igreja católica?
+
+*Não, para salvar-se não basta ser, de qualquer modo, membro da Igreja católica, mas é preciso ser membro vivo dela.*
+
+**25.** Quais são os membros vivos da Igreja?
+
+*Os membros vivos da Igreja são todos e somente os justos, isto é, aqueles que estão atualmente em graça de Deus.*
+
+**26.** E quais são os seus membros mortos?
+
+*Membros mortos da Igreja são os fiéis que se encontram em pecado mortal.*
+
+**27.** Pode alguém salvar-se fora da Igreja Católica, Apostólica, Romana?
+
+*Não, fora da Igreja Católica, Apostólica, Romana ninguém se pode salvar, como ninguém se pôde salvar do dilúvio fora da Arca de Noé, que era figura desta Igreja.*
+
+**28.** Como, então, se salvaram os antigos Patriarcas, os Profetas e todos os demais justos do Antigo Testamento?
+
+*Todos os justos do Antigo Testamento salvaram-se em virtude da fé que tinham no Cristo vindouro, por meio da qual já pertenciam espiritualmente a esta Igreja.*
+
+**29.** Mas quem se achasse, sem culpa sua, fora da Igreja, poderia salvar-se?
+
+*Quem, achando-se sem culpa sua, ou seja, em boa-fé, fora da Igreja, tivesse recebido o Batismo, ou tivesse ao menos o desejo implícito dele; procurasse, ademais, sinceramente a verdade e cumprisse a vontade de Deus como melhor pudesse; ainda que separado do corpo da Igreja, estaria unido à sua alma e, portanto, no caminho da salvação.*
+
+**30.** E quem, sendo embora membro da Igreja católica, não pusesse em prática os seus ensinamentos, salvar-se-ia?
+
+*Quem, sendo embora membro da Igreja católica, não pusesse em prática os seus ensinamentos, dela seria membro morto, e portanto não se salvaria, porque para a salvação de um adulto se requer não só o batismo e a fé, mas também as obras conformes à fé.*
+
+**31.** Somos nós obrigados a crer em todas as verdades que a Igreja nos ensina?
+
+*Sim, somos obrigados a crer em todas as verdades que a Igreja nos ensina, e Jesus Cristo declara que quem não crê já está condenado.*
+
+**32.** Somos também obrigados a fazer tudo o que a Igreja ordena?
+
+*Sim, somos obrigados a fazer tudo o que a Igreja ordena, porque Jesus Cristo disse aos Pastores da Igreja: «Quem vos ouve, a mim ouve; e quem vos despreza, a mim despreza.»*
+
+**33.** Pode a Igreja errar nas coisas que nos propõe a crer?
+
+*Não, nas coisas que nos propõe a crer, a Igreja não pode errar, porque, segundo a promessa de Jesus Cristo, ela é perenemente assistida pelo Espírito Santo.*
+
+**34.** A Igreja católica é, portanto, infalível?
+
+*Sim, a Igreja católica é infalível; e, portanto, aqueles que recusam as suas definições perdem a fé e tornam-se hereges.*
+
+**35.** A Igreja católica pode ser destruída ou perecer?
+
+*Não, a Igreja católica pode ser perseguida, mas não pode ser destruída nem perecer. Ela durará até o fim do mundo, porque até o fim do mundo Jesus Cristo estará com ela, como prometeu.*
+
+**36.** Por que é tão perseguida a Igreja católica?
+
+*A Igreja católica é tão perseguida porque assim foi perseguido também o seu divino Fundador, e porque reprova os vícios, combate as paixões e condena todas as injustiças e todos os erros.*
+
+**37.** Há outros deveres dos católicos para com a Igreja?
+
+*Todo católico deve ter pela Igreja um amor ilimitado, considerar-se infinitamente honrado e feliz por pertencer-lhe, e empenhar-se pela glória e pelo crescimento dela com todos os meios que estiverem em seu poder.*
+
+## § 3. Da Igreja docente e da Igreja discente
+
+**38.** Há alguma distinção entre os membros que compõem a Igreja?
+
+*Entre os membros que compõem a Igreja há uma distinção notabilíssima, porque há quem manda e quem obedece, quem ensina e quem é ensinado.*
+
+**39.** Como se chama aquela parte da Igreja que ensina?
+
+*A parte da Igreja que ensina chama-se docente, isto é, ensinante.*
+
+**40.** Como se chama a parte da Igreja que é ensinada?
+
+*A parte da Igreja que é ensinada chama-se discente.*
+
+**41.** Quem estabeleceu esta distinção na Igreja?
+
+*Esta distinção na Igreja foi estabelecida pelo próprio Jesus Cristo.*
+
+**42.** A Igreja docente e a Igreja discente são, então, duas Igrejas distintas?
+
+*A Igreja docente e a Igreja discente são duas partes distintas de uma só e mesma Igreja, como no corpo humano a cabeça é distinta dos demais membros e, no entanto, forma com eles um só corpo.*
+
+**43.** De quem se compõe a Igreja docente?
+
+*A Igreja docente compõe-se de todos os Bispos, com o Romano Pontífice à cabeça, quer estejam dispersos, quer estejam congregados em Concílio.*
+
+**44.** E a Igreja discente, de quem é composta?
+
+*A Igreja discente é composta de todos os fiéis.*
+
+**45.** Quais pessoas, então, têm na Igreja a autoridade de ensinar?
+
+*A autoridade de ensinar na Igreja a têm o Papa e os Bispos, e, sob a sua dependência, os demais ministros sagrados.*
+
+**46.** Somos nós obrigados a ouvir a Igreja docente?
+
+*Sim, sem dúvida, somos todos obrigados a ouvir a Igreja docente, sob pena de eterna condenação, porque Jesus Cristo disse aos Pastores da Igreja, na pessoa dos Apóstolos: «Quem vos ouve, a mim ouve; e quem vos despreza, a mim despreza.»*
+
+**47.** Além da autoridade de ensinar, tem a Igreja algum outro poder?
+
+*Sim, além da autoridade de ensinar, a Igreja tem especialmente o poder de administrar as coisas santas, de fazer leis e de exigir-lhes a observância.*
+
+**48.** O poder que têm os membros da hierarquia eclesiástica vem do povo?
+
+*O poder que têm os membros da hierarquia eclesiástica não vem do povo, e seria heresia dizê-lo, mas vem unicamente de Deus.*
+
+**49.** A quem cabe o exercício desses poderes?
+
+*O exercício desses poderes cabe unicamente ao corpo hierárquico, isto é, ao Papa e aos Bispos a ele subordinados.*
+
+## § 4. Do Papa e dos Bispos
+
+**50.** Quem é o Papa?
+
+*O Papa, a quem chamamos também Sumo Pontífice ou Romano Pontífice, é o sucessor de São Pedro na Cátedra de Roma, o Vigário de Jesus Cristo na terra e a cabeça visível da Igreja.*
+
+**51.** Por que o Romano Pontífice é sucessor de São Pedro?
+
+*O Romano Pontífice é sucessor de São Pedro, porque São Pedro reuniu em sua pessoa a dignidade de Bispo de Roma e de cabeça da Igreja; estabeleceu em Roma, por divina disposição, a sua sede, e ali morreu; por isso quem é eleito bispo de Roma é também o herdeiro de toda a sua autoridade.*
+
+**52.** Por que o Romano Pontífice é o Vigário de Jesus Cristo?
+
+*O Romano Pontífice é o Vigário de Jesus Cristo porque o representa sobre a terra e faz as suas vezes no governo da Igreja.*
+
+**53.** Por que o Romano Pontífice é a cabeça visível da Igreja?
+
+*O Romano Pontífice é a cabeça visível da Igreja, porque a rege visivelmente com a mesma autoridade de Jesus Cristo, que é a sua cabeça invisível.*
+
+**54.** Qual é, então, a dignidade do Papa?
+
+*A dignidade do Papa é a máxima dentre todas as dignidades da terra, e dá-lhe poder supremo e imediato sobre todos e cada um dos Pastores e fiéis.*
+
+**55.** Pode o Papa errar ao ensinar a Igreja?
+
+*O Papa não pode errar, ou seja, é infalível nas definições que dizem respeito à fé e aos costumes.*
+
+**56.** Por que motivo o Papa é infalível?
+
+*O Papa é infalível pela promessa de Jesus Cristo e pela contínua assistência do Espírito Santo.*
+
+**57.** Quando é que o Papa é infalível?
+
+*O Papa só é infalível quando, em sua qualidade de Pastor e Mestre de todos os cristãos, em virtude de sua suprema autoridade apostólica, define uma doutrina acerca da fé ou dos costumes a ser sustentada por toda a Igreja.*
+
+**58.** Quem não cresse nas solenes definições do Papa, que pecado cometeria?
+
+*Quem não cresse nas solenes definições do Papa, ou mesmo apenas delas duvidasse, pecaria contra a fé; e, se permanecesse obstinado nessa incredulidade, não seria mais católico, mas herege.*
+
+**59.** Para que fim Deus concedeu ao Papa o dom da infalibilidade?
+
+*Deus concedeu ao Papa o dom da infalibilidade para que todos estejamos certos e seguros da verdade que a Igreja ensina.*
+
+**60.** Quando se definiu que o Papa é infalível?
+
+*Que o Papa é infalível foi definido pela Igreja no Concílio Vaticano; e, se alguém presumisse contradizer a essa definição, seria herege e excomungado.*
+
+**61.** A Igreja, ao definir que o Papa é infalível, terá estabelecido uma nova verdade de fé?
+
+*Não, a Igreja, ao definir que o Papa é infalível, não estabeleceu uma nova verdade de fé, mas somente, para opor-se a novos erros, definiu que a infalibilidade do Papa, já contida na Sagrada Escritura e na Tradição, é uma verdade revelada por Deus, e portanto deve ser crida como dogma ou artigo de fé.*
+
+**62.** Como deve comportar-se todo católico em relação ao Papa?
+
+*Todo católico deve reconhecer o Papa como Pai, Pastor e Mestre universal, e estar a ele unido de mente e de coração.*
+
+**63.** Depois do Papa, quais são, por divina instituição, os personagens mais veneráveis na Igreja?
+
+*Depois do Papa, por divina instituição, os personagens mais veneráveis da Igreja são os Bispos.*
+
+**64.** Quem são os Bispos?
+
+*Os Bispos são os pastores dos fiéis, postos pelo Espírito Santo para reger a Igreja de Deus nas sedes a eles confiadas, sob a dependência do Romano Pontífice.*
+
+**65.** O que é o Bispo na própria diocese?
+
+*O Bispo, na própria diocese, é o Pastor legítimo, o Pai, o Mestre e o superior de todos os fiéis, eclesiásticos e leigos, que pertencem à mesma diocese.*
+
+**66.** Por que o Bispo se chama Pastor legítimo?
+
+*O Bispo chama-se Pastor legítimo porque a jurisdição, ou seja, o poder que tem de governar os fiéis da própria diocese, lhe foi conferido segundo as normas e leis da Igreja.*
+
+**67.** De quem são sucessores o Papa e os Bispos?
+
+*O Papa é o sucessor de São Pedro, príncipe dos Apóstolos, e os Bispos são os sucessores dos Apóstolos, no que diz respeito ao governo ordinário da Igreja.*
+
+**68.** Deve o fiel estar unido ao seu Bispo?
+
+*Sim, todo fiel, eclesiástico e leigo, deve estar unido, de mente e de coração, ao seu Bispo, em graça e comunhão com a Sé Apostólica.*
+
+**69.** Como deve comportar-se o fiel com seu Bispo?
+
+*Todo fiel, eclesiástico e leigo, deve reverenciar, amar e honrar o seu Bispo, e prestar-lhe obediência em tudo o que se refere ao cuidado das almas e ao governo espiritual da diocese.*
+
+**70.** Por quem é ajudado o Bispo no cuidado das almas?
+
+*O Bispo, no cuidado das almas, é ajudado pelos sacerdotes, e principalmente pelos párocos.*
+
+**71.** Quem é o Pároco?
+
+*O Pároco é um sacerdote designado para presidir e dirigir, sob a dependência do Bispo, uma porção da diocese, chamada paróquia.*
+
+**72.** Quais deveres têm os fiéis para com o seu pároco?
+
+*Os fiéis devem manter-se unidos ao seu pároco, ouvi-lo docilmente e professar-lhe respeito e submissão em tudo o que diz respeito ao cuidado da paróquia.*
+
+## § 5. Da comunhão dos santos
+
+**73.** Que nos ensina o nono artigo do Credo com aquelas palavras: a comunhão dos santos?
+
+*Com as palavras: a comunhão dos santos, o nono artigo do Credo nos ensina que na Igreja, pela íntima união que existe entre todos os seus membros, são comuns os bens espirituais, tanto internos como externos, que lhe pertencem.*
+
+**74.** Quais são, na Igreja, os bens comuns internos?
+
+*Os bens comuns internos na Igreja são: a graça que se recebe nos sacramentos, a fé, a esperança, a caridade, os méritos infinitos de Jesus Cristo, os méritos sobreabundantes da Virgem e dos Santos, e o fruto de todas as boas obras que se fazem na mesma Igreja.*
+
+**75.** Quais são os bens externos comuns na Igreja?
+
+*Os bens externos comuns na Igreja são: os sacramentos, o sacrifício da santa Missa, as orações públicas, as funções religiosas e todas as demais práticas exteriores que unem entre si os fiéis.*
+
+**76.** Entram nesta comunhão de bens todos os filhos da Igreja?
+
+*Entram na comunhão dos bens internos os cristãos que estão em graça de Deus; aqueles que estão em pecado mortal não participam destes bens.*
+
+**77.** Por que não participam destes bens aqueles que estão em pecado mortal?
+
+*Porque a graça de Deus é o que une os fiéis com Deus e entre si; e por isso aqueles que estão em pecado mortal, estando sem a graça de Deus, ficam excluídos da comunhão dos bens espirituais.*
+
+**78.** Então, os cristãos que estão em pecado mortal não têm vantagem alguma dos bens internos e espirituais da Igreja?
+
+*Os cristãos que estão em pecado mortal ainda têm alguma vantagem dos bens internos e espirituais da Igreja de que estão privados, na medida em que conservam o caráter de cristão, que é indelével, e são ajudados pelas orações e boas obras dos fiéis a obter a graça de converter-se a Deus.*
+
+**79.** Aqueles que estão em pecado mortal podem participar dos bens externos da Igreja?
+
+*Aqueles que estão em pecado mortal podem participar dos bens externos da Igreja, desde que não estejam separados dela pela excomunhão.*
+
+**80.** Por que os membros desta comunhão, tomados em conjunto, se chamam santos?
+
+*Os membros desta comunhão chamam-se santos porque todos são chamados à santidade e foram santificados pelo Batismo, e muitos deles já chegaram à perfeita santidade.*
+
+**81.** A comunhão dos santos estende-se também ao céu e ao purgatório?
+
+*Sim, a comunhão dos santos estende-se também ao céu e ao purgatório, porque a caridade une as três Igrejas — triunfante, purgante e militante; e os Santos pedem a Deus por nós e pelas almas do purgatório, e nós damos honra e glória aos Santos e podemos aliviar as almas do purgatório, aplicando-lhes em sufrágio Missas, esmolas, indulgências e outras obras boas.*
+
+## § 6. Daqueles que estão fora da Igreja
+
+**82.** Quem são aqueles que não pertencem à comunhão dos santos?
+
+*Não pertencem à comunhão dos santos, na outra vida, os condenados, e nesta, aqueles que se encontram fora da verdadeira Igreja.*
+
+**83.** Quem são aqueles que se encontram fora da verdadeira Igreja?
+
+*Encontram-se fora da verdadeira Igreja os infiéis, os judeus, os hereges, os apóstatas, os cismáticos e os excomungados.*
+
+**84.** Quem são os infiéis?
+
+*Os infiéis são aqueles que não têm o Batismo e não creem em Jesus Cristo, seja porque creem e adoram falsas divindades, como os idólatras; seja porque, ainda admitindo o único verdadeiro Deus, não creem em Cristo Messias, nem como já vindo na pessoa de Jesus Cristo, nem como vindouro — tais são os maometanos e outros semelhantes.*
+
+**85.** Quem são os judeus?
+
+*Os judeus são aqueles que professam a lei de Moisés, não receberam o batismo e não creem em Jesus Cristo.*
+
+**86.** Quem são os hereges?
+
+*Os hereges são os batizados que recusam pertinazmente crer em alguma verdade revelada por Deus e ensinada como de fé pela Igreja católica, por exemplo, os arianos, os nestorianos e as várias seitas dos protestantes.*
+
+**87.** Quem são os apóstatas?
+
+*Os apóstatas são aqueles que abjuram, isto é, renegam, por ato externo, a fé católica que antes professavam.*
+
+**88.** Quem são os cismáticos?
+
+*Os cismáticos são os cristãos que, não negando explicitamente nenhum dogma, separam-se voluntariamente da Igreja de Jesus Cristo, isto é, dos legítimos pastores.*
+
+**89.** Quem são os excomungados?
+
+*Os excomungados são aqueles que, por faltas gravíssimas, são atingidos pela excomunhão por parte do Papa ou do Bispo, e são, portanto, como indignos, separados do corpo da Igreja, a qual aguarda e deseja a sua conversão.*
+
+**90.** Deve-se temer a excomunhão?
+
+*A excomunhão deve ser muito temida, porque é a pena mais grave e mais terrível que a Igreja pode infligir aos seus filhos rebeldes e obstinados.*
+
+**91.** De quais bens ficam privados os excomungados?
+
+*Os excomungados ficam privados das orações públicas, dos sacramentos, das indulgências e da sepultura eclesiástica.*
+
+**92.** Podemos nós ajudar de algum modo os excomungados?
+
+*Nós podemos ajudar de algum modo os excomungados, e todos os outros que se encontram fora da verdadeira Igreja, com avisos salutares, com orações e boas obras, suplicando a Deus que, por sua misericórdia, lhes conceda a graça de converter-se à fé e de entrar na comunhão dos Santos.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-xi.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-xi.md
@@ -1,0 +1,17 @@
+# Capítulo XI — Do décimo artigo
+
+**1.** Que nos ensina o décimo artigo: A remissão dos pecados?
+
+*O décimo artigo do Credo nos ensina que Jesus Cristo deixou à sua Igreja o poder de perdoar os pecados.*
+
+**2.** A Igreja pode perdoar todo tipo de pecados?
+
+*Sim, a Igreja pode perdoar todos os pecados, por mais numerosos e graves que sejam, porque Jesus Cristo lhe deu pleno poder de desatar e ligar.*
+
+**3.** Quem são aqueles que, na Igreja, exercem este poder de perdoar os pecados?
+
+*Aqueles que, na Igreja, exercem o poder de perdoar os pecados são, em primeiro lugar, o Papa, que sozinho possui a plenitude deste poder; depois, os Bispos; e, sob a dependência dos Bispos, os sacerdotes.*
+
+**4.** Como a Igreja perdoa os pecados?
+
+*A Igreja perdoa os pecados pelos méritos de Jesus Cristo, conferindo os sacramentos por Ele instituídos para este fim, principalmente o Batismo e a Penitência.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-xii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-xii.md
@@ -1,0 +1,29 @@
+# Capítulo XII — Do décimo primeiro artigo
+
+**1.** Que nos ensina o décimo primeiro artigo: A ressurreição da carne?
+
+*O décimo primeiro artigo do Credo nos ensina que todos os homens ressuscitarão, retomando cada alma o corpo que teve nesta vida.*
+
+**2.** Como acontecerá a ressurreição dos mortos?
+
+*A ressurreição dos mortos acontecerá pela virtude de Deus onipotente, a quem nada é impossível.*
+
+**3.** Quando acontecerá a ressurreição dos mortos?
+
+*A ressurreição de todos os mortos acontecerá no fim do mundo, e então seguir-se-á o juízo universal.*
+
+**4.** Por que Deus quer a ressurreição dos corpos?
+
+*Deus quer a ressurreição dos corpos, porque, tendo a alma feito o bem ou o mal unida ao corpo, seja também juntamente com ele premiada ou punida.*
+
+**5.** Os homens ressuscitarão todos da mesma maneira?
+
+*Não, haverá grandíssima diferença entre os corpos dos eleitos e os corpos dos condenados, porque somente os corpos dos eleitos terão, à semelhança de Jesus Cristo ressuscitado, os dotes dos corpos gloriosos.*
+
+**6.** Quais são estes dotes que adornarão os corpos dos eleitos?
+
+*Os dotes que adornarão os corpos gloriosos dos eleitos são: 1.º a impassibilidade, pela qual não poderão mais estar sujeitos a males, a dores de qualquer espécie, nem à necessidade de alimento, de repouso ou de outra coisa; 2.º a claridade, pela qual resplandecerão como o sol e como outras tantas estrelas; 3.º a agilidade, pela qual poderão passar num momento e sem fadiga de um lugar a outro e da terra ao céu; 4.º a sutileza, pela qual, sem obstáculo, poderão penetrar qualquer corpo, como fez Jesus Cristo ressuscitado.*
+
+**7.** Como serão os corpos dos condenados?
+
+*Os corpos dos condenados serão privados dos dotes dos corpos gloriosos dos Bem-aventurados, e portarão a horrível marca da eterna reprovação.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-xiii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-prima-capo-xiii.md
@@ -1,0 +1,29 @@
+# Capítulo XIII — Do décimo segundo artigo
+
+**1.** Que nos ensina o último artigo: A vida eterna?
+
+*O último artigo do Credo nos ensina que, depois da vida presente, há uma outra vida — ou eternamente bem-aventurada para os eleitos no paraíso, ou eternamente infeliz para os condenados ao inferno.*
+
+**2.** Podemos nós compreender a felicidade do paraíso?
+
+*Não, nós não podemos compreender a felicidade do paraíso, porque supera os conhecimentos de nossa mente limitada, e porque os bens do céu não se podem comparar aos bens deste mundo.*
+
+**3.** Em que consiste a felicidade dos eleitos?
+
+*A felicidade dos eleitos consiste em ver, amar e possuir para sempre a Deus, fonte de todo bem.*
+
+**4.** Em que consiste a infelicidade dos condenados?
+
+*A infelicidade dos condenados consiste em ser para sempre privados da visão de Deus e punidos com eternos tormentos no inferno.*
+
+**5.** Os bens do paraíso e os males do inferno são somente para as almas?
+
+*Os bens do paraíso e os males do inferno são, agora, somente para as almas, porque só as almas estão, agora, no paraíso ou no inferno; mas, após a ressurreição da carne, os homens, na plenitude de sua natureza, isto é, em alma e corpo, serão felizes ou atormentados para sempre.*
+
+**6.** Os bens do paraíso para os bem-aventurados e os males do inferno para os condenados serão iguais?
+
+*Os bens do paraíso para os bem-aventurados, e os males do inferno para os condenados, serão iguais na substância e na duração eterna; mas na medida, isto é, nos graus, serão maiores ou menores, segundo os méritos ou deméritos de cada um.*
+
+**7.** O que quer dizer a palavra Amém no final do Credo?
+
+*A palavra Amém, no final das orações, significa: Assim seja; no final do Credo significa: Assim é, isto é: creio ser veríssimo tudo o que se contém nestes doze artigos, e estou disso mais certo do que se o visse com meus próprios olhos.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-i.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-i.md
@@ -1,0 +1,143 @@
+# Capítulo I — Dos sacramentos em geral
+
+## § 1. Natureza dos sacramentos
+
+**1.** De que se trata na quarta parte da Doutrina cristã?
+
+*Na quarta parte da Doutrina cristã trata-se dos sacramentos.*
+
+**2.** O que se entende com a palavra sacramento?
+
+*Com a palavra sacramento entende-se um sinal sensível e eficaz da graça, instituído por Jesus Cristo para santificar as nossas almas.*
+
+**3.** Por que chamais aos sacramentos sinais sensíveis e eficazes da graça?
+
+*Chamo aos sacramentos sinais sensíveis e eficazes da graça, porque todos os sacramentos significam, por meio de coisas sensíveis, a graça divina que eles produzem em nossa alma.*
+
+**4.** Explicai, com um exemplo, como os sacramentos são sinais sensíveis e eficazes da graça?
+
+*No Batismo, o derramar a água sobre a cabeça da pessoa, e as palavras: «Eu te batizo», isto é, te lavo, em nome do Pai, do Filho e do Espírito Santo, são um sinal sensível daquilo que o Batismo opera na alma; pois, assim como a água lava o corpo, assim a graça dada pelo Batismo purifica a alma do pecado.*
+
+**5.** Quantos e quais são os sacramentos?
+
+*Os sacramentos são sete, a saber: Batismo, Crisma, Eucaristia, Penitência, Extrema-Unção, Ordem Sacra, Matrimônio.*
+
+**6.** Quantas coisas se requerem para constituir um sacramento?
+
+*Para constituir um sacramento requerem-se a matéria, a forma e o ministro, o qual tenha a intenção de fazer o que faz a Igreja.*
+
+**7.** O que é a matéria dos sacramentos?
+
+*A matéria dos sacramentos é a coisa sensível que se emprega para fazê-lo, como, por exemplo, a água natural no Batismo, o óleo e o bálsamo na Crisma.*
+
+**8.** O que é a forma dos sacramentos?
+
+*A forma dos sacramentos são as palavras que se pronunciam para fazê-lo.*
+
+**9.** Quem é o ministro dos sacramentos?
+
+*O ministro dos sacramentos é a pessoa que faz ou confere o sacramento.*
+
+## § 2. Do efeito principal dos sacramentos, que é a graça
+
+**10.** O que é a graça?
+
+*A graça de Deus é um dom interno, sobrenatural, que nos é dado sem nenhum mérito nosso, mas pelos méritos de Jesus Cristo, em vista da vida eterna.*
+
+**11.** Como se distingue a graça?
+
+*A graça distingue-se em graça santificante, que também se chama habitual, e em graça atual.*
+
+**12.** O que é a graça santificante?
+
+*A graça santificante é um dom sobrenatural inerente à nossa alma, que nos torna justos, filhos adotivos de Deus e herdeiros do Paraíso.*
+
+**13.** De quantas espécies é a graça santificante?
+
+*A graça santificante é de duas espécies: graça primeira e graça segunda.*
+
+**14.** Qual é a graça primeira?
+
+*A graça primeira é aquela pela qual o homem passa do estado de pecado mortal ao estado de justiça.*
+
+**15.** E a graça segunda, qual é?
+
+*A graça segunda é um acréscimo da graça primeira.*
+
+**16.** O que é a graça atual?
+
+*A graça atual é um dom sobrenatural que ilumina a nossa mente e move e conforta a nossa vontade, a fim de que façamos o bem e nos abstenhamos do mal.*
+
+**17.** Podemos resistir à graça de Deus?
+
+*Sim, podemos resistir à graça de Deus, porque ela não destrói o nosso livre arbítrio.*
+
+**18.** Com as nossas próprias forças, podemos fazer alguma coisa que nos aproveite para a vida eterna?
+
+*Sem o auxílio da graça de Deus, com as nossas próprias forças, não podemos fazer coisa alguma que nos aproveite para a vida eterna.*
+
+**19.** Como nos é comunicada por Deus a graça?
+
+*A graça nos é comunicada por Deus principalmente por meio dos santos sacramentos.*
+
+**20.** Os sacramentos, além da graça santificante, nos conferem outra graça?
+
+*Os sacramentos, além da graça santificante, conferem também a graça sacramental.*
+
+**21.** O que é a graça sacramental?
+
+*A graça sacramental consiste no direito que se adquire, ao receber qualquer sacramento, de ter, no momento oportuno, as graças atuais necessárias para cumprir as obrigações que derivam do sacramento recebido. Assim nós, quando fomos batizados, recebemos o direito de ter as graças para viver cristãmente.*
+
+**22.** Os sacramentos dão sempre a graça a quem os recebe?
+
+*Os sacramentos dão sempre a graça, contanto que se recebam com as disposições necessárias.*
+
+**23.** Quem deu aos sacramentos a virtude de conferir a graça?
+
+*A virtude de conferir a graça foi dada aos sacramentos por Jesus Cristo com a sua paixão e morte.*
+
+**24.** Quais são os sacramentos que conferem a primeira graça santificante?
+
+*Os sacramentos que conferem a primeira graça santificante, a qual nos torna amigos de Deus, são dois: o Batismo e a Penitência.*
+
+**25.** Como se chamam, portanto, estes dois sacramentos?
+
+*Estes dois sacramentos, isto é, o Batismo e a Penitência, chamam-se, por isso, sacramentos dos mortos, porque são instituídos principalmente para restituir às almas mortas pelo pecado a vida da graça.*
+
+**26.** Quais são os sacramentos que aumentam a graça em quem a possui?
+
+*Os sacramentos que aumentam a graça em quem a possui são os outros cinco, isto é, a Crisma, a Eucaristia, a Extrema-Unção, a Ordem Sacra e o Matrimônio, os quais conferem a graça segunda.*
+
+**27.** Como se chamam, por isso, estes cinco sacramentos?
+
+*Estes cinco sacramentos, isto é, a Crisma, a Eucaristia, a Extrema-Unção, a Ordem Sacra e o Matrimônio, chamam-se sacramentos dos vivos, porque aqueles que os recebem devem estar sem pecado mortal, isto é, já vivos pela graça santificante.*
+
+**28.** Que pecado comete quem recebe um dos sacramentos dos vivos sabendo não estar em graça de Deus?
+
+*Quem recebe um dos sacramentos dos vivos sabendo não estar em graça de Deus comete um grave sacrilégio.*
+
+**29.** Quais são os sacramentos mais necessários para nos salvar?
+
+*Os sacramentos mais necessários para nos salvar são dois: o Batismo e a Penitência. O Batismo é necessário a todos, e a Penitência é necessária a todos os que pecaram mortalmente depois do Batismo.*
+
+**30.** Qual é o maior de todos os sacramentos?
+
+*O maior de todos os sacramentos é o da Eucaristia, porque contém não só a graça, mas também Jesus Cristo, autor da graça e dos sacramentos.*
+
+## § 3. Do caráter que imprimem alguns Sacramentos
+
+**31.** Quais sacramentos só se podem receber uma vez?
+
+*Os sacramentos que só se podem receber uma vez são três: o Batismo, a Crisma e a Ordem Sacra.*
+
+**32.** Por que os três sacramentos, Batismo, Crisma e Ordem Sacra, só se podem receber uma vez?
+
+*Os três sacramentos, Batismo, Crisma e Ordem Sacra, só se podem receber uma vez porque cada um deles imprime o caráter.*
+
+**33.** O que é o caráter que cada um dos três sacramentos — Batismo, Crisma e Ordem Sacra — imprime na alma?
+
+*O caráter que cada um dos três sacramentos — Batismo, Crisma e Ordem Sacra — imprime na alma é um sinal espiritual que nunca mais se apaga.*
+
+**34.** Para que serve o caráter que esses três sacramentos imprimem na alma?
+
+*O caráter que esses três sacramentos imprimem na alma serve para nos distinguir, no Batismo, como membros de Jesus Cristo; na Crisma, como seus soldados; na Ordem Sacra, como seus ministros.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-ii.md
@@ -1,0 +1,115 @@
+# Capítulo II — Do Batismo
+
+## § 1. Natureza e efeitos do Batismo
+
+**1.** O que é o sacramento do Batismo?
+
+*O Batismo é o sacramento pelo qual renascemos para a graça de Deus e nos tornamos cristãos.*
+
+**2.** Quais são os efeitos do sacramento do Batismo?
+
+*O sacramento do Batismo confere a primeira graça santificante, pela qual se apaga o pecado original e também o atual, se houver; remete toda a pena por eles devida; imprime o caráter de cristão; faz-nos filhos de Deus, membros da Igreja e herdeiros do paraíso, e torna-nos aptos a receber os demais sacramentos.*
+
+**3.** Qual é a matéria do Batismo?
+
+*A matéria do Batismo é a água natural, que se derrama sobre a cabeça de quem é batizado em quantidade suficiente para escorrer.*
+
+**4.** Qual é a forma do Batismo?
+
+*A forma do Batismo é esta: Eu te batizo em nome do Pai e do Filho e do Espírito Santo.*
+
+## § 2. Ministro do Batismo
+
+**5.** A quem cabe administrar o Batismo?
+
+*Administrar o Batismo cabe, por direito, aos Bispos e aos párocos; mas, em caso de necessidade, qualquer pessoa pode administrá-lo, seja homem ou mulher, mesmo um herege ou um infiel, contanto que execute o rito do Batismo e tenha a intenção de fazer o que faz a Igreja.*
+
+**6.** Se houver necessidade de batizar uma pessoa que está em perigo de morrer, e muitos se acharem presentes, quem deveria administrar o Batismo?
+
+*Se houver necessidade de batizar uma pessoa em perigo de morte, e muitos se acharem presentes, deveria batizá-la o sacerdote, se houver; e, na sua ausência, um eclesiástico de ordem inferior; e na ausência deste, o homem leigo, com preferência sobre a mulher, a não ser que a maior perícia da mulher, ou a decência, exijam o contrário.*
+
+**7.** Que intenção deve ter quem batiza?
+
+*Quem batiza deve ter a intenção de fazer aquilo que faz a santa Igreja ao batizar.*
+
+## § 3. Rito do Batismo e disposições de quem o recebe sendo adulto
+
+**8.** Como se administra o Batismo?
+
+*Administra-se o Batismo derramando água sobre a cabeça da pessoa a ser batizada — e, se não se puder sobre a cabeça, sobre alguma outra parte principal do corpo — e dizendo, ao mesmo tempo: Eu te batizo em nome do Pai e do Filho e do Espírito Santo.*
+
+**9.** Se uma pessoa derramasse a água e outra proferisse as palavras, a pessoa ficaria batizada?
+
+*Se uma pessoa derramasse a água e outra proferisse as palavras, a pessoa não ficaria batizada; é necessário que seja a mesma pessoa a derramar a água e a pronunciar as palavras.*
+
+**10.** Quando se duvida se a pessoa está morta, deve-se deixar de batizá-la?
+
+*Quando se duvida se a pessoa está morta, deve-se batizá-la sob condição, dizendo: Se estás vivo, eu te batizo em nome do Pai e do Filho e do Espírito Santo.*
+
+**11.** Quando se devem levar à igreja as crianças para serem batizadas?
+
+*As crianças devem ser levadas à igreja para serem batizadas o mais cedo possível.*
+
+**12.** Por que se deve ter tanta diligência em fazer com que as crianças recebam o Batismo?
+
+*Deve-se ter suma diligência em fazer batizar as crianças, porque, por sua tenra idade, estão expostas a muitos perigos de morrer e não podem salvar-se sem o Batismo.*
+
+**13.** Pecam, então, os pais que, por sua negligência, deixam morrer os filhos sem Batismo, ou o adiam?
+
+*Sim, os pais que, por sua negligência, deixam morrer os filhos sem batismo, pecam gravemente, porque privam seus filhos da vida eterna; e pecam também gravemente adiando por muito tempo o Batismo, porque os expõem ao perigo de morrer sem o ter recebido.*
+
+**14.** Quando quem se batiza é adulto, que disposições deve ter?
+
+*O adulto que se batiza deve, além da fé, ter a dor — ao menos imperfeita — dos pecados mortais que tiver cometido.*
+
+**15.** Se um adulto se batizasse em pecado mortal sem essa dor, o que receberia?
+
+*Se um adulto se batizasse em pecado mortal sem essa dor, receberia o caráter do Batismo, mas não a remissão dos pecados, nem a graça santificante. E esses efeitos ficariam suspensos enquanto não fosse removido o impedimento pela dor perfeita dos pecados ou pelo sacramento da Penitência.*
+
+## § 4. Necessidade do Batismo e deveres dos batizados
+
+**16.** O Batismo é necessário para salvar-se?
+
+*O Batismo é absolutamente necessário para salvar-se, tendo o Senhor dito expressamente: Quem não renascer da água e do Espírito Santo não poderá entrar no reino dos céus.*
+
+**17.** Pode-se, de algum modo, suprir a falta do Batismo?
+
+*A falta do sacramento do Batismo pode ser suprida pelo martírio, que se chama Batismo de sangue, ou por um ato de perfeito amor de Deus ou de contrição, que esteja unido ao desejo, ao menos implícito, do Batismo; e a este se chama Batismo de desejo.*
+
+**18.** A que fica obrigado quem recebe o Batismo?
+
+*Quem recebe o Batismo fica obrigado a professar sempre a fé e a observar a lei de Jesus Cristo e da sua Igreja.*
+
+**19.** A que se renuncia ao receber o santo Batismo?
+
+*Ao receber o santo Batismo, renuncia-se para sempre ao demônio, às suas obras e às suas pompas.*
+
+**20.** O que se entende por obras ou pompas do demônio?
+
+*Por obras e pompas do demônio entendem-se os pecados e as máximas do mundo contrárias às máximas do santo Evangelho.*
+
+## § 5. Nome e Padrinhos
+
+**21.** Por que se impõe o nome de um Santo àquele que se batiza?
+
+*Àquele que se batiza impõe-se o nome de um Santo para pô-lo sob a especial proteção de um celeste patrono e animá-lo a imitar os seus exemplos.*
+
+**22.** Quem são os padrinhos e madrinhas do Batismo?
+
+*Os padrinhos e madrinhas do Batismo são aquelas pessoas que, por disposição da Igreja, seguram as crianças à pia batismal, respondem em seu lugar e se tornam fiadores diante de Deus por sua educação cristã, especialmente se os pais faltassem.*
+
+**23.** Somos obrigados a manter aquelas promessas e renúncias que nossos padrinhos fizeram por nós?
+
+*Somos obrigados sem dúvida a manter as promessas e renúncias que nossos padrinhos fizeram por nós, porque Deus não nos recebeu em sua graça senão com essas condições.*
+
+**24.** Quais pessoas se devem eleger para padrinhos e madrinhas?
+
+*Devem-se eleger para padrinhos e madrinhas pessoas católicas, de bons costumes e obedientes às leis da Igreja.*
+
+**25.** Quais são as obrigações dos padrinhos e madrinhas?
+
+*Os padrinhos e madrinhas são obrigados a procurar que os seus filhos espirituais sejam instruídos nas verdades da fé e vivam como bons cristãos, edificando-os com o bom exemplo.*
+
+**26.** Que vínculo contraem os padrinhos do Batismo?
+
+*Os padrinhos contraem um parentesco espiritual com o batizado e com seus pais, o qual causa impedimento de matrimônio com os mesmos.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-iii.md
@@ -1,0 +1,77 @@
+# Capítulo III — Da Crisma ou Confirmação
+
+**1.** O que é o sacramento da Crisma?
+
+*A Crisma é um sacramento que nos dá o Espírito Santo, imprime em nossa alma o caráter de soldado de Jesus Cristo e nos torna cristãos perfeitos.*
+
+**2.** De que maneira o sacramento da Crisma nos torna cristãos perfeitos?
+
+*A Crisma nos torna cristãos perfeitos, porque nos confirma na fé e aperfeiçoa as demais virtudes e dons que recebemos no santo Batismo; por isso se chama Confirmação.*
+
+**3.** Quais são os dons do Espírito Santo que se recebem na Crisma?
+
+*Os dons do Espírito Santo que se recebem na Crisma são estes sete: Sabedoria, Entendimento, Conselho, Fortaleza, Ciência, Piedade e Temor de Deus.*
+
+**4.** Qual é a matéria deste sacramento?
+
+*A matéria deste sacramento, além da imposição das mãos do Bispo, é a unção feita sobre a fronte do batizado com o sagrado Crisma; e por isso também se chama Crisma, isto é, Unção.*
+
+**5.** O que é o sagrado Crisma?
+
+*O sagrado Crisma é óleo misturado com bálsamo, que o Bispo consagrou na Quinta-feira Santa.*
+
+**6.** O que significam o óleo e o bálsamo neste sacramento?
+
+*Neste sacramento, o óleo, que se expande e fortifica, significa a graça abundante que se espalha na alma do cristão para confirmá-lo na fé; e o bálsamo, que é perfumado e defende da corrupção, significa que o cristão, fortalecido por esta graça, é apto a exalar o bom odor das virtudes cristãs e a preservar-se da corrupção dos vícios.*
+
+**7.** Qual é a forma do sacramento da Crisma?
+
+*A forma do sacramento da Crisma é esta: Eu te selo com o sinal da Cruz e te confirmo com o crisma da salvação, em nome do Pai e do Filho e do Espírito Santo. Assim seja.*
+
+**8.** Quem é o ministro do sacramento da Crisma?
+
+*O ministro ordinário do sacramento da Crisma é apenas o Bispo.*
+
+**9.** Com que rito o Bispo administra a Crisma?
+
+*O Bispo, para administrar o sacramento da Crisma, primeiro estende as mãos sobre os crismandos, invocando sobre eles o Espírito Santo; depois faz uma unção em forma de cruz, com o sagrado Crisma, sobre a fronte de cada um, dizendo as palavras da forma; em seguida, com a sua mão direita, dá um leve tapa na face do crismado, dizendo-lhe: a paz esteja contigo; finalmente, abençoa solenemente todos os crismados.*
+
+**10.** Por que se faz a unção sobre a fronte?
+
+*Faz-se a unção sobre a fronte, onde aparecem os sinais do temor e do rubor, a fim de que o crismado entenda que não deve corar do nome e da profissão de cristão, nem ter medo dos inimigos da fé.*
+
+**11.** Por que se dá um leve tapa no crismado?
+
+*Dá-se um leve tapa no crismado para que saiba que deve estar pronto a sofrer toda afronta e toda pena pela fé de Jesus Cristo.*
+
+**12.** Devem todos procurar receber o sacramento da Crisma?
+
+*Sim, todos devem procurar receber o sacramento da Crisma e fazê-lo receber por seus dependentes.*
+
+**13.** Em que idade é bom receber o sacramento da Crisma?
+
+*A idade em que é bom receber o sacramento da Crisma é a de cerca de sete anos, porque então costumam começar as tentações, e pode-se conhecer suficientemente a graça deste sacramento e lembrar-se de tê-lo recebido.*
+
+**14.** Quais disposições se requerem para receber dignamente o sacramento da Crisma?
+
+*Para receber dignamente o sacramento da Crisma é preciso estar em graça de Deus, saber os mistérios principais de nossa santa fé e aproximar-se com reverência e devoção.*
+
+**15.** Pecaria quem recebesse a Crisma uma segunda vez?
+
+*Cometeria um sacrilégio, porque a Crisma é um daqueles sacramentos que imprimem o caráter na alma, e que por isso só se podem receber uma vez.*
+
+**16.** Que deve fazer o cristão para conservar a graça da Crisma?
+
+*Para conservar a graça da Crisma, o cristão deve orar com frequência, fazer boas obras e viver segundo a lei de Jesus Cristo, sem respeitos humanos.*
+
+**17.** Por que, também na Crisma, há padrinhos e madrinhas?
+
+*Para que estes, com palavras e exemplos, encaminhem o crismado no caminho da salvação e o ajudem na milícia espiritual.*
+
+**18.** Que condições se requerem no padrinho?
+
+*O padrinho deve ser de idade conveniente, católico, crismado, instruído nas coisas mais necessárias da religião e de bons costumes.*
+
+**19.** O padrinho da Crisma contrai algum parentesco com o crismado e com seus pais?
+
+*O padrinho da Crisma contrai o mesmo parentesco espiritual de quem segura a criança à pia batismal.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-iv.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-iv.md
@@ -1,0 +1,237 @@
+# Capítulo IV — Da Eucaristia
+
+## § 1. Da natureza deste sacramento e da presença real de Jesus Cristo no mesmo
+
+**1.** O que é o sacramento da Eucaristia?
+
+*A Eucaristia é um sacramento no qual, pela admirável conversão de toda a substância do pão no Corpo de Jesus Cristo e da do vinho no seu precioso Sangue, se contém verdadeira, real e substancialmente o Corpo, o Sangue, a Alma e a Divindade do mesmo Jesus Cristo, Nosso Senhor, sob as espécies do pão e do vinho, para ser nosso alimento espiritual.*
+
+**2.** Há na Eucaristia o mesmo Jesus Cristo que está no céu e que nasceu na terra da santíssima Virgem?
+
+*Sim, na Eucaristia está verdadeiramente o mesmo Jesus Cristo que está no céu e que nasceu na terra da santíssima Virgem.*
+
+**3.** Por que credes que no sacramento da Eucaristia está verdadeiramente Jesus Cristo?
+
+*Eu creio que no sacramento da Eucaristia está verdadeiramente presente Jesus Cristo, porque Ele mesmo o disse e a santa Igreja mo ensina.*
+
+**4.** Qual é a matéria do sacramento da Eucaristia?
+
+*A matéria do sacramento da Eucaristia é aquela usada por Jesus Cristo, isto é, o pão de trigo e o vinho de videira.*
+
+**5.** Qual é a forma do sacramento da Eucaristia?
+
+*A forma do sacramento da Eucaristia consiste nas palavras usadas por Jesus Cristo: «Este é o meu Corpo»; «Este é o meu Sangue.»*
+
+**6.** O que é, então, a hóstia antes da consagração?
+
+*A hóstia antes da consagração é pão.*
+
+**7.** Depois da consagração, o que é a hóstia?
+
+*Depois da consagração, a hóstia é o verdadeiro Corpo de Nosso Senhor Jesus Cristo sob as espécies do pão.*
+
+**8.** No cálice, antes da consagração, o que há?
+
+*No cálice, antes da consagração, há vinho com algumas gotas de água.*
+
+**9.** Depois da consagração, o que há no cálice?
+
+*Depois da consagração, no cálice está o verdadeiro Sangue de Nosso Senhor Jesus Cristo sob as espécies do vinho.*
+
+**10.** Quando se faz a conversão do pão no Corpo, e do vinho no Sangue de Jesus Cristo?
+
+*A conversão do pão no Corpo e do vinho no Sangue de Jesus Cristo se faz no próprio ato em que o sacerdote, na santa Missa, pronuncia as palavras da consagração.*
+
+**11.** O que é a consagração?
+
+*A consagração é a renovação, por meio do sacerdote, do milagre operado por Jesus Cristo na última ceia, de mudar o pão e o vinho em seu Corpo e em seu Sangue adorável, dizendo: «Este é o meu corpo», «este é o meu sangue».*
+
+**12.** Como a Igreja chama a milagrosa conversão do pão e do vinho no Corpo e no Sangue de Jesus Cristo?
+
+*A milagrosa conversão que cada dia se opera em nossos altares é chamada pela Igreja de transubstanciação.*
+
+**13.** Quem deu tamanha virtude às palavras da consagração?
+
+*Quem deu tamanha virtude às palavras da consagração foi o próprio Nosso Senhor Jesus Cristo, que é Deus onipotente.*
+
+**14.** Depois da consagração, não resta nada do pão e do vinho?
+
+*Depois da consagração restam somente as espécies do pão e do vinho.*
+
+**15.** O que são as espécies do pão e do vinho?
+
+*As espécies são a quantidade e as qualidades sensíveis do pão e do vinho, como a figura, a cor, o sabor.*
+
+**16.** De que maneira podem permanecer as espécies do pão e do vinho sem a sua substância?
+
+*As espécies do pão e do vinho permanecem admiravelmente sem a sua substância, pela virtude de Deus onipotente.*
+
+**17.** Sob as espécies do pão está só o Corpo de Jesus Cristo, e sob as espécies do vinho está só o seu Sangue?
+
+*Tanto sob as espécies do pão como sob as espécies do vinho está todo Jesus Cristo vivo, em Corpo, Sangue, Alma e Divindade.*
+
+**18.** Sabereis dizer por que tanto na hóstia como no cálice está todo Jesus Cristo?
+
+*Tanto na hóstia como no cálice está todo Jesus Cristo, porque Ele está na Eucaristia vivo e imortal, como no céu; por isso, onde está o seu Corpo, está também o Sangue, a Alma e a Divindade; e onde está o Sangue, está também o Corpo, a Alma e a Divindade, sendo tudo isso inseparável em Jesus Cristo.*
+
+**19.** Quando Jesus está na hóstia, cessa de estar no céu?
+
+*Quando Jesus está na hóstia, não cessa de estar no céu, mas encontra-se ao mesmo tempo no céu e no santíssimo Sacramento.*
+
+**20.** Jesus Cristo está em todas as hóstias consagradas do mundo?
+
+*Sim, Jesus Cristo está em todas as hóstias consagradas.*
+
+**21.** Como pode ser que Jesus Cristo esteja em todas as hóstias consagradas?
+
+*Jesus Cristo está em todas as hóstias consagradas pela onipotência de Deus, a quem nada é impossível.*
+
+**22.** Quando se parte a hóstia, parte-se o Corpo de Jesus Cristo?
+
+*Quando se parte a hóstia, não se parte o Corpo de Jesus Cristo, mas se partem somente as espécies do pão.*
+
+**23.** Em que parte da hóstia permanece o Corpo de Jesus Cristo?
+
+*O Corpo de Jesus Cristo permanece inteiro em todas as partes em que a hóstia tiver sido dividida.*
+
+**24.** Jesus Cristo está tanto em uma hóstia grande, como na partícula de uma hóstia?
+
+*Tanto em uma hóstia grande como na partícula de uma hóstia está o mesmo Jesus Cristo.*
+
+**25.** Por que motivo se conserva nas igrejas a santíssima Eucaristia?
+
+*A santíssima Eucaristia conserva-se nas igrejas para ser adorada pelos fiéis e levada aos enfermos conforme a necessidade.*
+
+**26.** Deve-se adorar a Eucaristia?
+
+*A Eucaristia deve ser adorada por todos, porque contém verdadeira, real e substancialmente o mesmo Nosso Senhor Jesus Cristo.*
+
+## § 2. Da instituição e dos efeitos do sacramento da Eucaristia
+
+**27.** Em que tempo Jesus Cristo instituiu o sacramento da Eucaristia?
+
+*Jesus Cristo instituiu o sacramento da Eucaristia na última ceia, que fez com os seus discípulos na noite anterior à sua paixão.*
+
+**28.** Por que Jesus Cristo instituiu a santíssima Eucaristia?
+
+*Jesus Cristo instituiu a santíssima Eucaristia por três principais razões:*
+
+*1.º Para que seja o sacrifício da nova lei.*
+
+*2.º Para que seja alimento de nossa alma.*
+
+*3.º Para que seja um perpétuo memorial de sua paixão e morte, e um penhor precioso do seu amor por nós e da vida eterna.*
+
+**29.** Por que Jesus Cristo instituiu este sacramento sob as espécies do pão e do vinho?
+
+*Jesus Cristo instituiu este sacramento sob as espécies do pão e do vinho, porque a Eucaristia havia de ser o nosso alimento espiritual; e por isso era conveniente que nos fosse dada em forma de comida e bebida.*
+
+**30.** Quais efeitos produz em nós a santíssima Eucaristia?
+
+*Os efeitos principais que a santíssima Eucaristia produz em quem a recebe dignamente são estes: 1.º conserva e aumenta a vida da alma, que é a graça, como o alimento material sustenta e aumenta a vida do corpo; 2.º perdoa os pecados veniais e preserva dos mortais; 3.º produz consolação espiritual.*
+
+**31.** A santíssima Eucaristia não produz em nós outros efeitos?
+
+*Sim, a santíssima Eucaristia produz em nós outros três efeitos, a saber: 1.º enfraquece as nossas paixões e, em particular, amortece em nós as chamas da concupiscência; 2.º aumenta em nós o fervor da caridade para com Deus e para com o próximo, e ajuda-nos a agir em conformidade com os desejos de Jesus Cristo; 3.º dá-nos um penhor da glória futura e da própria ressurreição do nosso corpo.*
+
+## § 3. Das disposições necessárias para bem comungar
+
+**32.** O sacramento da Eucaristia produz sempre em nós seus maravilhosos efeitos?
+
+*O sacramento da Eucaristia produz em nós seus maravilhosos efeitos quando se recebe com as devidas disposições.*
+
+**33.** Quantas coisas são necessárias para fazer uma boa Comunhão?
+
+*Para fazer uma boa Comunhão são necessárias três coisas: 1.º estar em graça de Deus; 2.º estar em jejum da meia-noite até o ato da Comunhão; 3.º saber o que se vai receber e aproximar-se da santa Comunhão com devoção.*
+
+**34.** Que quer dizer estar em graça de Deus?
+
+*Estar em graça de Deus quer dizer ter a consciência pura e limpa de todo pecado mortal.*
+
+**35.** Quem sabe estar em pecado mortal, o que deve fazer antes de comungar?
+
+*Quem sabe estar em pecado mortal deve, antes de comungar, fazer uma boa confissão; não bastando o ato de contrição perfeita, sem a confissão, para que aquele que está em pecado mortal possa comungar como convém.*
+
+**36.** Por que nem mesmo o ato de contrição perfeita basta a quem sabe estar em pecado mortal para poder comungar?
+
+*Porque a Igreja estabeleceu, por respeito a este sacramento, que quem é culpado de pecado mortal não ouse fazer a Comunhão sem se ter primeiro confessado.*
+
+**37.** Quem comungasse em pecado mortal receberia Jesus Cristo?
+
+*Quem comungasse em pecado mortal receberia Jesus Cristo, mas não a sua graça; antes, cometeria sacrilégio e se tornaria merecedor da sentença de danação.*
+
+**38.** Qual é o jejum que se requer antes da Comunhão?
+
+*Antes da Comunhão requer-se o jejum natural, o qual se quebra por qualquer pequena coisa que se ingira como alimento ou bebida.*
+
+**39.** Se alguém engole alguma coisa que ficou entre os dentes ou alguma gota de água que lhe entrou na boca, ainda pode comungar?
+
+*Quem engolisse alguma coisa que ficou entre os dentes, ou alguma gota de água ao lavar-se, ainda pode comungar; porque então essas coisas, ou não são tomadas como alimento ou bebida, ou já perderam essa natureza.*
+
+**40.** É alguma vez permitido fazer a Comunhão sem estar em jejum?
+
+*Fazer a Comunhão sem estar em jejum é permitido aos enfermos que estão em perigo de morte e a quem tiver obtido faculdade especial do Papa por motivo de enfermidade prolongada. A Comunhão feita pelos enfermos em perigo de morte chama-se Viático, porque os sustenta na viagem que fazem desta vida para a eternidade.*
+
+**41.** Que quer dizer: saber o que se vai receber?
+
+*Saber o que se vai receber quer dizer conhecer aquelas coisas que se ensinam sobre este sacramento na Doutrina cristã, e crê-las firmemente.*
+
+**42.** Que quer dizer: comungar com devoção?
+
+*Comungar com devoção quer dizer aproximar-se da santa Comunhão com humildade e modéstia, tanto na pessoa como no vestuário, e fazer a preparação antes e o agradecimento depois da santa Comunhão.*
+
+**43.** Em que consiste a preparação antes da Comunhão?
+
+*A preparação antes da Comunhão consiste em deter-se por algum tempo a considerar quem vamos receber e quem somos nós; e em fazer atos de fé, de esperança, de caridade, de contrição, de adoração, de humildade e de desejo de receber Jesus Cristo.*
+
+**44.** Em que consiste o agradecimento depois da Comunhão?
+
+*O agradecimento depois da Comunhão consiste em ficar recolhidos a honrar dentro de nós o Senhor, renovando os atos de fé, de esperança, de caridade, de adoração, de agradecimento, de oferecimento e de pedido, sobretudo das graças que mais nos forem necessárias para nós e para aqueles por quem estamos obrigados a orar.*
+
+**45.** O que se deve fazer no dia da Comunhão?
+
+*No dia da Comunhão deve-se manter o recolhimento na medida do possível, ocupar-se em obras de piedade e cumprir com maior diligência os deveres do próprio estado.*
+
+**46.** Depois da santa Comunhão, quanto tempo permanece em nós Jesus Cristo?
+
+*Depois da santa Comunhão, Jesus Cristo permanece em nós com sua graça enquanto não se peca mortalmente; e, com sua real presença, permanece em nós até que se hajam consumido as espécies sacramentais.*
+
+## § 4. Da maneira de comungar
+
+**47.** Como se deve apresentar no ato de receber a santa Comunhão?
+
+*No ato de receber a santa Comunhão é preciso estar ajoelhado, manter a cabeça moderadamente erguida, os olhos modestos e voltados para a sagrada partícula, a boca suficientemente aberta e a língua um pouco avançada sobre os lábios.*
+
+**48.** Como se deve segurar a toalha ou a salva da Comunhão?
+
+*A toalha ou a salva da Comunhão deve ser segurada de modo a recolher a sagrada partícula, caso esta venha a cair.*
+
+**49.** Quando se deve engolir a sagrada partícula?
+
+*Devemos procurar engolir a sagrada partícula o mais cedo possível, e por algum tempo abster-nos de cuspir.*
+
+**50.** Se a sagrada partícula se grudasse ao palato, o que se deveria fazer?
+
+*Se a sagrada partícula se grudasse ao palato, deveria ser despregada com a língua, e nunca com o dedo.*
+
+## § 5. Do preceito da Comunhão
+
+**51.** Quando há a obrigação de comungar?
+
+*Há a obrigação de comungar todo ano, na Páscoa da Ressurreição, cada um na própria paróquia, e, ademais, em perigo de morte.*
+
+**52.** Em que idade começa a obrigar o mandamento da Comunhão pascal?
+
+*O mandamento da Comunhão pascal começa a obrigar na idade em que a criança é capaz de aproximar-se dela com as devidas disposições.*
+
+**53.** Pecam aqueles que têm idade capaz para serem admitidos à Comunhão e não comungam?
+
+*Aqueles que, tendo idade capaz para serem admitidos à Comunhão, não comungam, ou porque não querem, ou porque, por sua culpa, não são instruídos, pecam sem dúvida. Pecam também os seus pais, ou quem faz suas vezes, se o adiamento da Comunhão ocorre por culpa deles; e disso deverão prestar grande conta a Deus.*
+
+**54.** É coisa boa e útil comungar com frequência?
+
+*É coisa ótima comungar com frequência, contanto que se faça com as disposições devidas.*
+
+**55.** Com que frequência se pode ir à Comunhão?
+
+*Cada um pode ir à Comunhão com aquela maior frequência que lhe for aconselhada por um pio e douto confessor.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-ix.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-ix.md
@@ -1,0 +1,111 @@
+# Capítulo IX — Do Matrimônio
+
+## § 1. Natureza do sacramento do Matrimônio
+
+**1.** O que é o sacramento do Matrimônio?
+
+*O Matrimônio é um sacramento, instituído por Nosso Senhor Jesus Cristo, que estabelece uma santa e indissolúvel união entre o homem e a mulher, e lhes dá a graça de amar-se um ao outro santamente e de criar cristãmente os filhos.*
+
+**2.** Por quem foi instituído o Matrimônio?
+
+*O Matrimônio foi instituído pelo próprio Deus no paraíso terrestre; e, no Novo Testamento, foi elevado por Jesus Cristo à dignidade de sacramento.*
+
+**3.** O sacramento do Matrimônio tem algum significado especial?
+
+*O sacramento do Matrimônio significa a indissolúvel união de Jesus Cristo com a santa Igreja, sua esposa e nossa amantíssima mãe.*
+
+**4.** Por que se diz que o vínculo do matrimônio é indissolúvel?
+
+*Diz-se que o vínculo do matrimônio é indissolúvel, ou seja, que não pode ser desfeito senão pela morte de um dos cônjuges, porque assim estabeleceu Deus desde o princípio, e assim solenemente proclamou Jesus Cristo, Nosso Senhor.*
+
+**5.** No matrimônio cristão poder-se-ia separar o contrato do sacramento?
+
+*Não, no matrimônio entre cristãos não se pode separar o contrato do sacramento, porque, para eles, o matrimônio nada mais é do que o próprio contrato natural elevado por Jesus Cristo à dignidade de sacramento.*
+
+**6.** Entre os cristãos, portanto, não pode haver verdadeiro matrimônio que não seja sacramento?
+
+*Entre os cristãos não pode haver verdadeiro matrimônio que não seja sacramento.*
+
+**7.** Quais efeitos produz o sacramento do Matrimônio?
+
+*O sacramento do Matrimônio: 1.º dá o aumento da graça santificante; 2.º confere a graça especial para cumprir fielmente todos os deveres matrimoniais.*
+
+## § 2. Ministros, rito e disposições
+
+**8.** Quais são os ministros deste sacramento?
+
+*Os ministros deste sacramento são os próprios esposos, que mutuamente conferem e recebem o sacramento.*
+
+**9.** De que modo se administra este sacramento?
+
+*Este sacramento, conservando a natureza de contrato, administra-se pelos próprios contraentes, ao declararem, na presença do seu pároco, ou de um seu delegado, e de duas testemunhas, que se unem em matrimônio.*
+
+**10.** Para que serve, então, a bênção que o pároco dá aos esposos?
+
+*A bênção que o pároco dá aos esposos não é necessária para constituir o sacramento, mas se dá para sancionar, em nome da Igreja, sua união, e para chamar cada vez mais sobre eles as bênçãos de Deus.*
+
+**11.** Que intenção deve ter quem contrai matrimônio?
+
+*Quem contrai matrimônio deve ter a intenção: 1.º de fazer a vontade de Deus, que o chama a tal estado; 2.º de promover nele a salvação da própria alma; 3.º de criar cristãmente os filhos, se Deus conceder tê-los.*
+
+**12.** De que maneira os esposos devem dispor-se para receber com fruto o sacramento do Matrimônio?
+
+*Os esposos, para receber com fruto o sacramento do Matrimônio, devem: 1.º encomendar-se de coração a Deus para conhecer a sua vontade e para obter dele as graças que são necessárias em tal estado; 2.º consultar-se com os próprios pais antes de fazer a promessa, como exigem a obediência e o respeito devidos a eles; 3.º preparar-se com uma boa confissão, mesmo geral, se necessário, de toda a vida; 4.º evitar toda perigosa familiaridade de trato e de palavra no conversar juntos.*
+
+**13.** Quais são as principais obrigações das pessoas unidas em matrimônio?
+
+*As pessoas unidas em matrimônio devem: 1.º guardar inviolada a fidelidade conjugal e comportar-se sempre cristãmente em tudo; 2.º amar-se mutuamente, suportando-se uns aos outros com paciência, e viver em paz e concórdia; 3.º se têm filhos, pensar seriamente em prover-lhes o necessário, dar-lhes uma educação cristã e deixar-lhes a liberdade de escolher o estado para o qual são chamados por Deus.*
+
+## § 3. Condições e impedimentos
+
+**14.** O que é necessário para contrair validamente o matrimônio cristão?
+
+*Para contrair validamente o matrimônio cristão, é necessário estar livre de qualquer impedimento matrimonial dirimente e prestar livremente o próprio consentimento ao contrato do matrimônio diante do próprio pároco, ou de um sacerdote por ele delegado, e de duas testemunhas.*
+
+**15.** O que é necessário para contrair licitamente o matrimônio cristão?
+
+*Para contrair licitamente o matrimônio cristão, é necessário estar livre dos impedimentos matrimoniais impedientes, estar instruído nas coisas principais da religião e estar em estado de graça; do contrário, cometer-se-ia um sacrilégio.*
+
+**16.** O que são os impedimentos matrimoniais?
+
+*Os impedimentos matrimoniais são aquelas circunstâncias que tornam o matrimônio inválido ou ilícito. No primeiro caso chamam-se impedimentos dirimentes; no segundo, impedimentos impedientes.*
+
+**17.** Dai-me algum exemplo de impedimento dirimente.
+
+*Impedimentos dirimentes são, por exemplo, a consanguinidade até o quarto grau, o parentesco espiritual, o voto solene de castidade, a disparidade de culto entre batizados e não batizados, etc.*
+
+**18.** Dai-me algum exemplo de impedimento impediente.
+
+*Impedimentos impedientes são, por exemplo, o tempo proibido, o voto simples de castidade, etc.*
+
+**19.** Os fiéis são obrigados a manifestar à autoridade eclesiástica os impedimentos matrimoniais que conhecem?
+
+*Os fiéis são obrigados a manifestar à autoridade eclesiástica os impedimentos matrimoniais que conhecem; e é por isso que os párocos fazem as proclamas.*
+
+**20.** Quem tem o poder de estabelecer impedimentos matrimoniais, de dispensar deles e de julgar da validade do matrimônio cristão?
+
+*Somente a Igreja tem o poder de estabelecer impedimentos e de julgar da validade do matrimônio entre os cristãos, como só a Igreja pode dispensar daqueles impedimentos que ela estabeleceu.*
+
+**21.** Por que somente a Igreja tem o poder de estabelecer impedimentos e de julgar da validade do matrimônio?
+
+*Somente a Igreja tem o poder de estabelecer impedimentos, de julgar da validade do matrimônio e de dispensar dos impedimentos que ela impôs, porque, no matrimônio cristão, não se podendo separar o contrato do sacramento, também o contrato recai sob o poder da Igreja, à qual só Jesus Cristo conferiu o direito de fazer leis e decisões nas coisas sagradas.*
+
+**22.** Pode a autoridade civil dissolver pelo divórcio o vínculo do matrimônio cristão?
+
+*Não, o vínculo do matrimônio cristão não pode ser dissolvido pela autoridade civil, porque esta não pode imiscuir-se em matéria de sacramentos, nem separar o que Deus uniu.*
+
+**23.** O que é o matrimônio civil?
+
+*O matrimônio civil nada mais é do que uma formalidade prescrita pela lei a fim de dar e assegurar os efeitos civis aos cônjuges e à sua prole.*
+
+**24.** Basta para um cristão fazer apenas o matrimônio, ou contrato civil?
+
+*Para um cristão não basta fazer apenas o contrato civil, porque este não é sacramento e, portanto, não é verdadeiro matrimônio.*
+
+**25.** Se os esposos convivessem entre si apenas com o matrimônio civil, em que condição se encontrariam?
+
+*Se os esposos convivessem entre si apenas com o matrimônio civil, estariam em estado de contínuo pecado mortal, e sua união permaneceria sempre ilegítima diante de Deus e da Igreja.*
+
+**26.** Deve-se também fazer o matrimônio civil?
+
+*Deve-se também fazer o matrimônio civil, porque, embora este não seja sacramento, contudo serve para garantir aos contraentes e a seus filhos os efeitos civis da sociedade conjugal; e, por isso, em regra geral, a autoridade eclesiástica não permite o matrimônio religioso senão quando se tenham iniciado os atos prescritos pela lei civil.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-v.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-v.md
@@ -1,0 +1,97 @@
+# Capítulo V — Do santo sacrifício da Missa
+
+## § 1. Da essência, da instituição e dos fins do santo sacrifício da Missa
+
+**1.** A Eucaristia deve ser considerada somente como sacramento?
+
+*A Eucaristia, além de ser sacramento, é também o sacrifício permanente da nova lei, que Jesus Cristo deixou à sua Igreja, a ser oferecido a Deus pelas mãos dos seus sacerdotes.*
+
+**2.** Em que consiste, em geral, o sacrifício?
+
+*O sacrifício, em geral, consiste em oferecer uma coisa sensível a Deus e destruí-la de algum modo, para reconhecer o supremo domínio que Ele tem sobre nós e sobre todas as coisas.*
+
+**3.** Como se chama este sacrifício da nova lei?
+
+*Este sacrifício da nova lei chama-se a santa Missa.*
+
+**4.** O que é, portanto, a santa Missa?
+
+*A santa Missa é o sacrifício do Corpo e do Sangue de Jesus Cristo, oferecido sobre os nossos altares sob as espécies do pão e do vinho, em memória do sacrifício da Cruz.*
+
+**5.** O sacrifício da Missa é o mesmo da Cruz?
+
+*O sacrifício da Missa é substancialmente o mesmo da Cruz, na medida em que o mesmo Jesus Cristo que se ofereceu sobre a Cruz é o que se oferece pelas mãos dos sacerdotes, seus ministros, sobre os nossos altares; mas, quanto ao modo pelo qual é oferecido, o sacrifício da Missa difere do sacrifício da Cruz, conservando, contudo, com este, a mais íntima e essencial relação.*
+
+**6.** Qual é, então, a diferença e a relação entre o sacrifício da Missa e o da Cruz?
+
+*Entre o sacrifício da Missa e o da Cruz há esta diferença e relação: Jesus Cristo, sobre a Cruz, ofereceu-se derramando o seu sangue e merecendo por nós; sobre os altares, ao contrário, Ele se sacrifica sem derramamento de sangue e aplica-nos os frutos da sua Paixão e Morte.*
+
+**7.** Que outra relação tem o sacrifício da Missa com o da Cruz?
+
+*Outra relação do sacrifício da Missa com o da Cruz é que o sacrifício da Missa representa de modo sensível o derramamento do sangue de Jesus Cristo sobre a Cruz, porque, em virtude das palavras da consagração, torna-se presente, sob as espécies do pão, somente o Corpo, e, sob as espécies do vinho, somente o Sangue do nosso Salvador; embora, por natural concomitância e pela união hipostática, esteja presente, sob cada uma das espécies, Jesus Cristo vivo e verdadeiro.*
+
+**8.** Não é, porventura, o sacrifício da Cruz o único sacrifício da nova lei?
+
+*O sacrifício da Cruz é o único sacrifício da nova lei, na medida em que por ele o Senhor aplacou a Divina Justiça, adquiriu todos os méritos necessários para nos salvar, e assim cumpriu, da sua parte, a nossa redenção. Esses méritos, porém, Ele no-los aplica pelos meios que instituiu em sua Igreja, entre os quais está o santo sacrifício da Missa.*
+
+**9.** Por quais fins, então, se oferece o sacrifício da santa Missa?
+
+*O sacrifício da santa Missa oferece-se a Deus por quatro fins: 1.º para honrá-Lo como convém, e por isso se chama latrêutico; 2.º para agradecer-Lhe os benefícios, e por isso se chama eucarístico; 3.º para aplacá-Lo, dar-Lhe a devida satisfação por nossos pecados e sufragar as almas do purgatório, e por isso se chama propiciatório; 4.º para obter todas as graças que nos são necessárias, e por isso se chama impetratório.*
+
+**10.** Quem é que oferece a Deus o sacrifício da santa Missa?
+
+*O primeiro e principal ofertante do sacrifício da santa Missa é Jesus Cristo; e o sacerdote é o ministro que, em nome de Jesus Cristo, oferece o mesmo sacrifício ao Eterno Pai.*
+
+**11.** Quem instituiu o sacrifício da santa Missa?
+
+*O sacrifício da santa Missa foi instituído pelo próprio Jesus Cristo, quando instituiu o sacramento da Eucaristia, e mandou que se fizesse em memória da sua Paixão.*
+
+**12.** A quem se oferece a santa Missa?
+
+*A santa Missa oferece-se somente a Deus.*
+
+**13.** Se a santa Missa só se oferece a Deus, por que se celebram tantas Missas em honra da santíssima Virgem e dos Santos?
+
+*A Missa celebrada em honra da Virgem e dos Santos é sempre um sacrifício oferecido somente a Deus; diz-se, porém, celebrada em honra da santíssima Virgem e dos Santos para agradecer a Deus pelos dons que lhes fez e para obter dele, por sua intercessão, com maior abundância, as graças de que necessitamos.*
+
+**14.** Quem é participante dos frutos da Missa?
+
+*Toda a Igreja participa dos frutos da Missa; mas particularmente: 1.º o sacerdote e os que assistem à Missa, os quais se consideram unidos ao sacerdote; 2.º aqueles por quem se aplica a Missa, que podem ser tanto vivos como defuntos.*
+
+## § 2. Do modo de assistir à santa Missa
+
+**15.** Quais coisas são necessárias para ouvir bem e com fruto a santa Missa?
+
+*Para ouvir bem e com fruto a santa Missa são necessárias duas coisas: 1.º a modéstia da pessoa; 2.º a devoção do coração.*
+
+**16.** Em que consiste a modéstia da pessoa?
+
+*A modéstia da pessoa consiste, de modo especial, em estar modestamente vestido, em observar silêncio e recolhimento, e em estar, quanto possível, de joelhos, exceto no tempo dos dois evangelhos, que se ouvem em pé.*
+
+**17.** Ao ouvir a santa Missa, qual é o melhor modo de praticar a devoção do coração?
+
+*O melhor modo de praticar a devoção do coração ao ouvir a santa Missa é o seguinte:*
+
+*1.º Unir, desde o início, a própria intenção à do sacerdote, oferecendo a Deus o santo sacrifício pelos fins para os quais foi instituído.*
+
+*2.º Acompanhar o sacerdote em cada oração e ação do sacrifício.*
+
+*3.º Meditar a paixão e morte de Jesus Cristo e detestar de coração os pecados que dela foram causa.*
+
+*4.º Fazer a Comunhão sacramental, ou ao menos a espiritual, no momento em que o sacerdote comunga.*
+
+**18.** O que é a Comunhão espiritual?
+
+*A Comunhão espiritual é um grande desejo de unir-se sacramentalmente a Jesus Cristo, dizendo, por exemplo: «Senhor meu Jesus Cristo, desejo de todo o coração unir-me a Vós agora e por toda a eternidade»; e fazendo os mesmos atos que se fazem antes e depois da Comunhão sacramental.*
+
+**19.** A recitação do Rosário ou de outras orações durante a Missa impede de ouvi-la com fruto?
+
+*A recitação dessas orações não impede de ouvir com fruto a Missa, contanto que se procure, quanto possível, seguir a ação do santo sacrifício.*
+
+**20.** É coisa boa orar também pelos outros enquanto se assiste à santa Missa?
+
+*É coisa boa orar também pelos outros enquanto se assiste à santa Missa; antes, o tempo da santa Missa é o mais oportuno para orar a Deus pelos vivos e pelos mortos.*
+
+**21.** Terminada a Missa, o que se deveria fazer?
+
+*Terminada a Missa, deveria-se agradecer a Deus a graça de nos ter feito assistir a este grande sacrifício, e pedir-Lhe perdão pelas faltas que tivermos cometido ao assisti-lo.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-vi.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-vi.md
@@ -1,0 +1,581 @@
+# Capítulo VI — Da Penitência
+
+## § 1. Da Penitência em geral
+
+**1.** O que é o sacramento da Penitência?
+
+*A Penitência, chamada também Confissão, é o sacramento instituído por Jesus Cristo para perdoar os pecados cometidos depois do Batismo.*
+
+**2.** Por que se dá a este sacramento o nome de Penitência?
+
+*Dá-se a este sacramento o nome de Penitência porque, para obter o perdão dos pecados, é necessário detestá-los com arrependimento; e porque quem cometeu uma culpa deve sujeitar-se à pena que o sacerdote impõe.*
+
+**3.** Por que este sacramento se chama também Confissão?
+
+*Este sacramento chama-se também Confissão porque, para obter o perdão dos pecados, não basta detestá-los, mas é necessário acusá-los ao sacerdote, isto é, fazer a confissão deles.*
+
+**4.** Quando Jesus Cristo instituiu o sacramento da Penitência?
+
+*Jesus Cristo instituiu o sacramento da Penitência no dia da sua ressurreição, quando, entrando no cenáculo, deu solenemente aos seus Apóstolos a faculdade de perdoar os pecados.*
+
+**5.** Como Jesus Cristo deu aos seus Apóstolos a faculdade de perdoar os pecados?
+
+*Jesus Cristo deu aos seus Apóstolos a faculdade de perdoar os pecados soprando sobre eles e dizendo: «Recebei o Espírito Santo; aqueles a quem perdoardes os pecados, ser-lhes-ão perdoados; e aqueles a quem os retiverdes, ser-lhes-ão retidos.»*
+
+**6.** Qual é a matéria do sacramento da Penitência?
+
+*A matéria do sacramento da Penitência distingue-se em remota e próxima. A matéria remota é constituída pelos pecados cometidos pelo penitente depois do Batismo; e a matéria próxima são os atos do próprio penitente, isto é, a contrição, a acusação e a satisfação.*
+
+**7.** Qual é a forma do sacramento da Penitência?
+
+*A forma do sacramento da Penitência é esta: Eu te absolvo dos teus pecados.*
+
+**8.** Quem é o ministro do sacramento da Penitência?
+
+*O ministro do sacramento da Penitência é o sacerdote aprovado pelo Bispo para ouvir confissões.*
+
+**9.** Por que dissestes que o sacerdote deve ser aprovado pelo Bispo?
+
+*O sacerdote deve ser aprovado pelo Bispo para ouvir confissões, porque, para administrar validamente este sacramento, não basta a potestade da ordem, mas é necessária também a potestade de jurisdição, isto é, a faculdade de julgar, que deve ser conferida pelo Bispo.*
+
+**10.** Quantas são as partes do sacramento da Penitência?
+
+*As partes do sacramento da Penitência são: a contrição, a confissão e a satisfação do penitente, e a absolvição do sacerdote.*
+
+**11.** O que é a contrição, ou dor dos pecados?
+
+*A contrição, ou dor dos pecados, é um desgosto da alma pelo qual se detestam os pecados cometidos e se propõe não cometê-los mais no futuro.*
+
+**12.** O que quer dizer esta palavra contrição?
+
+*A palavra contrição quer dizer ruptura ou despedaçamento, como quando uma pedra é triturada e reduzida a pó.*
+
+**13.** Por que se dá o nome de contrição à dor dos pecados?
+
+*Dá-se o nome de contrição à dor dos pecados para significar que o coração endurecido do pecador, de certo modo, se despedaça pela dor de ter ofendido a Deus.*
+
+**14.** Em que consiste a confissão dos pecados?
+
+*A confissão consiste em uma acusação distinta dos nossos pecados, feita ao confessor para receber a absolvição e a penitência.*
+
+**15.** Por que a confissão se chama acusação?
+
+*A confissão chama-se acusação porque não deve ser uma narração indiferente, mas uma verdadeira e dolorosa manifestação dos próprios pecados.*
+
+**16.** O que é a satisfação ou penitência?
+
+*A satisfação ou penitência é aquela oração ou outra obra boa que o confessor impõe ao penitente em expiação de seus pecados.*
+
+**17.** O que é a absolvição?
+
+*A absolvição é a sentença que o sacerdote pronuncia em nome de Jesus Cristo, para perdoar os pecados do penitente.*
+
+**18.** Das partes do sacramento da Penitência, qual é a mais necessária?
+
+*Das partes do sacramento da Penitência, a mais necessária é a contrição, porque sem ela jamais se pode obter o perdão dos pecados; e com ela só, quando for perfeita, pode-se obter o perdão, contanto que esteja unida ao desejo, ao menos implícito, de confessar-se.*
+
+## § 2. Dos efeitos e da necessidade do sacramento da Penitência, e das disposições para bem recebê-lo
+
+**19.** Quantos são os efeitos do sacramento da Penitência?
+
+*O sacramento da Penitência confere a graça santificante, com a qual são perdoados os pecados mortais e também os veniais que foram confessados e dos quais se tem dor; comuta a pena eterna em temporal, da qual também se perdoa mais ou menos, conforme as disposições; restitui os méritos das boas obras feitas antes de cometer o pecado mortal; dá à alma auxílios oportunos para não cair novamente em culpa; e restitui a paz à consciência.*
+
+**20.** O sacramento da Penitência é necessário a todos para salvar-se?
+
+*O sacramento da Penitência é necessário, para salvar-se, a todos aqueles que, depois do Batismo, cometeram algum pecado mortal.*
+
+**21.** É coisa boa confessar-se com frequência?
+
+*Confessar-se com frequência é coisa ótima, porque o sacramento da Penitência, além de cancelar os pecados, dá as graças oportunas para evitá-los no futuro.*
+
+**22.** O sacramento da Penitência tem o poder de perdoar todos os pecados, por mais numerosos e graves que sejam?
+
+*O sacramento da Penitência tem o poder de perdoar todos os pecados, por mais numerosos e graves que sejam, contanto que se receba com as devidas disposições.*
+
+**23.** Quantas coisas se requerem para fazer uma boa confissão?
+
+*Para fazer uma boa confissão requerem-se cinco coisas: 1.º exame de consciência; 2.º dor de ter ofendido a Deus; 3.º propósito de não pecar mais; 4.º acusação dos próprios pecados; 5.º satisfação ou penitência.*
+
+**24.** O que devemos fazer antes de tudo para nos confessarmos bem?
+
+*Para nos confessarmos bem, devemos antes de tudo orar de coração ao Senhor para que nos dê luz para conhecer todos os nossos pecados e força para detestá-los.*
+
+## § 3. Do exame
+
+**25.** O que é o exame de consciência?
+
+*O exame de consciência é uma diligente busca dos pecados que se cometeram depois da última confissão bem feita.*
+
+**26.** Como se faz o exame de consciência?
+
+*O exame de consciência faz-se trazendo diligentemente à memória, diante de Deus, todos os pecados cometidos, nunca confessados, em pensamentos, palavras, obras e omissões, contra os mandamentos de Deus e da Igreja e contra as obrigações do próprio estado.*
+
+**27.** Sobre que outras coisas devemos examinar-nos?
+
+*Devemos examinar-nos também sobre os maus hábitos e sobre as ocasiões do pecado.*
+
+**28.** No exame, devemos investigar também o número dos pecados?
+
+*No exame, devemos investigar também o número dos pecados mortais.*
+
+**29.** O que se requer para que um pecado seja mortal?
+
+*Para que um pecado seja mortal requerem-se três coisas: matéria grave, plena advertência e perfeito consentimento da vontade.*
+
+**30.** Quando há matéria grave?
+
+*Há matéria grave quando se trata de uma coisa notavelmente contrária à lei de Deus e da Igreja.*
+
+**31.** Quando há pleno conhecimento ao pecar?
+
+*Há pleno conhecimento ao pecar quando se sabe perfeitamente que se está fazendo um grave mal.*
+
+**32.** Quando, no pecado, há o perfeito consentimento da vontade?
+
+*Há, no pecado, o perfeito consentimento da vontade quando se quer fazer deliberadamente uma coisa, mesmo conhecendo-a pecaminosa.*
+
+**33.** Que diligência se deve empregar no exame de consciência?
+
+*No exame de consciência deve-se empregar aquela diligência que se empregaria em um negócio de grande importância.*
+
+**34.** Quanto tempo se deve empregar no exame?
+
+*Deve-se empregar no exame de consciência mais ou menos tempo, segundo a necessidade, isto é, segundo o número e a qualidade dos pecados que pesam sobre a consciência e segundo o tempo transcorrido desde a última confissão bem feita.*
+
+**35.** Como se pode facilitar o exame para a confissão?
+
+## § 4. Da dor
+
+**36.** O que é a dor dos pecados?
+
+*A dor dos pecados consiste em um desgosto e em uma sincera detestação da ofensa feita a Deus.*
+
+**37.** De quantas espécies é a dor?
+
+*A dor é de duas espécies: perfeita, ou de contrição; imperfeita, ou de atrição.*
+
+**38.** Qual é a dor perfeita, ou de contrição?
+
+*A dor perfeita é o desgosto de ter ofendido a Deus, por ser Ele infinitamente bom e digno, em si mesmo, de ser amado.*
+
+**39.** Por que chamais perfeita a dor de contrição?
+
+*Chamo perfeita a dor de contrição por duas razões: 1.º porque diz respeito exclusivamente à bondade de Deus, e não à nossa vantagem ou dano; 2.º porque nos faz obter logo o perdão dos pecados, restando, porém, a obrigação de confessar-nos.*
+
+**40.** Então, a dor perfeita nos obtém o perdão dos pecados independentemente da confissão?
+
+*A dor perfeita não nos obtém o perdão dos pecados independentemente da confissão, porque ela inclui sempre a vontade de confessar-se.*
+
+**41.** Por que a dor perfeita, ou contrição, produz este efeito de nos restituir à graça de Deus?
+
+*A dor perfeita, ou contrição, produz este efeito porque nasce da caridade, a qual não pode encontrar-se na alma juntamente com o pecado mortal.*
+
+**42.** Qual é a dor imperfeita ou de atrição?
+
+*A dor imperfeita ou de atrição é aquela pela qual nos arrependemos de ter ofendido a Deus como supremo Juiz, isto é, pelo temor dos castigos merecidos nesta ou na outra vida, ou pela própria feiura do pecado.*
+
+**43.** Quais condições deve ter a dor para ser boa?
+
+*A dor, para ser boa, deve ter quatro condições: deve ser interna, sobrenatural, suma e universal.*
+
+**44.** O que quer dizer que a dor deve ser interna?
+
+*Quer dizer que deve estar no coração e na vontade, e não somente nas palavras.*
+
+**45.** Por que a dor deve ser interna?
+
+*A dor deve ser interna porque a vontade, que se afastou de Deus pelo pecado, deve retornar a Deus detestando o pecado cometido.*
+
+**46.** O que quer dizer que a dor deve ser sobrenatural?
+
+*Quer dizer que deve ser excitada em nós pela graça do Senhor e concebida por motivos de fé.*
+
+**47.** Por que a dor deve ser sobrenatural?
+
+*A dor deve ser sobrenatural porque é sobrenatural o fim a que se dirige, isto é, o perdão de Deus, a aquisição da graça santificante e o direito à glória eterna.*
+
+**48.** Explicai melhor a diferença entre a dor sobrenatural e a natural.
+
+*Quem se arrepende por ter ofendido a Deus, infinitamente bom e digno em si mesmo de ser amado, por ter perdido o paraíso e merecido o inferno, ou pela malícia intrínseca do pecado, tem uma dor sobrenatural, porque esses são motivos de fé. Quem, ao contrário, se arrependesse só pela desonra ou pelo castigo que lhe vem dos homens, ou por algum dano puramente temporal, teria uma dor natural, porque se arrependeria só por motivos humanos.*
+
+**49.** Por que a dor deve ser suma?
+
+*A dor deve ser suma porque devemos considerar e odiar o pecado como o supremo de todos os males, sendo ofensa de Deus, sumo Bem.*
+
+**50.** Para a dor dos pecados, é, porventura, necessário chorar, como às vezes se chora pelas desgraças desta vida?
+
+*Não é necessário que materialmente se chore pela dor dos pecados; basta que, no coração, se considere mais grave ter ofendido a Deus do que qualquer outra desgraça.*
+
+**51.** O que quer dizer que a dor deve ser universal?
+
+*Quer dizer que deve estender-se a todos os pecados mortais cometidos.*
+
+**52.** Por que a dor deve estender-se a todos os pecados mortais cometidos?
+
+*Porque quem não se arrepende nem mesmo de um só pecado mortal permanece inimigo de Deus.*
+
+**53.** O que devemos fazer para ter a dor dos nossos pecados?
+
+*Para ter a dor dos nossos pecados, devemos pedi-la de coração a Deus e excitá-la em nós com a consideração do grande mal que fizemos ao pecar.*
+
+**54.** Como fareis para excitar-vos a detestar os pecados?
+
+*Para excitar-me a detestar os pecados: 1.º considerarei o rigor da infinita justiça de Deus e a deformidade do pecado, que desfigurou a minha alma e me tornou merecedor das penas eternas do inferno; 2.º considerarei que perdi a graça, a amizade, a filiação divina e a herança do paraíso; 3.º que ofendi o meu Redentor, que morreu por mim, e que os meus pecados foram a causa da sua morte; 4.º que desprezei o meu Criador, o meu Deus; que voltei as costas a Ele, meu sumo bem, digno de ser amado sobre todas as coisas e servido fielmente.*
+
+**55.** Devemos ser grandemente solícitos, quando vamos confessar-nos, em ter uma verdadeira dor dos nossos pecados?
+
+*Quando vamos confessar-nos, devemos certamente ser muito solícitos em ter uma verdadeira dor dos nossos pecados, porque esta é a coisa mais importante de todas; e, se faltar a dor, a confissão não vale.*
+
+**56.** Quem se confessa só de pecados veniais deve ter a dor de todos?
+
+*Quem se confessa só de pecados veniais, para que a confissão seja válida, basta que esteja arrependido de algum deles; mas, para obter o perdão de todos, é necessário que se arrependa de todos aqueles que reconhecer ter cometido.*
+
+**57.** Quem se confessa só de pecados veniais e não está arrependido nem de um só, faz uma boa confissão?
+
+*Quem se confessa só de pecados veniais e não está arrependido nem mesmo de um só faz uma confissão de nenhum valor; a qual é, ademais, sacrílega, se a falta da dor é advertida.*
+
+**58.** O que convém fazer para tornar mais segura a confissão de somente pecados veniais?
+
+*Para tornar mais segura a confissão de somente pecados veniais, é coisa prudente acusar, com verdadeira dor, também algum pecado mais grave da vida passada, ainda que já confessado outras vezes.*
+
+**59.** É coisa boa fazer com frequência o ato de contrição?
+
+*É coisa boa e utilíssima fazer com frequência o ato de contrição, sobretudo antes de ir dormir, e quando alguém se dá conta ou duvida ter caído em pecado mortal, para retornar mais depressa à graça de Deus; e ajuda sobretudo a obter de Deus, mais facilmente, a graça de fazer tal ato na maior necessidade, isto é, no perigo de morte.*
+
+## § 5. Do propósito
+
+**60.** Em que consiste o propósito?
+
+*O propósito consiste em uma vontade resoluta de não cometer mais o pecado e de empregar todos os meios necessários para fugir dele.*
+
+**61.** Quais condições deve ter o propósito para ser bom?
+
+*O propósito, para ser bom, deve ter principalmente três condições: deve ser absoluto, universal e eficaz.*
+
+**62.** O que quer dizer: propósito absoluto?
+
+*Quer dizer que o propósito deve ser sem condição alguma de tempo, de lugar ou de pessoa.*
+
+**63.** O que quer dizer: o propósito deve ser universal?
+
+*O propósito deve ser universal, isto quer dizer que devemos querer fugir de todos os pecados mortais, tanto daqueles já outras vezes cometidos, como dos outros que poderíamos vir a cometer.*
+
+**64.** O que quer dizer: o propósito deve ser eficaz?
+
+*O propósito deve ser eficaz, isto quer dizer que é preciso ter uma vontade resoluta de antes perder todas as coisas do que cometer um novo pecado, de fugir das ocasiões perigosas de pecar, de destruir os maus hábitos e de cumprir as obrigações contraídas em consequência dos nossos pecados.*
+
+**65.** O que se entende por mau hábito?
+
+*Por mau hábito entende-se a disposição adquirida de cair com facilidade naqueles pecados aos quais nos habituamos.*
+
+**66.** O que se deve fazer para corrigir os maus hábitos?
+
+*Para corrigir os maus hábitos devemos estar vigilantes sobre nós mesmos, fazer muita oração, frequentar a confissão, ter um bom diretor estável e pôr em prática os conselhos e remédios que ele nos propõe.*
+
+**67.** O que se entende por ocasiões perigosas de pecar?
+
+*Por ocasiões perigosas de pecar entendem-se todas aquelas circunstâncias de tempo, de lugar, de pessoas ou de coisas que, por sua própria natureza ou por nossa fragilidade, nos induzem a cometer o pecado.*
+
+**68.** Somos gravemente obrigados a evitar todas as ocasiões perigosas?
+
+*Estamos gravemente obrigados a evitar aquelas ocasiões perigosas que, ordinariamente, nos induzem a cometer pecado mortal, as quais se chamam ocasiões próximas do pecado.*
+
+**69.** O que deve fazer quem não pode fugir de alguma ocasião de pecado?
+
+*Quem não pode fugir de alguma ocasião de pecado, diga-o ao confessor e aceite seus conselhos.*
+
+**70.** Quais considerações servem para fazer o propósito?
+
+*Para fazer o propósito servem as mesmas considerações que valem para excitar a dor, isto é, a consideração dos motivos que temos para temer a justiça de Deus e para amar a sua infinita bondade.*
+
+## § 6. Da acusação dos pecados ao confessor
+
+**71.** Depois de bem disposto à confissão, com o exame, com a dor e com o propósito, o que fareis?
+
+*Depois de bem disposto pelo exame, pela dor e pelo propósito, irei ao confessor fazer-lhe a acusação dos meus pecados, para receber a absolvição.*
+
+**72.** De quais pecados somos obrigados a confessar-nos?
+
+*Somos obrigados a confessar-nos de todos os pecados mortais; é bom, porém, confessar também os veniais.*
+
+**73.** Quais são as condições que deve ter a acusação dos pecados, ou confissão?
+
+*As condições principais que a acusação dos pecados deve ter são cinco: deve ser humilde, íntegra, sincera, prudente e breve.*
+
+**74.** O que quer dizer: a acusação deve ser humilde?
+
+*A acusação deve ser humilde, isto quer dizer que o penitente deve acusar-se diante do seu confessor sem altivez de ânimo ou de palavras, mas com os sentimentos de um réu, que reconhece sua culpa e comparece diante do juiz.*
+
+**75.** O que quer dizer: a acusação deve ser íntegra?
+
+*A acusação deve ser íntegra, isto quer dizer que se devem manifestar, com suas circunstâncias e no seu número, todos os pecados mortais cometidos depois da última confissão bem feita e dos quais se tem consciência.*
+
+**76.** Quais circunstâncias se devem manifestar para que a acusação seja íntegra?
+
+*Para que a acusação seja íntegra, devem-se manifestar as circunstâncias que mudam a espécie do pecado.*
+
+**77.** Quais são as circunstâncias que mudam a espécie do pecado?
+
+*As circunstâncias que mudam a espécie do pecado são: 1.º aquelas pelas quais uma ação pecaminosa, de venial, torna-se mortal; 2.º aquelas pelas quais uma ação pecaminosa contém a malícia de dois ou mais pecados mortais.*
+
+**78.** Dai-me o exemplo de uma circunstância que faça um pecado venial tornar-se mortal.
+
+*Quem, para desculpar-se, dissesse uma mentira da qual viesse grave dano ao próximo, deveria manifestar essa circunstância que muda a mentira, de oficiosa, em gravemente prejudicial.*
+
+**79.** Dai-me agora o exemplo de uma circunstância pela qual uma mesma ação pecaminosa contém a malícia de dois ou mais pecados.
+
+*Quem houvesse furtado uma coisa sagrada deveria acusar essa circunstância, que acrescenta ao furto a malícia do sacrilégio.*
+
+**80.** Se alguém não estiver certo de ter cometido um pecado, deve confessar-se dele?
+
+*Se alguém não estiver certo de ter cometido um pecado, não é obrigado a confessá-lo; se, porém, quiser acusá-lo, deverá acrescentar que não está certo de tê-lo cometido.*
+
+**81.** Quem não se lembra precisamente do número dos seus pecados, o que deve fazer?
+
+*Quem não se lembra precisamente do número dos seus pecados deve acusar o número aproximado.*
+
+**82.** Quem calou, por pura distração, um pecado mortal, ou uma circunstância necessária, fez uma boa confissão?
+
+*Quem calou, por pura distração, um pecado mortal, ou uma circunstância necessária, fez uma boa confissão, contanto que tenha usado da devida diligência para lembrar-se deles.*
+
+**83.** Se um pecado mortal esquecido na confissão volta depois à mente, somos obrigados a acusá-lo em outra confissão?
+
+*Se um pecado mortal esquecido na confissão volta depois à mente, somos obrigados sem dúvida a acusá-lo na primeira vez em que nos confessarmos de novo.*
+
+**84.** Quem, por vergonha ou por outro motivo, cala culposamente na confissão algum pecado mortal, o que comete?
+
+*Aquele que, por vergonha ou por outro motivo, cala culposamente algum pecado mortal na confissão, profana o sacramento, e por isso torna-se réu de um gravíssimo sacrilégio.*
+
+**85.** Quem calou culposamente algum pecado mortal na confissão, como deve prover à própria consciência?
+
+*Quem calou culposamente algum pecado mortal na confissão deve expor ao confessor o pecado calado, dizer em quantas confissões o calou e refazer todas as confissões a partir da última bem feita.*
+
+**86.** Que deve considerar quem fosse tentado a calar algum pecado na confissão?
+
+*Quem fosse tentado a calar um pecado grave na confissão deve considerar:*
+
+*1.º que não teve pejo de pecar na presença de Deus, que tudo vê;*
+
+*2.º que é melhor manifestar os próprios pecados ao confessor em segredo do que viver inquieto no pecado, fazer uma morte infeliz e ser, por isso, envergonhado, no dia do juízo universal, diante de todo o mundo;*
+
+*3.º que o confessor está obrigado ao sigilo sacramental sob gravíssimo pecado e sob ameaça de severíssimas penas temporais e eternas.*
+
+**87.** O que quer dizer: a acusação deve ser sincera?
+
+*A acusação deve ser sincera, isto quer dizer que é preciso declarar os próprios pecados tais como são, sem escusá-los, diminuí-los ou aumentá-los.*
+
+**88.** O que quer dizer: a confissão deve ser prudente?
+
+*A confissão deve ser prudente, isto quer dizer que, ao confessar os pecados, devemos servir-nos dos termos mais modestos, e que devemos guardar-nos de descobrir os pecados dos outros.*
+
+**89.** O que significa: a confissão deve ser breve?
+
+*A confissão deve ser breve, isto significa que não devemos dizer nada de inútil ao confessor.*
+
+**90.** Não é, porventura, penoso ter de confessar a outrem os próprios pecados, sobretudo se são bastante vergonhosos?
+
+*Embora confessar a outrem os próprios pecados possa ser penoso, é preciso fazê-lo, porque é preceito divino, e de outro modo não se pode obter o perdão dos pecados cometidos; ademais, porque a dificuldade de confessar-se é compensada por muitas vantagens e por grandes consolações.*
+
+## § 7. Do modo de confessar-se
+
+**91.** Como vos apresentareis ao confessor?
+
+*Ajoelhar-me-ei aos pés do confessor e direi: «Abençoai-me, padre, porque pequei.»*
+
+**92.** O que fareis enquanto o confessor vos der a bênção?
+
+*Inclinar-me-ei humildemente para receber a bênção e farei o sinal da Cruz.*
+
+**93.** Feito o sinal da Cruz, o que se deve dizer?
+
+*Feito o sinal da Cruz, deve-se dizer: «Confesso-me a Deus todo-poderoso, à bem-aventurada Virgem Maria, a todos os Santos e a vós, padre meu espiritual, porque pequei.»*
+
+**94.** E depois, o que é preciso dizer?
+
+*Depois é preciso dizer: «Confessei-me em tal tempo; por graça de Deus recebi a absolvição, cumpri a penitência e fui à Comunhão.» Em seguida faz-se a acusação dos pecados.*
+
+**95.** Terminada a acusação dos pecados, o que fareis?
+
+*Terminada a acusação dos pecados, direi: «Acuso-me ainda de todos os pecados da vida passada, especialmente contra esta ou aquela virtude — por exemplo, contra a pureza, contra o quarto mandamento, etc.»*
+
+**96.** Depois desta acusação, o que se deve dizer?
+
+*Deve-se dizer: «De todos estes pecados, e dos que não recordo, peço perdão a Deus com todo o coração; e a vós, meu pai espiritual, peço a penitência e a absolvição.»*
+
+**97.** Completada assim a acusação dos pecados, o que resta fazer?
+
+*Completada a acusação dos pecados, é preciso escutar com respeito o que dirá o confessor; aceitar a penitência com sincera vontade de cumpri-la; e, enquanto ele der a absolvição, renovar de coração o ato de contrição.*
+
+**98.** Recebida a absolvição, o que resta fazer?
+
+*Recebida a absolvição, é preciso agradecer ao Senhor, fazer o quanto antes a penitência e pôr em prática os conselhos do confessor.*
+
+## § 8. Da absolvição
+
+**99.** Devem os confessores dar sempre a absolvição àqueles que se confessam?
+
+*Os confessores devem dar a absolvição somente àqueles que eles julgam bem dispostos a recebê-la.*
+
+**100.** Podem os confessores algumas vezes adiar ou negar a absolvição?
+
+*Os confessores não só podem como devem, em certos casos, adiar ou negar a absolvição, para não profanar o sacramento.*
+
+**101.** Quais são os penitentes que devem ser considerados mal dispostos, e aos quais se deve, ordinariamente, negar ou adiar a absolvição?
+
+*Os penitentes que devem ser considerados mal dispostos são, principalmente, estes:*
+
+*1.º aqueles que não sabem os mistérios principais da fé ou negligenciam aprender as demais coisas da Doutrina cristã que são obrigados a saber segundo o seu estado;*
+
+*2.º aqueles que são gravemente negligentes em fazer o exame de consciência ou não dão sinais de dor e arrependimento;*
+
+*3.º aqueles que não querem restituir, podendo, as coisas alheias, ou a reputação tirada;*
+
+*4.º aqueles que não perdoam de coração aos seus inimigos;*
+
+*5.º aqueles que não querem empregar os meios necessários para emendar-se dos seus maus hábitos;*
+
+*6.º aqueles que não querem deixar as ocasiões próximas do pecado.*
+
+**102.** Não é demasiado rigoroso o confessor que adia a absolvição ao penitente, por não acreditar que ele esteja ainda bem disposto?
+
+*O confessor que adia a absolvição ao penitente, por não acreditar que ele esteja ainda bem disposto, não é demasiado rigoroso, mas, ao contrário, muito caridoso, agindo como um bom médico, que tenta todos os remédios, mesmo desagradáveis e dolorosos, para salvar a vida ao doente.*
+
+**103.** O pecador a quem se adia ou se nega a absolvição deverá desesperar-se ou retirar-se totalmente da confissão?
+
+*O pecador a quem se adia ou se nega a absolvição não deve desesperar-se ou retirar-se totalmente da confissão; mas deve humilhar-se, reconhecer o seu deplorável estado, aproveitar os bons conselhos que o confessor lhe dá, e assim pôr-se o quanto antes em condição de merecer a absolvição.*
+
+**104.** O que deve fazer o penitente quanto à escolha do confessor?
+
+*O verdadeiro penitente deve encomendar-se muito a Deus para a escolha de um confessor pio, douto e prudente; depois, pôr-se em suas mãos e submeter-se a ele, como ao seu juiz e médico.*
+
+## § 9. Da satisfação ou penitência
+
+**105.** O que é a satisfação?
+
+*A satisfação, que também se chama penitência sacramental, é um dos atos do penitente, pelo qual ele dá um certo ressarcimento à justiça de Deus pelos pecados cometidos, cumprindo aquelas obras que o confessor lhe impõe.*
+
+**106.** O penitente é obrigado a aceitar a penitência imposta pelo confessor?
+
+*O penitente é obrigado a aceitar a penitência imposta pelo confessor, se puder cumpri-la; e, se não puder, deve dizê-lo humildemente ao próprio confessor e pedir-lhe outra.*
+
+**107.** Quando se deve fazer a penitência?
+
+*Se o confessor não prescreveu nenhum tempo, a penitência deve ser feita o quanto antes; e deve-se procurar fazê-la em estado de graça.*
+
+**108.** Como se deve fazer a penitência?
+
+*A penitência deve ser feita por inteiro e com devoção.*
+
+**109.** Por que, na confissão, se impõe a penitência?
+
+*A penitência se impõe porque, ordinariamente, após a absolvição sacramental, que remite a culpa e a pena eterna, resta uma pena temporal a ser expiada neste mundo ou no purgatório.*
+
+**110.** Por que razão quis o Senhor, no sacramento do Batismo, remir toda a pena devida aos pecados, e não no sacramento da Penitência?
+
+*O Senhor quis, no sacramento do Batismo, remir toda a pena devida aos pecados, e não no sacramento da Penitência, porque os pecados depois do Batismo são bem mais graves, sendo cometidos com maior conhecimento e ingratidão pelos benefícios de Deus; e também para que a obrigação de satisfazê-los seja um freio para não recair no pecado.*
+
+**111.** Podemos nós, por nós mesmos, satisfazer a Deus?
+
+*Nós, por nós mesmos, não podemos satisfazer a Deus; mas podemos fazê-lo unindo-nos a Jesus Cristo, que, com o mérito de sua paixão e morte, dá valor às nossas ações.*
+
+**112.** A penitência que o confessor dá basta sempre para cancelar a pena que ainda fica devida aos pecados?
+
+*A penitência que o confessor dá, ordinariamente, não basta para saldar a pena que ainda fica devida aos pecados; por isso é preciso procurar suprir com outras penitências voluntárias.*
+
+**113.** Quais são as obras de penitência?
+
+*As obras de penitência podem reduzir-se a três espécies: à oração, ao jejum, à esmola.*
+
+**114.** O que entendeis por oração?
+
+*Por oração entende-se toda espécie de exercício de piedade.*
+
+**115.** O que se entende por jejum?
+
+*Por jejum entende-se toda espécie de mortificação.*
+
+**116.** O que se entende por esmola?
+
+*Por esmola entende-se qualquer obra de misericórdia espiritual e corporal.*
+
+**117.** Qual penitência é mais meritória: a que dá o confessor ou a que fazemos por nossa própria escolha?
+
+*A penitência que nos dá o confessor é a mais meritória, porque, sendo parte do sacramento, recebe maior virtude dos méritos da paixão de Jesus Cristo.*
+
+**118.** Aqueles que morrem depois de ter recebido a absolvição, mas antes de ter satisfeito plenamente à justiça de Deus, vão logo ao paraíso?
+
+*Não, vão ao purgatório para ali satisfazer à justiça de Deus e purificar-se inteiramente.*
+
+**119.** As almas que estão no purgatório podem ser por nós aliviadas em suas penas?
+
+*Sim, as almas que estão no purgatório podem ser aliviadas com orações, com esmolas, com todas as outras boas obras e com indulgências; mas sobretudo com o santo sacrifício da Missa.*
+
+**120.** Além da penitência, que outra coisa deve fazer o penitente depois da confissão?
+
+*O penitente, depois da confissão, além da penitência, se danificou injustamente o próximo nos bens ou na honra, ou se lhe deu escândalo, deve, quanto possível, restituir-lhe o quanto antes os bens, reparar-lhe a honra e remediar o escândalo.*
+
+**121.** Como se pode remediar o escândalo que se causou?
+
+*Pode-se remediar o escândalo que se causou, fazendo cessar a sua ocasião e edificando, com palavras e com o bom exemplo, aqueles que escandalizamos.*
+
+**122.** De que maneira se deverá dar satisfação ao próximo, quando foi por nós ofendido?
+
+*Dever-se-á dar satisfação ao próximo, quando foi por nós ofendido, pedindo-lhe perdão ou dando-lhe alguma outra conveniente reparação.*
+
+**123.** Quais frutos produz em nós uma boa confissão?
+
+*Uma boa confissão: 1.º perdoa-nos os pecados cometidos e dá-nos a graça de Deus; 2.º restitui-nos a paz e a quietude da consciência; 3.º reabre-nos as portas do paraíso e muda a pena eterna do inferno em pena temporal; 4.º preserva-nos das recaídas e torna-nos capazes do tesouro das indulgências.*
+
+## § 10. Das indulgências
+
+**124.** O que é a indulgência?
+
+*A indulgência é a remissão da pena temporal devida pelos nossos pecados, já remidos quanto à culpa; remissão que a Igreja concede fora do sacramento da Penitência.*
+
+**125.** De quem recebeu a Igreja a faculdade de dar as indulgências?
+
+*A Igreja recebeu a faculdade de dar as indulgências de Jesus Cristo.*
+
+**126.** De que modo a Igreja nos remite a pena temporal por meio das indulgências?
+
+*A Igreja nos remite a pena temporal por meio das indulgências aplicando-nos as satisfações sobreabundantes de Jesus Cristo, de Maria Santíssima e dos Santos, as quais formam o que se chama o tesouro da Igreja.*
+
+**127.** Quem tem o poder de conceder as indulgências?
+
+*O poder de conceder as indulgências só o tem o Papa, em toda a Igreja, e o Bispo, em sua diocese, segundo a faculdade que lhe é concedida pelo Papa.*
+
+**128.** De quantas espécies são as indulgências?
+
+*As indulgências são de duas espécies: a indulgência plenária e a indulgência parcial.*
+
+**129.** Qual é a indulgência plenária?
+
+*A indulgência plenária é aquela com a qual nos é remitida toda a pena temporal devida pelos nossos pecados. Por isso, se alguém morresse depois de ter recebido tal Indulgência, iria logo ao Paraíso, totalmente isento das penas do purgatório.*
+
+**130.** Qual é a indulgência parcial?
+
+*A indulgência parcial é aquela com a qual nos é remitida somente uma parte da pena temporal devida pelos nossos pecados.*
+
+**131.** O que pretende fazer a Igreja ao conceder as indulgências?
+
+*Ao conceder as indulgências, a Igreja pretende vir em auxílio à nossa incapacidade de expiar neste mundo toda a pena temporal, fazendo-nos alcançar, por meio de obras de piedade e de caridade cristã, aquilo que nos primeiros séculos se procurava obter pelo rigor dos cânones penitenciais.*
+
+**132.** O que se entende por indulgência de quarenta ou cem dias, ou de sete anos, e semelhantes?
+
+*Por indulgência de quarenta ou cem dias, ou de sete anos e semelhantes, entende-se a remissão de tanta pena temporal quanta se saldaria com quarenta ou cem dias, ou sete anos, da penitência antigamente estabelecida pela Igreja.*
+
+**133.** Que apreço devemos ter pelas indulgências?
+
+*Pelas indulgências devemos ter grandíssimo apreço, porque, com elas, satisfaz-se à justiça de Deus, e mais cedo e mais facilmente se alcança a posse do céu.*
+
+**134.** O que se requer para adquirir as indulgências?
+
+*Para adquirir as indulgências requer-se: 1.º o estado de graça (pelo menos na última obra que se cumpre) e a limpeza também daquelas culpas veniais de que se quer cancelar a pena; 2.º o cumprimento das obras que a Igreja prescreve para adquirir a indulgência; 3.º a intenção de adquiri-la.*
+
+**135.** As indulgências podem ser aplicadas também às almas do purgatório?
+
+*Sim, as indulgências podem ser aplicadas também às almas do purgatório, quando aquele que as concede declarar que se podem aplicar a elas.*
+
+**136.** O que é o Jubileu?
+
+*O Jubileu, que ordinariamente se concede a cada vinte e cinco anos, é uma indulgência plenária à qual estão anexos muitos privilégios e particulares concessões, como o de poder obter a absolvição de alguns pecados reservados e das censuras, e a comutação de alguns votos.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-vii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-vii.md
@@ -1,0 +1,25 @@
+# Capítulo VII — Da Extrema-Unção
+
+**1.** O que é o sacramento da Extrema-Unção, também chamado Óleo Santo?
+
+*A Extrema-Unção, também chamada Óleo Santo, é o sacramento instituído para alívio espiritual, e também temporal, dos enfermos em perigo de morte.*
+
+**2.** Quais efeitos produz o sacramento da Extrema-Unção?
+
+*O sacramento da Extrema-Unção produz os seguintes efeitos: 1.º aumenta a graça santificante; 2.º apaga os pecados veniais e também os mortais, que o enfermo arrependido não pudesse mais confessar; 3.º remove aquela debilidade e languidez para o bem, que persiste mesmo depois de obtido o perdão dos pecados; 4.º dá a força para suportar pacientemente o mal, resistir às tentações e morrer santamente; 5.º ajuda a recuperar a saúde do corpo, se for útil à salvação da alma.*
+
+**3.** Em que tempo se deve receber o Óleo Santo?
+
+*O Óleo Santo deve-se receber quando a doença é perigosa, e depois que o enfermo recebeu, se pôde, os sacramentos da Penitência e da Eucaristia; aliás, é bom recebê-lo quando se ainda está com a mente sã e com alguma esperança de vida.*
+
+**4.** Por que é bom receber o Óleo Santo quando se está ainda com a mente sã e com alguma esperança de vida?
+
+*É bom receber o Óleo Santo quando se está ainda com a mente sã e com alguma esperança de vida, porque, recebendo-o com melhor disposição, pode-se receber dele maior fruto; e ainda porque, dando este sacramento a saúde do corpo, se for proveitoso para a alma, ajudando as forças da natureza, não se deve esperar que a saúde esteja perdida.*
+
+**5.** Com que disposições se deve receber o Óleo Santo?
+
+*As principais disposições para receber o Óleo Santo são: estar em graça de Deus, confiar na virtude do sacramento e na divina misericórdia, e resignar-se à vontade do Senhor.*
+
+**6.** Quais sentimentos deve experimentar o enfermo à vista do sacerdote?
+
+*À vista do sacerdote, o enfermo deve experimentar sentimento de gratidão a Deus por lho haver enviado, e deve receber de boa vontade — e pedir, se puder por si mesmo — os confortos da religião.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-viii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quarta-capo-viii.md
@@ -1,0 +1,71 @@
+# Capítulo VIII — Da Ordem Sacra
+
+**1.** O que é o sacramento da Ordem Sacra?
+
+*A Ordem Sacra é o sacramento que dá o poder de exercer os sagrados ministérios relativos ao culto de Deus e à salvação das almas, e que imprime na alma de quem o recebe o caráter de ministro de Deus.*
+
+**2.** Por que se chama Ordem?
+
+*Chama-se Ordem porque consiste em vários graus, um subordinado ao outro, dos quais resulta a sagrada Hierarquia.*
+
+**3.** Quais são esses graus?
+
+*Supremo entre eles é o Episcopado, que contém a plenitude do sacerdócio; depois, o Presbiterato ou Sacerdócio simples; em seguida, o Diaconato e as Ordens que se chamam menores.*
+
+**4.** Foi Jesus Cristo quem instituiu imediatamente todos os graus da Ordem Sacra?
+
+*Jesus Cristo instituiu imediatamente os dois graus superiores da Ordem Sacra, que são o Episcopado e o Sacerdócio simples; por meio dos Apóstolos instituiu, depois, o Diaconato, do qual derivam as outras Ordens inferiores.*
+
+**5.** Quando Jesus Cristo instituiu a Ordem Sacerdotal?
+
+*Jesus Cristo instituiu a Ordem Sacerdotal na última Ceia, quando conferiu aos Apóstolos e a seus sucessores o poder de consagrar a Santíssima Eucaristia. No dia da sua ressurreição, conferiu-lhes o poder de remitir e reter os pecados, constituindo-os assim os primeiros sacerdotes da nova lei, em toda a plenitude do seu poder.*
+
+**6.** Quem é o ministro deste sacramento?
+
+*O ministro deste sacramento é unicamente o Bispo.*
+
+**7.** É, portanto, grande a dignidade do Sacerdócio cristão?
+
+*A dignidade do Sacerdócio cristão é grandíssima, pelo duplo poder que Jesus Cristo lhe conferiu sobre o seu Corpo real e sobre o seu Corpo místico, que é a Igreja; e pela divina missão confiada aos sacerdotes de conduzir todos os homens à vida eterna.*
+
+**8.** O Sacerdócio católico é necessário na Igreja?
+
+*O Sacerdócio católico é necessário na Igreja, porque sem ele os fiéis ficariam privados do santo sacrifício da Missa e da maior parte dos sacramentos; não teriam quem os ensinasse na fé; e permaneceriam como ovelhas sem pastor, à mercê dos lobos; em suma, não existiria mais a Igreja como Jesus Cristo a instituiu.*
+
+**9.** Então, o Sacerdócio católico não cessará jamais sobre a terra?
+
+*O Sacerdócio católico, não obstante a guerra que lhe move o inferno, durará até o fim dos séculos, havendo Jesus Cristo prometido que as potestades do inferno jamais prevalecerão contra a sua Igreja.*
+
+**10.** É pecado desprezar os sacerdotes?
+
+*É um pecado gravíssimo, porque o desprezo e as injúrias que se dirigem contra os sacerdotes recaem sobre o próprio Jesus Cristo, que disse a seus Apóstolos: «Quem vos despreza, a mim despreza.»*
+
+**11.** Qual deve ser o fim de quem abraça o estado eclesiástico?
+
+*O fim de quem abraça o estado eclesiástico deve ser unicamente a glória de Deus e a salvação das almas.*
+
+**12.** O que é necessário para entrar no estado eclesiástico?
+
+*Para entrar no estado eclesiástico é necessária, antes de tudo, a vocação divina.*
+
+**13.** O que se deve fazer para conhecer se Deus chama ao estado eclesiástico?
+
+*Para conhecer se Deus chama ao estado eclesiástico deve-se: 1.º orar com fervor ao Senhor para que manifeste qual é a sua vontade; 2.º tomar conselho com o próprio Bispo ou com um sábio e prudente diretor; 3.º examinar com diligência se se tem a aptidão necessária aos estudos, aos ministérios e às obrigações deste estado.*
+
+**14.** Quem entrasse no estado eclesiástico sem vocação divina, faria mal?
+
+*Quem entrasse no estado eclesiástico sem vocação divina faria um grave mal e se poria em perigo de perdição.*
+
+**15.** Fazem mal os pais que, por motivos temporais, induzem os filhos a abraçar sem vocação o estado eclesiástico?
+
+*Os pais que, por motivos temporais, induzem os filhos a abraçar sem vocação o estado eclesiástico, cometem também gravíssima culpa, porque, com isso, usurpam o direito que Deus reservou só a Si de escolher os seus ministros, e põem os filhos em perigo de eterna danação.*
+
+**16.** Quais são os deveres dos fiéis para com aqueles que são chamados às Ordens sacras?
+
+*Os fiéis devem:*
+
+*1.º deixar a seus filhos e dependentes plena liberdade de seguir a vocação de Deus;*
+
+*2.º orar a Deus para que se digne conceder à sua Igreja bons pastores e ministros zelosos, sendo também a este fim instituídos os jejuns das Quatro Têmporas;*
+
+*3.º ter um singular respeito por todos aqueles que, por meio das Ordens, são consagrados ao serviço de Deus.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quinta-capo-i.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quinta-capo-i.md
@@ -1,0 +1,261 @@
+# Capítulo I — Das virtudes principais
+
+## § 1. Das virtudes teologais
+
+**1.** O que é a virtude?
+
+*A virtude é uma qualidade da alma, pela qual se tem propensão, facilidade e prontidão para conhecer e praticar o bem.*
+
+**2.** Quantas são as principais virtudes sobrenaturais?
+
+*As principais virtudes sobrenaturais são sete: a saber, três teologais e quatro cardeais.*
+
+**3.** Quais são as virtudes teologais?
+
+*As virtudes teologais são: a Fé, a Esperança e a Caridade.*
+
+**4.** Por que a Fé, a Esperança e a Caridade se chamam virtudes teologais?
+
+*A Fé, a Esperança e a Caridade chamam-se virtudes teologais, porque têm a Deus por objeto imediato e principal, e nos são infundidas por Ele.*
+
+**5.** De que modo as virtudes teologais têm a Deus por objeto imediato?
+
+*As virtudes teologais têm a Deus por objeto imediato, porque com a Fé nós cremos em Deus e cremos tudo o que Ele revelou; com a Esperança esperamos possuir a Deus; com a Caridade amamos a Deus e n'Ele amamos a nós mesmos e ao próximo.*
+
+**6.** Quando é que Deus nos infunde na alma as virtudes teologais?
+
+*Deus, por sua bondade, infunde-nos na alma as virtudes teologais quando nos adorna com a sua graça santificante; e por isso, quando recebemos o Batismo, fomos enriquecidos com essas virtudes, e com elas, com os dons do Espírito Santo.*
+
+**7.** Basta para salvar-se ter recebido no Batismo as virtudes teologais?
+
+*Para quem tem o uso da razão, não basta ter recebido no Batismo as virtudes teologais; é necessário fazer atos delas com frequência.*
+
+**8.** Quando somos obrigados a fazer atos de Fé, de Esperança e de Caridade?
+
+*Somos obrigados a fazer atos de Fé, de Esperança e de Caridade: 1.º chegados ao uso da razão; 2.º muitas vezes no decurso da vida; 3.º em perigo de morte.*
+
+## § 2. Da Fé
+
+**9.** O que é a Fé?
+
+*A Fé é uma virtude sobrenatural, infundida por Deus em nossa alma, pela qual nós, apoiados na autoridade do próprio Deus, cremos ser verdadeiro tudo aquilo que Ele revelou, e que por meio da Igreja nos propõe a crer.*
+
+**10.** De que maneira sabemos nós as verdades reveladas por Deus?
+
+*Nós sabemos as verdades reveladas por Deus por meio da santa Igreja, que é infalível; isto é, por meio do Papa, sucessor de São Pedro, e por meio dos Bispos, sucessores dos Apóstolos, os quais foram instruídos pelo próprio Jesus Cristo.*
+
+**11.** Estamos seguros das coisas que a santa Igreja nos ensina?
+
+*Das coisas que a santa Igreja nos ensina, estamos seguríssimos, porque Jesus Cristo empenhou a sua palavra de que a Igreja jamais se enganaria.*
+
+**12.** Com que pecado se perde a Fé?
+
+*A Fé perde-se negando ou duvidando voluntariamente, ainda que de um só artigo proposto a nós para crer.*
+
+**13.** Como se recupera a Fé perdida?
+
+*A Fé perdida recupera-se arrependendo-se do pecado cometido e crendo de novo em tudo aquilo que crê a santa Igreja.*
+
+## § 3. Dos mistérios
+
+**14.** Podemos compreender todas as verdades da Fé?
+
+*Não, nós não podemos compreender todas as verdades da Fé, porque algumas destas verdades são mistérios.*
+
+**15.** O que são os mistérios?
+
+*Os mistérios são verdades superiores à razão, que devemos crer ainda que não as possamos compreender.*
+
+**16.** Por que devemos crer nos mistérios?
+
+*Devemos crer nos mistérios porque os revelou Deus, o qual, sendo Verdade e Bondade infinita, não pode enganar-se nem enganar.*
+
+**17.** Os mistérios são contrários à razão?
+
+*Os mistérios são superiores, mas não contrários à razão; é antes a própria razão que nos persuade a admitir os mistérios.*
+
+**18.** Por que os mistérios não podem ser contrários à razão?
+
+*Os mistérios não podem ser contrários à razão, porque é o mesmo Deus que nos deu a luz da razão e revelou os mistérios, e Ele não pode contradizer-se a si mesmo.*
+
+## § 4. Da Sagrada Escritura
+
+**19.** Onde se contêm as verdades que Deus revelou?
+
+*As verdades que Deus revelou contêm-se na Sagrada Escritura e na Tradição.*
+
+**20.** O que é a Sagrada Escritura?
+
+*A Sagrada Escritura é a coleção dos livros escritos pelos Profetas e Hagiógrafos, pelos Apóstolos e pelos Evangelistas por inspiração do Espírito Santo, e recebidos pela Igreja como inspirados.*
+
+**21.** Em quantas partes se divide a Sagrada Escritura?
+
+*A Sagrada Escritura divide-se em duas partes: no Antigo e no Novo Testamento.*
+
+**22.** O que contém o Antigo Testamento?
+
+*O Antigo Testamento contém os livros inspirados, escritos antes da vinda de Jesus Cristo.*
+
+**23.** O que contém o Novo Testamento?
+
+*O Novo Testamento contém os livros inspirados, escritos depois da vinda de Jesus Cristo.*
+
+**24.** Com que nome se chama comumente a Sagrada Escritura?
+
+*A Sagrada Escritura chama-se comumente com o nome de Sagrada Bíblia.*
+
+**25.** O que quer dizer a palavra Bíblia?
+
+*A palavra Bíblia quer dizer a coleção dos livros santos, o livro por excelência, o livro dos livros, o livro inspirado por Deus.*
+
+**26.** Por que a Sagrada Escritura é chamada o livro por excelência?
+
+*A Sagrada Escritura é chamada o livro por excelência por causa da excelência da matéria de que trata e do Autor da mesma.*
+
+**27.** Não pode haver erro na Sagrada Escritura?
+
+*Na Sagrada Escritura não pode haver erro algum, porque, sendo toda inspirada, autor de todas as suas partes é o próprio Deus. Isso não impede que nas cópias e traduções dela possa ter ocorrido algum engano dos copistas ou dos tradutores. Porém, nas edições revistas e aprovadas pela Igreja católica não pode haver erro naquilo que diz respeito à fé ou à moral.*
+
+**28.** É necessária a todos os cristãos a leitura da Bíblia?
+
+*A leitura da Bíblia não é necessária a todos os cristãos, instruídos como são pela Igreja, mas é muito útil e recomendada a todos.*
+
+**29.** Pode-se ler qualquer tradução vulgar da Bíblia?
+
+*Podem-se ler aquelas traduções vulgares da Bíblia que são reconhecidas fiéis pela Igreja católica e são acompanhadas de explicações aprovadas pela mesma Igreja.*
+
+**30.** Por que se podem ler somente as traduções da Bíblia que são aprovadas pela Igreja?
+
+*Podem-se ler somente as traduções da Bíblia que são aprovadas pela Igreja, porque só ela é legítima guardiã da Bíblia.*
+
+**31.** Por meio de quem podemos nós conhecer o verdadeiro sentido das Sagradas Escrituras?
+
+*O verdadeiro sentido das Sagradas Escrituras podemos conhecê-lo somente por meio da Igreja, porque só a Igreja não pode errar ao interpretá-las.*
+
+**32.** Que deveria fazer o cristão se lhe fosse oferecida a Bíblia por um protestante ou por algum emissário dos protestantes?
+
+*Se a um cristão fosse oferecida a Bíblia por um protestante ou por algum emissário dos protestantes, ele deveria rejeitá-la com horror, porque proibida pela Igreja; e se a tivesse recebido sem reparar, deveria logo lançá-la às chamas, ou entregá-la ao próprio pároco.*
+
+**33.** Por que a Igreja proíbe as Bíblias protestantes?
+
+*A Igreja proíbe as Bíblias protestantes porque ou estão alteradas e contêm erros, ou então, faltando-lhes a sua aprovação e as notas declarativas dos sentidos obscuros, podem prejudicar a Fé. Por isso, a Igreja proíbe também as traduções da Sagrada Escritura já aprovadas por ela, mas reimpressas sem as explicações aprovadas pela mesma.*
+
+## § 5. Da Tradição
+
+**34.** Dizei-me: o que é a Tradição?
+
+*A Tradição é a palavra de Deus não escrita, mas comunicada viva voz por Jesus Cristo e pelos Apóstolos, e chegada inalterada, de século em século, por meio da Igreja, até nós.*
+
+**35.** Onde se contêm os ensinamentos da Tradição?
+
+*Os ensinamentos da Tradição contêm-se principalmente nos decretos dos Concílios, nos escritos dos santos Padres, nos atos da Santa Sé, nas palavras e nos usos da sagrada Liturgia.*
+
+**36.** Em que conta se deve ter a Tradição?
+
+*A Tradição deve ser tida na mesma conta em que se tem a palavra de Deus revelada, contida na Sagrada Escritura.*
+
+## § 6. Da Esperança
+
+**37.** O que é a Esperança?
+
+*A Esperança é uma virtude sobrenatural, infundida por Deus em nossa alma, pela qual desejamos e esperamos a vida eterna que Deus prometeu aos seus servos, e os auxílios necessários para obtê-la.*
+
+**38.** Por que motivo devemos nós esperar de Deus o paraíso e os auxílios necessários para alcançá-lo?
+
+*Nós devemos esperar de Deus o paraíso e os auxílios necessários para alcançá-lo, porque Deus misericordiosíssimo, pelos méritos de N. S. Jesus Cristo, o prometeu àqueles que o servem de coração; e, sendo fidelíssimo e onipotente, mantém sempre a sua promessa.*
+
+**39.** Quais são as condições necessárias para obter o paraíso?
+
+*As condições necessárias para obter o paraíso são a graça de Deus, o exercício das boas obras e a perseverança no santo amor de Deus até a morte.*
+
+**40.** Como se perde a Esperança?
+
+*Perde-se a Esperança toda vez que se perde a Fé; perde-se também pelo pecado de desesperação ou de presunção.*
+
+**41.** Como se recupera a Esperança perdida?
+
+*A Esperança perdida recupera-se arrependendo-se do pecado cometido, excitando de novo a confiança na bondade divina.*
+
+## § 7. Da Caridade
+
+**42.** O que é a Caridade?
+
+*A Caridade é uma virtude sobrenatural, infundida por Deus em nossa alma, pela qual amamos a Deus por si mesmo sobre todas as coisas, e ao próximo como a nós mesmos por amor de Deus.*
+
+**43.** Por que motivos devemos nós amar a Deus?
+
+*Nós devemos amar a Deus porque Ele é o sumo bem, infinitamente bom e perfeito; e ademais pelo mandamento que Ele nos faz disso, e pelos muitos benefícios que d'Ele recebemos.*
+
+**44.** Como se deve amar a Deus?
+
+*Deus deve ser amado sobre todas as coisas, com todo o coração, com toda a mente, com toda a alma e com todas as forças.*
+
+**45.** Que quer dizer amar a Deus sobre todas as coisas?
+
+*Amar a Deus sobre todas as coisas quer dizer preferi-Lo a todas as criaturas mais caras e mais perfeitas, e estar disposto a perder tudo, antes que ofendê-Lo e cessar de amá-Lo.*
+
+**46.** Que quer dizer amar a Deus com todo o coração?
+
+*Amar a Deus com todo o coração quer dizer consagrar-Lhe todos os nossos afetos.*
+
+**47.** Que quer dizer amar a Deus com toda a mente?
+
+*Amar a Deus com toda a mente quer dizer dirigir a Ele todos os nossos pensamentos.*
+
+**48.** Que quer dizer amar a Deus com toda a alma?
+
+*Amar a Deus com toda a alma quer dizer consagrar-Lhe o uso de todas as potências de nossa alma.*
+
+**49.** Que quer dizer amar a Deus com todas as nossas forças?
+
+*Amar a Deus com todas as nossas forças quer dizer procurar crescer sempre mais no amor d'Ele e fazer de modo que todas as nossas ações tenham por motivo e por fim o amor d'Ele e o desejo de agradar-Lhe.*
+
+**50.** Por que devemos nós amar o próximo?
+
+*Nós devemos amar o próximo por amor de Deus, porque Ele no-lo manda, e porque todo homem é imagem d'Ele.*
+
+**51.** Somos obrigados a amar também os inimigos?
+
+*Sim, somos obrigados a amar também os inimigos, porque também eles são nosso próximo, e porque Jesus Cristo nos fez um expresso mandamento disso.*
+
+**52.** Que quer dizer amar o próximo como a si mesmo?
+
+*Amar o próximo como a si mesmo quer dizer desejar-lhe e fazer-lhe, quanto se puder, aquele bem que devemos desejar a nós mesmos, e não lhe desejar nem fazer mal algum.*
+
+**53.** Quando é que nós amamos a nós mesmos como se deve?
+
+*Nós amamos a nós mesmos como se deve quando procuramos servir a Deus e pôr n'Ele toda a nossa felicidade.*
+
+**54.** Como se perde a Caridade?
+
+*A Caridade perde-se com qualquer pecado mortal.*
+
+**55.** Como se recupera a Caridade?
+
+*A Caridade recupera-se fazendo atos de amor de Deus, arrependendo-se e confessando-se como se deve.*
+
+## § 8. Das virtudes cardeais
+
+**56.** Quais são as virtudes cardeais?
+
+*As virtudes cardeais são a Prudência, a Justiça, a Fortaleza e a Temperança.*
+
+**57.** Por que a Prudência, a Justiça, a Fortaleza e a Temperança se chamam virtudes cardeais?
+
+*A Prudência, a Justiça, a Fortaleza e a Temperança chamam-se virtudes cardeais, porque são o gonzo e o fundamento das virtudes morais.*
+
+**58.** O que é a Prudência?
+
+*A Prudência é a virtude que dirige toda ação ao devido fim, e por isso busca os meios convenientes a fim de que a obra resulte em tudo bem feita, e portanto aceita ao Senhor.*
+
+**59.** O que é a Justiça?
+
+*A Justiça é a virtude pela qual damos a cada um aquilo que lhe é devido.*
+
+**60.** O que é a Fortaleza?
+
+*A Fortaleza é a virtude que nos torna corajosos para não temer perigo algum, nem mesmo a própria morte, pelo serviço de Deus.*
+
+**61.** O que é a Temperança?
+
+*A Temperança é a virtude pela qual refreamos os desejos desordenados dos prazeres sensíveis e usamos com moderação dos bens temporais.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quinta-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quinta-capo-ii.md
@@ -1,0 +1,37 @@
+# Capítulo II — Dos dons do Espírito Santo
+
+**1.** Quantos e quais são os dons do Espírito Santo?
+
+*Os dons do Espírito Santo são sete: 1.º o dom da Sabedoria; 2.º do Entendimento; 3.º do Conselho; 4.º da Fortaleza; 5.º da Ciência; 6.º da Piedade; 7.º do Temor de Deus.*
+
+**2.** Para que servem os dons do Espírito Santo?
+
+*Os dons do Espírito Santo servem para nos firmar na Fé, na Esperança e na Caridade, e para nos tornar prontos aos atos das virtudes necessárias para alcançar a perfeição da vida cristã.*
+
+**3.** O que é a Sabedoria?
+
+*A Sabedoria é um dom pelo qual nós, elevando a mente destas coisas terrenas e frágeis, contemplamos as eternas, isto é, a eterna Verdade que é Deus, gostando e amando a Ele, no qual consiste todo o nosso bem.*
+
+**4.** O que é o Entendimento?
+
+*O Entendimento é um dom pelo qual nos é facilitada, quanto se pode ao homem mortal, a inteligência das verdades da Fé e dos divinos mistérios, os quais com a luz natural do nosso entendimento não podemos conhecer.*
+
+**5.** O que é o Conselho?
+
+*O Conselho é um dom pelo qual, nas dúvidas e incertezas da vida humana, conhecemos aquilo que mais convém à glória de Deus, à nossa salvação e à do próximo.*
+
+**6.** O que é a Fortaleza?
+
+*A Fortaleza é um dom que nos inspira valor e coragem para observar fielmente a santa lei de Deus e da Igreja, superando todos os obstáculos e os assaltos dos nossos inimigos.*
+
+**7.** O que é a Ciência?
+
+*A Ciência é um dom pelo qual julgamos retamente das coisas criadas, e conhecemos o modo de bem usá-las e dirigi-las ao último fim, que é Deus.*
+
+**8.** O que é a Piedade?
+
+*A Piedade é um dom pelo qual veneramos e amamos a Deus e aos Santos, e conservamos um ânimo pio e benévolo para com o próximo por amor de Deus.*
+
+**9.** O que é o Temor de Deus?
+
+*O Temor de Deus é um dom que nos faz reverenciar a Deus e temer ofender a sua divina Majestade, e nos afasta do mal incitando-nos ao bem.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quinta-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quinta-capo-iii.md
@@ -1,0 +1,77 @@
+# Capítulo III — Das Bem-aventuranças evangélicas
+
+**1.** Quantas e quais são as Bem-aventuranças evangélicas?
+
+*As Bem-aventuranças evangélicas são oito:*
+
+*1.ª Bem-aventurados os pobres de espírito, porque deles é o reino dos céus.*
+
+*2.ª Bem-aventurados os mansos, porque eles possuirão a terra.*
+
+*3.ª Bem-aventurados os que choram, porque serão consolados.*
+
+*4.ª Bem-aventurados os que têm fome e sede de justiça, porque serão saciados.*
+
+*5.ª Bem-aventurados os misericordiosos, porque alcançarão misericórdia.*
+
+*6.ª Bem-aventurados os limpos de coração, porque verão a Deus.*
+
+*7.ª Bem-aventurados os pacíficos, porque serão chamados filhos de Deus.*
+
+*8.ª Bem-aventurados os que sofrem perseguições por amor da justiça, porque deles é o reino dos céus.*
+
+**2.** Por que Jesus Cristo nos propôs as Bem-aventuranças?
+
+*Jesus Cristo propôs-nos as Bem-aventuranças para nos fazer detestar as máximas do mundo, e para nos convidar a amar e praticar as máximas do seu Evangelho.*
+
+**3.** Quem são aqueles que o mundo chama bem-aventurados?
+
+*O mundo chama bem-aventurados aqueles que abundam em riquezas e em honras, que vivem alegremente, e que não têm ocasião alguma de padecer.*
+
+**4.** Quem são os pobres de espírito, que Jesus Cristo chama bem-aventurados?
+
+*Os pobres de espírito, segundo o Evangelho, são aqueles que têm o coração desapegado das riquezas; delas fazem bom uso, se as possuem; não as buscam com solicitude, se delas estão privados; sofrem com resignação a sua perda, se lhes são tiradas.*
+
+**5.** Quem são os mansos?
+
+*Os mansos são aqueles que tratam o próximo com doçura, e suportam com paciência os seus defeitos e as ofensas que deles recebem, sem queixas, ressentimentos ou vinganças.*
+
+**6.** Quem são os que choram, e contudo são chamados bem-aventurados?
+
+*Os que choram, e contudo são chamados bem-aventurados, são aqueles que sofrem resignados as tribulações, e que se afligem pelos pecados cometidos, pelos males e pelos escândalos que se veem no mundo, pela distância do paraíso e pelo perigo de perdê-lo.*
+
+**7.** Quem são os que têm fome e sede de justiça?
+
+*Os que têm fome e sede de justiça são aqueles que desejam ardentemente crescer sempre mais na divina graça e no exercício das obras boas e virtuosas.*
+
+**8.** Quem são os misericordiosos?
+
+*Os misericordiosos são aqueles que amam em Deus e por amor de Deus ao seu próximo, compadecem-se das suas misérias tanto espirituais como corporais, e procuram aliviá-las segundo as suas forças e o seu estado.*
+
+**9.** Quem são os limpos de coração?
+
+*Os limpos de coração são aqueles que não têm afeto algum ao pecado e dele se mantêm afastados, e evitam sobretudo toda espécie de impureza.*
+
+**10.** Quem são os pacíficos?
+
+*Os pacíficos são aqueles que conservam a paz com o próximo e consigo mesmos, e procuram pôr a paz entre os que estão em discórdia.*
+
+**11.** Quem são os que sofrem perseguição por amor da justiça?
+
+*Os que sofrem perseguição por amor da justiça são aqueles que suportam com paciência as zombarias, as reprovações e as perseguições por causa da fé e da lei de Jesus Cristo.*
+
+**12.** O que significam os diversos prêmios prometidos por Jesus Cristo nas Bem-aventuranças?
+
+*Os diversos prêmios prometidos por Jesus Cristo nas Bem-aventuranças significam todos, sob diversos nomes, a glória eterna do céu.*
+
+**13.** As Bem-aventuranças nos proporcionam somente a eterna glória do paraíso?
+
+*As Bem-aventuranças não nos proporcionam somente a eterna glória do paraíso, mas são também os meios para conduzir uma vida feliz, na medida do possível, neste mundo.*
+
+**14.** Aqueles que seguem as Bem-aventuranças recebem já alguma recompensa nesta vida?
+
+*Sim, certamente, aqueles que seguem as Bem-aventuranças recebem já alguma recompensa também nesta vida, porque já gozam de uma paz e contentamento interno, que é princípio, embora imperfeito, da eterna felicidade.*
+
+**15.** Aqueles que seguem as máximas do mundo poderão ser ditos felizes?
+
+*Não, aqueles que seguem as máximas do mundo não são felizes, porque não têm a verdadeira paz da alma, e correm perigo de condenar-se.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quinta-capo-iv.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quinta-capo-iv.md
@@ -1,0 +1,45 @@
+# Capítulo IV — Das obras de misericórdia
+
+**1.** Quais são as obras boas das quais nos será pedida conta particular no dia do Juízo?
+
+*As obras boas das quais nos será pedida conta particular no dia do Juízo são as obras de misericórdia.*
+
+**2.** O que se entende por obra de misericórdia?
+
+*Obra de misericórdia é aquela com a qual se socorre às necessidades corporais ou espirituais do nosso próximo.*
+
+**3.** Quais são as obras de misericórdia corporais?
+
+*As obras de misericórdia corporais são:*
+
+*1.ª Dar de comer a quem tem fome.*
+
+*2.ª Dar de beber a quem tem sede.*
+
+*3.ª Vestir os nus.*
+
+*4.ª Hospedar os peregrinos.*
+
+*5.ª Visitar os enfermos.*
+
+*6.ª Visitar os encarcerados.*
+
+*7.ª Sepultar os mortos.*
+
+**4.** Quais são as obras de misericórdia espirituais?
+
+*As obras de misericórdia espirituais são:*
+
+*1.ª Aconselhar os duvidosos.*
+
+*2.ª Ensinar os ignorantes.*
+
+*3.ª Admoestar os pecadores.*
+
+*4.ª Consolar os aflitos.*
+
+*5.ª Perdoar as ofensas.*
+
+*6.ª Suportar com paciência as pessoas molestas.*
+
+*7.ª Rogar a Deus pelos vivos e pelos mortos.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quinta-capo-v.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quinta-capo-v.md
@@ -1,0 +1,57 @@
+# Capítulo V — Dos pecados e das suas espécies principais
+
+**1.** Quantas espécies de pecados há?
+
+*Há duas espécies de pecados: o pecado original e o pecado atual.*
+
+**2.** Qual é o pecado original?
+
+*O pecado original é aquele com o qual todos nascemos, e que contraímos pela desobediência do nosso primeiro pai Adão.*
+
+**3.** Quais danos nos causou o pecado de Adão?
+
+*Os danos do pecado de Adão são: a privação da graça, a perda do paraíso, a ignorância, a inclinação ao mal, a morte e todas as outras misérias.*
+
+**4.** Como se apaga o pecado original?
+
+*O pecado original apaga-se com o santo Batismo.*
+
+**5.** Qual é o pecado atual?
+
+*O pecado atual é aquele que o homem, chegado ao uso da razão, comete com a sua livre vontade.*
+
+**6.** Quantas espécies de pecado atual há?
+
+*Há duas espécies de pecado atual: o mortal e o venial.*
+
+**7.** Qual é o pecado mortal?
+
+*O pecado mortal é uma transgressão da lei divina, pela qual se falta gravemente aos deveres para com Deus, para com o próximo, para conosco mesmos.*
+
+**8.** Por que se diz mortal?
+
+*Diz-se mortal porque dá morte à alma, fazendo perder a graça santificante, que é a vida da alma, como a alma é a vida do corpo.*
+
+**9.** Quais danos faz à alma o pecado mortal?
+
+*1.º O pecado mortal priva a alma da graça e da amizade de Deus; 2.º fá-la perder o paraíso; 3.º priva-a dos méritos adquiridos, e torna-a incapaz de adquirir novos; 4.º torna-a escrava do demônio; 5.º fá-la merecer o inferno, e também os castigos desta vida.*
+
+**10.** Além da gravidade da matéria, o que se requer para constituir um pecado mortal?
+
+*Além da gravidade da matéria, para constituir um pecado mortal requer-se a plena advertência de tal gravidade e a deliberada vontade de cometer o pecado.*
+
+**11.** Qual é o pecado venial?
+
+*O pecado venial é uma leve transgressão da lei divina, pela qual se falta somente levemente a algum dever para com Deus, para com o próximo e para conosco mesmos.*
+
+**12.** Por que se chama venial?
+
+*Porque é leve em relação ao pecado mortal, não nos faz perder a divina graça; e porque Deus mais facilmente o perdoa.*
+
+**13.** Então não se deve fazer grande caso do pecado venial?
+
+*Isso seria um engano grandíssimo, seja porque o pecado venial contém sempre alguma ofensa de Deus, seja porque traz danos não pequenos à alma.*
+
+**14.** Quais danos traz o pecado venial?
+
+*O pecado venial: 1.º enfraquece e esfria em nós a caridade; 2.º dispõe-nos ao pecado mortal; 3.º torna-nos merecedores de grandes penas temporais neste mundo ou no outro.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quinta-capo-vi.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quinta-capo-vi.md
@@ -1,0 +1,37 @@
+# Capítulo VI — Dos vícios capitais e de outros pecados mais graves
+
+**1.** O que é o vício?
+
+*O vício é uma má disposição da alma a fugir do bem e a fazer o mal, causada pela frequente repetição dos atos maus.*
+
+**2.** Que diferença há entre pecado e vício?
+
+*Entre pecado e vício há esta diferença: que o pecado é um ato que passa, ao passo que o vício é o mau hábito contraído de cair em algum pecado.*
+
+**3.** Quais são os vícios que se chamam capitais?
+
+*Os vícios que se chamam capitais são sete: 1.º Soberba; 2.º Avareza; 3.º Luxúria; 4.º Ira; 5.º Gula; 6.º Inveja; 7.º Preguiça.*
+
+**4.** Como se vencem os vícios capitais?
+
+*Os vícios capitais vencem-se com o exercício das virtudes opostas. Assim, a soberba vence-se com a humildade; a avareza com a liberalidade; a luxúria com a castidade; a ira com a paciência; a gula com a abstinência; a inveja com o amor fraterno; a preguiça com a diligência e com o fervor no serviço de Deus.*
+
+**5.** Por que estes vícios se chamam capitais?
+
+*Estes vícios chamam-se capitais porque são a fonte e a causa de muitos outros vícios e pecados.*
+
+**6.** Quantos são os pecados contra o Espírito Santo?
+
+*Os pecados contra o Espírito Santo são seis: 1.º desespero da salvação; 2.º presunção de salvar-se sem mérito; 3.º impugnar a verdade conhecida; 4.º inveja da graça alheia; 5.º obstinação nos pecados; 6.º impenitência final.*
+
+**7.** Por que estes pecados se dizem em particular contra o Espírito Santo?
+
+*Estes pecados dizem-se em particular contra o Espírito Santo, porque se cometem por pura malícia, a qual é contrária à bondade, que se atribui ao Espírito Santo.*
+
+**8.** Quais são os pecados que se dizem clamar vingança na presença de Deus?
+
+*Os pecados que se dizem clamar vingança na presença de Deus são quatro: 1.º homicídio voluntário; 2.º pecado impuro contra a ordem da natureza; 3.º opressão dos pobres; 4.º defraudar o salário dos trabalhadores.*
+
+**9.** Por que se diz que estes pecados clamam vingança na presença de Deus?
+
+*Estes pecados dizem-se clamar vingança na presença de Deus, porque assim o diz o Espírito Santo e porque a sua iniquidade é tão grave e manifesta que provoca Deus a puni-los com mais severos castigos.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quinta-capo-vii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quinta-capo-vii.md
@@ -1,0 +1,17 @@
+# Capítulo VII — Dos Novíssimos e de outros meios principais para evitar o pecado
+
+**1.** O que entendeis por Novíssimos?
+
+*Novíssimos são chamadas nos Livros santos as coisas últimas que acontecerão ao homem.*
+
+**2.** Quantos são os Novíssimos, ou coisas últimas do homem?
+
+*Os Novíssimos, ou coisas últimas do homem, são quatro: Morte, Juízo, Inferno e Paraíso.*
+
+**3.** Por que os Novíssimos se dizem coisas últimas do homem?
+
+*Os Novíssimos dizem-se coisas últimas do homem, porque a Morte é a última coisa que nos acontece neste mundo; o Juízo de Deus é o último dentre os juízos que devemos sustentar; o Inferno é o extremo mal que terão os maus; o Paraíso, o sumo bem que terão os bons.*
+
+**4.** Quando devemos nós pensar nos Novíssimos?
+
+*É bom pensar nos Novíssimos todos os dias, e sobretudo ao fazer oração de manhã, logo ao acordar, à noite, antes de ir repousar, e todas as vezes que somos tentados a fazer o mal, porque este pensamento é validíssimo para fazer-nos evitar o pecado.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-quinta-capo-viii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-quinta-capo-viii.md
@@ -1,0 +1,89 @@
+# Capítulo VIII — Dos exercícios devotos que se aconselham ao cristão para cada dia
+
+**1.** O que deve fazer um bom cristão pela manhã, logo ao acordar?
+
+*Um bom cristão, pela manhã, logo ao acordar, deve fazer o sinal da santa Cruz e oferecer o coração a Deus, dizendo estas ou outras palavras semelhantes: Meu Deus, eu Vos dou o meu coração e a minha alma.*
+
+**2.** Em que se deveria pensar ao levantar-se da cama e ao vestir-se?
+
+*Ao levantar-se da cama e ao vestir-se, dever-se-ia pensar que Deus está presente, que aquele dia pode ser o último da nossa vida; e levantar-se e vestir-se com toda a modéstia possível.*
+
+**3.** Levantado e vestido, o que deve fazer um bom cristão?
+
+*Um bom cristão, logo que se levante e vista, deve pôr-se na presença de Deus e ajoelhar-se, se puder, diante de alguma imagem devota, dizendo com devoção: «Adoro-Vos, meu Deus, e Vos amo de todo o coração; agradeço-Vos por me terdes criado, feito cristão e conservado nesta noite; ofereço-Vos todas as minhas ações, e Vos peço que me preserveis neste dia do pecado e me livreis de todo o mal. Assim seja». Recite em seguida o Pater Noster, a Ave-Maria, o Credo e os atos de Fé, de Esperança e de Caridade, acompanhando-os com vivo afeto do coração.*
+
+**4.** Quais práticas de piedade deveria o cristão cumprir cada dia?
+
+*O cristão, podendo, deveria cada dia: 1.º assistir com devoção à santa Missa; 2.º fazer uma visita, ainda que brevíssima, ao Santíssimo Sacramento; 3.º recitar a terceira parte do santo Rosário.*
+
+**5.** O que se deve fazer antes de trabalhar?
+
+*Antes de trabalhar, deve-se oferecer o trabalho a Deus, dizendo de coração: «Senhor, ofereço-Vos este trabalho: dai-me a Vossa bênção».*
+
+**6.** Com que fim se deve trabalhar?
+
+*Deve-se trabalhar pela glória de Deus e para fazer a sua vontade.*
+
+**7.** O que convém fazer antes de tomar alimento?
+
+*Antes de tomar alimento, em pé, convém fazer o sinal da santa Cruz e depois dizer com devoção: «Senhor Deus, dai a Vossa bênção a nós e ao alimento que agora tomaremos para conservar-nos no Vosso serviço».*
+
+**8.** Terminado de tomar alimento, o que convém fazer?
+
+*Terminado de tomar alimento, convém fazer o sinal da santa Cruz e dizer: «Senhor, agradeço-Vos pelo alimento que me destes; tornai-me digno de participar da mesa celeste».*
+
+**9.** Quando alguém percebe alguma tentação, o que deveria fazer?
+
+*Quando alguém percebe alguma tentação, deveria invocar com fé o Santíssimo Nome de Jesus, ou de Maria, ou dizer fervorosamente alguma jaculatória, como p. ex.: «dai-me graça, ó Senhor, para que jamais Vos ofenda», ou então fazer o sinal da Cruz; evitando, porém, que por sinais externos outros se apercebam das suas tentações.*
+
+**10.** Quando alguém sabe ou duvida de ter cometido algum pecado, o que deve fazer?
+
+*Quando alguém sabe ou duvida de ter pecado, deve fazer logo um ato de contrição, e procurar confessar-se o quanto antes.*
+
+**11.** Quando, fora da igreja, se ouve o sinal da elevação da hóstia na Missa solene, ou da bênção do Santíssimo Sacramento, o que se deve fazer?
+
+*Deve-se fazer, ao menos com o coração, um ato de adoração, dizendo p. ex.: «Seja louvado e agradecido a cada momento o santíssimo e diviníssimo Sacramento».*
+
+**12.** O que se deve dizer quando soa a Ave-Maria, ao amanhecer, ao meio-dia e à tarde?
+
+*Ao soar da Ave-Maria, o bom cristão recita o Angelus Domini, com três Ave-Marias.*
+
+**13.** À noite, antes de ir repousar, o que convém fazer?
+
+*À noite, antes do repouso, convém pôr-se, como pela manhã, na presença de Deus, recitar devotamente as mesmas orações, fazer um breve exame de consciência e pedir perdão a Deus dos pecados cometidos durante o dia.*
+
+**14.** O que fareis antes de adormecer?
+
+*Antes de adormecer farei o sinal da santa Cruz, pensarei que posso morrer naquela noite, e darei o coração a Deus, dizendo: «Senhor e Deus meu, eu Vos dou todo o meu coração; Santíssima Trindade, dai-me graça de bem viver e de bem morrer; Jesus, José e Maria, eu Vos recomendo a minha alma».*
+
+**15.** Além das orações da manhã e da noite, de que outra maneira se pode recorrer a Deus no decurso do dia?
+
+*No decurso do dia pode-se rezar a Deus frequentemente com outras breves orações que se chamam jaculatórias.*
+
+**16.** Dizei alguma jaculatória.
+
+*Senhor, ajudai-me — Senhor, seja feita a Vossa santíssima vontade — Meu Jesus, eu quero ser todo Vosso — Meu Jesus, misericórdia — Doce Coração do meu Jesus, fazei que eu sempre mais Vos ame.*
+
+**17.** É útil dizer durante o dia muitas jaculatórias?
+
+*É coisa utilíssima dizer durante o dia muitas orações jaculatórias, e podem-se dizer também com o coração, sem proferir palavra, caminhando, trabalhando, etc.*
+
+**18.** Além das orações jaculatórias, em que outra coisa se deveria exercitar com frequência o cristão?
+
+*Além das orações jaculatórias, o cristão deveria exercitar-se na cristã mortificação.*
+
+**19.** Que quer dizer mortificar-se?
+
+*Mortificar-se quer dizer deixar, por amor de Deus, aquilo que agrada, e aceitar aquilo que desagrada segundo os sentidos ou o amor próprio.*
+
+**20.** Quando se leva o Santíssimo Sacramento a um enfermo, o que se deve fazer?
+
+*Quando se leva o Santíssimo Sacramento a algum enfermo, deve-se procurar, podendo, acompanhá-lo com modéstia e recolhimento; e se não se puder, fazer um ato de adoração em qualquer lugar onde se esteja, e depois dizer: «Consolai, ó Senhor, este enfermo, e dai-lhe graça de conformar-se à Vossa santíssima vontade e de obter a sua saúde».*
+
+**21.** Ouvindo tocar a agonia de algum moribundo, o que fareis?
+
+*Ouvindo tocar a agonia de um moribundo, dirigir-me-ei, podendo, à Igreja para rezar por ele, e não podendo, recomendarei ao Senhor a sua alma, pensando que dentro de pouco tempo terei de encontrar-me eu também neste estado.*
+
+**22.** Ouvindo o sinal da morte de alguém, o que fareis?
+
+*Ouvindo o sinal da morte de alguém, procurarei dizer um De profundis ou um Requiem pela alma daquele defunto, e renovarei o pensamento da morte.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-seconda-capo-i.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-seconda-capo-i.md
@@ -1,0 +1,105 @@
+# Capítulo I — Da oração em geral
+
+**1.** De que se trata na segunda parte da Doutrina cristã?
+
+*Na segunda parte da Doutrina cristã trata-se da oração em geral e do Pater Noster em particular.*
+
+**2.** O que é a oração?
+
+*A oração é uma elevação da mente a Deus para adorá-Lo, agradecer-Lhe e pedir-Lhe aquilo de que necessitamos.*
+
+**3.** Como se distingue a oração?
+
+*A oração distingue-se em mental e vocal. A oração mental é a que se faz só com a mente; a oração vocal é a que se faz com palavras, acompanhadas da atenção da mente e da devoção do coração.*
+
+**4.** Pode-se distinguir a oração de outro modo?
+
+*A oração também se pode distinguir em privada e pública.*
+
+**5.** Qual é a oração privada?
+
+*A oração privada é aquela que cada um faz em particular por si ou por outrem.*
+
+**6.** Qual é a oração pública?
+
+*A oração pública é aquela que é feita pelos ministros sagrados em nome da Igreja e pela salvação do povo fiel. Pode-se chamar pública também a oração feita em comum e publicamente pelos fiéis, como nas procissões, peregrinações e no templo.*
+
+**7.** Temos esperança fundada de obter, por meio da oração, os auxílios e graças de que necessitamos?
+
+*A esperança de obter de Deus as graças de que necessitamos funda-se nas promessas de Deus Onipotente, misericordioso e fidelíssimo, e nos méritos de Jesus Cristo.*
+
+**8.** Em nome de quem devemos pedir a Deus as graças que nos são necessárias?
+
+*Nós devemos pedir a Deus as graças que nos são necessárias em nome de Jesus Cristo, como Ele mesmo nos ensinou e como pratica a Igreja, a qual encerra sempre as suas orações com estas palavras: per Dominum nostrum Iesum Christum, isto é: por Nosso Senhor Jesus Cristo.*
+
+**9.** Por que devemos pedir a Deus as graças em nome de Jesus Cristo?
+
+*Devemos pedir as graças em nome de Jesus Cristo porque, sendo Ele nosso mediador, somente por meio dele podemos aproximar-nos do trono de Deus.*
+
+**10.** Se a oração tem tanto poder, que quer dizer o fato de que muitas vezes não são atendidas nossas preces?
+
+*Muitas vezes nossas preces não são atendidas, ou porque pedimos coisas que não convêm à nossa eterna salvação, ou porque não oramos como se deve.*
+
+**11.** Quais são as coisas que devemos principalmente pedir a Deus?
+
+*Devemos principalmente pedir a Deus a sua glória, a nossa eterna salvação e os meios para alcançá-la.*
+
+**12.** Não é lícito pedir também os bens temporais?
+
+*Sim, é lícito pedir a Deus também os bens temporais, mas sempre com a condição de que sejam conformes à sua santíssima vontade e não sejam impedimento à nossa eterna salvação.*
+
+**13.** Se Deus sabe tudo o que nos é necessário, por que se deve orar?
+
+*Embora Deus saiba tudo o que nos é necessário, contudo quer que oremos para reconhecê-Lo como doador de todo bem, para atestar-Lhe nossa humilde submissão e para merecer os seus favores.*
+
+**14.** Qual é a primeira e melhor disposição para tornar eficazes as nossas orações?
+
+*A primeira e melhor disposição para tornar eficazes as nossas orações é estar em estado de graça, ou, não estando, ao menos desejar voltar a tal estado.*
+
+**15.** Que outras disposições se requerem para bem orar?
+
+*Para bem orar requerem-se especialmente o recolhimento, a humildade, a confiança, a perseverança e a resignação.*
+
+**16.** Que quer dizer orar com recolhimento?
+
+*Quer dizer pensar que falamos com Deus e, por isso, devemos orar com todo o respeito e devoção, evitando, quanto possível, as distrações, isto é, todo pensamento estranho à oração.*
+
+**17.** As distrações diminuem o mérito da oração?
+
+*Sim, quando nós mesmos as procuramos, ou quando não as rechaçamos com diligência. Se, porém, fazemos quanto é possível para estar recolhidos em Deus, então as distrações não diminuem o mérito de nossa oração, mas, ao contrário, podem aumentá-lo.*
+
+**18.** O que se requer para orar com recolhimento?
+
+*Devemos, antes da oração, afastar todas as ocasiões de distração, e devemos, durante a oração, pensar que estamos na presença de Deus, que nos vê e nos escuta.*
+
+**19.** Que quer dizer orar com humildade?
+
+*Quer dizer reconhecer sinceramente a própria indignidade, impotência e miséria, acompanhando a oração com a compostura do corpo.*
+
+**20.** Que quer dizer orar com confiança?
+
+*Quer dizer que devemos ter firme esperança de ser atendidos, se daí decorre a glória de Deus e o nosso verdadeiro bem.*
+
+**21.** Que quer dizer orar com perseverança?
+
+*Quer dizer que não devemos cansar-nos de orar, se Deus logo não nos atende, mas que devemos, antes, continuar a orar com maior fervor.*
+
+**22.** Que quer dizer orar com resignação?
+
+*Quer dizer que devemos conformar-nos com a vontade de Deus, o qual conhece melhor que nós o que é necessário à nossa eterna salvação, mesmo no caso em que nossas preces não fossem atendidas.*
+
+**23.** Deus atende sempre as orações bem feitas?
+
+*Sim, Deus atende sempre as orações bem feitas, mas do modo que Ele sabe ser mais útil para a nossa eterna salvação, e nem sempre segundo a nossa vontade.*
+
+**24.** Que efeitos produz em nós a oração?
+
+*A oração nos faz reconhecer a nossa dependência de Deus, supremo Senhor em todas as coisas; faz-nos pensar nas coisas celestes; faz-nos progredir na virtude; obtém-nos de Deus misericórdia; fortalece-nos contra as tentações; conforta-nos nas tribulações; ajuda-nos nas necessidades; e obtém-nos a graça da perseverança final.*
+
+**25.** Quando devemos especialmente orar?
+
+*Devemos orar especialmente nos perigos, nas tentações e na hora da morte; ademais, devemos orar com frequência, e é bom que se o faça de manhã e à noite, e no princípio das ações importantes do dia.*
+
+**26.** Por quem devemos orar?
+
+*Devemos orar por todos: por nós mesmos, por nossos parentes, superiores, benfeitores, amigos e inimigos; pela conversão dos pobres pecadores, dos que estão fora da verdadeira Igreja, e pelas santas almas do purgatório.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-seconda-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-seconda-capo-ii.md
@@ -1,0 +1,211 @@
+# Capítulo II — Da Oração Dominical
+
+## § 1. Da Oração Dominical em geral
+
+**1.** Qual é a oração vocal mais excelente?
+
+*A oração vocal mais excelente é aquela que o próprio Jesus Cristo nos ensinou, isto é, o Pater Noster.*
+
+**2.** Por que o Pater Noster é a oração mais excelente?
+
+*O Pater Noster é a oração mais excelente porque foi composta e ensinada pelo próprio Jesus Cristo; porque contém claramente, em poucas palavras, tudo o que podemos esperar de Deus; e é a regra e o modelo de todas as outras orações.*
+
+**3.** O Pater Noster é também a oração mais eficaz?
+
+*O Pater Noster é também a oração mais eficaz, porque é a mais aceita por Deus, orando nós com as próprias palavras que seu divino Filho nos ditou.*
+
+**4.** Por que o Pater Noster se chama Oração Dominical?
+
+*O Pater Noster chama-se Oração Dominical, que quer dizer oração do Senhor, justamente porque foi o próprio Jesus Cristo quem no-la ensinou.*
+
+**5.** Quantas petições há no Pater Noster?
+
+*No Pater Noster há sete petições, precedidas de um proêmio.*
+
+**6.** Recitai o Pater Noster.
+
+*Pai-Nosso, que estais nos céus:*
+
+*1.ª Santificado seja o vosso Nome.*
+
+*2.ª Venha a nós o vosso Reino.*
+
+*3.ª Seja feita a vossa vontade, assim na terra como no céu.*
+
+*4.ª O pão nosso de cada dia nos dai hoje.*
+
+*5.ª Perdoai-nos as nossas dívidas, assim como nós perdoamos aos nossos devedores.*
+
+*6.ª E não nos deixeis cair em tentação.*
+
+*7.ª Mas livrai-nos do mal. Assim seja.*
+
+**7.** Por que, invocando a Deus no princípio da Oração Dominical, O chamamos nosso Pai?
+
+*No princípio da Oração Dominical chamamos a Deus nosso Pai para despertar a nossa confiança em sua infinita bondade, sendo nós seus filhos.*
+
+**8.** Por que podemos dizer que somos filhos de Deus?
+
+*Nós somos filhos de Deus: 1.º porque Ele nos criou à sua imagem e nos conserva e governa com sua providência; 2.º porque nos adotou, por especial benevolência, no Batismo, como irmãos de Jesus Cristo e coerdeiros, juntamente com Ele, da glória eterna.*
+
+**9.** Por que chamamos a Deus Pai nosso e não Pai meu?
+
+*Chamamos a Deus Pai nosso e não Pai meu, porque todos somos seus filhos e, portanto, devemos considerar-nos e amar-nos todos como irmãos, e orar uns pelos outros.*
+
+**10.** Estando Deus em todo lugar, por que Lhe dizemos: que estais nos céus?
+
+*Deus está em todo lugar; mas dizemos: Pai nosso, que estais nos céus, para elevar os nossos corações ao céu, onde Deus se manifesta na glória aos seus filhos.*
+
+## § 2. Da primeira petição
+
+**11.** Que pedimos nós na primeira petição: Santificado seja o vosso Nome?
+
+*Na primeira petição: Santificado seja o vosso Nome, pedimos que Deus seja conhecido, amado, honrado e servido por todo o mundo e por nós em particular.*
+
+**12.** Que entendemos pedindo que Deus seja conhecido, amado e servido por todo o mundo?
+
+*Entendemos pedir que os infiéis cheguem ao conhecimento do verdadeiro Deus, que os hereges reconheçam os seus erros, que os cismáticos retornem à unidade da Igreja, que os pecadores se convertam e que os justos sejam perseverantes no bem.*
+
+**13.** Por que, antes de qualquer outra coisa, pedimos que seja santificado o nome de Deus?
+
+*Antes de qualquer outra coisa, pedimos que seja santificado o nome de Deus, porque a glória de Deus nos deve ser mais querida do que todos os nossos bens e vantagens.*
+
+**14.** De que modo podemos procurar a glória de Deus?
+
+*Podemos procurar a glória de Deus pela oração, pelo bom exemplo e dirigindo a Ele todos os nossos pensamentos, afetos e obras.*
+
+## § 3. Da segunda petição
+
+**15.** Que entendemos por reino de Deus?
+
+*Por reino de Deus entendemos um tríplice reino espiritual: o reino de Deus em nós, isto é, o reino da graça; o reino de Deus na terra, isto é, a santa Igreja católica; e o reino de Deus nos céus, isto é, o paraíso.*
+
+**16.** Que pedimos com as palavras: venha o vosso Reino, em relação à graça?
+
+*Em relação à graça, pedimos que Deus reine em nós com sua graça santificante, pela qual Ele se compraz em residir em nós como um rei em seu palácio, e em manter-nos unidos a Ele pelas virtudes da fé, da esperança e da caridade, pelas quais reina sobre o nosso entendimento, sobre o nosso coração e sobre a nossa vontade.*
+
+**17.** Que pedimos com as palavras: venha o vosso Reino, em relação à Igreja?
+
+*Em relação à Igreja, pedimos que esta cada vez mais se dilate e se propague por todo o mundo, para salvação dos homens.*
+
+**18.** Que pedimos com as palavras: venha o vosso Reino, em relação à glória?
+
+*Em relação à glória, pedimos poder ser um dia admitidos no santo paraíso, para o qual fomos criados, onde seremos plenamente felizes.*
+
+## § 4. Da terceira petição
+
+**19.** Que pedimos na terceira petição: seja feita a vossa vontade, assim na terra como no céu?
+
+*Na terceira petição: seja feita a vossa vontade, assim na terra como no céu, pedimos a graça de fazer em tudo a vontade de Deus, obedecendo aos seus santos mandamentos com tanta prontidão como os anjos e os santos Lhe obedecem no céu. Pedimos, ademais, a graça de corresponder às divinas inspirações e de viver resignados à vontade de Deus quando Ele nos envia tribulações.*
+
+**20.** É necessário cumprir a vontade de Deus?
+
+*É necessário cumprir a vontade de Deus tanto quanto é necessário alcançar a eterna salvação, porque Jesus Cristo disse que entrará no reino dos céus somente quem fizer a vontade do seu Pai.*
+
+**21.** De que modo podemos conhecer a vontade de Deus?
+
+*Nós podemos conhecer a vontade de Deus especialmente por meio da Igreja e dos nossos superiores espirituais, estabelecidos por Deus para guiar-nos no caminho da salvação. Podemos também conhecer esta santíssima vontade pelas divinas inspirações e pelas próprias circunstâncias nas quais o Senhor nos colocou.*
+
+**22.** Devemos sempre reconhecer a vontade de Deus nas coisas prósperas ou adversas da vida?
+
+*Nas coisas tanto prósperas como adversas da vida presente, devemos sempre reconhecer também a vontade de Deus, o qual tudo dispõe ou permite para o nosso bem.*
+
+## § 5. Da quarta petição
+
+**23.** Que pedimos na quarta petição: o pão nosso de cada dia nos dai hoje?
+
+*Na quarta petição: o pão nosso de cada dia nos dai hoje, pedimos a Deus aquilo que nos é necessário cada dia, tanto para a alma como para o corpo.*
+
+**24.** Que pedimos a Deus para a nossa alma?
+
+*Para a nossa alma pedimos a Deus o sustento da vida espiritual, isto é, suplicamos ao Senhor que nos dê a sua graça, da qual continuamente necessitamos.*
+
+**25.** Como se nutre a vida da nossa alma?
+
+*A vida da alma nutre-se especialmente com o alimento da divina palavra e com o Santíssimo Sacramento do altar.*
+
+**26.** Que pedimos a Deus para o nosso corpo?
+
+*Para o nosso corpo pedimos aquilo que é necessário ao sustento da vida temporal.*
+
+**27.** Por que dizemos: dai-nos hoje o nosso pão, e não antes: dai-nos hoje o pão?
+
+*Dizemos: dai-nos hoje o nosso pão, e não antes: dai-nos hoje o pão, para excluir todo desejo das coisas alheias; por isso pedimos ao Senhor que nos ajude nos ganhos justos e lícitos, a fim de que obtenhamos o sustento com o nosso trabalho, sem furtos nem enganos.*
+
+**28.** Por que dizemos: dai-nos o pão, e não dai-me?
+
+*Dizemos: dai-nos, em vez de dai-me, para nos lembrarmos de que, como os bens nos vêm de Deus, se Ele no-los dá em abundância, é com este fim: que distribuamos o supérfluo aos pobres.*
+
+**29.** Por que acrescentamos de cada dia?
+
+*Acrescentamos de cada dia, porque devemos desejar o que nos é necessário à vida, e não a abundância dos alimentos e dos bens da terra.*
+
+**30.** Que significa também a palavra hoje na quarta petição?
+
+*A palavra hoje significa que não devemos ser demasiadamente solícitos pelo futuro, mas pedir aquilo que nos é necessário no presente.*
+
+## § 6. Da quinta petição
+
+**31.** Que pedimos na quinta petição: perdoai-nos as nossas dívidas, assim como nós perdoamos aos nossos devedores?
+
+*Na quinta petição: perdoai-nos as nossas dívidas, assim como nós perdoamos aos nossos devedores, pedimos a Deus que nos perdoe os nossos pecados, assim como nós perdoamos aos que nos ofenderam.*
+
+**32.** Por que os nossos pecados se chamam dívidas?
+
+*Os nossos pecados chamam-se dívidas porque, por eles, devemos satisfazer à divina justiça, ou nesta vida ou na outra.*
+
+**33.** Aqueles que não perdoam ao próximo podem esperar que Deus os perdoe?
+
+*Aqueles que não perdoam ao próximo não têm razão alguma para esperar que Deus os perdoe, tanto mais que se condenam a si mesmos, dizendo a Deus que os perdoe assim como eles perdoam ao próximo.*
+
+## § 7. Da sexta petição
+
+**34.** Que pedimos na sexta petição: e não nos deixeis cair em tentação?
+
+*Na sexta petição: e não nos deixeis cair em tentação, pedimos a Deus que nos livre das tentações, ou não permitindo que sejamos tentados, ou dando-nos a graça de não sermos vencidos.*
+
+**35.** O que são as tentações?
+
+*As tentações são um incitamento ao pecado que nos vem do demônio, dos maus ou das nossas paixões.*
+
+**36.** É pecado ter tentações?
+
+*Não, não é pecado ter tentações; é pecado consentir nelas ou expor-se voluntariamente ao perigo de nelas consentir.*
+
+**37.** Por que Deus permite que sejamos tentados?
+
+*Deus permite que sejamos tentados para provar a nossa fidelidade, para fazer crescer as nossas virtudes e para aumentar os nossos méritos.*
+
+**38.** Que devemos fazer para evitar as tentações?
+
+*Para evitar as tentações devemos fugir das ocasiões perigosas, custodiar os nossos sentidos, receber com frequência os santos sacramentos e fazer uso da oração.*
+
+## § 8. Da sétima petição
+
+**39.** Que pedimos na sétima petição: mas livrai-nos do mal?
+
+*Na sétima petição: mas livrai-nos do mal, pedimos a Deus que nos livre dos males passados, presentes e futuros, e especialmente do supremo mal, que é o pecado, e da eterna danação, que é a sua pena.*
+
+**40.** Por que dizemos: livrai-nos do mal, e não dos males?
+
+*Dizemos: livrai-nos do mal, e não dos males, porque não devemos desejar ficar livres de todos os males desta vida, mas somente daqueles que não são proveitosos para a nossa alma; por isso pedimos a libertação do mal em geral, isto é, de tudo aquilo que Deus vê ser mal para nós.*
+
+**41.** Não é lícito pedir a libertação de algum mal em particular, por exemplo, de uma doença?
+
+*Sim, é lícito pedir a libertação de algum mal em particular, mas sempre remetendo-nos à vontade de Deus, o qual pode também ordenar aquela tribulação em proveito da nossa alma.*
+
+**42.** Para que nos servem as tribulações que Deus nos envia?
+
+*As tribulações nos servem para fazer penitência das nossas culpas, para exercitar as virtudes e, sobretudo, para imitar Jesus Cristo, nossa cabeça, ao qual é justo que nos conformemos nos padecimentos, se quisermos ter parte em sua glória.*
+
+**43.** Que quer dizer Amém no final do Pai-Nosso?
+
+*Amém quer dizer: assim seja, assim desejo, assim peço ao Senhor e assim espero.*
+
+**44.** Para obter as graças pedidas no Pater Noster, basta recitá-lo de qualquer maneira?
+
+*Para obter as graças pedidas no Pater Noster é preciso recitá-lo sem pressa, com atenção e acompanhá-lo com o coração.*
+
+**45.** Quando devemos nós dizer o Pater?
+
+*O Pater devemos dizê-lo todos os dias, porque todos os dias necessitamos do auxílio de Deus.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-seconda-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-seconda-capo-iii.md
@@ -1,0 +1,61 @@
+# Capítulo III — Da «Ave-Maria»
+
+**1.** Que oração costumamos dizer depois do Pater?
+
+*Depois do Pater, dizemos a saudação angélica, isto é, a Ave-Maria, pela qual recorremos à santíssima Virgem.*
+
+**2.** Por que a Ave-Maria se chama saudação angélica?
+
+*A Ave-Maria chama-se saudação angélica porque começa com a saudação que o arcanjo Gabriel fez a Maria Virgem.*
+
+**3.** De quem são as palavras da Ave-Maria?
+
+*As palavras da Ave-Maria parte são do arcanjo Gabriel, parte de Santa Isabel e parte da Igreja.*
+
+**4.** Quais são as palavras do arcanjo Gabriel?
+
+*As palavras do arcanjo Gabriel são: «Deus te salve, cheia de graça: o Senhor é contigo: bendita és tu entre as mulheres.»*
+
+**5.** Quando foi que o Anjo disse a Maria essas palavras?
+
+*O Anjo disse a Maria essas palavras quando foi anunciar-lhe, da parte de Deus, o mistério da Encarnação que nela se devia operar.*
+
+**6.** Que entendemos fazer ao saudar a santíssima Virgem com as próprias palavras do Arcanjo?
+
+*Ao saudar a santíssima Virgem com as palavras do Arcanjo, nós nos alegramos com ela, fazendo memória dos singulares privilégios e dons que Deus lhe concedeu acima de todas as outras criaturas.*
+
+**7.** Quais são as palavras de Santa Isabel?
+
+*As palavras de Santa Isabel são: «Bendita és tu entre as mulheres, e bendito é o fruto do teu ventre.»*
+
+**8.** Quando foi que Santa Isabel disse estas palavras?
+
+*Santa Isabel disse estas palavras, inspirada por Deus, quando, três meses antes de dar à luz São João Batista, foi visitada pela santíssima Virgem, que já trazia em seu seio o seu divino Filho.*
+
+**9.** Que fazemos nós ao dizer estas palavras?
+
+*Ao dizer as palavras de Santa Isabel, nós nos alegramos com Maria Santíssima por sua excelsa dignidade de Mãe de Deus, e bendizemos a Deus e Lhe agradecemos por nos ter dado Jesus Cristo por meio de Maria.*
+
+**10.** De quem são as outras palavras da Ave-Maria?
+
+*Todas as outras palavras da Ave-Maria foram acrescentadas pela Igreja.*
+
+**11.** Que pedimos com as últimas palavras da Ave-Maria?
+
+*Com as últimas palavras da Ave-Maria, pedimos a proteção da santíssima Virgem no decorrer desta vida, e especialmente na hora de nossa morte, em que dela teremos maior necessidade.*
+
+**12.** Por que, depois do Pater, dizemos a Ave-Maria, em vez de qualquer outra oração?
+
+*Porque a Santíssima Virgem é a Advogada mais poderosa junto a Jesus Cristo, e por isso, depois de ter dito a oração ensinada por Jesus Cristo, suplicamos à Santíssima Virgem que nos alcance as graças que pedimos.*
+
+**13.** Por que motivo a Virgem santíssima é tão poderosa?
+
+*A santíssima Virgem é tão poderosa porque é Mãe de Deus, e é impossível que não seja por Ele atendida.*
+
+**14.** Que nos ensinam os Santos sobre a devoção a Maria?
+
+*Sobre a devoção a Maria, os Santos nos ensinam que os seus verdadeiros devotos são por ela amados e protegidos com amor de terníssima Mãe, e que por meio dela estão certos de encontrar Jesus e de alcançar o paraíso.*
+
+**15.** Que devoção a Maria a Igreja nos recomenda de modo especial?
+
+*A devoção que a Igreja nos recomenda de modo especial a Maria santíssima é a recitação do santo Rosário.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-seconda-capo-iv.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-seconda-capo-iv.md
@@ -1,0 +1,13 @@
+# Capítulo IV — Da invocação dos Santos
+
+**1.** É coisa boa e útil recorrer à intercessão dos Santos?
+
+*É coisa utilíssima pedir aos Santos, e deve fazê-lo todo cristão. Devemos pedir particularmente aos nossos Anjos Custódios, a São José, Patrono da Igreja, aos santos Apóstolos, aos Santos cujo nome levamos, e aos Santos Protetores da diocese e da paróquia.*
+
+**2.** Que diferença há entre as orações que dirigimos a Deus e aquelas que dirigimos aos Santos?
+
+*Entre as orações que dirigimos a Deus e aquelas que dirigimos aos Santos há esta diferença: que a Deus oramos para que, como autor das graças, nos dê os bens e nos livre dos males; e aos Santos oramos para que, como advogados junto a Deus, intercedam por nós.*
+
+**3.** Quando dizemos que um Santo concedeu uma graça, que entendemos dizer?
+
+*Quando dizemos que um Santo concedeu uma graça, entendemos dizer que aquele Santo obteve de Deus tal graça.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-terza-capo-i.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-terza-capo-i.md
@@ -1,0 +1,55 @@
+# Capítulo I — Dos mandamentos de Deus em geral
+
+**1.** De que se trata na terceira parte da Doutrina cristã?
+
+*Na terceira parte da Doutrina cristã trata-se dos mandamentos de Deus e da Igreja.*
+
+**2.** Quantos são os mandamentos da lei de Deus?
+
+*Os mandamentos da lei de Deus são dez:*
+
+*Eu sou o Senhor teu Deus:*
+
+*1.º Não terás outro Deus diante de mim.*
+
+*2.º Não tomarás o nome de Deus em vão.*
+
+*3.º Lembra-te de santificar as festas.*
+
+*4.º Honra teu pai e tua mãe.*
+
+*5.º Não matarás.*
+
+*6.º Não pecarás contra a castidade.*
+
+*7.º Não furtarás.*
+
+*8.º Não levantarás falso testemunho.*
+
+*9.º Não desejarás a mulher do próximo.*
+
+*10.º Não cobiçarás as coisas alheias.*
+
+**3.** Por que os mandamentos de Deus têm este nome?
+
+*Os mandamentos de Deus têm este nome porque o próprio Deus os imprimiu na alma de todo homem, promulgou-os no monte Sinai, na antiga lei, esculpidos sobre duas tábuas de pedra, e Jesus Cristo os confirmou na lei nova.*
+
+**4.** Quais são os mandamentos da primeira tábua?
+
+*Os mandamentos da primeira tábua são os três primeiros, que dizem respeito diretamente a Deus e aos deveres que temos para com Ele.*
+
+**5.** Quais são os mandamentos da segunda tábua?
+
+*Os mandamentos da segunda tábua são os sete últimos, que dizem respeito ao próximo e aos deveres que temos para com ele.*
+
+**6.** Somos nós obrigados a observar os mandamentos?
+
+*Sim, somos todos obrigados a observar os mandamentos, porque todos devemos viver segundo a vontade de Deus, que nos criou; e basta transgredir gravemente um só deles para merecer o inferno.*
+
+**7.** Podemos nós observar os mandamentos?
+
+*Nós podemos sem dúvida observar os mandamentos de Deus, porque Deus não nos manda nada que seja impossível e dá a graça de observá-los a quem a pede como se deve.*
+
+**8.** O que se deve considerar geralmente em cada mandamento?
+
+*Em cada mandamento se deve considerar a parte positiva e a parte negativa, isto é, aquilo que nos é mandado e aquilo que nos é proibido.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-terza-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-terza-capo-ii.md
@@ -1,0 +1,203 @@
+# Capítulo II — Dos mandamentos que dizem respeito a Deus
+
+## § 1. Do primeiro mandamento
+
+**1.** Por que se diz, no princípio: Eu sou o Senhor teu Deus?
+
+*No princípio dos mandamentos diz-se: Eu sou o Senhor teu Deus, para que reconheçamos que Deus, sendo nosso Criador e Senhor, pode mandar o que quer, e nós, suas criaturas, somos obrigados a obedecer-Lhe.*
+
+**2.** O que Deus nos ordena com as palavras do primeiro mandamento: Não terás outro Deus diante de mim?
+
+*Com as palavras do primeiro mandamento: Não terás outro Deus diante de mim, Deus nos ordena reconhecer, adorar, amar e servir somente a Ele, como nosso supremo Senhor.*
+
+**3.** Como se cumpre o primeiro mandamento?
+
+*O primeiro mandamento cumpre-se com o exercício do culto interno e externo.*
+
+**4.** O que é o culto interno?
+
+*O culto interno é a honra que se presta a Deus apenas com as faculdades do espírito, ou seja, com a mente e com a vontade.*
+
+**5.** O que é o culto externo?
+
+*O culto externo é a homenagem que se presta a Deus por meio de atos exteriores e de objetos sensíveis.*
+
+**6.** Não basta adorar a Deus apenas com o coração, internamente?
+
+*Não, não basta adorar a Deus apenas com o coração, internamente; é preciso adorá-Lo também externamente, com o espírito juntamente com o corpo, porque Ele é Criador e Senhor absoluto de um e de outro.*
+
+**7.** Pode existir o culto externo sem o interno?
+
+*Não, de modo algum pode existir o culto externo sem o interno, porque aquele, desligado deste, fica privado de vida, de mérito e de eficácia, como um corpo sem alma.*
+
+**8.** O que nos proíbe o primeiro mandamento?
+
+*O primeiro mandamento nos proíbe a idolatria, a superstição, o sacrilégio, a heresia e todo outro pecado contra a religião.*
+
+**9.** O que é a idolatria?
+
+*Chama-se idolatria dar a alguma criatura, por exemplo a uma estátua, a uma imagem, a um homem, o culto supremo de adoração devido só a Deus.*
+
+**10.** Como se acha expressa na Sagrada Escritura esta proibição?
+
+*Na Sagrada Escritura acha-se expressa esta proibição com as palavras: Não farás escultura nem representação alguma do que está lá em cima no céu nem aqui embaixo na terra. E não adorarás tais coisas nem lhes prestarás culto.*
+
+**11.** Proíbem estas palavras toda sorte de imagens?
+
+*Não, certamente; mas somente aquelas das falsas divindades, feitas com o fim de adoração, como faziam os idólatras. E tanto é assim que o próprio Deus ordenou a Moisés que fizesse algumas, como as duas estátuas de querubins sobre a arca e a serpente de bronze no deserto.*
+
+**12.** O que é a superstição?
+
+*Chama-se superstição qualquer devoção contrária à doutrina e ao uso da Igreja, como também atribuir a uma ação ou a uma coisa qualquer uma virtude sobrenatural que não possui.*
+
+**13.** O que é o sacrilégio?
+
+*O sacrilégio é a profanação de um lugar, de uma pessoa ou de uma coisa consagrada a Deus e destinada ao seu culto.*
+
+**14.** O que é a heresia?
+
+*A heresia é um erro culpável do intelecto, pelo qual se nega com pertinácia alguma verdade da fé.*
+
+**15.** Que outras coisas o primeiro mandamento proíbe?
+
+*O primeiro mandamento nos proíbe também qualquer trato com o demônio e o agregar-se às seitas anticristãs.*
+
+**16.** Quem recorresse ao demônio ou o invocasse cometeria grave pecado?
+
+*Quem recorresse ao demônio ou o invocasse cometeria um pecado enorme, porque o demônio é o mais perverso inimigo de Deus e do homem.*
+
+**17.** É lícito interrogar as chamadas mesas falantes ou escreventes, ou consultar de algum modo as almas dos falecidos por meio do espiritismo?
+
+*Todas as práticas do espiritismo são ilícitas, porque são supersticiosas e frequentemente não imunes à intervenção diabólica; e por isso foram justamente proibidas pela Igreja.*
+
+**18.** O primeiro mandamento proíbe, porventura, honrar e invocar os Anjos e os Santos?
+
+*Não, não é proibido honrar e invocar os Anjos e os Santos; ao contrário, devemos fazê-lo, porque é coisa boa e útil, e altamente recomendada pela Igreja, sendo eles os amigos de Deus e nossos intercessores junto a Ele.*
+
+**19.** Sendo Jesus Cristo o nosso único Mediador junto a Deus, por que recorremos também à mediação de Maria santíssima e dos Santos?
+
+*Jesus Cristo é o nosso Mediador junto a Deus, na medida em que, sendo verdadeiro Deus e verdadeiro Homem, Ele só, em virtude dos próprios méritos, nos reconciliou com Deus e nos obtém todas as graças. A Virgem e os Santos, por sua vez, em virtude dos méritos de Jesus Cristo e pela caridade que os une a Deus e a nós, ajudam-nos com sua intercessão a obter as graças que pedimos. E este é um dos grandes bens da comunhão dos Santos.*
+
+**20.** Podemos honrar também as sagradas imagens de Jesus Cristo e dos Santos?
+
+*Sim, porque a honra que se presta às sagradas imagens de Jesus Cristo e dos Santos refere-se às suas próprias pessoas.*
+
+**21.** E as relíquias dos Santos podem ser honradas?
+
+*Sim, também as relíquias dos Santos devem ser honradas, porque os seus corpos foram membros vivos de Jesus Cristo e templos do Espírito Santo, e hão de ressurgir gloriosos para a vida eterna.*
+
+**22.** Que diferença há entre o culto que prestamos a Deus e o culto que prestamos aos Santos?
+
+*Entre o culto que prestamos a Deus e o culto que prestamos aos Santos há esta diferença: a Deus adoramos por sua infinita excelência; os Santos, ao contrário, não os adoramos, mas os honramos e veneramos como amigos de Deus e nossos intercessores junto a Ele. O culto que se presta a Deus chama-se latria, isto é, de adoração; e o culto que se presta aos Santos chama-se dulia, isto é, de veneração aos servos de Deus; o culto particular que prestamos a Maria santíssima chama-se hiperdulia, isto é, de especialíssima veneração, como a Mãe de Deus.*
+
+## § 2. Do segundo mandamento
+
+**23.** O que nos proíbe o segundo mandamento: Não tomarás o nome de Deus em vão?
+
+*O segundo mandamento, Não tomarás o nome de Deus em vão, nos proíbe: 1.º tomar o nome de Deus sem respeito; 2.º blasfemar contra Deus, contra a santíssima Virgem e contra os Santos; 3.º fazer juramentos falsos, ou desnecessários, ou de qualquer modo ilícitos.*
+
+**24.** Que quer dizer tomar o nome de Deus sem respeito?
+
+*Tomar o nome de Deus sem respeito quer dizer pronunciar este santo nome, e tudo o que se refere de modo especial ao próprio Deus, como o nome de Jesus, de Maria e dos Santos, na ira, por brincadeira, ou de outro modo pouco reverente.*
+
+**25.** O que é a blasfêmia?
+
+*A blasfêmia é um pecado horrível, que consiste em palavras ou atos de desprezo ou de maldição contra Deus, a Virgem, os Santos, ou contra as coisas santas.*
+
+**26.** Há diferença entre a blasfêmia e a imprecação?
+
+*Há diferença, porque com a blasfêmia se amaldiçoa, ou se deseja o mal, a Deus, à Nossa Senhora, aos Santos; ao passo que, com a imprecação, se amaldiçoa, ou se deseja o mal, a si mesmo ou ao próximo.*
+
+**27.** O que é o juramento?
+
+*O juramento é chamar a Deus como testemunha da verdade daquilo que se diz, ou se promete.*
+
+**28.** Está sempre proibido jurar?
+
+*Não está sempre proibido jurar; é lícito e até honroso a Deus quando há necessidade e o juramento é feito com verdade, com discernimento e com justiça.*
+
+**29.** Quando não se jura com verdade?
+
+*Quando se afirma sob juramento aquilo que se sabe, ou se crê, ser falso; e quando sob juramento se promete fazer aquilo que não se tem intenção de cumprir.*
+
+**30.** Quando não se jura com discernimento?
+
+*Quando se jura sem prudência e sem madura consideração, ou por coisas de pouca importância.*
+
+**31.** Quando não se jura com justiça?
+
+*Quando se jura fazer uma coisa que não seja justa ou lícita, como vingar-se, roubar e outras coisas semelhantes.*
+
+**32.** Somos obrigados a manter o juramento de fazer coisas injustas ou ilícitas?
+
+*Não só não somos obrigados, mas pecaríamos fazendo-as, porque são proibidas pela lei de Deus ou da Igreja.*
+
+**33.** Quem jura falsamente, que pecado comete?
+
+*Quem jura falsamente comete pecado mortal, porque desonra gravemente a Deus, verdade infinita, chamando-O como testemunha da falsidade.*
+
+**34.** O que nos ordena o segundo mandamento?
+
+*O segundo mandamento nos ordena honrar o santo nome de Deus e cumprir, além dos juramentos, também os votos.*
+
+**35.** O que é o voto?
+
+*O voto é uma promessa que se faz a Deus de uma coisa boa, e para nós possível, e melhor que a coisa contrária, à qual nos obrigamos como se nos fosse ordenada.*
+
+**36.** Se a observância do voto resultar em todo ou em parte muito difícil, que se deve fazer?
+
+*Pode-se pedir a comutação ou a dispensa ao próprio Bispo, ou ao Sumo Pontífice, segundo a qualidade do voto.*
+
+**37.** É pecado transgredir os votos?
+
+*Transgredir os votos é pecado; e por isso não devemos fazer votos sem madura reflexão e, ordinariamente, sem o conselho do confessor ou de outra pessoa prudente, para não nos expor ao perigo de pecar.*
+
+**38.** Podem-se fazer votos a Nossa Senhora e aos Santos?
+
+*Os votos só se fazem a Deus; pode-se, porém, prometer a Deus fazer alguma coisa em honra de Nossa Senhora ou dos Santos.*
+
+## § 3. Do terceiro mandamento
+
+**39.** O que nos ordena o terceiro mandamento: Lembra-te de santificar as festas?
+
+*O terceiro mandamento, Lembra-te de santificar as festas, nos ordena honrar a Deus com obras de culto nos dias de festa.*
+
+**40.** Quais são os dias de festa?
+
+*Na antiga lei eram os sábados e outros dias particularmente solenes para o povo hebreu; na lei nova são os domingos e outras festividades estabelecidas pela Igreja.*
+
+**41.** Por que, na lei nova, se santifica o domingo em vez do sábado?
+
+*O domingo, que significa dia do Senhor, foi substituído ao sábado porque em tal dia ressuscitou Jesus Cristo, Nosso Senhor.*
+
+**42.** Que obra de culto nos é mandada nos dias de festa?
+
+*Nos é mandado assistir devotamente ao santo sacrifício da Missa.*
+
+**43.** Com que outras obras santifica um bom cristão as festas?
+
+*O bom cristão santifica as festas: 1.º assistindo à Doutrina cristã, às pregações e aos divinos ofícios; 2.º recebendo com frequência, com as devidas disposições, os sacramentos da Penitência e da Eucaristia; 3.º exercitando-se na oração e nas obras de cristã caridade para com o próximo.*
+
+**44.** O que nos proíbe o terceiro mandamento?
+
+*O terceiro mandamento nos proíbe as obras servis e qualquer obra que nos impeça o culto de Deus.*
+
+**45.** Quais são as obras servis proibidas nos dias de festa?
+
+*As obras servis proibidas nos dias de festa são as chamadas obras manuais, isto é, aqueles trabalhos materiais em que tem parte mais o corpo do que o espírito, como aqueles que ordinariamente fazem os criados, os operários e os artesãos.*
+
+**46.** Que pecado se comete trabalhando em dia de festa?
+
+*Trabalhando em dia de festa comete-se pecado mortal; escusa, porém, da culpa grave a brevidade do tempo empregado.*
+
+**47.** Não há nenhuma obra servil permitida nos dias de festa?
+
+*Nos dias de festa são permitidas aquelas obras que são necessárias à vida ou ao serviço de Deus, e aquelas que se fazem por uma causa grave, pedindo-se licença, se possível, ao próprio pároco.*
+
+**48.** Com que fim, nas festas, são proibidas as obras servis?
+
+*São proibidas nas festas as obras servis para que possamos melhor dedicar-nos ao divino culto e à salvação da nossa alma, e descansar das fadigas. Por isso não é proibido algum honesto divertimento.*
+
+**49.** Que outras coisas devemos evitar sobretudo nas festas?
+
+*Nas festas devemos evitar sobretudo o pecado e tudo o que nos pode induzir ao pecado, como os divertimentos e os encontros perigosos.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-terza-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-terza-capo-iii.md
@@ -1,0 +1,293 @@
+# Capítulo III — Dos mandamentos que dizem respeito ao próximo
+
+## § 1. Do quarto mandamento
+
+**1.** O que nos ordena o quarto mandamento: Honra teu pai e tua mãe?
+
+*O quarto mandamento, Honra teu pai e tua mãe, nos ordena respeitar o pai e a mãe, obedecer-lhes em tudo o que não seja pecado e ajudá-los em suas necessidades espirituais e temporais.*
+
+**2.** O que nos proíbe o quarto mandamento?
+
+*O quarto mandamento nos proíbe ofender os pais com palavras, com obras e de qualquer outro modo.*
+
+**3.** Sob o nome de pai e mãe, que outras pessoas compreende este mandamento?
+
+*Este mandamento, sob o nome de pai e mãe, compreende também todos os superiores, tanto eclesiásticos como seculares, aos quais, portanto, devemos obedecer e respeitar.*
+
+**4.** Donde vem aos pais a autoridade de mandar nos filhos, e a obrigação dos filhos de obedecer-lhes?
+
+*A autoridade que os pais têm de mandar nos filhos, e a obrigação dos filhos de obedecer, vem de Deus, que constituiu e ordenou a família, a fim de que nela o homem encontre os primeiros meios necessários ao seu aperfeiçoamento material e espiritual.*
+
+**5.** Os pais têm deveres para com os filhos?
+
+*Os pais têm o dever de amar, alimentar e sustentar os seus filhos, prover à sua educação religiosa e civil, dar-lhes bom exemplo, afastá-los das ocasiões de pecado, corrigi-los de suas faltas e ajudá-los a abraçar o estado para o qual são chamados por Deus.*
+
+**6.** Deus nos deu o exemplo de família perfeita?
+
+*Deus nos deu o exemplo de família perfeita na Sagrada Família, na qual Jesus Cristo viveu sujeito a Maria santíssima e a São José até os trinta anos, isto é, até quando começou a exercer a missão a Ele confiada pelo Eterno Pai de pregar o Evangelho.*
+
+**7.** Se as famílias vivessem sozinhas, separadas umas das outras, poderiam prover a todas as suas necessidades materiais e morais?
+
+*Se as famílias vivessem sozinhas, separadas umas das outras, não poderiam prover às próprias necessidades; e por isso é necessário que se tenham unido em sociedade civil, a fim de ajudar-se mutuamente para o aperfeiçoamento e a felicidade comum.*
+
+**8.** O que é a sociedade civil?
+
+*A sociedade civil é a união de muitas famílias, dependentes da autoridade de um chefe, para ajudar-se mutuamente a alcançar o aperfeiçoamento mútuo e a felicidade temporal.*
+
+**9.** Donde vem à sociedade civil a autoridade que a governa?
+
+*A autoridade que governa a sociedade civil vem de Deus, que a quer constituída para o bem comum.*
+
+**10.** Há obrigação de respeitar e obedecer à autoridade que governa a sociedade civil?
+
+*Sim, todos os que pertencem à sociedade civil têm a obrigação de respeitar e obedecer à autoridade, porque ela vem de Deus, e porque assim o exige o bem comum.*
+
+**11.** Devem-se respeitar todas as leis impostas pela autoridade civil?
+
+*Devem-se respeitar todas as leis que a autoridade civil impõe, contanto que não sejam contrárias à lei de Deus, segundo o mandamento e o exemplo de Nosso Senhor Jesus Cristo.*
+
+**12.** Além do respeito e da obediência às leis impostas pela autoridade, têm os que fazem parte da sociedade civil outros deveres?
+
+*Aqueles que fazem parte da sociedade civil têm, além da obrigação do respeito e da obediência às leis, o dever de viver em concórdia e de empenhar-se, cada um com os meios e forças próprias, para que ela seja virtuosa, pacífica, ordeira e próspera, para vantagem comum.*
+
+## § 2. Do quinto mandamento
+
+**13.** O que proíbe o quinto mandamento: Não matarás?
+
+*O quinto mandamento, Não matarás, proíbe dar a morte, bater, ferir ou fazer qualquer outro dano ao próximo no corpo, seja por si mesmo, seja por meio de outros; como também ofendê-lo com palavras injuriosas e querer-lhe mal. Neste mandamento Deus proíbe também o dar-se a morte a si mesmo, isto é, o suicídio.*
+
+**14.** Por que é pecado grave matar o próximo?
+
+*Porque o homicida usurpa temerariamente o direito que só Deus tem sobre a vida do homem; porque destrói a segurança do convívio humano; e porque tira do próximo a vida, que é o maior bem natural que ele tem sobre a terra.*
+
+**15.** Há casos em que seja lícito matar o próximo?
+
+*É lícito matar o próximo quando se combate em uma guerra justa; quando se executa, por ordem da autoridade suprema, a condenação de morte em pena de algum delito; e, enfim, quando se trata de necessária e legítima defesa da vida contra um injusto agressor.*
+
+**16.** Deus, no quinto mandamento, proíbe também causar dano à vida espiritual do próximo?
+
+*Sim, Deus, no quinto mandamento, proíbe também causar dano à vida espiritual do próximo com o escândalo.*
+
+**17.** O que é o escândalo?
+
+*O escândalo é qualquer dito, ato ou omissão que se torna ocasião para outros cometerem pecados.*
+
+**18.** É pecado grave o escândalo?
+
+*O escândalo é um pecado grave, porque tende a destruir a maior obra de Deus, que é a redenção, com a perda das almas; dá ao próximo a morte da alma, tirando-lhe a vida da graça, que é mais preciosa do que a vida do corpo; e é causa de uma multidão de pecados. Por isso Deus ameaça os escandalosos com os mais severos castigos.*
+
+**19.** Por que, no quinto mandamento, Deus proíbe dar-se a morte a si mesmo, isto é, o suicídio?
+
+*No quinto mandamento Deus proíbe o suicídio porque o homem não é dono da sua vida, como não o é da dos outros. E a Igreja pune o suicida com a privação da sepultura eclesiástica.*
+
+**20.** Está proibido no quinto mandamento também o duelo?
+
+*Sim, no quinto mandamento está proibido também o duelo, porque o duelo participa da malícia do suicídio e do homicídio; e é excomungado todo aquele que voluntariamente dele participa, ainda que apenas como simples espectador.*
+
+**21.** Está também proibido o duelo quando seja excluído o perigo de morte?
+
+*Está também proibido este duelo, porque não somente não podemos matar, mas nem mesmo ferir voluntariamente a nós mesmos e aos outros.*
+
+**22.** A defesa da honra pode escusar o duelo?
+
+*Não, porque não é verdade que no duelo se repare a ofensa, e porque não se pode reparar a honra com uma ação injusta, irracional e bárbara, qual é o duelo.*
+
+**23.** O que nos ordena o quinto mandamento?
+
+*O quinto mandamento nos ordena perdoar aos nossos inimigos e querer bem a todos.*
+
+**24.** O que deve fazer quem danificou o próximo na vida do corpo ou na da alma?
+
+*Quem danificou o próximo não basta que se confesse, mas deve também reparar o mal que fez, ressarcindo ao próximo os danos causados, retratando os erros ensinados e dando bons exemplos.*
+
+## § 3. Do sexto e do nono mandamentos
+
+**25.** O que nos proíbe o sexto mandamento: Não pecarás contra a castidade?
+
+*O sexto mandamento, Não pecarás contra a castidade, nos proíbe todo ato, todo olhar, todo discurso contrário à castidade, e a infidelidade no matrimônio.*
+
+**26.** O que proíbe o nono mandamento?
+
+*O nono mandamento proíbe expressamente todo desejo contrário à fidelidade que os cônjuges juraram um ao outro ao contrair matrimônio; e proíbe também todo pensamento ou desejo culpável de ação vedada pelo sexto mandamento.*
+
+**27.** É um grande pecado a impureza?
+
+*É um pecado gravíssimo e abominável diante de Deus e dos homens; envilece o homem à condição dos brutos, arrasta-o a muitos outros pecados e vícios, e provoca os mais terríveis castigos nesta vida e na outra.*
+
+**28.** São pecados todos os pensamentos que nos vêm à mente contra a pureza?
+
+*Os pensamentos que nos vêm à mente contra a pureza, por si mesmos, não são pecados, mas antes tentações e incentivos ao pecado.*
+
+**29.** Quando é que são pecados os maus pensamentos?
+
+*Os maus pensamentos, mesmo ineficazes, são pecados quando culposamente lhes damos motivo, ou consentimos neles, ou nos expomos ao perigo próximo de neles consentir.*
+
+**30.** O que nos ordenam o sexto e o nono mandamentos?
+
+*O sexto mandamento nos ordena ser castos e modestos nos atos, nos olhares, no porte e nas palavras. O nono mandamento nos ordena ser castos e puros também no interior, isto é, na mente e no coração.*
+
+**31.** O que nos convém fazer para observar o sexto e o nono mandamentos?
+
+*Para bem observar o sexto e o nono mandamentos, devemos orar com frequência e de coração a Deus, ser devotos de Maria Virgem, Mãe da pureza, lembrar-nos de que Deus nos vê, pensar na morte, nos castigos divinos, na paixão de Jesus Cristo, custodiar os nossos sentidos, praticar a mortificação cristã e frequentar, com as devidas disposições, os sacramentos.*
+
+**32.** O que devemos fugir para mantermo-nos castos?
+
+*Para mantermo-nos castos, convém fugir do ócio, das más companhias, da leitura de livros e jornais maus, da intemperança, do olhar imagens indecentes, dos espetáculos licenciosos, das conversações perigosas e de todas as demais ocasiões de pecado.*
+
+## § 4. Do sétimo mandamento
+
+**33.** O que nos proíbe o sétimo mandamento: Não furtarás?
+
+*O sétimo mandamento, Não furtarás, proíbe tomar e reter injustamente as coisas alheias e causar dano ao próximo nos seus bens, de qualquer outro modo.*
+
+**34.** Que quer dizer furtar?
+
+*Quer dizer tomar injustamente as coisas alheias, contra a vontade do dono, isto é, quando este tem toda a razão e o direito de não querer ser delas privado.*
+
+**35.** Por que se proíbe furtar?
+
+*Porque se peca contra a justiça, e se faz injúria ao próximo, tomando e retendo, contra o seu direito e a sua vontade, aquilo que lhe pertence.*
+
+**36.** O que são as coisas alheias?
+
+*É tudo aquilo que pertence ao próximo, do qual ele tem a propriedade ou o uso, ou que conserva em depósito.*
+
+**37.** De quantos modos se toma injustamente as coisas dos outros?
+
+*De dois modos: pelo furto e pela rapina.*
+
+**38.** Como se comete o furto?
+
+*O furto comete-se tomando ocultamente as coisas dos outros.*
+
+**39.** Como se comete a rapina?
+
+*A rapina comete-se tomando com violência e manifestamente as coisas dos outros.*
+
+**40.** Em que casos se pode tomar as coisas dos outros sem fazer pecado?
+
+*Quando o dono não fosse contrário, ou quando injustamente não quisesse, como seria o caso de quem se encontrasse em extrema necessidade, contanto que tomasse somente o que lhe é estritamente necessário para suprir a urgente e extrema necessidade.*
+
+**41.** Só com o furto e com a rapina se prejudica o próximo nos bens?
+
+*Prejudica-se também com a fraude, com a usura e com qualquer outra injustiça contra os seus bens.*
+
+**42.** Como se comete a fraude?
+
+*A fraude comete-se enganando o próximo no comércio com pesos, medidas ou moedas falsas e com mercadorias defeituosas; falsificando escrituras e documentos; em suma, fazendo enganos nas compras, nas vendas e em qualquer outro contrato, e também quando não se quer dar o justo e o combinado.*
+
+**43.** De que modo se comete a usura?
+
+*A usura comete-se exigindo, sem legítimo título, um juro ilícito por uma soma emprestada, abusando da necessidade e da ignorância alheias.*
+
+**44.** Que outras injustiças se cometem contra os bens do próximo?
+
+*Fazendo-o perder injustamente o que tem; danificando-o em suas posses; não trabalhando conforme o dever; não pagando, por malícia, as dívidas e os salários devidos; ferindo ou matando animais que lhe pertencem; estragando as coisas recebidas em custódia; impedindo a alguém de obter um ganho justo; favorecendo os ladrões; recebendo, ocultando ou comprando coisa furtada.*
+
+**45.** É pecado grave furtar?
+
+*É um pecado grave contra a justiça, quando se trata de matéria grave, sendo coisa muito importante que seja respeitado o direito que cada um tem sobre seus bens; e isto para o bem dos indivíduos, das famílias e da sociedade.*
+
+**46.** Quando é grave a matéria do furto?
+
+*É grave quando se subtrai coisa de valor relevante, e também quando, subtraindo-se coisa de pouca monta, o próximo sofre grave dano.*
+
+**47.** O que nos ordena o sétimo mandamento?
+
+*O sétimo mandamento nos ordena respeitar os bens dos outros, dar o justo salário aos operários e observar a justiça em tudo o que diz respeito à propriedade alheia.*
+
+**48.** Quem pecou contra o sétimo mandamento, basta que se confesse?
+
+*Quem pecou contra o sétimo mandamento não basta que se confesse, mas é preciso que faça o que pode para restituir as coisas alheias e ressarcir os danos.*
+
+**49.** O que é o ressarcimento dos danos?
+
+*O ressarcimento dos danos é a compensação que se deve dar ao próximo pelos frutos e ganhos perdidos por causa do furto e das demais injustiças cometidas em seu detrimento.*
+
+**50.** A quem se deve restituir as coisas furtadas?
+
+*A quem se furtou; a seus herdeiros, se ele tiver morrido; e, se isto for verdadeiramente impossível, deve-se aplicar o seu valor em benefício dos pobres e de obras pias.*
+
+**51.** O que se deve fazer quando se encontra alguma coisa de grande valor?
+
+*Deve-se empregar grande diligência para encontrar o dono e restituí-la fielmente.*
+
+## § 5. Do oitavo mandamento
+
+**52.** O que nos proíbe o oitavo mandamento: Não levantarás falso testemunho?
+
+*O oitavo mandamento, Não levantarás falso testemunho, nos proíbe atestar o falso em juízo; e proíbe também a detração ou murmuração, a calúnia, a adulação, o juízo e a suspeita temerária, e toda sorte de mentira.*
+
+**53.** O que é a detração ou murmuração?
+
+*A detração ou murmuração é um pecado que consiste em manifestar, sem justo motivo, os pecados e defeitos alheios.*
+
+**54.** O que é a calúnia?
+
+*A calúnia é um pecado que consiste em atribuir maliciosamente ao próximo culpas e defeitos que ele não tem.*
+
+**55.** O que é a adulação?
+
+*A adulação é um pecado que consiste em enganar alguém falando falsamente bem dele ou de outros, com o fim de obter alguma vantagem.*
+
+**56.** O que é o juízo ou suspeita temerária?
+
+*O juízo ou suspeita temerária é um pecado que consiste em julgar ou suspeitar mal dos outros sem um justo fundamento.*
+
+**57.** O que é a mentira?
+
+*A mentira é um pecado que consiste em afirmar como verdadeiro ou como falso, em palavras ou atos, aquilo que não se crê ser tal.*
+
+**58.** De quantas espécies é a mentira?
+
+*A mentira é de três espécies: jocosa, oficiosa e prejudicial.*
+
+**59.** Qual é a mentira jocosa?
+
+*A mentira jocosa é aquela com que se mente por gracejo e sem prejuízo de ninguém.*
+
+**60.** Qual é a mentira oficiosa?
+
+*A mentira oficiosa é a afirmação do falso para utilidade própria ou alheia, sem prejuízo de ninguém.*
+
+**61.** Qual é a mentira prejudicial?
+
+*A mentira prejudicial é a afirmação do falso com prejuízo do próximo.*
+
+**62.** É alguma vez lícito dizer mentira?
+
+*Nunca é lícito dizer mentira, nem por gracejo, nem para proveito próprio ou alheio, sendo coisa por si mesma má.*
+
+**63.** Que pecado é a mentira?
+
+*A mentira, quando é jocosa ou oficiosa, é pecado venial; quando é prejudicial, é pecado mortal, se o dano que causa é grave.*
+
+**64.** É sempre necessário dizer tudo como se pensa?
+
+*Não é sempre necessário, especialmente quando quem interroga não tem o direito de saber o que pergunta.*
+
+**65.** Quem pecou contra o oitavo mandamento, basta que se confesse?
+
+*Quem pecou contra o oitavo mandamento não basta que se confesse, mas é obrigado também a retratar o que disse caluniando o próximo e a reparar, do melhor modo que puder, os danos que lhe causou.*
+
+**66.** O que nos ordena o oitavo mandamento?
+
+*O oitavo mandamento nos ordena dizer, a tempo e lugar, a verdade, e interpretar em bem, quanto possível, as ações do nosso próximo.*
+
+## § 6. Do décimo mandamento
+
+**67.** O que nos proíbe o décimo mandamento: Não cobiçarás as coisas alheias?
+
+*O décimo mandamento, Não cobiçarás as coisas alheias, proíbe o desejo de privar outros de seus bens e o desejo de adquirir bens por meios injustos.*
+
+**68.** Por que Deus proíbe também o desejo das coisas alheias?
+
+*Deus nos proíbe os desejos desordenados das coisas alheias, porque quer que nós, mesmo internamente, sejamos justos e nos mantenhamos cada vez mais afastados das obras injustas.*
+
+**69.** O que nos ordena o décimo mandamento?
+
+*O décimo mandamento nos ordena contentar-nos com o estado em que Deus nos colocou e suportar com paciência a pobreza, quando Deus nos quiser em tal estado.*
+
+**70.** Como pode o cristão estar contente no estado de pobreza?
+
+*O cristão pode estar contente até mesmo no estado de pobreza, considerando que o supremo bem é a consciência pura e tranquila; que a nossa verdadeira pátria é o céu; e que Jesus Cristo fez-se pobre por amor de nós e prometeu um prêmio especial a todos os que suportam com paciência a pobreza.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-terza-capo-iv.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-terza-capo-iv.md
@@ -1,0 +1,179 @@
+# Capítulo IV — Dos preceitos da Igreja
+
+## § 1. Dos preceitos da Igreja em geral
+
+**1.** Além dos mandamentos de Deus, o que mais devemos observar?
+
+*Além dos mandamentos de Deus, devemos observar os preceitos da Igreja.*
+
+**2.** Somos obrigados a obedecer à Igreja?
+
+*Sem dúvida, somos obrigados a obedecer à Igreja, porque o próprio Jesus Cristo o ordena, e porque os preceitos da Igreja ajudam a observar os mandamentos de Deus.*
+
+**3.** Quando começa a obrigação de observar os preceitos da Igreja?
+
+*A obrigação de observar os preceitos da Igreja, geralmente, começa com o uso da razão.*
+
+**4.** É pecado transgredir um preceito da Igreja?
+
+*Transgredir advertidamente um preceito da Igreja em matéria grave é pecado mortal.*
+
+**5.** Quem pode dispensar de um preceito da Igreja?
+
+*De um preceito da Igreja só pode dispensar o Papa, e quem dele tiver recebido as faculdades.*
+
+**6.** Quantos e quais são os preceitos da Igreja?
+
+*Os Preceitos da Igreja são cinco:*
+
+*1.º Ouvir Missa todos os domingos e nas demais festas de guarda.*
+
+*2.º Jejuar na Quaresma, nas Quatro Têmporas e nas vigílias prescritas; não comer carne nos dias proibidos.*
+
+*3.º Confessar-se ao menos uma vez por ano, e comungar pela Páscoa da Ressurreição, cada um na própria paróquia.*
+
+*4.º Pagar os dízimos devidos à Igreja, segundo os costumes.*
+
+*5.º Não celebrar núpcias nos tempos proibidos, isto é, do primeiro domingo do Advento até a Epifania, e do primeiro dia da Quaresma até a oitava de Páscoa.*
+
+## § 2. Do primeiro preceito da Igreja
+
+**7.** O que nos ordena o primeiro preceito ou mandamento da Igreja: Ouvir Missa todos os domingos e nas demais festas de guarda?
+
+*O primeiro preceito da Igreja, Ouvir Missa todos os domingos e nas demais festas de guarda, nos ordena assistir devotamente à santa Missa em todos os domingos e nas demais festas de preceito.*
+
+**8.** Qual é a Missa à qual a Igreja deseja que se assista nos domingos e nas demais festas de preceito?
+
+*A Missa à qual a Igreja deseja que, se possível, se assista nos domingos e nas demais festas de preceito é a Missa paroquial.*
+
+**9.** Por que a Igreja recomenda aos fiéis que assistam à Missa paroquial?
+
+*A Igreja recomenda aos fiéis que assistam à Missa paroquial: 1.º para que aqueles que pertencem à mesma paróquia se unam para orar juntos com o pároco, que é a sua cabeça; 2.º para que os paroquianos participem mais intensamente do santo sacrifício, que é aplicado principalmente por eles; 3.º para que ouçam as verdades do Evangelho, que os párocos têm obrigação de expor na santa Missa; 4.º para que conheçam as prescrições e os avisos que se publicam na referida Missa.*
+
+**10.** O que quer dizer domingo?
+
+*Domingo quer dizer dia do Senhor, isto é, dia especialmente consagrado ao serviço divino.*
+
+**11.** Por que, no primeiro mandamento da Igreja, se faz menção especial do domingo?
+
+*No primeiro mandamento da Igreja faz-se menção especial do domingo porque ele é a festa principal entre os cristãos, como o sábado era a festa principal entre os hebreus, instituída pelo próprio Deus.*
+
+**12.** Que outras festas a Igreja instituiu?
+
+*A Igreja instituiu também as festas de Nosso Senhor, da Santíssima Virgem, dos Anjos e dos Santos.*
+
+**13.** Por que a Igreja instituiu outras festas de Nosso Senhor?
+
+*A Igreja instituiu outras festas de Nosso Senhor em memória dos seus divinos mistérios.*
+
+**14.** Por que foram instituídas as festas da Santíssima Virgem, dos Anjos e dos Santos?
+
+*As festas da santíssima Virgem, dos Anjos e dos Santos foram instituídas: 1.º em memória das graças que Deus lhes fez, e para agradecer por elas à divina bondade; 2.º a fim de que os honremos, imitemos os seus exemplos e sejamos ajudados pelas suas orações.*
+
+## § 3. Do segundo preceito da Igreja
+
+**15.** O que nos ordena o segundo preceito da Igreja com as palavras: Jejuar nos dias prescritos?
+
+*O segundo preceito da Igreja, com as palavras: Jejuar nos dias prescritos, nos ordena observar o jejum: 1.º na Quaresma; 2.º em alguns dias do Advento, onde isto é prescrito; 3.º nas Quatro Têmporas; 4.º em algumas vigílias.*
+
+**16.** Em que consiste o jejum?
+
+*O jejum consiste em fazer uma só refeição ao dia e em abster-se dos alimentos proibidos.*
+
+**17.** Nos dias de jejum, pode-se fazer à noite uma pequena refeição?
+
+*Por condescendência da Igreja, pode-se, nos dias de jejum, fazer um pouco de refeição à noite.*
+
+**18.** Para que serve o jejum?
+
+*O jejum serve para melhor dispor-nos à oração, fazer penitência dos pecados cometidos e preservar-nos de cometer novos.*
+
+**19.** Quem é obrigado ao jejum?
+
+*Ao jejum estão obrigados todos os cristãos que completaram vinte e um anos e que não estão dispensados ou escusados por legítimo impedimento.*
+
+**20.** Aqueles que não têm a obrigação do jejum estão totalmente isentos da mortificação?
+
+*Aqueles que não têm a obrigação do jejum não estão totalmente isentos da mortificação, porque todos somos obrigados a fazer penitência.*
+
+**21.** Com que fim foi instituída a Quaresma?
+
+*A Quaresma foi instituída para imitar, de algum modo, o rigoroso jejum de quarenta dias que Jesus Cristo fez no deserto, e para preparar-nos, por meio da penitência, a celebrar santamente a Páscoa.*
+
+**22.** Com que fim foi instituído o jejum do Advento?
+
+*O jejum do Advento foi instituído para dispor-nos a celebrar santamente o Natal de Nosso Senhor Jesus Cristo.*
+
+**23.** Com que fim foi instituído o jejum das Quatro Têmporas?
+
+*O jejum das Quatro Têmporas foi instituído para consagrar cada estação do ano com a penitência de alguns dias; para pedir a Deus a conservação dos frutos da terra; para agradecer-Lhe os frutos já dados; e para pedir-Lhe que dê à sua Igreja bons ministros, dos quais se faz a ordenação nos sábados das Quatro Têmporas.*
+
+**24.** Com que fim foi instituído o jejum das vigílias?
+
+*O jejum das vigílias foi instituído para preparar-nos a celebrar santamente as festas principais.*
+
+**25.** O que nos é proibido na sexta-feira e no sábado não dispensado?
+
+*Na sexta-feira e no sábado não dispensado, é-nos proibido comer carne, exceto em caso de necessidade.*
+
+**26.** Por que a Igreja quis que nos abstivéssemos de comer carne nesses dias?
+
+*A fim de que façamos penitência em cada semana, e principalmente na sexta-feira, em honra da Paixão, e no sábado, em memória da sepultura de Jesus Cristo e em honra de Maria Santíssima.*
+
+## § 4. Do terceiro preceito da Igreja
+
+**27.** O que nos manda a Igreja com as palavras do terceiro preceito: Confessar-se ao menos uma vez por ano?
+
+*Com as palavras do terceiro preceito, Confessar-se ao menos uma vez por ano, a Igreja obriga todos os cristãos que chegaram ao uso da razão a aproximar-se ao menos uma vez por ano do sacramento da Penitência.*
+
+**28.** Qual é o tempo mais oportuno para satisfazer ao preceito da confissão anual?
+
+*O tempo mais oportuno para satisfazer ao preceito da confissão anual é a Quaresma, segundo o uso introduzido e aprovado por toda a Igreja.*
+
+**29.** Por que a Igreja diz que nos confessemos ao menos uma vez por ano?
+
+*A Igreja diz: ao menos, para nos dar a conhecer o seu desejo de que nos aproximemos com maior frequência dos santos sacramentos.*
+
+**30.** É, portanto, coisa útil confessar-se com frequência?
+
+*É coisa utilíssima confessar-se com frequência, sobretudo porque é difícil que se confesse bem e se mantenha afastado do pecado mortal aquele que se confessa raramente.*
+
+**31.** O que nos prescreve a Igreja com as outras palavras do terceiro preceito: Comungar ao menos pela Páscoa da Ressurreição, cada um na própria paróquia?
+
+*Com as outras palavras do terceiro preceito, Comungar ao menos pela Páscoa da Ressurreição, cada um na própria paróquia, a Igreja obriga todos os cristãos que chegaram à idade da discrição a receber, todo ano, a santíssima Eucaristia na própria paróquia, durante o tempo pascal.*
+
+**32.** Somos, em outro tempo, fora da Páscoa, obrigados a comungar?
+
+*Estamos obrigados a comungar também em perigo de morte.*
+
+**33.** Por que se diz que comunguemos ao menos pela Páscoa?
+
+*Porque a Igreja deseja vivamente que não somente pela Páscoa da Ressurreição, mas com a maior frequência possível, nos aproximemos da santa Comunhão, que é o divino alimento das nossas almas.*
+
+**34.** Satisfaz-se este preceito com uma confissão ou comunhão sacrílega?
+
+*Quem fizesse uma confissão e comunhão sacrílegas não satisfaz ao terceiro preceito da Igreja, porque a intenção da Igreja é que se recebam esses sacramentos para o fim para o qual foram instituídos, isto é, para a nossa santificação.*
+
+## § 5. Do quarto preceito da Igreja
+
+**35.** Como se observa o quarto preceito da Igreja: Pagar os dízimos devidos à Igreja?
+
+*O quarto preceito, Pagar os dízimos devidos à Igreja, observa-se pagando aquelas ofertas ou contribuições que foram estabelecidas para reconhecer o supremo domínio que Deus tem sobre todas as coisas e para prover ao honesto sustento dos seus ministros.*
+
+**36.** Como se devem pagar os dízimos?
+
+*Os dízimos devem ser pagos das coisas e na forma que comporta o costume dos lugares.*
+
+## § 6. Do quinto preceito da Igreja
+
+**37.** O que nos proíbe a Igreja no quinto preceito: Não celebrar núpcias nos tempos proibidos?
+
+*No quinto preceito a Igreja não proíbe a celebração do sacramento do Matrimônio; mas somente a solenidade das núpcias do primeiro domingo do Advento até a Epifania, e do primeiro dia de Quaresma até a oitava de Páscoa.*
+
+**38.** Qual é a solenidade das núpcias que está proibida?
+
+*A solenidade proibida por este preceito consiste na Missa própria dos esposos, na bênção nupcial e na pompa extraordinária das núpcias.*
+
+**39.** Por que as demonstrações de pompa não convêm no Advento e na Quaresma?
+
+*As demonstrações de pompa não convêm no Advento e na Quaresma porque estes são tempos especialmente consagrados à penitência e à oração.*

--- a/content/books/pius-x-greater-catechism/pt-BR/parte-terza-capo-v.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/parte-terza-capo-v.md
@@ -1,0 +1,41 @@
+# Capítulo V — Dos deveres particulares do próprio estado e dos conselhos evangélicos
+
+## § 1. Dos deveres do próprio estado
+
+**1.** O que são os deveres do próprio estado?
+
+*Por deveres do próprio estado entendem-se aquelas obrigações particulares que cada um tem em virtude do estado, da condição e do ofício em que se encontra.*
+
+**2.** Quem impôs aos vários estados os seus deveres particulares?
+
+*O próprio Deus impôs aos vários estados os seus deveres particulares, porque eles derivam dos seus divinos mandamentos.*
+
+**3.** Explicai-me com algum exemplo como os deveres particulares derivam dos dez mandamentos.
+
+*No quarto mandamento, sob o nome de pai e mãe, entendem-se também todos os nossos superiores; e por isso daquele mandamento derivam todos os deveres de obediência, de amor e de respeito dos inferiores para com os seus superiores, e todos os deveres de vigilância que têm os superiores para com os seus inferiores.*
+
+**4.** De que mandamentos derivam os deveres dos artesãos, dos comerciantes, dos administradores de bens alheios e semelhantes?
+
+*Os deveres de fidelidade, de sinceridade, de justiça e de equidade que eles têm derivam do sétimo, do oitavo e do décimo mandamentos, que proíbem toda fraude, injustiça, negligência e duplicidade.*
+
+**5.** Os deveres das pessoas consagradas a Deus, de que mandamento derivam?
+
+*Os deveres das pessoas consagradas a Deus derivam do segundo mandamento, que ordena cumprir os votos e as promessas feitas a Deus, tendo tais pessoas obrigado-se desse modo à observância de todos ou de alguns dos conselhos evangélicos.*
+
+## § 2. Dos conselhos evangélicos
+
+**6.** O que são os conselhos evangélicos?
+
+*Os conselhos evangélicos são alguns meios sugeridos por Jesus Cristo no santo Evangelho para chegar à perfeição cristã.*
+
+**7.** Quais são os conselhos evangélicos?
+
+*Os conselhos evangélicos são: a pobreza voluntária, a castidade perpétua e a obediência em tudo aquilo que não seja pecado.*
+
+**8.** Para que servem os conselhos evangélicos?
+
+*Os conselhos evangélicos servem para facilitar a observância dos mandamentos e para assegurar melhor a eterna salvação.*
+
+**9.** Por que os conselhos evangélicos facilitam a observância dos mandamentos?
+
+*Os conselhos evangélicos facilitam a observância dos mandamentos porque nos ajudam a desapegar o coração do amor aos bens, aos prazeres e às honras, e assim nos afastam do pecado.*

--- a/content/books/pius-x-greater-catechism/pt-BR/prime-nozioni-capo-i.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/prime-nozioni-capo-i.md
@@ -1,0 +1,101 @@
+# Primeiras noções — Capítulo I. Das verdades principais de nossa santa Fé
+
+**1.** Fazei o sinal da Cruz.
+
+*Em nome do Pai e do Filho e do Espírito Santo. Assim seja.*
+
+**2.** Dizei-o em latim.
+
+*In nomine Patris et Filii et Spiritus Sancti. Amen.*
+
+**3.** Quem vos criou?
+
+*Criou-me Deus.*
+
+**4.** Para que fim Deus vos criou?
+
+*Deus criou-me para conhecê-Lo, amá-Lo e servi-Lo nesta vida, e depois gozá-Lo para sempre na outra.*
+
+**5.** Quem é Deus?
+
+*Deus é o Ser perfeitíssimo, Criador e Senhor do céu e da terra.*
+
+**6.** Existe um só Deus?
+
+*Sim, existe um só Deus.*
+
+**7.** Onde está Deus?
+
+*Deus está no céu, na terra e em todo lugar.*
+
+**8.** Deus vê tudo?
+
+*Sim, Deus vê tudo, até mesmo os nossos pensamentos.*
+
+**9.** Deus sempre existiu?
+
+*Deus sempre existiu e sempre existirá, porque é eterno.*
+
+**10.** Deus tem corpo como nós?
+
+*Deus não tem corpo, porque é um espírito puríssimo.*
+
+**11.** Quantas Pessoas há em Deus?
+
+*Em Deus há três Pessoas realmente distintas.*
+
+**12.** Como se chamam as três Pessoas divinas?
+
+*As três Pessoas divinas chamam-se Pai, Filho e Espírito Santo.*
+
+**13.** As Pessoas da Santíssima Trindade são iguais ou desiguais entre si?
+
+*As Pessoas da Santíssima Trindade são perfeitamente iguais, porque têm a mesma essência ou natureza divina.*
+
+**14.** Das três Pessoas divinas, qual se fez homem?
+
+*Das três Pessoas divinas, fez-se homem a segunda, isto é, o Filho.*
+
+**15.** De que modo o Filho de Deus se fez homem?
+
+*O Filho de Deus fez-se homem tomando um corpo e uma alma, como nós temos, no puríssimo seio de Maria Virgem, por obra do Espírito Santo.*
+
+**16.** Como se chama o Filho de Deus feito homem?
+
+*O Filho de Deus feito homem chama-se Jesus Cristo.*
+
+**17.** Quem é, portanto, Jesus Cristo?
+
+*Jesus Cristo é o Filho de Deus feito homem.*
+
+**18.** Por que o Filho de Deus se fez homem?
+
+*O Filho de Deus fez-se homem para nos salvar.*
+
+**19.** Que quer dizer: para nos salvar?
+
+*Para nos salvar quer dizer para nos livrar do pecado e do Inferno e para nos merecer a glória do Paraíso.*
+
+**20.** Que se goza no paraíso?
+
+*No paraíso goza-se para sempre da visão de Deus e de todo bem, sem padecer nenhuma espécie de mal.*
+
+**21.** A quem concede Deus o paraíso?
+
+*Deus concede o paraíso como prêmio àqueles que nesta vida O amam e O servem.*
+
+**22.** Que se sofre no inferno?
+
+*No inferno sofre-se para sempre a privação da visão de Deus, o fogo eterno e todo o mal, sem jamais ter alguma espécie de bem.*
+
+**23.** Quem é condenado ao inferno?
+
+*Ao inferno são condenados aqueles que nesta vida não quiseram amar nem servir a Deus e morrem impenitentes.*
+
+**24.** Que fez Jesus Cristo para nos salvar?
+
+*Jesus Cristo, para nos salvar, padeceu e morreu na cruz.*
+
+**25.** Depois da sua morte, Jesus Cristo ressuscitou?
+
+*Jesus Cristo, três dias depois da sua morte, ressuscitou glorioso e triunfante, para nunca mais morrer.*

--- a/content/books/pius-x-greater-catechism/pt-BR/prime-nozioni-capo-ii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/prime-nozioni-capo-ii.md
@@ -1,0 +1,133 @@
+# Primeiras noções — Capítulo II. Partes principais da Doutrina cristã
+
+**1.** Quais são as partes principais da Doutrina cristã?
+
+*As partes principais da Doutrina cristã são quatro, a saber: o Credo, o Pai-Nosso, os Mandamentos e os Sacramentos.*
+
+**2.** Dizei o Credo.
+
+*1.º Creio em Deus Pai todo-poderoso, Criador do céu e da terra.*
+
+*2.º E em Jesus Cristo, seu único Filho, Nosso Senhor.*
+
+*3.º O qual foi concebido pelo poder do Espírito Santo; nasceu da Virgem Maria.*
+
+*4.º Padeceu sob Pôncio Pilatos; foi crucificado, morto e sepultado.*
+
+*5.º Desceu à mansão dos mortos; ressuscitou ao terceiro dia.*
+
+*6.º Subiu ao Céu; está sentado à direita de Deus Pai todo-poderoso.*
+
+*7.º Donde há de vir a julgar os vivos e os mortos.*
+
+*8.º Creio no Espírito Santo.*
+
+*9.º Na santa Igreja Católica; na comunhão dos santos.*
+
+*10.º Na remissão dos pecados.*
+
+*11.º Na ressurreição da carne.*
+
+*12.º Na vida eterna. Amém.*
+
+**3.** Dizei o Pai-Nosso em português.
+
+*Pai-Nosso, que estais nos céus,*
+
+*1.º Santificado seja o vosso Nome.*
+
+*2.º Venha a nós o vosso Reino.*
+
+*3.º Seja feita a vossa vontade, assim na terra como no céu.*
+
+*4.º O pão nosso de cada dia nos dai hoje.*
+
+*5.º Perdoai-nos as nossas dívidas, assim como nós perdoamos aos nossos devedores.*
+
+*6.º E não nos deixeis cair em tentação.*
+
+*7.º Mas livrai-nos do mal. Assim seja.*
+
+**4.** Dizei o Pater Noster em latim.
+
+*Pater noster qui es in coelis,*
+
+*1.º Sanctificetur nomen tuum.*
+
+*2.º Adveniat regnum tuum.*
+
+*3.º Fiat voluntas tua, sicut in coelo et in terra.*
+
+*4.º Panem nostrum quotidianum da nobis hodie;*
+
+*5.º Et dimitte nobis debita nostra, sicut et nos dimittimus debitoribus nostris;*
+
+*6.º Et ne nos inducas in tentationem;*
+
+*7.º Sed libera nos a malo. Amen.*
+
+**5.** Dizei a Ave-Maria em português.
+
+*Deus te salve, ó Maria, cheia de graça. O Senhor é convosco. Bendita sois vós entre as mulheres, e bendito é o fruto do vosso ventre, Jesus. Santa Maria, Mãe de Deus, rogai por nós pecadores, agora e na hora da nossa morte. Assim seja.*
+
+**6.** Dizei a Ave-Maria em latim.
+
+*Ave, Maria, gratia plena. Dominus tecum. Benedicta tu in mulieribus et benedictus fructus ventris tui, Iesus. Sancta Maria, Mater Dei, ora pro nobis peccatoribus, nunc et in hora mortis nostrae. Amen.*
+
+**7.** Dizei o Glória em português.
+
+*Glória ao Pai, ao Filho e ao Espírito Santo, como era no princípio, agora e sempre, e pelos séculos dos séculos. Assim seja.*
+
+**8.** Dizei o Glória em latim.
+
+*Gloria Patri et Filio et Spiritui Sancto, sicut erat in principio et nunc et semper et in saecula saeculorum. Amen.*
+
+**9.** Quantos e quais são os mandamentos de Deus?
+
+*Os mandamentos de Deus são dez.*
+
+*Eu sou o Senhor teu Deus:*
+
+*1.º Não terás outro Deus diante de mim.*
+
+*2.º Não tomarás o nome de Deus em vão.*
+
+*3.º Lembra-te de santificar as festas.*
+
+*4.º Honra teu pai e tua mãe.*
+
+*5.º Não matarás.*
+
+*6.º Não pecarás contra a castidade.*
+
+*7.º Não furtarás.*
+
+*8.º Não levantarás falso testemunho.*
+
+*9.º Não desejarás a mulher do próximo.*
+
+*10.º Não cobiçarás as coisas alheias.*
+
+**10.** Quantos e quais são os preceitos da Igreja?
+
+*Os Preceitos da Igreja são cinco:*
+
+*1.º Ouvir Missa todos os domingos e nas demais festas de guarda.*
+
+*2.º Jejuar na Quaresima, nas Quatro Têmporas e nas vigílias prescritas; não comer carne nos dias proibidos.*
+
+*3.º Confessar-se ao menos uma vez por ano e comungar pela Páscoa da Ressurreição, na própria paróquia.*
+
+*4.º Pagar os dízimos devidos à Igreja, segundo os costumes.*
+
+*5.º Não celebrar núpcias nos tempos proibidos, isto é, do primeiro domingo do Advento até a Epifania, e do primeiro dia da Quaresma até a oitava de Páscoa.*
+
+**11.** Quantos e quais são os sacramentos?
+
+*Os Sacramentos são sete:*
+
+*1.º Batismo; 2.º Crisma; 3.º Eucaristia; 4.º Penitência; 5.º Extrema-Unção; 6.º Ordem Sacra; 7.º Matrimônio.*
+
+**12.** Quem instituiu estes sacramentos?
+
+*Foi Nosso Senhor Jesus Cristo quem os instituiu.*

--- a/content/books/pius-x-greater-catechism/pt-BR/prime-nozioni-capo-iii.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/prime-nozioni-capo-iii.md
@@ -1,0 +1,21 @@
+# Primeiras noções — Capítulo III. Atos de Fé, de Esperança, de Caridade e de Contrição
+
+**1.** Dizei o Ato de Fé.
+
+*Eu creio firmemente, porque assim revelou Deus, verdade infalível, à santa Igreja católica, e por meio dela o revela também a nós, que existe um só Deus em três Pessoas Divinas, iguais e distintas, que se chamam Pai, Filho e Espírito Santo; que o Filho se fez homem, tomando, por obra do Espírito Santo, carne e alma humana no seio da puríssima Virgem Maria; morreu por nós na cruz, ressuscitou, subiu ao céu, e de lá há de vir, no fim do mundo, a julgar todos os vivos e os mortos, para dar para sempre aos bons o paraíso e aos maus o inferno. E, ademais, pelo mesmo motivo, creio tudo o que crê e ensina a mesma santa Igreja.*
+
+**2.** Dizei o Ato de Esperança.
+
+*Meu Deus, porque sois onipotente e infinitamente bom e misericordioso, espero que, pelos méritos da paixão e morte de Jesus Cristo, nosso Salvador, me dareis a vida eterna, a qual Vós, fidelíssimo, prometestes a quem fizer obras de bom cristão, como me proponho a fazer com o Vosso santo auxílio.*
+
+**3.** Dizei o Ato de Caridade.
+
+*Meu Deus, porque sois Sumo e Perfeitíssimo Bem, eu Vos amo de todo o coração e sobre todas as coisas, e, antes do que ofender-Vos, estou disposto a perder qualquer outra coisa; e, por Vosso amor, amo também e quero amar o meu próximo como a mim mesmo.*
+
+**4.** Dizei o Ato de Contrição.
+
+*Meu Deus, por serdes Vós suma Bondade, e porque Vos amo sobre todas as coisas, arrependo-me e doí-me de verdadeiro coração de Vos ter ofendido, e proponho firmemente, com o Vosso santo auxílio, nunca mais pecar para o futuro, e em particular fugir das ocasiões próximas do pecado.*
+
+**5.** Dizei o Ato de Atrição e Contrição.
+
+*Ó meu Deus, arrependo-me e doí-me de verdadeiro coração de Vos ter ofendido. Arrependo-me pelo inferno que mereci e pelo paraíso que perdi; mas muito mais me arrependo, porque, pecando, ofendi um Deus tão bom, tão grande como sois Vós. Antes quisera ter morrido do que Vos ter ofendido; e proponho firmemente não pecar mais para o futuro e fugir das ocasiões próximas do pecado.*

--- a/content/books/pius-x-greater-catechism/pt-BR/translation-journal.md
+++ b/content/books/pius-x-greater-catechism/pt-BR/translation-journal.md
@@ -1,0 +1,117 @@
+# Diário de tradução — Catecismo Maior de São Pio X (1905) — pt-BR
+
+Fonte: `it/` — italiano canônico de 1905 (Wikisource, *Compendio della dottrina cristiana*).
+Alvo: `pt-BR/` — português brasileiro moderno, fiel ao registro catequético tradicional, conforme ao Acordo Ortográfico de 1990.
+
+## Termos-chave
+
+| Italiano | Português | Notas |
+|---|---|---|
+| Catechismo | Catecismo | |
+| dottrina cristiana | doutrina cristã | |
+| Capo | Capítulo | |
+| Parte | Parte | |
+| Simbolo apostolico | Símbolo Apostólico | |
+| Credo | Credo | Manter em itálico quando citado como nome próprio, como no original |
+| Pater noster | Pater Noster | Manter forma latina; "Pai-Nosso" apenas em contexto narrativo apropriado |
+| Ave Maria | Ave-Maria | Forma portuguesa hifenizada |
+| Gloria Patri | Glória ao Pai / Gloria Patri | "Glória ao Pai" no narrativo; "Gloria Patri" em contexto litúrgico |
+| Salve Regina | Salve Rainha | Forma portuguesa |
+| Angele Dei | Angele Dei (Anjo da Guarda) | Manter referência latina |
+| Spirito Santo | Espírito Santo | |
+| Santa Chiesa cattolica | Santa Igreja Católica | |
+| comunione dei santi | comunhão dos santos | |
+| risurrezione della carne | ressurreição da carne | |
+| vita eterna | vida eterna | |
+| peccato mortale | pecado mortal | |
+| peccato veniale | pecado venial | |
+| grazia | graça | |
+| paradiso | paraíso / céu | "céu" como recompensa final; "paraíso" para o estado |
+| inferno | inferno | |
+| purgatorio | purgatório | |
+| Romano Pontefice | Romano Pontífice | |
+| Papa | Papa | |
+| Vescovi | Bispos | |
+| sacerdote | sacerdote | |
+| chierico | clérigo | Em contexto da Missa ("S. / C."); pode-se manter "C." |
+| comandamenti | mandamentos | |
+| precetti | preceitos | |
+| Sacramento | Sacramento | |
+| Battesimo | Batismo | |
+| Cresima / Confermazione | Crisma / Confirmação | |
+| Eucaristia | Eucaristia | |
+| Penitenza | Penitência | |
+| Estrema Unzione | Extrema-Unção | Fiel à terminologia de 1905 |
+| Ordine Sacro | Ordem Sacra | |
+| Matrimonio | Matrimônio | |
+| Beatitudini | Bem-aventuranças | |
+| Novissimi | Novíssimos (morte, juízo, inferno, céu) | |
+| virtù teologali | virtudes teologais | |
+| virtù cardinali | virtudes cardeais | |
+| atto di contrizione | ato de contrição | |
+| Confiteor | Confiteor | Manter latim |
+| SS.mo Sacramento | Santíssimo Sacramento | Expandir a abreviação |
+| Maria SS.ma | Maria Santíssima / Virgem Maria | |
+| segno della Croce | sinal da Cruz | |
+| onnipotente | onipotente | |
+| Iddio | Deus | |
+| perfettissimo | perfeitíssimo | |
+| virtù teologali | virtudes teologais | Fé, Esperança, Caridade |
+| virtù cardinali | virtudes cardeais | Prudência, Justiça, Fortaleza, Temperança |
+| doni dello Spirito Santo | dons do Espírito Santo | Sabedoria, Entendimento, Conselho, Fortaleza, Ciência, Piedade, Temor de Deus |
+| Beatitudini evangeliche | Bem-aventuranças evangélicas | Forma tradicional: "Bem-aventurados os..."; "limpos de coração" (não "puros") |
+| opere di misericordia | obras de misericórdia | Corporais (sepultar os mortos, hospedar peregrinos) e espirituais (admoestar pecadores, suportar pessoas molestas) |
+| vizi capitali | vícios capitais | Soberba, Avareza, Luxúria, Ira, Gula, Inveja, Preguiça (não "acídia"; pt-BR catequético usa "Preguiça" para *accidia*) |
+| accidia | preguiça | Forma catequética tradicional pt-BR; vencida pela "diligência e fervor no serviço de Deus" |
+| peccati che gridano vendetta | pecados que clamam vingança | "clamar vingança na presença de Deus" para *gridar vendetta nel cospetto di Dio* |
+| peccati contro lo Spirito Santo | pecados contra o Espírito Santo | desespero da salvação, presunção, impugnar a verdade conhecida, inveja da graça alheia, obstinação, impenitência final |
+| Novissimi | Novíssimos | Morte, Juízo, Inferno, Paraíso (capitalizar como termos técnicos) |
+| giaculatorie | jaculatórias | Orações breves e fervorosas |
+| Angelus Domini | Angelus Domini | Manter latim litúrgico |
+| De profundis / Requiem | De profundis / Requiem | Manter latim litúrgico |
+| Pater Noster | Pater Noster | Manter latim quando citado como nome de oração; "Pai-Nosso" no narrativo |
+| mortificazione cristiana | cristã mortificação | Mantida a ordem do italiano para preservar registro |
+| mansueti | mansos | (Bem-aventurança) |
+| mondi di cuore | limpos de coração | Forma tradicional pt-BR (não "puros de coração") |
+| poveri di spirito | pobres de espírito | |
+| pacifici | pacíficos | "serão chamados filhos de Deus" |
+| sopportare le persone moleste | suportar as pessoas molestas | 6.ª obra de misericórdia espiritual |
+| ammonire i peccatori | admoestar os pecadores | 3.ª obra de misericórdia espiritual |
+| dar da bere agli assetati | dar de beber a quem tem sede | |
+| vestire gl’ignudi | vestir os nus | |
+| alloggiare i pellegrini | hospedar os peregrinos | |
+| seppellire i morti | sepultar os mortos | |
+| disperazione delle salute | desespero da salvação | |
+| impenitenza finale | impenitência final | |
+| gridar vendetta | clamar vingança | |
+| omicidio volontario | homicídio voluntário | |
+| fraudare la mercede agli operai | defraudar o salário dos trabalhadores | Forma moderna pt-BR de *fraudar a mercê dos operários* |
+
+## Regras de estilo
+
+- **Formato Q&A** preservado tal qual: `**N.** Pergunta?` linha em branco, depois `*Resposta.*` em itálico. Numeração por capítulo idêntica ao italiano.
+- **Subtítulos `§`** renderizados como `## § N. Cabeçalho` igual ao italiano.
+- **Texto litúrgico em latim** **nunca traduzido** — é a forma litúrgica real. Apenas as rubricas (instruções italianas como "*Per la mattina*") são traduzidas.
+- **Nomes de santos**: forma portuguesa padrão (São Pedro, São João Batista).
+- **Tom**: fiel ao registro catequético de 1905 — claro, direto, doutrinariamente preciso. Não modernizar para coloquial, mas também não usar pseudo-arcaísmos.
+- **Ortografia**: pós-Acordo Ortográfico de 1990 (sem trema, sem acento agudo em "ideia", etc.).
+- **Markdown**: não introduzir ênfase extra, não adicionar cabeçalhos além dos do original, não dividir parágrafos.
+
+## Decisões de tradução
+
+- Numeração de Q&A por capítulo segue o italiano (renumerado pelo Wikisource a partir da sequência original de ~993; consistente dentro de cada capítulo).
+- A carta de promulgação é traduzida em português formal contemporâneo; as saudações usam linguagem formal mas contemporânea.
+- Para *Orazioni quotidiane*, traduzir integralmente as rubricas e orações italianas; manter o diálogo latino do servidor da Missa em latim, mas traduzir os cabeçalhos italianos das seções.
+- "Non fornicare" (6.º mandamento) → "Não pecarás contra a castidade" (forma tradicional pt-BR do decálogo catequético).
+- "Non desiderare la roba d’altri" → "Não cobiçarás as coisas alheias" (10.º mandamento).
+- Pronomes reverenciais para Deus mantêm a 2.ª pessoa do plural ("Vós/Vossa") em orações; no texto catequético em prosa narrativa usa-se 3.ª pessoa.
+- "domma" (forma arcaica italiana) → "dogma".
+- "tener fermamente" e formas equivalentes → "crer firmemente" / "ter por veríssimo".
+- "frutto" no contexto da paixão → "fruto" (não "frutos").
+- Bem-aventuranças (Parte V, Capo III): forma catequética tradicional pt-BR — "Bem-aventurados os pobres de espírito", "os mansos", "os que choram", "os que têm fome e sede de justiça", "os misericordiosos", "os limpos de coração" (não "puros"), "os pacíficos", "os que sofrem perseguições por amor da justiça". Recompensas: "deles é o reino dos céus", "possuirão a terra", "serão consolados", "serão saciados", "alcançarão misericórdia", "verão a Deus", "serão chamados filhos de Deus".
+- *Accidia* → "Preguiça" no decálogo dos vícios capitais (forma catequética pt-BR padrão). A virtude oposta é "diligência e fervor no serviço de Deus".
+- *Gridar vendetta nel cospetto di Dio* → "clamar vingança na presença de Deus" (não "clamar aos céus"; preserva o registro de 1905).
+- *Cardine* (no contexto de virtudes cardeais) → "gonzo" (sentido literal preservado; rima com a etimologia *cardo* = dobradiça).
+- Orações ditadas em primeira pessoa (Capo VIII, devoções diárias) mantêm o tratamento "Vós/Vos" para Deus — coerente com a forma litúrgica tradicional pt-BR.
+- "Jesus, José e Maria, eu Vos recomendo a minha alma" — forma tradicional da jaculatória.
+- *Angelus Domini*, *De profundis*, *Requiem*, *Pater Noster* — preservados em latim mesmo no corpo da resposta.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/avvertenza.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/avvertenza.txt
@@ -1,0 +1,12 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Avvertenza ===
+=== TITLE: Avvertenza ===
+
+AVVERTENZA.
+
+L’istruzione pei giovanetti nella Dottrina Cristiana viene divisa in due Classi o Sezioni: alla prima risponde il Catechismo breve destinato principalmente ai fanciulli che non hanno ancora fatta la prima Comunione, alla seconda il Catechismo maggiore pei giovanetti già istruiti di ciò che si insegna nel Catechismo breve . A questo si fanno precedere poche pagine di prime nozioni di Catechismo pei fanciulli di tenera età che sia in casa, sia negli asili infantili, cominciano ad apprendere i primi rudimenti della Fede.
+
+Al Catechismo maggiore fa seguito una Istruzione sulle feste principali della Chiesa ed un brevissimo compendio di Storia della Religione , affinchè nulla manchi ai giovanetti di ciò che conviene alla loro istruzione religiosa.
+
+È interdetta a termini di legge la riproduzione.
+
+Gli editori si riservano di accordare ai singoli Eccellentissimi Vescovi che ne faranno domanda, l’autorizzazione di riprodurre questa edizione.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/lettera-promulgazione.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/lettera-promulgazione.txt
@@ -1,0 +1,18 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Lettera_di_S.S._Papa_Pio_X ===
+=== TITLE: Lettera di S.S. Papa Pio X ===
+
+AL SIGNOR CARDINALE
+
+PIETRO RESPIGHI
+
+nostro vicario generale
+
+Signor Cardinale,
+
+La necessità di provvedere per quanto è possibile alla religiosa istituzione della tenera gioventù Ci ha consigliato la stampa di un Catechismo, che esponga in modo chiaro i rudimenti della santa fede, e quelle divine verità, alle quali deve informarsi la vita d’ogni cristiano. Pertanto fatti esaminare i molti libri di testo già in uso nelle Diocesi d’Italia, Ci parve opportuno di adottare con lievi ritocchi il testo da vari anni approvato dai Vescovi del Piemonte, della Liguria, della Lombardia, della Emilia e della Toscana. L’uso di questo testo sarà obbligatorio per l’insegnamento pubblico e privato nella Diocesi di Roma e in tutte le altre della Provincia Romana; e confidiamo che anche le altre Diocesi vorranno adottarlo per arrivare così a quel testo unico, almeno per tutta l’Italia, che è nell’universale desiderio.
+
+Con questa dolce speranza impartiamo di tutto cuore a Lei, Signor Cardinale, l’Apostolica Benedizione.
+
+Dal Vaticano, li 14 Giugno 1905.
+
+PIUS PP. X

--- a/content/books/pius-x-greater-catechism/sources/it-originals/lezione-preliminare.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/lezione-preliminare.txt
@@ -1,0 +1,62 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Lezione_preliminare ===
+=== TITLE: Catechismo Maggiore — Lezione preliminare (Della dottrina cristiana e delle sue parti principali) ===
+
+LEZIONE PRELIMINARE.
+
+DELLA DOTTRINA CRISTIANA E DELLE SUE PARTI PRINCIPALI
+
+D. Siete voi cristiano?
+
+R. Sì, io sono cristiano per grazia di Dio.
+
+D. Perchè dite voi: per grazia di Dio?
+
+R. Io dico: per grazia di Dio , perchè l’essere cristiano è un dono tutto gratuito di Dio, che noi non abbiamo potuto meritare.
+
+D. Chi è vero cristiano?
+
+R. Vero cristiano è colui che è battezzato, che crede e professa la dottrina cristiana e obbedisce ai legittimi Pastori della Chiesa.
+
+D. Che cosa è la dottrina cristiana?
+
+R. La dottrina cristiana è la dottrina che Gesù Cristo nostro Signore ci ha insegnato per mostrarci la strada della salute.
+
+D. È necessario imparare la dottrina insegnata da Gesù Cristo?
+
+R. certamente necessario imparare la dottrina insegnata da Gesù Cristo e mancano gravemente quelli che trascurano di farlo.
+
+D. I genitori e i padroni sono obbligati a mandare al catechismo i loro figliuoli e dipendenti?
+
+R. I genitori e i padroni sono obbligati a procurare che i loro figliuoli e dipendenti imparino la dottrina cristiana, e si rendono colpevoli dinanzi a Dio se trascurano quest’obbligo.
+
+D. D. chi dobbiamo noi ricevere e imparare la dottrina cristiana?
+
+R. Noi dobbiamo ricevere e imparare la dottrina cristiana dalla santa Chiesa cattolica.
+
+D. Come siamo certi che la dottrina cristiana che noi riceviamo dalla santa Chiesa cattolica è proprio vera?
+
+R. Siamo certi che la dottrina cristiana che noi riceviamo dalla Chiesa cattolica è vera, perchè Gesù Cristo autore divino di questa dottrina, l’ha affidata per mezzo de’ suoi Apostoli alla Chiesa da sè fondata e costituita maestra infallibile di tutti gli uomini; promettendole la sua divina assistenza fino alla fine dei secoli.
+
+D. Vi sono altre prove della verità della dottrina cristiana?
+
+R. La verità della dottrina cristiana è dimostrata pure dalla santità eminente di tanti che la professarono e la professano, dall’eroica fortezza dei martiri, dalla rapida e mirabile sua propagazione nel mondo, e dalla sua piena conservazione attraverso tanti secoli di lotte varie e continue.
+
+D. Quante e quali sono le parti principali e più necessarie della dottrina cristiana?
+
+R. Le parti principali e più necessarie della dottrina cristiana sono quattro: il Credo, il Pater noster, i Comandamenti, ei Sacramenti.
+
+D. Che cosa c’insegna il Credo?
+
+R. Il Credo c’insegna i principali articoli della nostra santa fede.
+
+D. Che cosa c’insegna il Pater noster?
+
+R. Il Pater noster c’insegna tutto quello che dobbiamo sperare da Dio e tutto quello che dobbiamo a Lui domandare.
+
+D. Che cosa c’insegnano i Comandamenti?
+
+R. I Comandamenti c’insegnano tutto quello che dobbiamo fare per piacere a Dio: il che tutto si compendia nell’amar Dio sopra ogni cosa e il prossimo come noi stessi, per amor di Dio.
+
+D. Che cosa c’insegna la dottrina dei Sacramenti?
+
+R. La dottrina dei Sacramenti ci fa conoscere la natura e il buon uso di quei mezzi che Gesù Cristo ha istituito per rimetterci i peccati, comunicarci la sua grazia, e infondere e accrescere in noi le virtù della fede, della speranza e della carità.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/orazioni-quotidiane.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/orazioni-quotidiane.txt
@@ -1,0 +1,364 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Orazioni_quotidiane_ed_altre_preci ===
+=== TITLE: Orazioni quotidiane ed altre preci ===
+
+ORAZIONI QUOTIDIANE
+
+E ALTRE PRECI
+
+Per la mattina.
+
+Fatto il segno della Croce, direte:
+
+Vi adoro, Dio mio, e vi amo con tutto il cuore: vi ringrazio di avermi creato, fatto cristiano e conservato in questa notte: vi offerisco tutte la mie azioni, vi prego di preservarmi in questo giorno dal peccato e liberarmi da ogni male. Così sia.
+
+Poi direte il Pater noster , l’ Ave Maria , il Credo e gli Atti di Fede , di Speranza e di Carità ; la Salve Regina e l’ Angele Dei.
+
+Durante la giornata.
+
+Prima del lavoro . — Signore, vi offerisco questo lavoro, vi prego a benedirlo perchè riesca a vostra gloria.
+
+Prima di mangiare . – Signore, vi offerisco questo cibo e vi prego a benedirlo.
+
+Dopo mangiato . – Signore, vi ringrazio del cibo che mi avete dato e fatemi degno di essere ammesso alla vostra mensa celeste.
+
+Nelle tentazioni . — Gesù mio, aiutatemi e datemi grazia di non offendervi.
+
+Preghiere per la sera.
+
+Vi adoro, Dio mio, e vi amo con tutto il cuore; vi ringrazio d’avermi creato, fatto cristiano e conservato in questo giorno: vi offerisco tutto quello che oggi ho fatto di bene e vi prego a liberarmi da ogni male. Così sia.
+
+Poi direte : Pater noster, Ave Maria, Gloria Patri, Atto di contrizione.
+
+Gesù, Giuseppe e Maria, vi dono il cuore e l’anima mia.
+
+Gesù, Giuseppe e Maria, assistetemi nell’ultima agonia.
+
+Gesù, Giuseppe e Maria, spiri in pace con voi l’anima mia.
+
+Breve preparazione alla confessione.
+
+Amabilissimo mio Salvatore, datemi la grazia di accostarmi a questo sacramento di Penitenza a salute dell’anima mia ed a gloria vostra.
+
+Vergine santissima, Madre di Gesù e Madre mia, impetratemi dal vostro benedetto Figliuolo la grazia di conoscere, di detestare e di confessare sinceramente tutti i miei peccati.
+
+Pater noster ed Ave Maria. Quindi si faccia con diligenza l’esame, dinanzi a Dio, sopra i peccati commessi in pensieri, in parole, in opere ed in omissioni, contro i comandamenti di Dio e della Chiesa, e contro gli obblighi del proprio stato.
+
+In seguito per eccitare il pentimento dei peccati commessi, si consideri il gran male che si è fatto peccando, cioè che pel peccato mortale si è perduto la grazia di Dio, il paradiso; si sono meritate le pene dell inferno, e si è offeso Dio nostro Signore e Padre; il quale ci ha fatto tanti benefizi, tanto ci ama, ed ha merito infinito di essere amato sopra ogni cosa e servito fedelmente.
+
+Si reciti l’ Atto di contrizione.
+
+Dopo la confessione.
+
+Innanzi tutto si rendano grazie al Signore dell’inestimabile beneficio del perdono: si faccia subito la penitenza imposta dal confessore, si rinnovi il proposito di evitare i peccati e le loro occasioni.
+
+Poi si reciti la seguente orazione:
+
+Quanto siete stato buono con me, o Signore! Invece di punirmi di tanti peccati che ho commesso, me li avete tutti perdonati con infinita misericordia in questa santa confessione. Di nuovo me ne pento con tutto il cuore e prometto, coll’aiuto della vostra grazia, di non offendervi mai più e di compensare con altrettanto amore le offese che vi ho fatte in tutta la mia vita.
+
+Vergine santissima, Angeli e Santi del cielo, vi ringrazio della vostra assistenza: e voi pure rendete per me grazie al Signore della sua misericordia ed ottenetemi costanza ed accrescimento nel bene.
+
+Pater noster, Ave Maria, Gloria Patri, ed Angele Dei.
+
+Breve preparazione alla SS. Comunione.
+
+Atto di fede.
+
+Signor mio Gesù Cristo, io credo fermamente che voi siete realmente presente nel SSm̃o Sacramento col vostro Corpo, Sangue, Anima e Divinità.
+
+Atto di adorazione.
+
+Signore, io vi adoro in questo Sacramento, e vi riconosco per mio Creatore, Redentore, e sovrano padrone, sommo ed unico mio bene.
+
+Atto di umiltà.
+
+Signore, io non son degno che voi veniate dentro di me, ma dite una sola parola e l’anima mia sarà salva.
+
+Atto di contrizione.
+
+Signore, detesto tutti i miei peccati, che mi rendono indegno di ricevervi nel mio cuore, e propongo colla vostra grazia di non commetterli più per l’avvenire, di fuggirne le occasioni, e di farne la penitenza.
+
+Atto di speranza.
+
+Signore, io spero che dandovi tutto a me in questo divin Sacramento, mi userete misericordia e mi concederete tutte le grazie che sono necessarie per la mia eterna salute.
+
+Atto di carità.
+
+Signore, voi siete infinitamente amabile, voi siete il mio padre, il mio Redentore, il mio Dio: e perciò vi amo con tutto il cuore sopra ogni cosa, e per amor vostro amo il mio prossimo come me stesso, e perdono di cuore a chi mi ha offeso.
+
+Atto di desiderio.
+
+Signore, desidero ardentemente che veniate nell’anima mia, affinchè io non mi separi più da voi, ma viva sempre nella vostra grazia.
+
+Breve ringraziamento dopo la SS. Comunione.
+
+Atto di fede.
+
+Signor mio Gesù Cristo, io credo che voi siete veramente in me col vostro Corpo, Sangue, Anima e Divinità, e lo credo più fermamente che se lo vedessi coi miei propri occhi.
+
+Atto di adorazione.
+
+O Gesù mio, io vi adoro presente dentro di me; e mi unisco a Maria SSm̃a, agli Angeli ed ai Santi per adorarvi come meritate.
+
+Atto di ringraziamento.
+
+Gesù, Signor mio, io vi ringrazio di tutto cuore perchè siete venuto nell’anima mia. SSm̃a Vergine Maria, Angelo mio Custode, e voi tutti Angeli e Santi del paradiso, ringraziate Gesù per me.
+
+Atto di carità.
+
+O Gesù, mio Dio, io vi amo quanto so e posso, e desidero di amarvi quanto meritate: fate che vi ami sopra di ogni cosa adesso e per tutta l’eternità.
+
+Atto di offerta.
+
+O mio Gesù, voi vi siete donato tutto a me, ecco io mi dono tutto a Voi; vi offro il mio cuore e l’anima mia, vi consacro tutta la mia vita, e voglio essere vostro per tutta l’eternità.
+
+Atto di speranza.
+
+O mio Gesù, ora che siete venuto nell’anima mia, spero che non vi separerete mai più da me, ma reste rete sempre con me colla vostra divina grazia.
+
+Atto di domanda.
+
+O mio Gesù datemi, ve ne prego, tutte quelle grazie spirituali e temporali che voi conoscete essere utili all’anima mia; e soccorrete i miei superiori, parenti, amici, benefattori, e le anime sante del purgatorio.
+
+Poi direte: Pater Noster, Ave Maria, Gloria Patri.
+
+MISTERI DEL SANTO ROSARIO
+
+Gaudiosi – ( lunedì e giovedì ).
+
+1. L’annunciazione dell’Angelo a Maria santissima.
+
+2. La visita di Maria Vergine a S. Elisabetta.
+
+3. La natività di G. C. nella capanna di Betlemme.
+
+4. La presentazione di Gesù Bambino al tempio.
+
+5. Il ritrovamento di Gesù fra i dottori nel tempio.
+
+Dolorosi — ( martedì e venerdì ).
+
+1. L’orazione di Gesù Cristo nell’orto.
+
+2. La flagellazione di Gesù Cristo alla colonna.
+
+3. La coronazione di spine.
+
+4. Il viaggio al Calvario di Gesù Cristo caricato della croce.
+
+5. La crocifissione e morte di Gesù Cristo.
+
+Gloriosi — ( mercoledì, sabato e domenica ).
+
+1. La risurrezione di Gesù Cristo.
+
+2. L’ascensione di Gesù Cristo al cielo.
+
+3. La venuta dello Spirito Santo sopra gli Apostoli e sopra Maria santissima.
+
+4. L’assunzione di Maria Vergine al cielo.
+
+5. L’incoronazione di Maria Vergine sopra tutti gli Angeli e Santi.
+
+LITANIE DELLA B. VERGINE
+
+Inni al Santissimo Sacramento
+
+Dio sia benedetto:
+
+Benedetto il suo santo Nome:
+
+Benedetto Gesù Cristo vero Dio e vero uomo:
+
+Benedetto il nome di Gesù:
+
+Benedetto il suo sacratissimo Cuore:
+
+Benedetto Gesù nel SSm̃o Sacramento dell’altare:
+
+Benedetta la gran Madre di Dio Maria SSm̃a:
+
+Benedetta la sua santa ed immacolata Concezione:
+
+Benedetto il nome di Maria Vergine e Madre:
+
+Benedetto Dio ne’ suoi Angeli e ne’ suoi Santi.
+
+MODO DI SERVIRE LA S. MESSA
+
+al principio
+
+Sacerdote. In nomine Patris et Filii, et Spiritus Sancti. Amen. Introibo ad altare Dei.
+
+Chierico. Ad Deum qui lætificat iuventutem meam.
+
+S. Iudica me, Deus, et discerne causam meam de gente non sancta, ab homine iniquo et doloso erue me.
+
+C. Quia tu es, Deus, fortitudo mea; quare me repulisti, et quare tristis incedo, dum affligit me inimicus?
+
+S. Emitte lucem tuam et veritatem tuam: ipsa me deduxerunt et adduxerunt in montem sanctum tuum et in tabernacula tua.
+
+C. Et introibo ad altare Dei; ad Deum qui lætificat iuventutem meam.
+
+S. Confitebor tibi in cithara, Deus, Deus meus, quare tristis es anima mea, et quare conturbas me?
+
+C. Spera in Deo, quoniam adhuc confitebor illi, salutare vultus mei et Deus meus.
+
+S. Gloria Patri et Filio et Spiritui Sancto.
+
+C. Sicut erat in principio, et nunc et semper, et in sæcula sæculorum. Amen.
+
+S. Introibo ad altare Dei.
+
+C. Ad Deum, qui lætificat iuventutem meam.
+
+S. Adiutorium nostrum in nomine Domini.
+
+C. Qui fecit cœlum et terram.
+
+S. Confiteor, ecc.
+
+C. Misereatur tui omnipotens Deus, et dimissis peccatis tuis, perducat te ad vitam æternam.
+
+S. Amen.
+
+C. Confiteor Deo omnipotenti, beatæ Mariæ semper Virgini, beato Michaëli archangelo, beato Ioanni Baptistae, sanctis apostolis Petro et Paulo, omnibus sanctis et tibi, pater; quia peccavi nimis cogitatione, verbo et opere; mea culpa, mea culpa, mea maxima culpa. Ideo precor beatam Mariam semper Virginem, beatum Michaëlem archangelum, beatum Ioannem Baptistam, sanctos apostolos Petrum et Paulum, omnes sanctos et te, pater, orare pro me ad Dominum Deum nostrum.
+
+S. Misereatur... vitam aeternam.
+
+C. Amen.
+
+S. Indulgentiam... misericors Dominus.
+
+C. Amen.
+
+S. Deus, tu conversus vivificabis nos.
+
+C. Et plebs tua lætabitur in te.
+
+S. Ostende nobis, Domine, misericordiam tuam.
+
+C. Et salutare tuum da nobis.
+
+S. Domine, exaudi orationem meam.
+
+C. Et clamor meus ad te veniat.
+
+S. Dominus vobiscum.
+
+al «kyrie eleison».
+
+C. Kyrie, eleison; Christe, eleison; Christe, eleison; Kyrie, eleison.
+
+dopo il «kyrie» o il «gloria in excelsis».
+
+S. Dominus vobiscum.
+
+C. Et cum spiritu tuo.
+
+al fine degli «oremus» si risponde:
+
+C. Amen.
+
+finita l’epistola si risponde:
+
+C. Deo gratias.
+
+prima del vangelo.
+
+S. Dominus vobiscum.
+
+C. Et cum spiritu tuo.
+
+S. Initium o Sequentia sancti Evangelii secundum N.
+
+C. Gloria tibi, Domine.
+
+finito il vangelo si risponde:
+
+C. Laus tibi, Christe.
+
+S. Dominus vobiscum.
+
+C. Et cum spiritu tuo.
+
+all’«orate fratres».
+
+C. Suscipiat Dominus sacrificium de manibus tuis ad laudem et gloriam nominis sui; ad utilitatem quoque nostram, totiusque Ecclesiæ suæ sanctæ.
+
+al prefazio.
+
+S. Per omnia saecula saeculorum.
+
+C. Amen.
+
+S. Dominus vobiscum.
+
+C. Et cum spiritu tuo.
+
+S. Sursum corda.
+
+C. Habemus ad Dominum.
+
+S. Gratias agamus Domino Deo nostro.
+
+C. Dignum et iustum est.
+
+avanti il «pater noster».
+
+S. Per omnia saecula saeculorum.
+
+C. Amen.
+
+alla fine del «pater noster»
+
+S. Et ne nos inducas in tentationem.
+
+C. Sed libera nos a malo.
+
+alla frazione dell’ostia.
+
+S. Per omnia saecula saeculorum.
+
+C. Amen.
+
+S. Pax Domini sit semper vobiscum.
+
+C. Et cum spiritu tuo.
+
+dopo la comunione.
+
+S. Dominus vobiscum.
+
+C. Et cum spiritu tuo.
+
+al fine degli «oremus» si risponde:
+
+C. Amen.
+
+S. Dominus vobiscum.
+
+C. Et cum spiritu tuo.
+
+S. Ite, missa est, o Benedicamus Domino.
+
+C. Deo gratias.
+
+alla benedizione.
+
+S. Benedicat vos... Spiritus Sanctus.
+
+C. Amen.
+
+all’ultimo vangelo.
+
+S. Dominus vobiscum.
+
+C. Et cum spiritu tuo.
+
+S. Initium o sequentia sancti Evangelii secundum N.
+
+C. Gloria tibi Domine.
+
+finito il vangelo si risponde:
+
+C. Deo gratias.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-i.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-i.txt
@@ -1,0 +1,54 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_prima/Capo_I ===
+=== TITLE: Parte I — Il Credo o Simbolo apostolico — Compendio della dottrina cristiana/Catechismo maggiore/Parte prima/Capo I ===
+
+Capo I. Del «Credo» in generale.
+
+D. Qual’è la prima parte della dottrina cristiana?
+
+R. La prima parte della dottrina cristiana è il simbolo degli Apostoli, detto volgarmente il Credo .
+
+D. Perchè chiamate voi il Credo: Simbolo degli Apostoli?
+
+R. Il Credo si chiama simbolo degli Apostoli, perchè è un compendio delle verità della fede insegnate dagli Apostoli.
+
+D. Quanti articoli sono nel Credo?
+
+R. Nel Credo vi sono dodici articoli.
+
+D. Recitateli.
+
+R. 1.º Io credo in Dio Padre onnipotente, Creatore del cielo e della terra.
+
+2.º Ed in Gesù Cristo suo Figliuolo unico, Signor nostro.
+
+3.º Il quale fu concepito di Spirito Santo: nacque di Maria Vergine.
+
+4.º Patì sotto Ponzio Pilato: fu crocifisso, morto e seppellito.
+
+5.º Discese all’inferno: il terzo dì risuscitò da morte.
+
+6.º Salì al cielo: siede alla destra di Dio Padre onnipotente.
+
+7.º Di là ha da venire a giudicare i i vivi ed i morti.
+
+8.º Credo nello Spirito Santo.
+
+9.º La santa Chiesa cattolica; la comunione dei santi.
+
+10.º La remissione dei peccati.
+
+11.º La risurrezione della carne.
+
+12.º La vita eterna. Amen.
+
+D. Che cosa vuol dire la parola Credo , che dite in principio del Simbolo?
+
+R. La parola Credo vuol dire: io tengo per verissimo tutto quello che in questi dodici articoli si contiene: e credo più fermamente queste cose, che se le vedessi cogli occhi miei, perchè le ha rivelate Iddio, che non può ingannarsi, nè ingannare, alla santa Chiesa cattolica e per mezzo di essa le rivela anche a noi.
+
+D. Che cosa contengono gli articoli del Credo?
+
+R. Gli articoli del Credo contengono tutto quello che principalmente si ha da credere di Dio, di Gesù Cristo e della Chiesa sua sposa.
+
+D. È cosa molto utile il recitare spesso il Credo?
+
+R. È cosa utilissima recitare spesso il Credo per imprimere sempre più nel cuore le verità della fede.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-ii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-ii.txt
@@ -1,0 +1,198 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_prima/Capo_II ===
+=== TITLE: Parte I — Il Credo o Simbolo apostolico — Compendio della dottrina cristiana/Catechismo maggiore/Parte prima/Capo II ===
+
+Capo II. Del primo articolo del Simbolo.
+
+§ 1. - Di Dio Padre e della creazione.
+
+D. Che cosa c’insegna il primo articolo: Io credo in Dio Padre onnipotente, creatore del cielo e della terra?
+
+R. Il primo articolo del Credo c’insegna che vi è un Dio solo, che è onnipotente, e ha creato il cielo, la terra e tutte le cose che nel cielo e nella terra si contengono, cioè l’universo mondo.
+
+D. Come sappiamo noi che vi è Dio?
+
+R. Noi sappiamo che vi è Dio, perchè la nostra ragione ce lo dimostra, e la fede ce lo conferma.
+
+D. Perchè si dice che Dio è Padre?
+
+R. Si dice che Dio e Padre, 1.º perchè è Padre per natura della seconda Persona della Santissima Trinità, cioè del Figliuolo da lui generato: 2.º perchè Dio ė Padre di tutti gli uomini, che egli ha creato, conserva e governa: 3.º perchè finalmente è Padre per grazia di tutti i buoni cristiani, i quali perciò si chiamano figliuoli di Dio adottivi.
+
+D. Perchè il Padre è la prima Persona della Santissima Trinità?
+
+R. Il Padre è la prima Persona della Santis sima Trinità, perchè non procede da altra persona, ma è il principio delle altre due persone, cioè del Figliuolo e dello Spirito Santo.
+
+D. Che vuol dire la parola onnipotente?
+
+R. La parola onnipotente vuol dire che Dio può fare tutto quello che vuole.
+
+D. Dio non può peccare nè morire; come dunque si dice ch’egli può far tutto?
+
+R. Si dice che Dio può far tutto, quantunque non possa nė peccare nė morire, perchè il poter peccare o morire non è effetto di potenza, ma di debolezza, che non può essere in Dio, il quale è perfettissimo.
+
+D. Che cosa vuol dire; Creatore del cielo e della terra?
+
+R. Creare vuol dire fare dal niente; perciò Dio si dice creatore del cielo e della terra per che ha fatto dal niente il cielo e la terra e tutte le cose che nel cielo e nella terra si contengono, cioè l’universo mondo.
+
+D. Il mondo è stato creato solamente dal Padre?
+
+R. Il mondo è stato creato ugualmente da tutte e tre le persone divine, perchè tutto ciò che fa una persona riguardo alle creature, lo fanno con uno stesso atto anche le altre.
+
+D. Perchè dunque la creazione si attribuisce particolarmente al Padre?
+
+R. La creazione si attribuisce particolarmente al Padre, perchè la creazione è effetto della divina onnipotenza, la quale si attribuisce specialmente al Padre, come si attribuisce la sapienza al Figliuolo, e la bontà allo Spirito Santo, benchè tutte e tre le persone abbiano la stessa onnipotenza, sapienza e bontà.
+
+D. Dio ha egli cura del mondo e delle cose tutte che ha create?
+
+R. Sì, Iddio ha cura del mondo e delle cose tutte che ha create, le conserva e le governa con la sua infinita bontà e sapienza, e nulla succede quaggiù, senza che Dio lo voglia o lo permetta.
+
+D. Perchè dite che nulla succede senza che Dio lo voglia o lo permetta?
+
+R. Si dice che nulla succede quaggiù senza che Dio lo voglia o lo permetta, perchè vi sono delle cose che Dio vuole e comanda, altre poi che egli non impedisce, come il peccato.
+
+D. Perchè Iddio non impedisce il peccato?
+
+R. Dio non impedisce il peccato, perchè anche dall’abuso che l’uomo fa della libertà che gli ha concesso, sa cavare un bene e far sempre più risplendere la sua misericordia, o la sua giustizia.
+
+§ 2. - Degli Angeli.
+
+D. Quali sono le creature più nobili che Dio ha creato?
+
+R. Le creature più nobili create da Dio sono gli Angeli.
+
+D. Chi sono gli Angeli?
+
+R. Gli Angeli sono creature intelligenti e puramente spirituali.
+
+D. Per qual fine Iddio ha creato gli Angeli?
+
+R. Dio ha creato gli Angeli per essere da essi onorato e servito e per renderli eternamente felici.
+
+D. Quale forma e figura hanno gli Angeli?
+
+R. Gli Angeli non hanno nè forma, nè figura alcuna sensibile, perchè sono puri spiriti, creati da Dio per sussistere senza dover essere uniti a corpo alcuno.
+
+D. Perchè dunque gli Angeli si rappresentano sotto forme sensibili?
+
+R. Gli Angeli si rappresentano sotto forme sensibili: 1.º per aiuto della nostra imaginazione; 2.º perchè sono così apparsi molte volte agli uomini, come leggiamo nella Sacra Scrittura.
+
+D. Gli Angeli furono tutti fedeli a Dio?
+
+R. No, gli Angeli non furono tutti fedeli a Dio, ma molti di essi per superbia pretesero essere uguali a Lui e da Lui indipendenti; e per questo peccato, furono esclusi per sempre dal paradiso e condannati all’inferno.
+
+D. Come si chiamano gli Angeli esclusi per sempre dal paradiso e condannati all’inferno?
+
+R. Gli Angeli esclusi per sempre dal paradiso e condannati all’inferno si chiamano demoni, e il loro capo si chiama Lucifero o Satana.
+
+D. I demoni possono farci alcun male?
+
+R. Sì, i demoni possono farci molto male e nell’anima e nel corpo, se però Dio ne dà loro il permesso, massime col tentarci a peccare.
+
+D. Perchè ci tentano?
+
+R. I demoni ci tentano per l’invidia che ci portano, la quale fa loro desiderare la nostra eterna dannazione, e per odio a Dio, la cui imagine risplende in noi. Iddio poi permette le tentazioni, affinchè noi, vincendole con la sua grazia, esercitiamo le virtù ed acquistiamo meriti pel paradiso.
+
+D. Come possiamo vincere le tentazioni?
+
+R. Le tentazioni si vincono colla vigilanza, colla preghiera, e colla mortificazione cristiana.
+
+D. Gli Angeli rimasti fedeli a Dio come si chiamano?
+
+R. Gli Angeli rimasti fedeli a Dio si chiamano Angeli buoni, Spiriti celesti, o semplicemente Angeli.
+
+D. Che cosa avvenne degli Angeli rimasti fedeli a Dio?
+
+R. Gli Angeli rimasti fedeli a Dio furono confermati in grazia, godono per sempre la vista di Dio, lo amano, lo benedicono, e lo lodano eternamente.
+
+D. Dio si serve degli Angeli come suoi ministri?
+
+R. Sì, Dio si serve degli Angeli come suoi ministri, e specialmente affida a molti di essi l’ufficio di nostri custodi e protettori.
+
+D. Dobbiamo noi avere particolare devozione verso l’Angelo nostro custode?
+
+R. Sì, noi dobbiamo avere particolare devozione verso l’Angelo nostro custode, onorarlo, invocarne l’aiuto, seguirne le inspirazioni ed essergli riconoscenti per l’assistenza continua ch’egli ci presta.
+
+§ 3. - Dell’uomo.
+
+D. Qual è la creatura più nobile che Dio ha posto sulla terra?
+
+R. La creatura più nobile che Dio ha posto sulla terra è l’uomo.
+
+D. Che cosa è l’uomo?
+
+R. L’uomo è una creatura ragionevole composta d’anima e di corpo.
+
+D. Che cosa è l’anima?
+
+R. L’anima è la parte più nobile dell’uomo, perchè è sostanza spirituale, dotata d’intelletto e di volontà, capace di conoscere Dio e di possederlo eternamente.
+
+D. L’anima umana si può vedere e toccare?
+
+R. L’anima nostra non si può nè vedere nè toccare perchè è spirito.
+
+D. L’anima umana muore col corpo?
+
+R. L’anima umana non muore mai: la fede e la stessa ragione provano che essa è immortale.
+
+D. L’uomo è libero nelle sue azioni?
+
+R. Sì, l’uomo è libero nelle sue azioni; e ciascuno sente dentro se stesso che può fare una cosa e non farla, o farne una piuttosto che un’altra.
+
+D. Spiegate con un esempio la libertà umana.
+
+R. Se io dico volontariamente una bugia, sento che potrei non dirla e tacere, e che potrei anche parlare diversamente, dicendo la verità.
+
+D. Perchè si dice che l’uomo fu creato ad imagine e somiglianza di Dio?
+
+R. Si dice che l’uomo fu creato ad imagine e somiglianza di Dio, perchè l’anima umana è spirituale e ragionevole, libera nel suo operare, capace di conoscere e di amare Dio e di goderlo eternamente: perfezioni che rispecchiano in noi un raggio dell’infinita grandezza del Signore.
+
+D. In quale stato pose Dio i nostri primi progenitori Adamo ed Eva?
+
+R. Dio pose Adamo ed Eva nello stato di innocenza e di grazia; ma presto ne decaddero per il peccato.
+
+D. Oltre l’innocenza e la grazia santificante conferì Dio altri doni ai nostri progenitori?
+
+R. Oltre l’innocenza e la grazia santificante Iddio conferì altri doni ai nostri progenitori, che essi dovevano trasmettere insieme con la grazia santificante ai loro discendenti ed erano: l’ integrità , cioè la perfetta soggezione del senso alla ragione; l’ immortalità ; l’ immunità da ogni dolore e miseria; e la scienza proporzionata al loro stato.
+
+D. Quale fu il peccato di Adamo?
+
+R. Il peccato di Adamo fu un peccato di superbia e di grave disobbedienza.
+
+D. Quale fu il castigo del peccato di Adamo ed Eva?
+
+R. Adamo ed Eva perdettero la grazia di Dio e il diritto che avevano al cielo, furono cacciati dal paradiso terrestre, sottoposti a molte miserie nell’anima e nel corpo, e condannati a morire.
+
+D. Se Adamo ed Eva non avessero peccato, sarebbero stati esenti dalla morte?
+
+R. Se Adamo ed Eva non avessero peccato, ma si fossero mantenuti fedeli a Dio, dopo una dimora felice e tranquilla su questa terra, senza morire sarebbero stati trasferiti da Dio nel Cielo a godere una vita eterna e gloriosa.
+
+D. Erano questi doni dovuti all’uomo?
+
+R. Questi doni non erano dovuti in verun modo all’uomo, ma erano assolutamente gratuiti e soprannaturali; e perciò, disubbidendo Adamo al divino precetto, potè Iddio senza ingiustizia privarne Adamo e tutta la sua posterità.
+
+D. Questo peccato è proprio solamente di Adamo?
+
+R. Questo peccato non è solo di Adamo, ma è anche nostro, sebbene diversamente. È proprio di Adamo, perchè questi lo commise con atto di sua volontà e perciò in lui fu personale. È proprio nostro, perchè, avendo Adamo peccato come capo e fonte di tutto il genere umano, viene trasfuso per naturale generazione in tutti i suoi discendenti, e perciò per noi è peccato originale.
+
+D. Com’è possibile che il peccato originale si trasfonda in tutti gli uomini?
+
+R. Il peccato originale si trasfonde in tutti gli uomini, perchè avendo Iddio conferito all’uman genere in Adamo la grazia santificante e gli altri doni soprannaturali, a condizione che Adamo non disobbedisse; avendo questi disobbedito nella sua qualità di capo e padre del genere umano, rese l’umana natura ribelle a Dio. Perciò la natura umana viene trasfusa a tutti i discendenti di Adamo in uno stato di ribellione a Dio, priva della divina grazia e degli altri doni.
+
+D. Quali danni ci ha dunque cagionato il peccato originale?
+
+R. I danni del peccato originale sono: la privazione della grazia, la perdita del paradiso, l’ignoranza, l’inclinazione al male, tutte le miserie di questa vita, e infine la morte.
+
+D. Tutti gli uomini contraggono il peccato originale?
+
+R. Sì, tutti gli uomini contraggono il peccato originale, eccetto la santissima Vergine, che ne fu preservata da Dio per singolare privilegio, in previsione dei meriti di Gesù Cristo nostro Salvatore.
+
+D. Dopo il peccato di Adamo gli uomini non avrebbero più potuto salvarsi?
+
+R. Dopo il peccato di Adamo gli uomini non avrebbero più potuto salvarsi, se Dio non avesse loro usato misericordia.
+
+D. Quale fu la misericordia usata da Dio al genere umano?
+
+R. La misericordia usata da Dio al genere umano fu di promettere subito ad Adamo il Redentore divino, o Messia, e di mandarlo poi a suo tempo, per liberare gli uomini dalla schiavitù del demonio, e del peccato.
+
+D. Chi è il Messia promesso?
+
+R. Il Messia promesso è Gesù Cristo, come c’insegna il secondo articolo del Credo.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-iii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-iii.txt
@@ -1,0 +1,60 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_prima/Capo_III ===
+=== TITLE: Parte I — Il Credo o Simbolo apostolico — Compendio della dottrina cristiana/Catechismo maggiore/Parte prima/Capo III ===
+
+Capo III. Del secondo articolo.
+
+D. Che cosa c’insegna il secondo articolo: E in Gesù Cristo suo figliuolo unico, Signor nostro?
+
+R. Il secondo articolo del Credo c’insegna che il Figliuolo di Dio è la seconda persona della santissima Trinità: che egli è Dio eterno, onnipotente, Creatore e Signore, come il Padre: che egli si è fatto uomo per salvarci: e che il Figliuolo di Dio fatto uomo si chiama Gesù Cristo.
+
+D. Perchè la seconda persona chiamasi Figliuolo?
+
+R. La seconda persona chiamasi Figliuolo perchè è generata dal Padre per via d’intelletto da tutta l’eternità; e per questo si chiama anche Verbo eterno del Padre.
+
+D. Essendo anche noi figliuoli di Dio, perchè Gesù Cristo si chiama Figliuolo unico di Dio Padre?
+
+R. Gesù Cristo si chiama Figliuolo unico di Dio Padre , perchè Egli solo è per natura suo Figliuolo e noi siamo suoi figliuoli per creazione e per adozione.
+
+D. Perchè Gesù Cristo si chiama Signor nostro?
+
+R. Gesù Cristo si chiama Signor nostro perchè oltre l’averci creati insieme al Padre e allo Spirito Santo in quanto è Dio, ci ha pure redenti in quanto Dio ed uomo.
+
+D. Perchè il Figliuolo di Dio fatto uomo si chiama Gesù?
+
+R. Il Figliuolo di Dio fatto uomo si chiama Gesù che vuol dire Salvatore, perchè ci ha sal vati dalla morte eterna meritata per i nostri peccati.
+
+D. Chi ha dato il nome di Gesù al Figliuolo di Dio fatto uomo?
+
+R. Il nome di Gesù al Figliuolo di Dio fatto uomo l’ha dato lo stesso eterno Padre per mezzo dell’arcangelo Gabriele, quando questi annunzio alla Vergine il mistero dell’Incarnazione.
+
+D. Perchè il Figliuolo di Dio fatto uomo si chiama anche Cristo?
+
+R. Il Figliuolo di Dio fatto uomo si chiama anche Cristo , che vuol dire unto e consacrato, perchè anticamente si ungevano i re, i sacer doti, e i profeti; e Gesù è re dei re, sommo sacerdote e sommo profeta.
+
+D. Gesù Cristo fu veramente unto e consacrato con unzione corporale?
+
+R. L’unzione di Gesù Cristo non fu corporale, come quella degli antichi re, sacerdoti e profeti, ma tutta spirituale e divina perchè la pienezza della divinità abita in lui sostanzialmente.
+
+D. Di Gesù Cristo prima della sua venuta, ebbero gli uomini cognizione alcuna?
+
+R. Sì, gli uomini ebbero cognizione di Gesù Cristo prima della sua venuta, per la promessa del Messia che Iddio fece ai nostri progenitori Adamo ed Eva, e che rinnovò ai santi Patriarchi; e per le profezie e le molte figure che lo designavano.
+
+D. Donde sappiamo noi che Gesù Cristo è veramente il Messia e Redentore promesso?
+
+R. Noi sappiamo che Gesù Cristo è veramente il Messia e Redentore promesso dall’essersi adempito in lui, 1.º tutto ciò che annunziavano le profezie; 2.º tutto ciò che rappresentavano le figure dell’antico Testamento.
+
+D. Le profezie che cosa predicevano del Redentore?
+
+R. Le profezie predicevano del Redentore la tribù e la famiglia, dalla quale doveva uscire; il luogo e il tempo della nascita; i suoi miracoli e le più minute circostanze della sua passione e morte; la sua risurrezione ed ascensione al cielo; il suo regno spirituale, universale e perpetuo, che è la santa Chiesa cattolica.
+
+D. Quali sono le principali figure del Redentore nell’antico Testamento?
+
+R. Le principali figure del Redentore nell’antico Testamento sono l’innocente Abele, il sommo sacerdote Melchisedecco, il sacrificio d’Isacco; Giuseppe venduto dai fratelli, il profeta Giona, l’agnello pasquale, e il serpente di bronzo innalzato da Mosè nel deserto.
+
+D. Donde sappiamo noi che Gesù Cristo è vero Dio?
+
+R. Noi sappiamo che Gesù Cristo è vero Dio: 1.º dalla testimonianza del Padre allorchè disse: Questo è il mio Figlio diletto, nel quale mi sono compiaciuto; ascoltatelo: 2.º dell’attestazione di Gesù Cristo stesso, confermata coi più stupendi miracoli; 3.º dalla dottrina degli Apostoli: 4.º dalla tradizione costante della Chiesa cattolica.
+
+D. Quali sono i principali miracoli operati da Gesù Cristo?
+
+R. I principali miracoli operati da Gesù Cristo sono, oltre la sua risurrezione, la sanità resa agli infermi, la vista ai ciechi, l’udito ai sordi, la vita ai morti.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-iv.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-iv.txt
@@ -1,0 +1,56 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_prima/Capo_IV ===
+=== TITLE: Parte I — Il Credo o Simbolo apostolico — Compendio della dottrina cristiana/Catechismo maggiore/Parte prima/Capo IV ===
+
+Capo IV. Del terzo articolo.
+
+D. Che cosa c’insegna il terzo articolo: Il quale fu concepito di Spirito Santo; nacque di Maria Vergine.
+
+R. Il terzo articolo del Credo c’insegna che il Figliuolo di Dio ha preso un corpo e un’anima, come abbiamo noi, nel seno purissimo di Maria Vergine per opera dello Spirito Santo, e che è nato da questa Vergine.
+
+D. Il Padre e il Figliuolo concorsero anche essi a formare il corpo e a creare l’anima di Gesù Cristo?
+
+R. Sì, a formare il corpo e a creare l’anima di Gesù Cristo concorsero tutte le tre Persone divine.
+
+D. Perchè si dice solo: fu concepito di Spirito Santo?
+
+R. Si dice solo: fu concepito di Spirito Santo , perchè l’incarnazione del Figliuolo di Dio è opera di bontà e di amore, e le opere di bontà e amore si attribuiscono allo Spirito Santo.
+
+D. Il Figlio di Dio facendosi uomo cessò di esser Dio?
+
+R. No, il Figlio di Dio si fece uomo, senza cessare di esser Dio.
+
+D. Dunque Gesù Cristo è Dio e uomo insieme?
+
+R. Sì, il Figlio di Dio incarnato, cioè Gesù Cristo, è Dio e uomo insieme, perfetto Dio e perfetto uomo.
+
+D. Sono dunque in Gesù Cristo due nature?
+
+R. Sì, in Gesù Cristo, che è Dio e uomo, sono due nature: la divina e l’umana.
+
+D. Sono in Gesù Cristo anche due persone, la divina e l’umana?
+
+R. No, nel Figlio di Dio fatto uomo non vi ha che una sola persona, cioè la divina.
+
+D. Quante volontà sono in Gesù Cristo?
+
+R. In Gesù Cristo sono due volontà: l’una divina, l’altra umana.
+
+D. Gesù Cristo aveva volontà libera?
+
+R. Sì, Gesù Cristo aveva volontà libera, ma non poteva fare il male, perchè poter fare il male è difetto, non perfezione della libertà.
+
+D. Il Figliuolo di Dio e il Figliuolo di Maria, sono la medesima persona?
+
+R. Il Figliuolo di Dio e il Figliuolo di Maria sono la medesima persona, cioè Gesù Cristo, vero Dio e vero uomo.
+
+D. Maria Vergine è Madre di Dio?
+
+R. Sì, Maria Vergine è Madre di Dio, perchè è Madre di Gesù Cristo, che è vero Dio.
+
+D. In qual modo Maria divenne Madre di Gesù Cristo?
+
+R. Maria divenne Madre di Gesù Cristo unicamente per opera e virtù dello Spirito Santo.
+
+D. È di fede che Maria fu sempre Vergine?
+
+R. Sì, è di fede che Maria Santissima fu sempre Vergine, ed è chiamata la Vergine per eccellenza.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-ix.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-ix.txt
@@ -1,0 +1,52 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_prima/Capo_IX ===
+=== TITLE: Parte I — Il Credo o Simbolo apostolico — Compendio della dottrina cristiana/Catechismo maggiore/Parte prima/Capo IX ===
+
+Capo IX. Dell’ottavo articolo.
+
+D. Che cosa c’insegna l’ottavo articolo : Io credo nello Spirito Santo?
+
+R. L’ottavo articolo del Credo c’insegna che vi è lo Spirito Santo, terza Persona della santissima Trinità, che Egli è Dio eterno, infinito, onnipotente, Creatore e Signore di tutte le cose, come il Padre e il Figliuolo.
+
+D. Da chi procede lo Spirito Santo?
+
+R. Lo Spirito Santo procede dal Padre e dal Figliuolo per via di volontà e di amore, come da un solo principio.
+
+D. Se il Figliuolo procede dal Padre, e lo Spirito Santo procede dal Padre e dal Figliuolo, pare che il Padre e il Figliuolo siano prima dello Spirito Santo: come dunque si dice che sono eterne tutte e tre le Persone?
+
+R. Si dice che sono eterne tutte e tre le Persone, perchè il Padre ab eterno ha generato il Figliuolo; e dal Padre e dal Figliuolo ab eterno procede lo Spirito Santo.
+
+D. Perchè la terza Persona della santissima Trinità si chiama particolarmente col nome di Spirito Santo?
+
+R. La terza Persona della santissima Trinità si chiama particolarmente col nome di Spirito Santo perchè Essa procede dal Padre e dal Figliuolo per modo di spirazione e d’amore.
+
+D. Quale opera viene attribuita specialmente allo Spirito Santo?
+
+R. Allo Spirito Santo viene attribuita specialmente la santificazione delle anime.
+
+D. Il Padre e il Figliuolo ci santificano egualmente che lo Spirito Santo?
+
+R. Sì, tutte e tre le divine Persone ci santificano egualmente.
+
+D. Se così è, perchè la santificazione delle anime si attribuisce in particolare allo Spirito Santo?
+
+R. La santificazione delle anime si attribuisce in particolare allo Spirito Santo perchè essa è opera d’amore, e le opere d’amore si attribuiscono allo Spirito Santo.
+
+D. Quando discese lo Spirito Santo sopra gli Apostoli?
+
+R. Lo Spirito Santo discese sopra gli Apostoli nel giorno della Pentecoste, cioè cinquanta giorni dopo la Risurrezione di Gesù Cristo, e dieci dopo la sua Ascensione.
+
+D. Dov’erano gli Apostoli nei dieci giorni prima della Pentecoste?
+
+R. Gli Apostoli erano riuniti nel cenacolo in compagnia di Maria Vergine e degli altri discepoli, e perseveravano nell’orazione, aspettando lo Spirito Santo, che Gesù Cristo aveva loro promesso.
+
+D. Quali effetti produsse lo Spirito Santo negli Apostoli?
+
+R. Lo Spirito Santo confermò nella fede gli Apostoli, li riempì di lumi, di forza, di carità e dell’abbondanza di tutti i suoi doni.
+
+D. Lo Spirito Santo è egli stato mandato per i soli Apostoli?
+
+R. Lo Spirito Santo è stato mandato per tutta la Chiesa, e per ogni anima fedele.
+
+D. Che cosa opera lo Spirito Santo nella Chiesa?
+
+R. Lo Spirito Santo, come l’anima nel corpo, vivifica la Chiesa con la sua grazia e coi suoi doni; vi stabilisce il regno della verità e dell’amore; e l’assiste perchè conduca sicuramente i suoi figliuoli per la via del cielo.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-v.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-v.txt
@@ -1,0 +1,80 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_prima/Capo_V ===
+=== TITLE: Parte I — Il Credo o Simbolo apostolico — Compendio della dottrina cristiana/Catechismo maggiore/Parte prima/Capo V ===
+
+Capo V. Del quarto articolo.
+
+D. Che cosa c’insegna il quarto articolo: Patì sotto Ponzio Pilato, fu crocifisso, morto e sepolto?
+
+R. Il quarto articolo del Credo c’insegna che Gesù Cristo per redimere il mondo col suo Sangue prezioso, patì sotto Ponzio Pilato governatore della Giudea, e morì sul legno della croce, dalla quale deposto, fu seppellito.
+
+D. Che cosa vuol dire la parola patì?
+
+R. La parola patì esprime tutte le pene sofferte da Gesù Cristo nella sua passione.
+
+D. Gesù Cristo patì come Dio, o come uomo?
+
+R. Gesù Cristo patì come uomo solamente, perchè come Dio non poteva nè patire nè morire.
+
+D. Qual sorta di supplizio era quello della croce?
+
+R. Il supplizio della croce era in quei tempi il più crudele e ignominioso di tutti i supplizi.
+
+D. Chi fu che condannò Gesù Cristo ad essere crocifisso?
+
+R. Colui che condanno Gesù Cristo ad essere crocifisso fu Ponzio Pilato governatore della Giudea, il quale aveva riconosciuta la innocenza di Lui; ma cedette vilmente alla minacciosa insistenza del popolo di Gerusalemme.
+
+D. Non avrebbe potuto Gesù Cristo liberarsi dalle mani dei giudei e di Pilato?
+
+R. Sì, Gesù Cristo avrebbe potuto liberarsi dalle mani dei giudei e di Pilato, ma conoscendo che la volontà del suo Eterno Padre era che Egli patisse e morisse per la nostra salute, vi si sottomise volontariamente, anzi andò Egli stesso incontro a’ suoi nemici, e si lasciò spontaneamente prendere e condurre alla morte.
+
+D. Dove fu crocifisso Gesù Cristo?
+
+R. Gesù Cristo fu crocifisso sul monte Calvario.
+
+D. Che cosa operò Gesù Cristo sopra la croce?
+
+R. Gesù Cristo sopra la croce pregò per i suoi nemici; diede per madre al discepolo san Giovanni e in persona di lui a noi tutti, la sua stessa madre Maria santissima: offrì la sua morte in sacrificio, e soddisfece alla giustizia di Dio per i peccati degli uomini.
+
+D. Non sarebbe bastato che venisse un Angelo a soddisfare per noi?
+
+R. No, non sarebbe bastato che venisse un Angelo a soddisfare per noi, perchè l’offesa fatta a Dio per il peccato era, sotto un certo aspetto, infinita, e per soddisfarla si richiedeva una persona che avesse un merito infinito.
+
+D. Per soddisfare alla divina Giustizia era necessario che Gesù Cristo fosse Dio e uomo insieme?
+
+R. Sì, bisognava che Gesù Cristo fosse uomo per poter patire e morire, e bisognava che fosse Dio perchè i suoi patimenti fossero d’un valore infinito.
+
+D. Perchè era necessario che i meriti di Gesù Cristo fossero di un valore infinito?
+
+R. Era necessario che i meriti di Gesù Cristo fossero di un valore infinito, perchè la maestà di Dio, offesa col peccato, è infinita.
+
+D. Era necessario che Gesù patisse tanto?
+
+R. No, non era assolutamente necessario che Gesù patisse tanto, perchè il minimo dei suoi patimenti sarebbe stato sufficiente alla nostra redenzione, essendo ciascun suo atto di infinito valore.
+
+D. Perchè dunque volle Gesù patir tanto?
+
+R. Gesù volle patir tanto per soddisfare più abbondantemente alla divina giustizia, per dimostrarci maggiormente il suo amore, e per ispirarci il più grande orrore al peccato.
+
+D. Accaddero prodigi alla morte di Gesù?
+
+R. Sì, alla morte di Gesù si oscurò il sole, tremò la terra, si aprirono i sepolcri e molti morti risuscitarono.
+
+D. Dove fu sepolto il corpo di Gesù Cristo?
+
+R. Il corpo di Gesù Cristo fu sepolto in un sepolcro nuovo, scavato nella pietra del monte, poco lontano dal luogo dove era stato crocifisso .
+
+D. Nella morte di Gesù Cristo si separò la divinità dal corpo e dall’anima?
+
+R. Nella morte di Gesù Cristo la divinità non si separò nè dal corpo nè dall’anima, ma solamente si separò l’anima dal corpo.
+
+D. Per chi è morto Gesù Cristo?
+
+R. Gesù Cristo è morto per la salute di tutti gli uomini ed ha soddisfatto per tutti.
+
+D. Se Gesù Cristo è morto per la salute di tutti, perchè non tutti si salvano?
+
+R. Gesù Cristo è morto per tutti, ma non tutti si salvano, perchè non tutti lo vogliono riconoscere, non tutti osservano la sua legge, non tutti si valgono dei mezzi di santificazione che ci ha lasciati.
+
+D. Per essere salvi basta che Gesù Cristo sia morto per noi?
+
+R. Per essere salvi non basta che Gesù Cristo sia morto per noi, ma è necessario che siano applicati a ciascun di noi il frutto e i meriti della sua passione e morte, il che avviene sopratutto per mezzo dei sacramenti istituiti a questo fine dal medesimo Gesù Cristo; e siccome molti o non ricevono i sacramenti o non li ricevono bene, perciò rendono a se stessi inutile la morte di Gesù Cristo.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-vi.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-vi.txt
@@ -1,0 +1,24 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_prima/Capo_VI ===
+=== TITLE: Parte I — Il Credo o Simbolo apostolico — Compendio della dottrina cristiana/Catechismo maggiore/Parte prima/Capo VI ===
+
+Capo VI. Del quinto articolo.
+
+D. Che cosa c’insegna il quinto articolo: Discese all’inferno, il terzo dì risuscitò da morte?
+
+R. Il quinto articolo del Credo c’insegna: che l’anima di Gesù Cristo, separata che fu dal corpo, andò al Limbo dei santi Padri, e che nel terzo giorno si unì di nuovo al corpo suo, per non separarsene mai più.
+
+D. Che cosa s’intende qui per inferno?
+
+R. Per inferno s’intende qui il Limbo dei santi Padri cioè quel luogo dove erano trattenute le anime dei giusti aspettando la redenzione di Gesù Cristo.
+
+D. Perchè le anime dei santi Padri non furono introdotte nel paradiso prima della morte di Gesù Cristo?
+
+R. Le anime dei santi Padri non furono introdotte nel paradiso prima della morte di Gesù Cristo, perchè pel peccato di Adamo il paradiso era chiuso, e conveniva che Gesù Cristo, il quale con la sua morte lo riaprì, fosse il primo ad entrarvi.
+
+D. Perchè Gesù Cristo volle differire sino al terzo giorno la propria risurrezione?
+
+R. Gesù Cristo volle differire sino al terzo giorno la propria risurrezione per manifestare ad evidenza che era veramente morto.
+
+D. La risurrezione di Gesù Cristo fu simile alla risurrezione degli altri uomini risuscitati?
+
+R. No, la risurrezione di Gesù Cristo non fu simile alla risurrezione degli altri uomini risuscitati, perchè Gesù Cristo risuscitò per virtù propria, e gli altri furono risuscitati per virtù di Dio.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-vii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-vii.txt
@@ -1,0 +1,24 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_prima/Capo_VII ===
+=== TITLE: Parte I — Il Credo o Simbolo apostolico — Compendio della dottrina cristiana/Catechismo maggiore/Parte prima/Capo VII ===
+
+Capo VII . Del sesto articolo.
+
+D. Che cosa c’insegna il sesto articolo: Salì al cielo, siede alla destra di Dio Padre onnipotente?
+
+R. Il sesto articolo del Credo c’insegna che Gesù Cristo, quaranta giorni dopo la sua risurrezione, alla presenza de’ suoi discepoli, ascese da se stesso al cielo, e che essendo, come Dio, eguale al Padre nella gloria, come uomo è stato innalzato sopra tutti gli Angeli e tutti i Santi, e costituito Signore di tutte le cose.
+
+D. Perchè Gesù Cristo dopo la sua risurrezione stette quaranta giorni sulle terra prima di salire al cielo?
+
+R. Gesù Cristo dopo la sua risurrezione stette quaranta giorni sulla terra, prima di salire al cielo, per provare con varie apparizioni che era veramente risorto, e per istruire sempre più e confermare gli Apostoli nelle verità della fede.
+
+D. Perchè Gesù Cristo è salito al cielo?
+
+R. Gesù Cristo è salito al cielo: 1.º per prendere possesso del suo regno meritato colla sua morte; 2.º per preparare il nostro posto di gloria e per essere nostro Mediatore ed Avvocato appresso il Padre; 3.º per mandare lo Spirito Santo a’ suoi Apostoli.
+
+D. Perchè si dice di Gesù Cristo che salì al cielo, e della Madre sua santissima che fu assunta?
+
+R. Si dice di Gesù Cristo che salì al cielo, e della Madre sua santissima che fu assunta, perchè Gesù Cristo, essendo Uomo-Dio, per virtù propria salì al cielo, ma la Madre che era creatura, sebbene la più degna di tutte, salì al cielo per virtù di Dio.
+
+D. Spiegatemi le parole; siede alla destra di Dio Padre onnipotente.
+
+R. La parola: siede significa il pacifico possesso, che Gesù Cristo ha della sua gloria, e le parole: alla destra di Dio Padre onnipotente esprimono che Egli ha il posto d’onore sopra tutte le creature.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-viii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-viii.txt
@@ -1,0 +1,28 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_prima/Capo_VIII ===
+=== TITLE: Parte I — Il Credo o Simbolo apostolico — Compendio della dottrina cristiana/Catechismo maggiore/Parte prima/Capo VIII ===
+
+Capo VIII. Del settimo articolo.
+
+D. Che cosa c’insegna il settimo articolo: Di là ha da venire a giudicare i vivi e i morti?
+
+R. Il settimo articolo del Credo c’insegna che alla fine del mondo Gesù Cristo pieno di gloria e maestà verrà dal cielo per giudicare tutti gli uomini, buoni e cattivi, e per dare a ciascuno il premio o la pena che avrà meritato.
+
+D. Se ciascuno, subito dopo morte, dovrà essere giudicato da Gesù Cristo nel giudizio particolare, perchè dovremo essere giudicati tutti nel giudizio universale?
+
+R. Dovremo essere giudicati tutti nel giudizio universale per più ragioni: 1.º per gloria di Dio; 2.º per gloria di Gesù Cristo; 3.º per gloria dei Santi; 4.º per confusione dei cattivi; 5.º finalmente affinchè il corpo abbia con l’anima la sua sentenza di premio o di pena.
+
+D. Nel giudizio universale come si manifesterà la gloria di Dio?
+
+R. Nel giudizio universale si manifesterà la gloria di Dio, perchè tutti conosceranno con quanta giustizia Dio governi il mondo, sebbene ora si vedano qualche volta i buoni in afflizione e i cattivi in prosperità.
+
+D. Nel giudizio universale come si manifesterà la gloria di Gesù Cristo?
+
+R. Nel giudizio universale si manifesterà la gloria di Gesù Cristo, perchè essendo Egli stato dagli uomini ingiustamente condannato, comparirà allora in faccia a tutto il mondo giudice supremo di tutti.
+
+D. Nel giudizio universale come si manifesterà la gloria dei Santi?
+
+R. Nel giudizio universale si manifesterà la gloria dei Santi, perchè molti di essi, che sono morti disprezzati dai cattivi, saranno glorificati in presenza di tutto il mondo.
+
+D. Nel giudizio universale quale sarà la confusione dei cattivi?
+
+R. Nel giudizio universale la confusione dei cattivi sarà grandissima, massime per quelli che oppressero i giusti e per quelli che si studiarono in vita di essere stimati per uomini di virtù e bontà, vedendo manifestati a tutto il mondo i peccati da loro commessi, anche i più segreti.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-x.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-x.txt
@@ -1,0 +1,384 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_prima/Capo_X ===
+=== TITLE: Parte I — Il Credo o Simbolo apostolico — Compendio della dottrina cristiana/Catechismo maggiore/Parte prima/Capo X ===
+
+Capo X. Del nono articolo.
+
+§ 1 . - Della Chiesa in generale.
+
+D. Che cosa c’insegna il nono articolo: la santa Chiesa cattolica, la comunione dei santi?
+
+R. Il nono articolo del Credo c’insegna che Gesù Cristo ha fondato sulla terra una società visibile che si chiama Chiesa cattolica e che tutte le persone che fanno parte di questa Chiesa sono in comunione tra loro.
+
+D. Perchè dopo l’articolo che tratta dello Spirito Santo si parla subito della Chiesa cattolica?
+
+R. Dopo l’articolo che tratta dello Spirito Santo si parla subito della Chiesa cattolica per indicare che tutta la santità della Chiesa medesima deriva dallo Spirito Santo, il quale è l’autore di ogni santità.
+
+D. Che cosa vuol dire questa parola Chiesa?
+
+R. La parola Chiesa vuol dire convocazione o adunanza di molte persone.
+
+D. Chi ci ha convocati o chiamati alla Chiesa di Gesù Cristo?
+
+R. Noi siamo stati chiamati alla Chiesa di Gesù Cristo da una grazia particolare di Dio, affinchè col lume della fede e l’osservanza della divina legge gli rendiamo il debito culto e per veniamo alla vita eterna.
+
+D. Dove si trovano i membri della Chiesa?
+
+R. I membri della Chiesa si trovano parte in cielo, e formano la Chiesa trionfante; parte nel purgatorio, e formano la Chiesa purgante; parte sulla terra e formano la Chiesa militante.
+
+D. Queste diverse parti della Chiesa costituiscono una sola Chiesa?
+
+R. Sì, queste diverse parti della Chiesa costituiscono una sola Chiesa ed un solo corpo, perchè hanno il medesimo capo che è Gesù Cristo, il medesimo spirito che le anima e le unisce, e il medesimo fine che è la felicità eterna, la quale si gode già dagli uni e si aspetta dagli altri.
+
+D. A qual parte della Chiesa si riferisce principalmente questo nono articolo?
+
+R. Questo nono articolo del Credo si rife risce principalmente alla Chiesa militante, che è la Chiesa nella quale noi siamo attualmente.
+
+§ 2. - Della Chiesa in particolare.
+
+D. Che cosa è la Chiesa cattolica?
+
+R. La Chiesa cattolica è la società o congregazione di tutti i battezzati che, vivendo sulla terra, professano la stessa fede e legge di Cristo, partecipano agli stessi sacramenti, e obbediscono ai legittimi Pastori, principalmente al Romano Pontefice.
+
+D. Dite distintamente che cosa è necessario per esser membro della Chiesa?
+
+R. Per esser membro della Chiesa è necessario esser battezzato, credere e professare la dottrina di Gesù Cristo, partecipare ai medesimi sacramenti, riconoscere il Papa e gli altri legittimi Pastori della Chiesa.
+
+D. Chi sono i legittimi Pastori della Chiesa?
+
+R. I legittimi Pastori della Chiesa, sono il Romano Pontefice, cioè il Papa, che è il Pastore universale, ed i Vescovi. Inoltre, sotto la dipendenza dei Vescovi e del Papa, hanno parte nell’officio di pastori gli altri sacerdoti e specialmente i parrochi.
+
+D. Perchè dite che il Romano Pontefice è il Pastore universale della Chiesa?
+
+R. Perchè Gesù Cristo disse a san Pietro, primo Papa: «Tu sei Pietro e sopra questa pietra edificherò la mia Chiesa, e darò a te le chiavi del regno de’ cieli, e tutto ciò che legherai sulla terra sarà legato anche in cielo, e tutto ciò che scioglierai sulla terra sarà sciolto anche in cielo». E gli disse ancora: «Pasci i miei agnelli, pasci le mie pecorelle».
+
+D. Non appartengono dunque alla Chiesa di Gesù Cristo tante società di uomini battezzati che non riconoscono il Romano Pontefice per loro capo?
+
+R. No, tutti coloro che non riconoscono il Romano Pontefice per loro capo, non appartengono alla Chiesa di Gesù Cristo.
+
+D. Come si può distinguere la Chiesa di Gesù Cristo da tante società o sette fondate dagli uomini e che si dicono cristiane?
+
+R. Da tante società o sette fondate dagli uomini, che si dicono cristiane, si può facilmente distinguere la vera Chiesa di Gesù Cristo per quattro contrassegni. Essa è Una, Santa, Cattolica e Apostolica.
+
+D. Perchè la Chiesa si dice Una?
+
+R. La vera Chiesa si dice Una , perchè i suoi figli, di qualunque tempo e luogo, sono uniti fra loro nella medesima fede, nel medesimo culto, nella medesima legge e nella partecipazione dei medesimi sacramenti, sotto un medesimo capo visibile, il Romano Pontefice.
+
+D. Non vi potrebbero essere più Chiese?
+
+R. No, non vi possono essere più Chiese, perchè siccome vi è un solo Dio, una sola Fede e un solo Battesimo, così non vi è, e non vi può essere che una sola vera Chiesa.
+
+D. Ma non si chiamano Chiese anche i fedeli uniti insieme di una nazione, o di una diocesi?
+
+R. Si chiamano Chiese anche i fedeli uniti insieme di una nazione o di una diocesi, ma sono sempre porzioni della Chiesa universale e formano con essa una Chiesa sola.
+
+D. Perchè la vera Chiesa si dice Santa?
+
+R. La vera Chiesa si dice Santa , perchè santo è il suo capo invisibile, che è Gesù Cristo, santi sono molti suoi membri, santi sono la sua fede, la sua legge, i suoi sacramenti, e fuori di essa non vi è nè vi può essere vera santità.
+
+D. Perchè la Chiesa si chiama Cattolica?
+
+R. La vera Chiesa si chiama Cattolica , che vuol dire universale, perchè abbraccia i fedeli di tutti i tempi, di tutti i luoghi, di ogni età e condizione, e tutti gli uomini del mondo sono chiamati a farne parte.
+
+D. Perchè la Chiesa si chiama inoltre Apostolica?
+
+R. La vera Chiesa si chiama inoltre Apostolica , perchè rimonta senza interruzione fino agli Apostoli; perchè crede ed insegna tutto ciò che hanno creduto e insegnato gli Apostoli; e perchè è guidata e governata dai loro legittimi successori.
+
+D. E perchè la vera Chiesa si chiama anche Romana?
+
+R. La vera Chiesa si chiama anche Romana , perchè i quattro caratteri dell’unità, santità, cattolicità, e apostolicità si riscontrano solo nella Chiesa che riconosce per capo il Vescovo di Roma, successore di san Pietro.
+
+D. Come è costituita la Chiesa di Gesù Cristo?
+
+R. La Chiesa di Gesù Cristo è costituita come una vera e perfetta società; ed in essa, come in una persona morale possiamo distinguere l’anima e il corpo.
+
+D. In che consiste l’anima della Chiesa?
+
+R. L’anima della Chiesa consiste in ciò che essa ha d’interno e spirituale, cioè la fede, la speranza, la carità, i doni della grazia e dello Spirito Santo e tutti i celesti tesori che le sono derivati pei meriti di Cristo Redentore e dei Santi.
+
+D. Il corpo della Chiesa in che consiste?
+
+R. Il corpo della Chiesa consiste in ciò che essa ha di visibile e di esterno, sia nella associazione dei congregati, sia nel culto e nel ministero d’insegnamento, sia nel suo esterno ordine e governo.
+
+D. Per salvarsi basta l’essere comunque membro della Chiesa cattolica?
+
+R. No, non basta per salvarsi l’essere comunque membro della Chiesa cattolica, ma bisogna esserne membro vivo.
+
+D. Quali sono i membri vivi della Chiesa?
+
+R. I membri vivi della Chiesa sono tutti e solamente i giusti, quelli cioè, che sono attualmente in grazia di Dio.
+
+D. E quali ne sono i membri morti?
+
+R. Membri morti della Chiesa sono i fedeli che trovansi in peccato mortale.
+
+D. Può alcuno salvarsi fuori della Chiesa Cattolica, Apostolica, Romana?
+
+R. No, fuori della Chiesa Cattolica, Apostolica, Romana nessuno può salvarsi, come niuno potè salvarsi dal diluvio fuori dell’Arca di Noè, che era figura di questa Chiesa.
+
+D. Come dunque si sono salvati gli antichi Patriarchi, i Profeti e tutti gli altri giusti dell’antico Testamento?
+
+R. Tutti i giusti dell’antico Testamento si sono salvati in virtù della fede che avevano in Cristo venturo, per mezzo della quale essi già appartenevano spiritualmente a questa Chiesa.
+
+D. Ma chi si trovasse, senza sua colpa, fuori della Chiesa, potrebbe salvarsi?
+
+R. Chi, trovandosi senza sua colpa, ossia in buona fede, fuori della Chiesa, avesse ricevuto il Battesimo, o ne avesse il desiderio almeno implicito; cercasse inoltre sinceramente la verità e compisse la volontà di Dio come meglio può; benchè separato dal corpo della Chiesa, sarebbe unito all’anima di lei e quindi in via di salute.
+
+D. E chi essendo pur membro della Chiesa cattolica non mettesse in pratica gl’insegnamenti di essa, si salverebbe?
+
+R. Chi, essendo pur membro della Chiesa cattolica, non mettesse in pratica gli insegnamenti di essa, ne sarebbe membro morto e perciò non si salverebbe, perchè per la salute di un adulto si richiede non solo il battesimo e la fede, ma le opere altresì conformi alla fede.
+
+D. Siamo noi obbligati a credere tutte le verità che la Chiesa c’insegna?
+
+R. Sì, noi siamo obbligati a credere tutte le verità che la Chiesa c’insegna, e Gesù Cristo dichiara che chi non crede è già condannato.
+
+D. Siamo altresì obbligati a fare tutto quello che la Chiesa comanda?
+
+R. Sì, siamo obbligati a fare tutto quello che la Chiesa comanda, perchè Gesù Cristo ha detto ai Pastori della Chiesa: «Chi ascolta voi, ascolta me, e chi disprezza voi, disprezza me».
+
+D. Può sbagliare la Chiesa nelle cose che ci propone a credere?
+
+R. No, nelle cose che ci propone a credere, la Chiesa non può sbagliare, perchè secondo la promessa di Gesù Cristo ella è perennemente assistita dallo Spirito Santo.
+
+D. La Chiesa cattolica è dunque infallibile?
+
+R. Sì, la Chiesa cattolica è infallibile, epperò quelli che rifiutano le sue definizioni perdono la fede e diventano eretici.
+
+D. La Chiesa cattolica può essere distrutta o perire?
+
+R. No; la Chiesa cattolica può essere perseguitata, ma non può essere distrutta, nè perire. Ella durerà sino alla fine del mondo, perchè sino alla fine del mondo Gesù Cristo sarà con lei, come ha promesso.
+
+D. Perchè è tanto perseguitata la Chiesa cattolica?
+
+R. La Chiesa cattolica è tanto perseguitata perchè fu così perseguitato anche il suo divin Fondatore e, perchè riprova i vizi, combatte le passioni e condanna tutte le ingiustizie e tutti gli errori.
+
+D. Vi sono altri doveri dei cattolici verso la Chiesa?
+
+R. Ogni cattolico deve avere per la Chiesa un amore illimitato, riputarsi infinitamente onorato e felice di appartenerle, e adoprarsi alla gloria e all’incremento di lei con tutti quei mezzi che sono in suo potere.
+
+§ 3. - Della Chiesa docente e della Chiesa discente.
+
+D. Vi è distinzione alcuna fra i membri che compongono la Chiesa?
+
+R. Fra i membri che compongono la Chiesa vi è distinzione notevolissima, perchè vi è chi comanda e chi obbedisce, chi ammaestra e chi è ammaestrato.
+
+D. Come si chiama quella parte della Chiesa che ammaestra?
+
+R. La parte della Chiesa che ammaestra si chiama docente ossia insegnante .
+
+D. La parte della Chiesa che viene ammaestrata come si chiama?
+
+R. La parte della Chiesa che viene ammaestrata si chiama discente .
+
+D. Chi ha stabilito questa distinzione nella Chiesa?
+
+R. Questa distinzione nella Chiesa l’ha stabilita Gesù Cristo medesimo.
+
+D. La Chiesa docente e la Chiesa discente sono dunque due Chiese distinte?
+
+R. La Chiesa docente e la Chiesa discente sono due parti distinte di una sola e medesima Chiesa come nel corpo umano il capo è distinto dalle altre membra e tuttavia forma con esse un corpo solo.
+
+D. Da chi si compone la Chiesa docente?
+
+R. La Chiesa docente si compone di tutti i Vescovi con a capo il Romano Pontefice, sia che si trovino dispersi, sia che si trovino congregati in Concilio.
+
+D. E la Chiesa discente di chi è composta?
+
+R. La Chiesa discente è composta di tutti i fedeli.
+
+D. Quali persone adunque hanno nella Chiesa l’autorità d’insegnare?
+
+R. L’autorità d’insegnare nella Chiesa l’hanno il Papa e i Vescovi, e sotto la loro dipendenza, gli altri sacri ministri.
+
+D. Siamo noi obbligati ad ascoltare la Chiesa docente?
+
+R. Sì, senza dubbio, siamo tutti obbligati ad ascoltare la Chiesa docente sotto pena di eterna condanna, perchè Gesù Cristo disse ai Pastori della Chiesa, nella persona degli Apostoli: «Chi ascolta voi, ascolta me, e chi disprezza voi disprezza me».
+
+D. Oltre l’autorità d’insegnare, ha la Chiesa qualche altro potere?
+
+R. Sì, oltre l’autorità d’insegnare, la Chiesa ha specialmente il potere di amministrare le cose sante, di far leggi e di esigerne l’osservanza.
+
+D. Il potere che hanno i membri della gerarchia ecclesiastica viene dal popolo?
+
+R. Il potere che hanno i membri della gerarchia ecclesiastica non viene dal popolo, e sarebbe eresia il dirlo, ma viene unicamente da Dio.
+
+D. A chi spetta l’esercizio di questi poteri?
+
+R. L’esercizio di questi poteri spetta unicamente al ceto gerarchico, vale a dire al Papa e ai Vescovi a lui subordinati.
+
+§ 4. - Del Papa e dei Vescovi.
+
+D. Chi è il Papa?
+
+R. Il Papa, che noi chiamiamo pure il Sommo Pontefice, o anche il Romano Pontefice, è il successore di san Pietro nella Cattedra di Roma, il Vicario di Gesù Cristo sulla terra e il capo visibile della Chiesa.
+
+D. Perchè il Romano Pontefice è successore di san Pietro?
+
+R. Il Romano Pontefice è successore di S. Pietro, perchè S. Pietro nella sua persona riunì la dignità di Vescovo di Roma e di capo della Chiesa; stabilì in Roma per divina disposizione la sua sede e ivi morì, perciò chi viene eletto vescovo di Roma è anche l’erede di tutta la sua autorità.
+
+D. Perchè il Romano Pontefice è il Vicario di Gesù Cristo?
+
+R. Il Romano Pontefice è il Vicario di Gesù Cristo, perchè lo rappresenta sopra la terra e ne fa le veci nel governo della Chiesa.
+
+D. Perchè il Romano Pontefice è capo visibile della Chiesa?
+
+R. Il Romano Pontefice è il capo visibile della Chiesa, perchè egli la regge visibilmente coll’autorità medesima di Gesù Cristo, che ne è il capo invisibile.
+
+D. Qual’è dunque la dignità del Papa?
+
+R. La dignità del Papa è la massima fra tutte le dignità della terra, e gli dà potere supremo ed immediato sopra tutti e singoli i Pastori e i fedeli.
+
+D. Può errare il Papa nell’ammaestrare la Chiesa?
+
+R. Il Papa non può errare, ossia è infallibile nelle definizioni che riguardano la fede e i costumi.
+
+D. Per qual motivo il Papa è infallibile?
+
+R. Il Papa è infallibile per la promessa di Gesù Cristo e per la continua assistenza dello Spirito Santo.
+
+D. Quando è che il Papa è infallibile?
+
+R. Il Papa è infallibile allora soltanto che nella sua qualità di Pastore e Maestro di tutti i cristiani, in virtù della suprema sua apostolica autorità, definisce una dottrina intorno alla fede o ai costumi da tenersi da tutta la Chiesa.
+
+D. Chi non credesse alle solenni definizioni del Papa, quale peccato commetterebbe?
+
+R. Chi non credesse alle definizioni solenni del Papa, o anche solo ne dubitasse, peccherebbe contro la fede, e se rimanesse ostinato in questa incredulità, non sarebbe più cattolico, ma eretico.
+
+D. Per qual fine Dio ha concesso al Papa il dono della infallibilità?
+
+R. Dio ha concesso al Papa il dono della infallibilità affinchè tutti siamo certi e sicuri della verità che la Chiesa insegna.
+
+D. Quando fu definito che il Papa è infallibile?
+
+R. Che il Papa è infallibile fu definito dalla Chiesa nel Concilio Vaticano, e se alcuno presumesse di contraddire a questa definizione sarebbe eretico e scomunicato.
+
+D. La Chiesa nel definire che il Papa è infallibile ha forse stabilito una nuova verità di fede?
+
+R. No, la Chiesa nel definire che il Papa è infallibile non ha stabilito una nuova verità di fede, ma solo, per opporsi a nuovi errori, ha definito che l’infallibilità del Papa, contenuta già nella Sacra Scrittura e nella Tradizione, è una verità rivelata da Dio, e quindi da credersi come dogma o articolo di fede.
+
+D. Come deve comportarsi ogni cattolico verso il Papa?
+
+R. Ogni cattolico deve riconoscere il Papa, qual Padre, Pastore e Maestro universale e stare a lui unito di mente e di cuore.
+
+D. Dopo il Papa, quali sono per divina istituzione i personaggi più venerandi nella Chiesa?
+
+R. Dopo il Papa, per divina istituzione i personaggi più venerandi della Chiesa sono i Vescovi.
+
+D. Chi sono i Vescovi?
+
+R. I Vescovi sono i pastori dei fedeli, posti dallo Spirito Santo a reggere la Chiesa di Dio nelle sedi a loro affidate, sotto la dipendenza del Romano Pontefice.
+
+D. Che cosa è il Vescovo nella propria diocesi?
+
+R. Il Vescovo nella propria diocesi è il Pastore legittimo, il Padre, il Maestro, il superiore di tutti i fedeli, ecclesiastici e laici, che appartengono alla diocesi stessa.
+
+D. Perchè il Vescovo si chiama Pastore legittimo?
+
+R. Il Vescovo si chiama Pastore legittimo perchè la giurisdizione, ossia il potere che ha di governare i fedeli della propria diocesi, gli è stato conferito secondo le norme e le leggi della Chiesa.
+
+D. Di chi sono successori il Papa e i Vescovi?
+
+R. Il Papa è il successore di S. Pietro principe degli Apostoli, e i Vescovi sono i successori degli Apostoli, in ciò che riguarda il governo ordinario della Chiesa.
+
+D. Deve il fedele stare unito al proprio Vescovo?
+
+R. Sì, ogni fedele, ecclesiastico e laico, deve stare unito di mente e di cuore al proprio Vescovo in grazia e comunione con la Sede Apostolica.
+
+D. Come deve comportarsi il fedele col proprio Vescovo?
+
+R. Ogni fedele, ecclesiastico e laico, deve riverire, amare e onorare il proprio Vescovo, e prestargli obbedienza in tutto ciò che si riferisce alla cura delle anime è al governo spirituale della diocesi.
+
+D. Da chi è aiutato il Vescovo nella cura delle anime?
+
+R. Il Vescovo nella cura delle anime è aiutato dai sacerdoti, e principalmente dai parrochi.
+
+D. Chi è il Parroco?
+
+R. Il Parroco è un sacerdote deputato a presiedere e dirigere, sotto la dipendenza del Vescovo, una porzione della diocesi che chiamasi parrocchia.
+
+D. Quali doveri hanno i fedeli verso il loro parroco?
+
+R. I fedeli devono tenersi uniti al loro parroco, ascoltarlo docilmente e professargli rispetto e sommissione in tutto ciò che riguarda la cura della parrocchia.
+
+§ 5. - Della comunione dei santi.
+
+D. Che cosa c’insegna il nono articolo del Credo con quelle parole: la comunione dei santi?
+
+R. Con le parole: la comunione dei santi , il nono articolo del Credo c’insegna che nella Chiesa, per l’intima unione che esiste tra tutti i suoi membri, sono comuni i beni spirituali, così interni come esterni, che le appartengono.
+
+D. Quali sono nella Chiesa i beni comuni interni?
+
+R. I beni comuni interni nella Chiesa sono: la grazia che si riceve nei sacramenti, la fede, la speranza, la carità, i meriti infiniti di Gesù Cristo, i meriti sovrabbondanti della Vergine e dei Santi, e il frutto di tutte le opere buone che in essa Chiesa si fanno.
+
+D. Quali sono i beni esterni comuni nella Chiesa?
+
+R. I beni esterni comuni nella Chiesa sono: i sacramenti, il sacrificio della santa Messa, le pubbliche preghiere, le funzioni religiose e tutte le altre pratiche esteriori che uniscono insieme i fedeli.
+
+D. In questa comunione di beni entrano tutti i figli della Chiesa?
+
+R. Nella comunione dei beni interni entrano i cristiani, i quali sono in grazia di Dio; quelli poi che sono in peccato mortale non partecipano di questi beni.
+
+D. Perchè non partecipano di questi beni quelli che sono in peccato mortale?
+
+R. Perchè la grazia di Dio è quella che unisce i fedeli con Dio e tra loro: e perciò quelli che sono in peccato mortale, essendo senza la grazia di Dio, sono esclusi dalla comunione dei beni spirituali.
+
+D. Dunque i cristiani che sono in peccato mortale non hanno alcun vantaggio dai beni interni e spirituali della Chiesa?
+
+R. I cristiani che sono in peccato mortale hanno ancora qualche vantaggio dai beni interni e spirituali della Chiesa de’ quali son privi, in quanto essi conservano il carattere del cristiano che è indelebile, e sono aiutati dalle orazioni e dalle buone opere dei fedeli ad ottenere la grazia di convertirsi a Dio.
+
+D. Quelli che sono in peccato mortale possono partecipare dei beni esterni della Chiesa?
+
+R, Quelli che sono in peccato mortale possono partecipare dei beni esterni della Chiesa, se pure non siano separati dalla Chiesa con la scomunica.
+
+D. Perchè i membri di questa comunione presi insieme, si chiamano santi?
+
+R. I membri di questa comunione si chiamano santi perchè tutti sono chiamati alla santità e furono santificati per mezzo del Battesimo, e molti di essi sono già pervenuti alla perfetta santità.
+
+D. La comunione dei santi si estende ella anche al cielo e al purgatorio?
+
+R. Sì, la comunione dei santi si estende anche al cielo e al purgatorio, perchè la carità unisce le tre Chiese: trionfante, purgante e militante; e i Santi pregano Iddio per noi e per le anime del purgatorio, e noi diamo onore e gloria ai Santi e possiamo sollevare le anime del purgatorio, applicando in loro suffragio Messe, elemosine, indulgenze e altre opere buone.
+
+§ 6. - Di coloro che sono fuori della Chiesa.
+
+D. Chi sono quelli che non appartengono alla comunione dei santi?
+
+R. Non appartengono alla comunione dei santi nell’altra vita i dannati ed in questa coloro che si trovano fuori della vera Chiesa.
+
+D. Chi sono quelli che si trovano fuori della vera Chiesa?
+
+R. Si trovano fuori della vera Chiesa gli infedeli, gli ebrei, gli eretici, gli apostati, gli scismatici e gli scomunicati.
+
+D. Chi sono gl’infedeli?
+
+R. Gl’infedeli sono quelli che non hanno il Battesimo e non credono in Gesù Cristo; sia perchè credono e adorano false divinità, come gl’idolatri; sia perchè pure ammettendo l’unico vero Dio, non credono in Cristo Messia, nè come venuto nella persona di Gesù Cristo, nè come venturo, tali sono i maomettani ed altri somiglianti.
+
+D. Chi sono gli ebrei?
+
+R. Gli ebrei sono quelli che professano la legge di Mosè; non hanno ricevuto il battesimo e non credono in Gesù Cristo.
+
+D. Chi sono gli eretici?
+
+R. Gli eretici sono i battezzati che ricusano con pertinacia di credere qualche verità rivelata da Dio e insegnata come di fede dalla Chiesa cattolica, per esempio gli ariani, i nestoriani, e le varie sette dei protestanti.
+
+D. Chi sono gli apostati?
+
+R. Gli apostati sono coloro che abiurano, ossia rinnegano con atto esterno la fede cattolica, che prima professavano.
+
+D. Chi sono gli scismatici?
+
+R. Gli scismatici sono i cristiani che, non negando esplicitamente alcun domma, si separano volontariamente dalla Chiesa di Gesù Cristo, ossia dai legittimi pastori.
+
+D. Chi sono gli scomunicati?
+
+R. Gli scomunicati sono quelli che per mancanze gravissime vengono colpiti di scomunica dal Papa, o dal Vescovo, e sono quindi, siccome indegni, separati dal corpo della Chiesa, la quale aspetta e desidera la loro conversione.
+
+D. Si deve temere la scomunica?
+
+R. La scomunica si deve temere grandemente, perchè è la pena più grave e più terribile che la Chiesa possa infliggere a’ suoi figli ribelli ed ostinati.
+
+D. Di quali beni rimangono privi gli scomunicati?
+
+R. Gli scomunicati rimangono privi delle preghiere pubbliche, dei sacramenti, delle indulgenze e della sepoltura ecclesiastica.
+
+D. Possiamo noi giovare in qualche modo agli scomunicati?
+
+R. Noi possiamo giovare in qualche modo agli scomunicati e a tutti gli altri che sono fuori della vera Chiesa, con salutari avvisi, colle orazioni e colle buone opere, supplicando Iddio che per sua misericordia conceda loro la grazia di convertirsi alla fede e di entrare nella comunione dei Santi.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-xi.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-xi.txt
@@ -1,0 +1,20 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_prima/Capo_XI ===
+=== TITLE: Parte I — Il Credo o Simbolo apostolico — Compendio della dottrina cristiana/Catechismo maggiore/Parte prima/Capo XI ===
+
+Capo XI. Del decimo articolo.
+
+D. Che cosa c’insegna il decimo articolo: La remissione dei peccati?
+
+R. Il decimo articolo del Credo c’insegna che Gesù Cristo ha lasciato alla sua Chiesa la potestà di rimettere i peccati.
+
+D. La Chiesa può rimettere ogni sorta di peccati?
+
+R. Sì, la Chiesa può rimettere tutti i peccati per quanto siano molti e gravi, perchè Gesù Cristo le ha data piena potestà di sciogliere e legare.
+
+D. Chi sono coloro che nella Chiesa esercitano questa potestà di rimettere i peccati?
+
+R. Coloro che nella Chiesa esercitano la potestà di rimettere i peccati sono in primo luogo il Papa, il quale solo possiede la pienezza di tale potestà; poi i Vescovi, e, sotto la dipendenza dei Vescovi, i sacerdoti.
+
+D. Come rimette la Chiesa i peccati?
+
+R. La Chiesa rimette i peccati pei meriti di Gesù Cristo, conferendo i sacramenti da esso istituiti a questo fine, principalmente il Battesimo e la Penitenza.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-xii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-xii.txt
@@ -1,0 +1,32 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_prima/Capo_XII ===
+=== TITLE: Parte I — Il Credo o Simbolo apostolico — Compendio della dottrina cristiana/Catechismo maggiore/Parte prima/Capo XII ===
+
+Capo XII. Dell’undecimo articolo.
+
+D. Che cosa c’insegna l’undecimo articolo: La risurrezione della carne?
+
+R. L’undecimo articolo del Credo c’insegna che tutti gli uomini risusciteranno, ripigliando ogni anima il corpo che ebbe in questa vita.
+
+D. Come avverrà la risurrezione dei morti?
+
+R. La risurrezione dei morti avverrà per virtù di Dio onnipotente, a cui nulla è impossibile.
+
+D. Quando avverrà la risurrezione dei morti?
+
+R. La risurrezione di tutti i morti avverrà alla fine del mondo, e allora seguirà il giudizio universale.
+
+D. Perchè vuole Iddio la risurrezione dei corpi?
+
+R. Dio vuole la risurrezione dei corpi, perchè, avendo l’anima operato il bene o il male unita al corpo, sia ancora insieme con esso premiata o punita.
+
+D. Gli uomini risorgeranno tutti alla stessa maniera?
+
+R. No, vi sarà grandissima differenza tra i corpi degli eletti e i corpi dei dannati, perchè i soli corpi degli eletti, avranno a somiglianza di Gesù Cristo risorto le doti dei corpi gloriosi.
+
+D. Quali sono queste doti che adorneranno i corpi degli eletti?
+
+R. Le doti che adorneranno i corpi gloriosi degli eletti sono: 1.º la impassibilità , per cui non potranno più essere soggetti a mali, a dolori di veruna sorta, nè a bisogno di cibo, di riposo o d’altro; 2.º la chiarezza , per cui risplenderanno a guisa del sole e d’altrettante stelle; 3.º l’ agilità per cui potranno passare in un momento e senza fatica da un luogo all’altro e dalla terra al cielo; 4.º la sottigliezza , per cui senza ostacolo potranno penetrare qualunque corpo, come fece Gesù Cristo risorto.
+
+D. I corpi dei dannati come saranno?
+
+R. I corpi dei dannati saranno privi delle doti dei corpi gloriosi dei Beati, e porteranno l’orribile marchio dell’eterna riprovazione.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-xiii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-prima-capo-xiii.txt
@@ -1,0 +1,32 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_prima/Capo_XIII ===
+=== TITLE: Parte I — Il Credo o Simbolo apostolico — Compendio della dottrina cristiana/Catechismo maggiore/Parte prima/Capo XIII ===
+
+Capo XIII. Del dodicesimo articolo.
+
+D. Che cosa c’insegna l’ultimo articolo: La vita eterna?
+
+R. L’ultimo articolo del Credo c’insegna che dopo la vita presente vi è un’altra vita o eternamente beata per gli eletti in paradiso, o eternamente infelice pei dannati all’inferno.
+
+D. Possiamo noi comprendere la felicità del paradiso?
+
+R. No, noi non possiamo comprendere la felicità del paradiso, perchè supera le cognizioni della nostra mente limitata, e perchè i beni del cielo non possono paragonarsi ai beni di questo mondo.
+
+D. In che consiste la felicità degli eletti?
+
+R. La felicità degli eletti consiste nel vedere, amare e possedere per sempre Dio, fonte di ogni bene.
+
+D. In che consiste la infelicità dei dannati?
+
+R. L’infelicità dei dannati consiste nell’essere sempre privi della vista di Dio e puniti da eterni tormenti nell’inferno.
+
+D. I beni del paradiso e i mali dell’inferno sono solamente per le anime?
+
+R. I beni del paradiso e i mali dell’inferno sono adesso solamente per le anime, perchè solo le anime sono adesso in paradiso o nell’inferno; ma dopo la risurrezione della carne, gli uomini, nella pienezza di loro natura, cioè in anima e in corpo, saranno o felici o tormentati per sempre.
+
+D. Saranno uguali per i beati i beni del paradiso, e per i dannati i mali dell’inferno?
+
+R. I beni del paradiso per i beati, e i mali dell’inferno per i dannati, saranno uguali nella sostanza e nella eterna durata; ma nella misura, ossia nei gradi, saranno maggiori o minori, secondo i meriti, o demeriti di ciascuno.
+
+D. Che vuol dire la parola Amen in fine del Credo?
+
+R. La parola Amen in fine delle preghiere significa: Così sia; in fine del Credo significa: Così è; vale a dire: credo essere verissimo tutto quello che in questi dodici articoli si contiene, ed io ne sono più certo che se lo vedessi cogli occhi miei.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-i.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-i.txt
@@ -1,0 +1,146 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quarta/Capo_I ===
+=== TITLE: Parte IV — Dei sacramenti — Compendio della dottrina cristiana/Catechismo maggiore/Parte quarta/Capo I ===
+
+Capo I. Dei sacramenti in generale.
+
+§ 1 . - Natura dei sacramenti.
+
+D. Di che cosa si tratta nella quarta parte della Dottrina cristiana?
+
+R. Nella quarta parte della Dottrina cristiana si tratta dei sacramenti.
+
+D. Che cosa s’intende con la parola sacramento?
+
+R. Con la parola sacramento s’intende un segno sensibile ed efficace della grazia, istituito da Gesù Cristo per santificare le anime nostre.
+
+D. Perchè chiamate voi i sacramenti segni sensibili ed efficaci della grazia?
+
+R. Chiamo i sacramenti segni sensibili ed efficaci della grazia, perchè tutti i sacramenti significano, per mezzo di cose sensibili, la grazia divina che essi producono nell’anima nostra.
+
+D. Spiegate con un esempio come i sacramenti siano segni sensibili ed efficaci della grazia?
+
+R. Nel Battesimo, il versar l’acqua sul capo della persona, e le parole: io ti battezzo, cioè ti lavo, nel nome del Padre, del Figliuolo, e dello Spirito Santo, sono un segno sensibile di quello che il Battesimo opera nell’anima; perchè siccome l’acqua lava il corpo, così la grazia data dal Battesimo monda l’anima dal peccato.
+
+D. Quanti e quali sono i sacramenti?
+
+R. I sacramenti sono sette, cioè: Battesimo, Cresima, Eucaristia, Penitenza, Estrema Unzione, Ordine Sacro, Matrimonio.
+
+D. Quante cose si richiedono per fare un sacramento?
+
+R. Per fare un sacramento si richiedono la materia, la forma ed il ministro, il quale abbia l’intenzione di fare ciò che fa la Chiesa.
+
+D. Che cosa è la materia dei sacramenti?
+
+R. La materia dei sacramenti e la cosa sensibile che si adopera per farlo: come per esempio l’acqua naturale nel Battesimo; l’olio ed il balsamo nella Cresima.
+
+D. Che cosa è la forma dei sacramenti?
+
+R. La forma dei sacramenti sono le parole che si proferiscono per farlo.
+
+D. Chi è il ministro dei sacramenti?
+
+R. Il ministro dei sacramenti è la persona che fa o conferisce il sacramento.
+
+§ 2 . - Dell’effetto principale dei sacramenti, che è la grazia.
+
+D. Che cosa è la grazia?
+
+R. La grazia di Dio è un dono interno, soprannaturale, che ci vien dato senza alcun me rito nostro, ma per i meriti di Gesù Cristo in ordine alla vita eterna.
+
+D. Come si distingue la grazia?
+
+R. La grazia si distingue in grazia santificante , che si chiama anche abituale , e in grazia attuale .
+
+D. Che cosa è la grazia santificante?
+
+R. La grazia santificante è un dono soprannaturale inerente all’anima nostra, che ci rende giusti, figliuoli adottivi di Dio ed eredi del Paradiso.
+
+D. Di quante sorta è la grazia santificante?
+
+R. La grazia santificante è di due sorta: grazia prima e grazia seconda.
+
+D. Qual’è la grazia prima?
+
+R. La grazia prima è quella per cui l’uomo passa dallo stato di peccato mortale allo stato di giustizia.
+
+D. E la grazia seconda qual’è?
+
+R. La grazia seconda è un accrescimento della grazia prima.
+
+D. Che cosa è la grazia attuale?
+
+R. La grazia attuale è un dono soprannaturale, che illumina la nostra mente e muove e conforta la nostra volontà, affinchè noi operiamo il bene e ci asteniamo dal male.
+
+D. Possiamo noi resistere alla grazia di Dio?
+
+R. Sì, noi possiamo resistere alla grazia di Dio, perchè essa non distrugge il nostro libero arbitrio.
+
+D. Con le sole nostre forze possiamo noi fare alcuna cosa che ci giovi per la vita eterna?
+
+R. Senza il soccorso della grazia di Dio, con le sole nostre forze, noi non possiamo fare alcuna cosa che ci giovi per la vita eterna.
+
+D. Come ci viene da Dio comunicata la grazia?
+
+R. La grazia ci viene comunicata da Dio principalmente per mezzo dei santi sacramenti.
+
+D. I sacramenti, oltre la grazia santificante ci conferiscono altra grazia?
+
+R. I sacramenti, oltre la grazia santificante, conferiscono anche la grazia sacramentale.
+
+D. Che cos’è la grazia sacramentale?
+
+R. La grazia sacramentale consiste nel diritto che si acquista ricevendo un sacramento qualunque, di aver a tempo opportuno le grazie attuali necessarie per adempiere gli obblighi che derivano dal sacramento ricevuto. Così noi quando fummo battezzati, ricevemmo il diritto di avere le grazie per vivere cristianamente.
+
+D. I sacramenti dànno sempre la grazia a chi li riceve?
+
+R. I sacramenti dànno sempre la grazia, purchè si ricevano con le necessarie disposizioni.
+
+D. Chi ha dato ai sacramenti la virtù di conferire la grazia?
+
+R. La virtù di conferire la grazia l’ha data ai sacramenti Gesù Cristo con la sua passione e morte.
+
+D. Quali sono i sacramenti che conferiscono la prima grazia santificante?
+
+R. I sacramenti che conferiscono la prima grazia santificante, che ci rende amici di Dio, sono due: il Battesimo e la Penitenza.
+
+D. Come si chiamano perciò questi due sacramenti?
+
+R. Questi due sacramenti, cioè il Battesimo e la Penitenza, si chiamano perciò sacramenti dei morti, perchè sono istituiti principalmente per ridare alle anime morte per il peccato, la vita della grazia.
+
+D. Quali sono i sacramenti che accrescono la grazia in chi la possiede?
+
+R. I sacramenti che accrescono la grazia in chi la possiede, sono gli altri cinque, cioè la Cresima, l’Eucaristia, l’Estrema Unzione, l’Ordine Sacro ed il Matrimonio, i quali conferiscono la grazia seconda.
+
+D. Come si chiamano perciò questi cinque sacramenti?
+
+R. Questi cinque sacramenti, cioè la Cresima, l’Eucaristia, l’Estrema Unzione, l’Ordine Sacro ed il Matrimonio si chiamano sacramenti dei vivi, perchè quelli che li ricevono, devono essere senza peccato mortale, cioè già vivi alla grazia santificante.
+
+D. Qual peccato commette chi riceve uno dei sacramenti dei vivi sapendo di non essere in grazia di Dio?
+
+R. Chi riceve uno dei sacramenti dei vivi, sapendo di non essere in grazia di Dio, commette un grave sacrilegio.
+
+D. Quali sono i sacramenti più necessari per salvarci?
+
+R. I sacramenti più necessari per salvarci sono due: il Battesimo e la Penitenza: il Battesimo è necessario a tutti, e la Penitenza e necessaria a tutti quelli che hanno peccato mortalmente dopo il Battesimo.
+
+D. Qual’è il più grande di tutti i sacramenti?
+
+R. Il più grande di tutti i sacramenti è quello della Eucaristia, perchè contiene non solo la grazia, ma anche Gesù Cristo, autore della grazia e dei sacramenti.
+
+§ 3 . - Del carattere che imprimono alcuni Sacramenti.
+
+D. Quali sacramenti si possono ricevere una volta sola?
+
+R. I sacramenti che si possono ricevere una volta sola, sono tre: il Battesimo, la Cresima e l’Ordine Sacro.
+
+D. Perchè i tre sacramenti, Battesimo, Cresima e Ordine Sacro si possono ricevere una volta sola?
+
+R. I tre sacramenti, Battesimo, Cresima e Ordine Sacro, si possono ricevere una volta sola, perchè ciascuno di essi imprime il carattere.
+
+D. Che cosa è il carattere che ciascuno dei tre sacramenti, Battesimo, Cresima e Ordine Sacro imprime nell’anima?
+
+R. Il carattere che ciascuno dei tre sacra menti, Battesimo, Cresima, e Ordine Sacro imprime nell’anima è un segno spirituale, che non si cancella mai più.
+
+D. A che serve il carattere che imprimono nell’anima questi tre sacramenti?
+
+R. Il carattere che imprimono nell’anima questi tre Sacramenti, serve per contrassegnarci nel Battesimo come membri di Gesù Cristo, nella Cresima come suoi soldati, nell’Ordine Sacro come suoi ministri.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-ii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-ii.txt
@@ -1,0 +1,118 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quarta/Capo_II ===
+=== TITLE: Parte IV — Dei sacramenti — Compendio della dottrina cristiana/Catechismo maggiore/Parte quarta/Capo II ===
+
+Capo II. Del Battesimo.
+
+§ 1 . - Natura ed effetti del Battesimo.
+
+D. Che cosa è il sacramento del Battesimo?
+
+R. Il Battesimo è il sacramento, pel quale rinasciamo alla grazia di Dio e diventiamo cristiani.
+
+D. Quali sono gli effetti del sacramento del Battesimo?
+
+R. Il sacramento del Battesimo conferisce la prima grazia santificante per la quale si cancella il peccato originale, ed anche l’attuale se vi è; rimette tutta la pena per essi dovuta; imprime il carattere di cristiani; ci fa figliuoli di Dio; membri della Chiesa ed eredi del paradiso, e ci rende capaci di ricevere gli altri sacramenti.
+
+D. Qual’è la materia del Battesimo?
+
+R. La materia del Battesimo è l’acqua turale che si versa sul capo di chi viene battezzato in tanta quantità che scorra.
+
+D. Qual’è la forma del Battesimo?
+
+R. La forma del Battesimo è questa: Io ti battezzo nel nome del Padre e del Figliuolo e dello Spirito Santo .
+
+§ 2 . - Ministro del Battesimo.
+
+D. A chi spetta dare il Battesimo?
+
+R. Il dare il Battesimo spetta per diritto ai Vescovi ed ai parrochi; ma, in caso di necessità, qualunque persona può darlo, sia uomo, sia donna, anche un eretico od un infedele, purchè eseguisca il rito del Battesimo ed abbia l’intenzione di fare quello che fa la Chiesa.
+
+D. Se vi fosse necessità di battezzare una persona, che è in pericolo di morire, e molti si trovassero presenti, chi dovrebbe dare il Battesimo?
+
+R. Se vi fosse necessità di battezzare una persona in pericolo di morte, e molti si trovassero presenti, dovrebbe battezzarla il sacerdote, se vi fosse, e in sua assenza un ecclesiastico di ordine inferiore, e in assenza di questo, l’uomo secolare a preferenza della donna, se pure la maggior perizia della donna, o la decenza, non richiedessero altrimenti.
+
+D. Quale intenzione deve avere chi battezza?
+
+R. Chi battezza deve avere l’intenzione di fare quello che fa la santa Chiesa nel battezzare.
+
+§ 3 . - Rito del Battesimo e disposizioni di chi lo riceve adulto.
+
+D. Come si fa a dare il Battesimo?
+
+R. Si dà il Battesimo versando dell’acqua sul capo del battezzando, e se non si può sul capo, su qualche altra parte principale del corpo, e dicendo nello stesso tempo: Io ti battezzo nel nome del Padre e del Figliuolo e dello Spirito Santo.
+
+D. Se uno versasse l’acqua e un altro proferisse le parole, la persona resterebbe battezzata?
+
+R. Se uno versasse l’acqua, e un altro proferisse le parole, la persona non resterebbe battezzata; ma è necessario che sia la stessa persona che versi l’acqua e pronunci le parole.
+
+D. Quando si dubita se la persona sia morta, si deve tralasciare di battezzarla?
+
+R. Quando si dubita se la persona sia morta, si deve battezzarla sotto condizione, dicendo: Se tu sei vivo, io ti battezzo nel nome del Padre e del Figliuolo e dello Spirito Santo.
+
+D. Quando si devono portare alla chiesa i bambini perchè siano battezzati?
+
+R. I bambini si devono portare alla chiesa perchè siano battezzati, il più presto possibile.
+
+D. Perchè si deve avere tanta premura per far ricevere il Battesimo ai bambini?
+
+R. Si deve avere somma premura per far battezzare i bambini, perchè essi per la loro tenera età sono esposti a molti pericoli di morire, e non possono salvarsi senza il Battesimo.
+
+D. Peccano adunque i padri e le madri che per la loro negligenza lasciano morire i loro figliuoli senza Battesimo, o lo differiscono?
+
+R. Sì, i padri e le madri che per la loro negligenza, lasciano morire i figliuoli senza battesimo, peccano gravemente, perchè privano i loro figliuoli dell’eterna vita; e peccano pure gravemente col differirne a lungo il Battesimo, perchè li espongono al pericolo di morire, senza averlo ricevuto.
+
+D. Quando chi si battezza è adulto quali disposizioni deve avere?
+
+R. L’adulto che si battezza, deve oltre la fede avere il dolore almeno imperfetto dei peccati mortali, che avesse commessi.
+
+D. Se un adulto si battezzasse in peccato mortale senza questo dolore che cosa riceverebbe?
+
+R. Se un adulto si battezzasse in peccato mortale senza questo dolore riceverebbe il carattere del Battesimo, ma non la remissione dei peccati, nè la grazia santificante. E questi effetti rimarrebbero sospesi, finchè non fosse tolto l’impedimento col dolore perfetto de’ peccati o col sacramento della Penitenza.
+
+§ 4 . - Necessità del Battesimo e doveri dei battezzati.
+
+D. Il Battesimo è necessario per salvarsi?
+
+R. Il Battesimo è assolutamente necessario per salvarsi, avendo detto espressamente il Signore: Chi non rinascerà nell’acqua e nello Spirito Santo non potrà entrare nel regno dei cieli.
+
+D. Si può supplire in qualche modo alla mancanza del Battesimo?
+
+R. Alla mancanza del sacramento del Battesimo può supplire il martirio, che chiamasi Battesimo di sangue , o un atto di perfetto amor di Dio o di contrizione, che sia congiunto col desiderio almeno implicito del Battesimo, e questo si chiama Battesimo di desiderio.
+
+D. Chi riceve il Battesimo a che cosa resta obbligato?
+
+R. Chi riceve il Battesimo resta obbligato a professare sempre la fede, e ad osservare la legge di Gesù Cristo e della sua Chiesa.
+
+D. A che cosa si rinuncia nel ricevere il santo Battesimo?
+
+R. Nel ricevere il santo Battesimo, si rinuncia per sempre al demonio, alle sue opere, ed alle sue pompe.
+
+D. Che cosa s’intende per le opere o per le pompe del demonio?
+
+R. Per opere e pompe del demonio si intendono i peccati, e le massime del mondo contrarie alle massime del santo Vangelo.
+
+§ 5 . - Nome e Padrini.
+
+D. Perchè s’impone il nome di un Santo a colui che si battezza?
+
+R. A colui che si battezza s’impone il nome di un Santo per porlo sotto la speciale prote zione di un celeste patrono ed animarlo ad imitarne gli esempi.
+
+D. Chi sono i padrini e le madrine del Battesimo?
+
+R. I padrini e le madrine del Battesimo sono quelle persone, che per disposizione della Chiesa tengono al sacro fonte i bambini, rispondono in vece loro e si rendono garanti in faccia a Dio della loro cristiana educazione, specialmente se vi mancassero i genitori.
+
+D. Siamo noi obbligati a stare a quelle promesse e rinunzie che hanno fatto per noi i nostri padrini?
+
+R. Siamo obbligati senza dubbio a stare alle promesse e alle rinunzie che hanno fatto per noi i nostri padrini, perchè Dio non ci ha ricevuti nella sua grazia che a queste condizioni.
+
+D. Quali persone si debbono eleggere per padrini e madrine?
+
+R. Si debbono eleggere per padrini e madrine persone cattoliche, di buoni costumi e ossequenti alle leggi della Chiesa.
+
+D. Quali sono le obbligazioni dei padrini e delle madrine?
+
+R. I padrini e le madrine sono obbligati a procurare che i loro figli spirituali siano istruiti nelle verità della fede, e vivano da buoni cri stiani, edificandoli col buon esempio.
+
+D. Quale vincolo contraggono i padrini del Battesimo?
+
+R. I padrini contraggono una parentela spirituale col battezzato e coi suoi genitori, la quale cagiona impedimento di matrimonio coi medesimi.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-iii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-iii.txt
@@ -1,0 +1,80 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quarta/Capo_III ===
+=== TITLE: Parte IV — Dei sacramenti — Compendio della dottrina cristiana/Catechismo maggiore/Parte quarta/Capo III ===
+
+Capo III. Della Cresima o Confermazione.
+
+D. Che cosa è il sacramento della Cresima?
+
+R. La Cresima è un sacramento che ci dà lo Spirito Santo, imprime nell’anima nostra il carattere di soldato di Gesù Cristo, e ci fa perfetti cristiani.
+
+D. In qual maniera il sacramento della Cresima ci fa perfetti cristiani?
+
+R. La Cresima ci fa perfetti cristiani, perchè ci conferma nella fede e perfeziona le altre virtù e i doni che abbiamo ricevuti nel santo Battesimo; e perciò si chiama Confermazione .
+
+D. Quali sono i doni dello Spirito Santo, che si ricevono nella Cresima?
+
+R. I doni dello Spirito Santo, che si ricevono nella Cresima sono questi sette: Sapienza, Intelletto, Consiglio, Fortezza, Scienza, Pietà e Timor di Dio.
+
+D. Qual’è la materia di questo sacramento?
+
+R. La materia di questo sacramento oltre l’imposizione delle mani del Vescovo, è la unzione fatta sulla fronte del battezzato col sacro Crisma; epperciò si chiama anche Cresima , cioè Unzione .
+
+D. Che cosa è il sacro Crisma?
+
+R. Il sacro Crisma e olio mischiato con balsamo, che il Vescovo ha consacrato il giovedi santo.
+
+D. Che cosa significano l’olio e il balsamo in questo sacramento?
+
+R. In questo sacramento, l’olio che si espande e fortifica, significa la grazia abbondante, che si sparge nell’anima del cristiano per confermarlo nella fede: e il balsamo, che è odoroso e difende dalla corruzione, significa che il cristiano fortificato da questa grazia, è atto a dare buon odore di cristiane virtù e a preservarsi dalla corruzione dei vizi.
+
+D. Qual’è la forma del sacramento della Cresima?
+
+R. La forma del sacramento della Cresima è questa: Io ti segno col segno della Croce e ti confermo col crisma della salute in nome del Padre e del Figliuolo e dello Spirito Santo, così sia.
+
+D. Chi è il ministro del sacramento della Cresima?
+
+R. Il ministro ordinario del sacramento della Cresima è il solo Vescovo.
+
+D. Con qual rito il Vescovo amministra la Cresima?
+
+R. Il Vescovo per amministrare il sacramento della Cresima, prima stende le mani sopra i cresimandi, invocando sopra di loro lo Spirito Santo; poi fa un’unzione in forma di croce col sacro Crisma sulla fronte di ciascheduno, dicendo le parole della forma; indi con la sua destra dà un leggiero schiaffo sulla guancia del cresimato dicendogli: la pace sia teco; finalmente benedice solennemente tutti i cresimati.
+
+D. Perchè si fa l’unzione sulla fronte?
+
+R. Si fa l’unzione sulla fronte, dove appariscono i segni del timore e del rossore, affinchè il cresimato intenda che non deve arrossire del nome e della professione di cristiano, nè aver paura dei nemici della fede.
+
+D. Perchè si dà un leggiero schiaffo al cresimato?
+
+R. Si dà un leggiero schiaffo al cresimato perchè sappia che deve esser pronto a soffrire ogni affronto e ogni pena per la fede di Gesù Cristo.
+
+D. Devono tutti procurare di ricevere il sacramento della Cresima?
+
+R. Sì, tutti devono procurare di ricevere il sacramento della Cresima e di farlo ricevere ai loro dipendenti.
+
+D. In quale età è bene ricevere il sacramento della Cresima?
+
+R. L’età, in cui è bene ricevere il sacramento della Cresima, è quella di anni sette circa; perchè allora sogliono cominciare le tentazioni, e si può abbastanza conoscere la grazia di questo sacramento, e ricordarsi d’averlo ricevuto.
+
+D. Quali disposizioni si ricercano per ricevere degnamente il sacramento della Cresima?
+
+R. Per ricevere degnamente il sacramento della Cresima, bisogna essere in grazia di Dio, sapere i misteri principali di nostra santa fede e accostarvisi con riverenza e divozione.
+
+D. Peccherebbe chi ricevesse la Cresima una seconda volta?
+
+R. Commetterebbe un sacrilegio, perchè la Cresima è uno di quei sacramenti, che imprimono il carattere nell’anima, e che perciò si possono ricevere una volta sola.
+
+D. Che cosa deve fare il cristiano per conservare la grazia della Cresima?
+
+R. Per conservare la grazia della Cresima, il cristiano deve spesso pregare, fare buone opere, e vivere secondo la legge di Gesù Cristo, senza rispetti umani.
+
+D. Perchè anche nella Cresima vi sono i padrini e le madrine?
+
+R. Affinchè questi indirizzino con le parole e con gli esempi il cresimato nella via della salute e lo aiutino nella milizia spirituale.
+
+D. Quali condizioni si richiedono nel padrino?
+
+R. Il padrino deve essere di età conveniente; cattolico, cresimato, istruito nelle cose più necessarie della religione, e di buoni costumi.
+
+D. Il padrino della Cresima contrae alcuna parentela col cresimato e con i suoi genitori?
+
+R. Il padrino della Cresima contrae la medesima parentela spirituale di chi tiene a battesimo.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-iv.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-iv.txt
@@ -1,0 +1,240 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quarta/Capo_IV ===
+=== TITLE: Parte IV — Dei sacramenti — Compendio della dottrina cristiana/Catechismo maggiore/Parte quarta/Capo IV ===
+
+Capo IV. Dell’Eucaristia.
+
+§ 1 . - Della natura di questo sacramento e della presenza reale di Gesù Cristo nel medesimo.
+
+D. Che cosa è il sacramento dell’Eucaristia?
+
+R. L’Eucaristia è un sacramento nel quale per l’ammirabile conversione di tutta la sostanza del pane nel Corpo di Gesù Cristo e di quella del vino nel suo prezioso Sangue, si contiene veramente, realmente e sostanzialmente il Corpo, il Sangue, l’Anima e la Divinità del medesimo Gesù Cristo Signor Nostro sotto le specie del pane e del vino per essere nostro nutrimento spirituale.
+
+D. Vi è nell’Eucaristia lo stesso Gesù Cristo che è nel cielo e che nacque in terra dalla santissima Vergine?
+
+R. Sì, nell’Eucaristia vi è veramente lo stesso Gesù Cristo che è nel cielo e che nacque in terra dalla santissima Vergine.
+
+D. Perchè credete voi che nel sacramento della Eucaristia è veramente Gesù Cristo?
+
+R. Io credo che nel sacramento dell’Eucaristia è veramente presente Gesù Cristo, perchè lo ha detto Egli stesso, e me lo insegna la santa Chiesa.
+
+D. Qual è la materia del sacramento dell’Eucaristia?
+
+R. La materia del sacramento dell’Eucari stia è quella adoperata da Gesù Cristo, cioè il pane di frumento ed il vino di vite.
+
+D. Qual è la forma del sacramento dell’Eucaristia?
+
+R. La forma del sacramento dell’Eucaristia consiste nelle parole usate da Gesù Cristo: questo è il mio Corpo; questo è il mio Sangue.
+
+D. Che cosa è dunque l’ostia prima della consacrazione?
+
+R. L’ostia prima della consacrazione è pane.
+
+D. Dopo la consacrazione che cosa è l’ostia?
+
+R. Dopo la consacrazione l’ostia è il vero Corpo di Nostro Signor Gesù Cristo sotto le specie del pane.
+
+D. Nel calice prima della consacrazione che cosa vi è?
+
+R. Nel calice prima della consacrazione vi e del vino con alcune gocce d’acqua.
+
+D. Dopo la consacrazione che cosa è nel calice?
+
+R. Dopo la consacrazione nel calice è il vero Sangue di Nostro Signore Gesù Cristo sotto le specie del vino.
+
+D. Quando si fa la conversione del pane nel Corpo, e del vino nel Sangue di Gesù Cristo?
+
+R. La conversione del pane nel Corpo, e del vino nel Sangue di Gesù Cristo si fa nell’atto stesso in cui il sacerdote, nella santa Messa, pronuncia le parole della consacrazione.
+
+D. Che cosa è la consacrazione?
+
+R. La consacrazione è la rinnovazione, per mezzo del sacerdote, del miracolo operato da Gesù Cristo nell’ultima cena di mutare il pane ed il vino nel suo Corpo e nel suo Sangue adorabile, dicendo: questo è il mio corpo, questo è il mio sangue.
+
+D. Come è chiamata dalla Chiesa la miracolosa conversione del pane e del vino nel Corpo e nel Sangue di Gesù Cristo?
+
+R. La miracolosa conversione , che ogni giorno si opera sui nostri altari, è chiamata dalla Chiesa transustanziazione .
+
+D. Chi ha dato tanta virtù alle parole della consacrazione?
+
+R. Ha dato tanta virtù alle parole della consacrazione lo stesso Signor nostro Gesù Cristo, il quale è Dio onnipotente.
+
+D. Dopo la consacrazione non resta niente del pane e del vino?
+
+R. Dopo la consacrazione restano soltanto le specie del pane e del vino.
+
+D. Che cosa sono le specie del pane e del vino?
+
+R. Le specie sono la quantità e le qualità sensibili del pane e del vino, come la figura, il colore, il sapore.
+
+D. In che maniera possono restare le specie del pane e del vino senza la loro sostanza?
+
+R. Le specie del pane e del vino restano mirabilmente senza la loro sostanza, per virtù di Dio onnipotente.
+
+D. Sotto le specie del pane vi è solo il Corpo di Gesù Cristo, e sotto le specie del vino vi è solo il suo Sangue?
+
+R. Tanto sotto le specie del pane, quanto sotto le specie del vino vi è tutto Gesù Cristo vivente, in Corpo, Sangue, Anima e Divinità.
+
+D. Mi sapreste dire perchè tanto nell’ostia, quanto nel calice, vi è tutto Gesù Cristo?
+
+R. Tanto nell’ostia, quanto nel calice, vi è tutto Gesù Cristo, perchè egli è nell’Eucaristia vivo ed immortale come nel cielo; perciò dove è il suo Corpo vi è anche il Sangue, l’Anima e la Divinità, e dove è il Sangue, vi è ancora il Corpo, l’Anima e la Divinità, essendo tutto questo inseparabile in Gesù Cristo.
+
+D. Quando Gesù è nell’ostia, cessa di essere in cielo?
+
+R. Quando Gesù è nell’ostia, non cessa di essere in cielo, ma si trova nel medesimo tempo in cielo e nel santissimo Sacramento.
+
+D. Gesù Cristo si trova in tutte le ostie consacrate del mondo?
+
+R. Sì, Gesù Cristo si trova in tutte le ostie consacrate.
+
+D. Come può essere che Gesù Cristo si trovi in tutte le ostie consacrate?
+
+R. Gesù Cristo si trova in tutte le ostie consacrate, per onnipotenza di Dio, al quale niente è impossibile.
+
+D. Quando si rompe l’ostia, si rompe il Corpo di Gesù Cristo?
+
+R. Quando si rompe l’ostia, non si rompe il Corpo di Gesù Cristo, ma si rompono solamente le specie del pane.
+
+D. In quale parte dell’ostia resta il Corpo di Gesù Cristo?
+
+R. Il Corpo di Gesù Cristo, resta intiero in tutte le parti, nelle quali l’ostia è stata divisa.
+
+D. Gesù Cristo è tanto in un’ostia grande, quanto nella particella di un’ostia?
+
+R. Tanto in un’ostia grande, quanto nella particella di un’ostia, vi è il medesimo Gesù Cristo.
+
+D. Per qual motivo si conserva nelle chiese la santissima Eucaristia?
+
+R. La santissima Eucaristia si conserva nelle chiese affinchè sia adorata dai fedeli, e portata agli infermi secondo il bisogno.
+
+D. Si deve adorare l’Eucaristia?
+
+R. L’Eucaristia si deve adorare da tutti, perchè contiene veramente, realmente e sostanzialmente lo stesso N. S. Gesù Cristo.
+
+§ 2 . - Della istituzione e degli effetti del sacramento dell’Eucaristia.
+
+D. In qual tempo Gesù Cristo ha istituito il sacramento dell’Eucaristia?
+
+R. Gesù Cristo ha istituito il sacramento della Eucaristia nell’ultima cena, che fece co’ suoi discepoli la sera avanti la sua passione.
+
+D. Perchè Gesù Cristo ha istituito la santissima Eucaristia?
+
+R. Gesù Cristo ha istituito la santissima Eucaristia per tre principali ragioni:
+
+1.º Perchè sia sacrificio della nuova legge.
+
+2.º Perchè sia cibo dell’anima nostra.
+
+3.º Perchè sia un perpetuo memoriale di sua passione e morte, ed un pegno prezioso dell’amor suo verso di noi, e della vita eterna.
+
+D. Perchè Gesù Cristo istituì questo sacramento sotto le specie del pane e del vino?
+
+R. Gesù Cristo istituì questo sacramento sotto le specie del pane e del vino, perchè l’Eucaristia doveva essere nostro nutrimento spirituale, ed era perciò conveniente che ci venisse data in forma di cibo e di bevanda.
+
+D. Quali effetti produce in noi la santissima Eucaristia?
+
+R. Gli effetti principali che la santissima Eucaristia produce in chi la riceve degnamente sono questi: 1.º conserva ed accresce la vita dell’anima che è la grazia, come il cibo materiale sostiene ed accresce la vita del corpo; 2.º rimette i peccati veniali e preserva dai mortali; 3.º produce spirituale consolazione.
+
+D. La santissima Eucaristia non produce in noi altri effetti?
+
+R. Sì, la santissima Eucaristia produce in noi altri tre effetti, cioè: 1.º indebolisce le nostre passioni, ed in ispecie ammorza in noi le fiamme della concupiscenza; 2.º accresce in noi il fervore della carità verso Dio e verso il prossimo e ci aiuta ad operare in uniformità ai desiderî di Gesù Cristo; 3.º ci dà un pegno della gloria futura e della stessa risurrezione del nostro corpo.
+
+§ 3 . - Delle disposizioni necessarie per ben comunicarsi.
+
+D. Il sacramento dell’Eucaristia produce sempre in noi i suoi meravigliosi effetti?
+
+R. Il sacramento dell’Eucaristia produce in noi i suoi meravigliosi effetti, quando si riceve con le dovute disposizioni.
+
+D. Quante cose sono necessarie per fare una buona Comunione?
+
+R. Per fare una buona Comunione sono necessarie tre cose; 1.º essere in grazia di Dio; 2.º essere digiuno dalla mezzanotte fino all’atto della Comunione; 3.º sapere che cosa si va a ricevere e accostarsi alla santa Comunione con divozione.
+
+D. Che cosa vuol dire essere in grazia di Dio?
+
+R. Essere in grazia di Dio vuol dire: avere la coscienza pura e monda da ogni peccato mortale.
+
+D. Chi sa di essere in peccato mortale, che cosa deve fare prima di comunicarsi?
+
+R. Chi sa di essere in peccato mortale, deve prima di comunicarsi fare una buona confessione; non bastando l’atto di contrizione perfetta, senza la confessione, a chi è in peccato mortale per comunicarsi come conviene.
+
+D. Perchè non basta neppure l’atto di contrizione perfetta a chi sa di essere in peccato mortale, per potersi comunicare?
+
+R. Perchè la Chiesa ha stabilito, per ri spetto a questo sacramento, che chi è colpevole di peccato mortale non ardisca di fare la Comunione se prima non si è confessato.
+
+D. Chi si comunicasse in peccato mortale riceverebbe Gesù Cristo?
+
+R. Chi si comunicasse in peccato mortale, riceverebbe Gesù Cristo, ma non la sua grazia, anzi commetterebbe sacrilegio e si farebbe meritevole della sentenza di dannazione.
+
+D. Qual’è il digiuno che si richiede prima della Comunione?
+
+R. Prima della Comunione si richiede il digiuno naturale, il quale si rompe per ogni piccola cosa che si prenda per modo di cibo o di bevanda.
+
+D. Se uno inghiottisce qualche cosa rimasta fra i denti o qualche goccia d’acqua entratagli in bocca, si può ancora comunicare?
+
+R. Chi inghiottisse qualche cosa rimasta fra i denti, o qualche goccia d’acqua nel lavarsi, si può ancora comunicare; perchè allora queste cose o non si prendono per modo di cibo o di bevanda, o ne hanno già perduta la natura.
+
+D. È mai permesso fare la Comunione senza essere digiuno?
+
+R. Il fare la Comunione senza essere digiuno, è permesso agli infermi che sono in pericolo di morte e a chi ne ha ottenuta speciale facoltà dal Papa a cagione di prolungata infermità. La Comunione poi fatta dagli infermi in pericolo di morte, si chiama Viatico perchè li sostenta nel viaggio che fanno da questa vita all’eternità.
+
+D. Che cosa vuol dire: sapere ciò che si va a ricevere?
+
+R. Sapere ciò che si va a ricevere , vuol dire: conoscere quelle cose che s’insegnano intorno a questo sacramento nella Dottrina cristiana, e crederle fermamente.
+
+D. Che cosa vuol dire: comunicarsi con divozione?
+
+R. Comunicarsi con divozione , vuol dire accostarsi alla santa Comunione con umiltà e modestia, sì nella persona, come nel vestito; e fare la preparazione prima e il ringraziamento dopo la santa Comunione.
+
+D. In che consiste la preparazione prima della Comunione?
+
+R. La preparazione prima della Comunione consiste in trattenersi per qualche tempo a considerare chi andiamo a ricevere e chi siamo noi; e in fare atti di fede, di speranza, di carità, di contrizione, di adorazione, di umiltà e di desiderio di ricevere Gesù Cristo.
+
+D. In che consiste il ringraziamento dopo la Comunione?
+
+R. Il ringraziamento dopo la Comunione consiste nel trattenerci raccolti ad onorare dentro di noi stessi il Signore; rinnovando gli atti di fede, di speranza, di carità, di adorazione, di ringraziamento, di offerta e di domanda, sopratutto di quelle grazie che maggiormente sono necessarie per noi e per coloro pei quali siamo obbligati a pregare.
+
+D. Che cosa si deve fare nel giorno della Comunione?
+
+R. Nel giorno della Comunione si deve stare raccolti per quanto è possibile, occuparsi in opere di pietà e adempiere con maggiore diligenza i doveri del proprio stato.
+
+D. Dopo la santa Comunione quanto tempo resta in noi Gesù Cristo?
+
+R. Dopo la santa Comunione Gesù Cristo resta in noi con la sua grazia finchè non si pecca mortalmente; e con la sua reale presenza resta in noi finchè non si sono consumate le specie sacramentali.
+
+§ 4 . - Della maniera di comunicarsi.
+
+D. Come bisogna presentarsi nell’atto di ricevere la santa Comunione?
+
+R. Nell’atto di ricevere la santa Comunione bisogna essere inginocchiati, tenere la testa mediocremente alzata, gli occhi modesti e rivolti alla sacra particola, la bocca sufficientemente aperta e la lingua un poco avanzata sulle labbra.
+
+D. Come bisogna tenere la tovaglia o la tavoletta della Comunione?
+
+R. La tovaglia o la tavoletta della Comunione bisogna tenerla in modo che raccolga la sacra particola qualora essa venisse a cadere.
+
+D. Quando si deve inghiottire la sacra particola?
+
+R. Dobbiamo procurare d’inghiottire la sacra particola più presto che si può, e per qualche tempo astenerci dallo sputare.
+
+D. Se la sacra particola si attaccasse al palato, che cosa si dovrebbe fare?
+
+R. Se la sacra particola si attaccasse al palato, la si dovrebbe distaccare con la lingua, e non mai col dito.
+
+§ 5 . - Del precetto della Comunione.
+
+D. Quando vi è l’obbligo di comunicarsi?
+
+R. Vi è l’obbligo di comunicarsi in ogni anno, alla Pasqua di Risurrezione, ciascuno alla propria parrocchia; e inoltre in pericolo di morte.
+
+D. In quale età comincia ad obbligare il comandamento della Comunione pasquale?
+
+R. Il comandamento della Comunione pasquale comincia ad obbligare nell’età in cui il fanciullo è capace di accostarvisi con le dovute disposizioni.
+
+D. Peccano coloro che hanno l’età capace per essere ammessi alla Comunione e non si comunicano?
+
+R. Coloro che, avendo l’etả capace per essere ammessi alla Comunione, non si comunicano, o perchè non vogliono, o perchè non sono per loro colpa istruiti, peccano senza dubbio. Peccano altresì i loro genitori, o chi ne fa le veci, se la dilazione della Comunione avviene per loro colpa, e ne dovranno rendere gran conto a Dio.
+
+D. È cosa buona ed utile comunicarsi spesso?
+
+R. È cosa ottima il comunicarsi spesso, pur che si faccia con le disposizioni dovute.
+
+D. Con quale frequenza si può andare alla Comunione?
+
+R. Ciascuno può andare alla Comunione con quella maggior frequenza che gli sia consigliata da un pio e dotto confessore.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-ix.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-ix.txt
@@ -1,0 +1,114 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quarta/Capo_IX ===
+=== TITLE: Parte IV — Dei sacramenti — Compendio della dottrina cristiana/Catechismo maggiore/Parte quarta/Capo IX ===
+
+Capo IX. Del Matrimonio.
+
+§ 1 . - Natura del sacramento del Matrimonio.
+
+D. Che cosa è il sacramento del Matrimonio?
+
+R. Il Matrimonio è un sacramento, istituito da nostro Signore Gesù Cristo, che stabilisce una santa ed indissolubile unione tra l’uomo e la donna, e dà loro la grazia di amarsi l’un l’altro santamente e di allevare cristianamente i figliuoli.
+
+D. Da chi fu istituito il Matrimonio?
+
+R. Il Matrimonio fu istituito da Dio stesso nel paradiso terrestre, e nel nuovo Testamento fu elevato da Gesù Cristo alla dignità di sacramento.
+
+D. Il sacramento del Matrimonio ha qualche speciale significato?
+
+R. Il sacramento del Matrimonio significa l’indissolubile unione di Gesù Cristo con la santa Chiesa sua sposa e nostra amantissima madre.
+
+D. Perchè si dice che il vincolo del matrimonio è indissolubile?
+
+R. Si dice che il vincolo del matrimonio è indissolubile ossia che non si può sciogliere se non per la morte di uno dei coniugi, perchè così ha stabilito Dio fin da principio, e così ha solennemente proclamato Gesù Cristo Signor nostro.
+
+D. Nel matrimonio cristiano si potrebbe dividere il contratto dal sacramento?
+
+R. No, nel matrimonio fra i cristiani non si può dividere il contratto dal sacramento, perchè per essi il matrimonio non è altro che lo stesso contratto naturale elevato da Gesù Cristo alla dignità di sacramento.
+
+D. Fra i cristiani dunque non vi può essere vero matrimonio che non sia sacramento?
+
+R. Fra i cristiani non vi può essere vero matrimonio, che non sia sacramento.
+
+D. Quali effetti produce il sacramento del Matrimonio?
+
+R. Il sacramento del Matrimonio: 1.º dà l’aumento della grazia santificante: 2.º conferisce la grazia speciale per adempiere fedelmente tutti i doveri matrimoniali.
+
+§ 2 . - Ministri, rito e disposizioni.
+
+D. Quali sono i ministri di questo sacramento?
+
+R. I ministri di questo sacramento sono gli stessi sposi, che vicendevolmente conferiscono e ricevono il sacramento.
+
+D. In qual modo si amministra questo sacramento?
+
+R. Questo sacramento, conservando la natura di contratto, si amministra dagli stessi contraenti col dichiarare alla presenza del loro parroco, o di un suo delegato, e di due testimoni di unirsi in matrimonio.
+
+D. A che serve dunque la benedizione che il parroco dà agli sposi?
+
+R. La benedizione che il parroco dà agli sposi non è necessaria per costituire il sacramento, ma si dà per sanzionare a nome della Chiesa la loro unione, e per chiamare sempre più sopra di essi le benedizioni di Dio.
+
+D. Che intenzione deve avere chi contrae matrimonio?
+
+R. Chi contrae matrimonio deve avere l’intenzione: 1.º di fare la volontà di Dio, che lo chiama a tale stato: 2.º di operare in esso la salute dell’anima propria: 3.º di allevare cristianamente i figliuoli, se Dio concede di averne.
+
+D. In qual maniera gli sposi devono disporsi per ricevere con frutto il sacramento del Matrimonio?
+
+R. Gli sposi, per ricevere con frutto il sacramento del Matrimonio devono: 1.º raccomandarsi di cuore a Dio per conoscere la sua volontà, e per ottenere da lui quelle grazie, che sono necessarie in tale stato; 2.º consultarsi coi propri genitori prima di farne la promessa, come lo esige l’ubbidienza e il rispetto dovuto ai medesimi; 3.º prepararsi con una buona confessione, anche generale, se fa bisogno, di tutta la vita; 4. schivare ogni pericolosa familiarità di tratto e di parola nel conversare insieme.
+
+D. Quali sono le principali obbligazioni delle persone congiunte in matrimonio?
+
+R. Le persone congiunte in matrimonio devono: 1.º custodire inviolata la fedeltà coniugale e diportarsi sempre cristianamente in tutto; 2.º amarsi scambievolmente, sopportandosi a vicenda con pazienza, e vivere in pace e concordia; 3.º se hanno dei figliuoli, pensare seriamente a provvederli secondo il bisogno; dar loro una cristiana educazione; e lasciare ad essi la libertà di scegliere quello stato a cui da Dio sono chiamati.
+
+§ 3 . - Condizioni e impedimenti.
+
+D. Che cosa è necessario per contrarre validamente il matrimonio cristiano?
+
+R. Per contrarre validamente il matrimonio cristiano è necessario esser libero da ogni impedimento matrimoniale dirimente , e prestare liberamente il proprio consenso al contratto del matrimonio dinanzi al proprio parroco o ad un sacerdote da lui delegato, e a due testimoni.
+
+D. Che cosa è necessario per contrarre lecitamente il matrimonio cristiano?
+
+R. Per contrarre lecitamente il matrimonio cristiano è necessario esser libero dagli impedimenti matrimoniali impedienti , essere istruito nelle cose principali della religione, ed essere in istato di grazia, altrimenti si commetterebbe un sacrilegio.
+
+D. Che cosa sono gli impedimenti matrimoniali?
+
+R. Gli impedimenti matrimoniali sono tali circostanze che rendono il matrimonio o invalido , o illecito . Nel primo caso si dicono impedimenti dirimenti , nel secondo impedimenti impedienti .
+
+D. Datemi qualche esempio di impedimento dirimente.
+
+R. Impedimenti dirimenti sono, per esempio, la consanguineità fino al quarto grado, la parentela spirituale, il voto solenne di castità, la diversità di culto tra battezzati e non battezzati, ecc.
+
+D. Datemi qualche esempio di impedimento impediente.
+
+R. Impedimenti impedienti sono, per esempio, il tempo proibito, il voto semplice di castità, ecc.
+
+D. I fedeli sono obbligati a manifestare all’autorità ecclesiastica gl’impedimenti matrimoniali che conoscono?
+
+R. I fedeli sono obbligati a manifestare all’autorità ecclesiastica gl’impedimenti matrimoniali che conoscono; ed è perciò che dai parroci si fanno le pubblicazioni.
+
+D. Chi ha la podestà di stabilire impedimenti matrimoniali, di dispensare da essi e di giudicare della validità del matrimonio cristiano?
+
+R. Solamente la Chiesa ha la podestà di stabilire impedimenti e di giudicare della validità del matrimonio fra i cristiani, come la Chiesa sola può dispensare da quelli impedimenti che essa ha stabiliti.
+
+D. Perchè solamente la Chiesa ha la podestà di stabilire impedimenti e di giudicare della validità del matrimonio?
+
+R. Solamente la Chiesa ha la podestà di stabilire impedimenti, di giudicare della validità del matrimonio, e dispensare dagli impedimenti che essa ha posti, perchè nel matrimonio cristiano non potendosi dividere il contratto dal sacramento, anche il contratto cade sotto la podestà della Chiesa, alla quale sola Gesù Cristo conferì il diritto di far leggi e decisioni nelle cose sacre.
+
+D. Può l’autorità civile sciogliere col divorzio il vincolo del matrimonio cristiano?
+
+R. No, il vincolo del matrimonio cristiano non può essere sciolto dall’autorità civile, perchè questa non può ingerirsi in materia di sacramenti, e separare ciò che Dio ha congiunto.
+
+D. Che cosa è il matrimonio civile?
+
+R. Il matrimonio civile non è altro che una formalità prescritta dalla legge al fine di dare e di assicurare gli effetti civili ai coniugati e alla loro prole.
+
+D. Basta per un cristiano fare il solo matrimonio ossia contratto civile?
+
+R. Per un cristiano, non basta fare il solo contratto civile, perchè questo non è sacramento, e quindi non è vero matrimonio.
+
+D. Se gli sposi convivessero tra loro col solo matrimonio civile, in che condizione si troverebbero?
+
+R. Se gli sposi convivessero tra loro col solo matrimonio civile sarebbero in istato di continuo peccato mortale, e la loro unione resterebbe sempre illegittima innanzi a Dio e alla Chiesa.
+
+D. Si deve fare anche il matrimonio civile?
+
+R. Si deve fare anche il matrimonio civile, perchè sebbene questo non sia sacramento, pur tuttavia serve per garantire ai contraenti e ai loro figliuoli gli effetti civili della società coniugale; e però di regola generale dall’autorità ecclesiastica non si permette il matrimonio religioso se non quando siano iniziati gli atti prescritti dalla legge civile.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-v.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-v.txt
@@ -1,0 +1,100 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quarta/Capo_V ===
+=== TITLE: Parte IV — Dei sacramenti — Compendio della dottrina cristiana/Catechismo maggiore/Parte quarta/Capo V ===
+
+Capo V. Del santo sacrificio della Messa.
+
+§ 1 . - Della essenza, della istituzione e dei fini del santo sacrificio della Messa.
+
+D. L’Eucaristia si deve considerare solamente come sacramento?
+
+R. L’Eucaristia, oltre essere sacramento, è anche il sacrificio permanente della nuova legge, che Gesù Cristo lasciò alla sua Chiesa, da offrirsi a Dio per mano de’ suoi sacerdoti.
+
+D. In che consiste, in generale, il sacrificio?
+
+R. Il sacrificio, in generale, consiste nell’offerire una cosa sensibile a Dio, e distruggerla in qualche maniera per riconoscere il supremo dominio di lui sopra di noi e sopra tutte le cose.
+
+D. Come si chiama questo sacrificio della nuova legge?
+
+R. Questo sacrificio della nuova legge si chiama la santa Messa.
+
+D. Che cosa è dunque la santa Messa?
+
+R. La santa Messa è il sacrificio del Corpo e del Sangue di Gesù Cristo offerto sui nostri altari sotto le specie del pane e del vino, in memoria del sacrificio della Croce.
+
+D. Il sacrificio della Messa è il medesimo della Croce?
+
+R. Il sacrificio della Messa è sostanzialmente il medesimo della Croce in quanto lo stesso Gesù Cristo, che si è offerto sopra la Croce, è quello che si offerisce per mano dei sacerdoti, suoi ministri, sui nostri altari; ma in quanto al modo con cui viene offerto il sacrificio della Messa differisce dal sacrificio della Croce, pur ritenendo con questo la più intima ed essenziale relazione.
+
+D. Quale differenza dunque e relazione vi è tra il sacrificio della Messa e quello della Croce?
+
+R. Tra il sacrificio della Messa è quello della Croce vi è questa differenza e relazione; che Gesù Cristo sulla Croce si offrì spargendo il suo sangue e meritando per noi; invece sugli altari Egli si sacrifica senza spargimento di sangue e ci applica i frutti della sua Passione e Morte.
+
+D. Quale altra relazione ha il sacrificio della Messa con quello della Croce?
+
+R. Un’altra relazione del sacrificio della Messa con quello della Croce è che il sacrificio della Messa rappresenta in modo sensibile lo spargimento del sangue di Gesù Cristo sulla Croce; perchè in virtù delle parole della consacrazione si rende presente sotto le specie del pane il solo Corpo, e sotto le specie del vino il solo Sangue del nostro Salvatore; sebbene per naturale concomitanza e per l’unione ipostatica sia presente sotto ciascuna delle specie Gesù Cristo vivo e vero.
+
+D. Non è forse il sacrificio della Croce l’unico sacrificio della nuova legge?
+
+R. Il sacrificio della Croce è l’unico sacrificio della nuova legge, inquantochè per esso il Signore placò la Divina Giustizia, acquistò tutti i meriti necessari a salvarci, e così compiè da parte sua la nostra redenzione. Questi meriti però Egli ci applica pei mezzi da lui istituiti nella sua Chiesa, tra i quali è il santo sacrificio della Messa.
+
+D. Per quali fini dunque si offre il sacrificio della santa Messa ?
+
+R. Il sacrificio della santa Messa si offerisce a Dio per quattro fini: 1.º per onorarlo come si conviene, e per questo si chiama latreutico ; 2.º per ringraziarlo dei suoi benefizi, e per questo si chiama eucaristico ; 3.º per placarlo, per dargli la dovuta soddisfazione dei nostri peccati e per suffragare le anime del purgatorio; e per questo si chiama propiziatorio ; 4.º per ottenere tutte le grazie che ci sono necessarie, e per questo si chiama impetratorio .
+
+D. Chi è che offre a Dio il sacrificio della santa Messa?
+
+R. Il primo e principale offerente del sacri ficio della santa Messa è Gesù Cristo, e il sacerdote e il ministro che in nome di Gesù Cristo offre lo stesso sacrificio all’Eterno Padre.
+
+D. Chi ha istituito il sacrificio della santa Messa?
+
+R. Il sacrificio della santa Messa lo istituì Gesù Cristo medesimo quando istituì il sacramento dell’Eucaristia; e disse che si facesse in memoria della sua Passione.
+
+D. A chi si offre la santa Messa?
+
+R. La santa Messa si offre a Dio solo.
+
+D. Se la santa Messa si offre a Dio solo, perchè si celebrano tante Messe in onore della santissima Vergine e dei Santi?
+
+R. La Messa celebrata in onore della Vergine e dei Santi è sempre un sacrificio offerto a Dio solo: si dice però celebrata in onore della santissima Vergine e dei Santi per ringraziare Dio dei doni che loro ha fatti e ottenere da Lui con la loro intercessione più abbondantemente le grazie di cui abbiamo bisogno.
+
+D. Chi è partecipe dei frutti della Messa?
+
+R. Tutta la Chiesa partecipa dei frutti della Messa, ma particolarmente: 1.º il sacerdote e quelli che assistono alla Messa, i quali si considerano uniti al sacerdote; 2.º quelli per cui si applica la Messa, che possono essere sì vivi che defunti.
+
+§ 2 . - Del modo di assistere alla santa Messa.
+
+D. Quali cose sono necessarie per ascoltare bene e con frutto la santa Messa?
+
+R. Per ascoltare bene e con frutto la santa Messa sono necessarie due cose: 1.º la modestia della persona; 2.º la divozione del cuore.
+
+D. In che consiste la modestia della persona?
+
+R. La modestia della persona consiste in modo speciale nell’essere modestamente vestito; nell’osservare silenzio e raccoglimento, e nello stare, per quanto si può, ginocchioni, eccettuato il tempo dei due vangeli, che si ascoltano stando in piedi.
+
+D. Nell’ascoltare la santa Messa qual è il miglior modo di praticare la divozione del cuore?
+
+R. Il miglior modo di praticare la divozione del cuore nell’ascoltare la santa Messa è il seguente:
+
+1.º Unire da principio la propria intenzione a quella del sacerdote, offerendo a Dio il santo sacrificio per i fini pei quali è stato istituito.
+
+2.º Accompagnare il sacerdote in ciascuna preghiera e azione del sacrificio.
+
+3.º Meditare la passione e morte di Gesù Cristo e detestare di cuore i peccati che ne sono stati la cagione.
+
+4.º Fare la Comunione sacramentale, o almeno la spirituale, nel tempo che si comunica il sacerdote.
+
+D. Che cosa è la Comunione spirituale?
+
+R. La Comunione spirituale è un gran desiderio di unirsi sacramentalmente a Gesù Cristo dicendo, per esempio: Signore mio Gesù Cristo, io desidero con tutto il cuore di unirmi a Voi adesso e per tutta l’eternità; e facendo i medesimi atti che si fanno avanti, e dopo la Comunione sacramentale.
+
+D. La recita del Rosario o di altre orazioni durante la Messa impedisce di ascoltarla con frutto?
+
+R. La recita di queste preghiere non impedisce di ascoltare con frutto la Messa, purchè si procuri per quanto si può di seguire l’azione del santo sacrificio.
+
+D. È cosa ben fatta il pregare anche per gli altri nell’assistere alla santa Messa?
+
+R. È cosa ben fatta il pregare anche per gli altri nell’assistere alla santa Messa: anzi il tempo della santa Messa è il più opportuno per pregar Dio per i vivi e per i morti.
+
+D. Finita la Messa che cosa si dovrebbe fare?
+
+R. Finita la Messa, si dovrebbe ringraziar Dio della grazia d’averci fatto assistere a questo grande sacrificio, e domandargli perdono delle mancanze che abbiamo commesso nell’assistervi.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-vi.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-vi.txt
@@ -1,0 +1,584 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quarta/Capo_VI ===
+=== TITLE: Parte IV — Dei sacramenti — Compendio della dottrina cristiana/Catechismo maggiore/Parte quarta/Capo VI ===
+
+Capo VI. Della Penitenza.
+
+§ 1 . - Della Penitenza in generale.
+
+D. Che cosa è il sacramento della Penitenza?
+
+R. La Penitenza detta anche Confessione, è il sacramento istituito da Gesù Cristo per rimettere i peccati commessi dopo il Battesimo.
+
+D. Perchè a questo sacramento si dà il nome di Penitenza?
+
+R. A questo sacramento si dà il nome di Penitenza, perchè ad ottenere il perdono dei peccati è necessario detestarli con pentimento, e perchè chi ha commesso una colpa, deve sottoporsi alla pena che il sacerdote impone.
+
+D. Perchè questo sacramento si chiama anche Confessione?
+
+R. Questo sacramento si chiama anche Confessione, perchè ad ottenere il perdono dei peccati non basta detestarli, ma è necessario accusarli al sacerdote, cioè farne la confessione.
+
+D. Quando Gesù Cristo ha istituito il sacramento della Penitenza?
+
+R. Gesù Cristo ha istituito il sacramento della Penitenza il giorno della sua risurrezione, quando entrato nel cenacolo solennemente diede ai suoi Apostoli la facoltà di rimettere i peccati.
+
+D. Come Gesù Cristo diede ai suoi Apostoli la facoltà di rimettere i peccati?
+
+R. Gesù Cristo diede ai suoi Apostoli la facoltà di rimettere i peccati, soffiando sopra di loro, e dicendo: Ricevete lo Spirito Santo: i peccati di coloro ai quali voi li rimetterete, saranno rimessi; ed i peccati di coloro ai quali voi li riterrete, saranno ritenuti.
+
+D. Qual’è la materia del sacramento della Penitenza?
+
+R. La materia del sacramento della Penitenza si distingue in remota e prossima. La materia remota è costituita dai peccati commessi dal penitente dopo il Battesimo, e la materia prossima sono gli atti del penitente stesso, cioè la contrizione, l’accusa e la soddisfazione.
+
+D. Qual’è la forma del sacramento della Penitenza?
+
+R. La forma del sacramento della Penitenza è questa: Io ti assolvo dai tuoi peccati.
+
+D. Chi è il ministro del sacramento della Penitenza?
+
+R. Il ministro del sacramento della Penitenza è il sacerdote approvato dal Vescovo per ascoltare le confessioni.
+
+D. Perchè avete detto che il sacerdote deve essere approvato dal Vescovo?
+
+R. Il sacerdote deve essere approvato dal Vescovo ad ascoltare le confessioni, perchè ad amministrare validamente questo sacramento non basta la potestà dell’ordine, ma è necessaria anche la potestà di giurisdizione, cioè la facoltà di giudicare, che deve essere data dal Vescovo.
+
+D. Quante sono le parti del sacramento della Penitenza?
+
+R. Le parti del sacramento della Penitenza sono: la contrizione, la confessione e la soddisfazione del penitente, e l’assoluzione del sacerdote.
+
+D. Che cosa è la contrizione, ossia il dolore dei peccati?
+
+R. La contrizione ossia il dolore dei peccati, è un dispiacere dell’animo, pel quale si detestano i peccati commessi e si propone di non farne più in avvenire.
+
+D. Che cosa vuol dire questa parola contrizione?
+
+R. La parola contrizione , vuol dire rottura o spezzamento, come quando una pietra è pestata e ridotta in polvere.
+
+D. Perchè si dà il nome di contrizione al dolore dei peccati?
+
+R. Si dà il nome di contrizione al dolore dei peccati, per significare che il cuor duro del peccatore in certo modo si spezza per dolore di avere offeso Dio.
+
+D. In che consiste la confessione dei peccati?
+
+R. La confessione consiste in un’accusa distinta dei nostri peccati fatta al confessore per averne l’assoluzione e la penitenza.
+
+D. Perchè la confessione si chiama accusa?
+
+R. La confessione si chiama accusa, perchè non dev’essere un indifferente racconto, ma una vera e dolorosa manifestazione de’ propri peccati.
+
+D. Che cosa è la soddisfazione o penitenza?
+
+R. La soddisfazione o penitenza è quella preghiera o altra opera buona, che il confessore ingiunge al penitente in espiazione de’ suoi peccati.
+
+D. Che cosa è l’assoluzione?
+
+R. L’assoluzione è la sentenza, che il sacerdote pronunzia in nome di Gesù Cristo, per rimettere i peccati al penitente.
+
+D. Delle parti del sacramento della Penitenza qual è la più necessaria?
+
+R. Delle parti del sacramento della Penitenza la più necessaria è la contrizione, perchè senza di essa non si può mai ottenere il perdono dei peccati, e con essa sola, quando sia perfetta, si può ottenere il perdono, purchè sia congiunta col desiderio, almeno implicito, di confessarsi.
+
+§ 2 . - Degli effetti e della necessità del sacramento della Penitenza e delle disposizioni per ben riceverlo.
+
+D. Quanti sono gli effetti del sacramento della Penitenza?
+
+R. Il sacramento della Penitenza conferisce la grazia santificante con la quale sono rimessi i peccati mortali e anche i veniali che si sono confessati e dei quali si ha dolore; commuta la pena eterna nella temporale, della quale pure vien rimesso più o meno secondo le disposizioni; restituisce i meriti delle buone opere fatte prima di commettere il peccato mortale; dà al l’anima aiuti opportuni per non ricadere nella colpa, e ridona la pace alla coscienza.
+
+D. Il sacramento della Penitenza è necessario a tutti per salvarsi?
+
+R. Il sacramento della Penitenza è necessario per salvarsi a tutti quelli che dopo il Battesimo hanno commesso qualche peccato mortale.
+
+D. È cosa buona confessarsi spesso?
+
+R. Il confessarsi spesso è cosa ottima, perchè il sacramento della Penitenza, oltre al cancellare i peccati dà le grazie opportune per evitarli in avvenire.
+
+D. Il sacramento della Penitenza ha virtù di rimettere tutti i peccati per molti e grandi che siano?
+
+R. Il sacramento della Penitenza ha virtù di rimettere tutti i peccati per molti e grandi che siano, purchè si riceva con le dovute disposizioni.
+
+D. Quante cose si richiedono per fare una buona confessione?
+
+R. Per fare una buona confessione si richiedono cinque cose: 1.º esame di coscienza; 2.º dolore di avere offeso Iddio; 3.º proponimento di non più peccare, 4.º accusa dei propri peccati; 5.º soddisfazione o penitenza.
+
+D. Che cosa dobbiamo noi fare prima di tutto per confessarci bene?
+
+R. Per confessarci bene dobbiamo prima di tutto pregare di cuore il Signore a darci lume per conoscere tutti i nostri peccati e forza per detestarli.
+
+§ 3 . - Dell’esame.
+
+D. Che cos’è l’esame di coscienza?
+
+R. L’esame di coscienza è una diligente ricerca dei peccati che si sono commessi, dopo l’ultima confessione ben fatta.
+
+D. Come si fa l’esame di coscienza?
+
+R. L’esame di coscienza si fa col richiamare diligentemente alla memoria, innanzi a Dio, tutti i peccati commessi, non mai confessati, in pensieri, parole, opere ed omissioni, contro i comandamenti di Dio e della Chiesa, e gli obblighi del proprio stato.
+
+D. Sopra quali altre cose dobbiamo esaminarci?
+
+R. Dobbiamo esaminarci ancora sopra le abitudini cattive e sopra le occasioni del peccato.
+
+D. Nell’esame dobbiamo ricercare anche il numero dei peccati?
+
+R. Nell’esame dobbiamo ricercare anche il numero dei peccati mortali.
+
+D. Che cosa si richiede perchè un peccato sia mortale?
+
+R. Perchè un peccato sia mortale si richiedono tre cose: materia grave, piena avvertenza, e perfetto consenso della volontà.
+
+D. Quand’è che vi ha materia grave?
+
+R. Vi ha materia grave quando si tratta di una cosa notabilmente contraria alla legge di Dio e della Chiesa.
+
+D. Quand’è che vi ha piena conoscenza nel peccare?
+
+R. Vi ha piena conoscenza nel peccare, quando si conosca perfettamente di fare un grave male.
+
+D. Quand’è che, nel peccato, si ha il perfetto consenso della volontà?
+
+R. Si ha, nel peccato, il perfetto consenso della volontà, quando si vuol fare deliberatamente una cosa, sebbene si conosca peccaminosa.
+
+D. Qual diligenza si deve usare nell’esame di coscienza?
+
+R. Nell’esame di coscienza si deve usare quella diligenza che si userebbe in un affare di grande importanza.
+
+D. Quanto tempo si deve impiegare nell’esame?
+
+R. Si deve impiegare nell’esame di coscienza più o meno tempo, secondo il bisogno, cioè secondo il numero e la qualità dei peccati che aggravano la coscienza e secondo il tempo scorso dalla ultima confessione ben fatta.
+
+D. Come si può facilitare l’esame per la confessione?
+
+§ 4 . - Del dolore.
+
+D. Che cosa è il dolore dei peccati?
+
+R. Il dolore dei peccati consiste in un dispiacere ed in una sincera detestazione dell’offesa fatta a Dio.
+
+D. Di quante sorta è il dolore?
+
+R. Il dolore è di due sorta: perfetto, ossia di contrizione; imperfetto, ossia di attrizione.
+
+D. Qual è il dolore perfetto, o di contrizione?
+
+R. Il dolore perfetto è il dispiacere di avere offeso Dio, perchè infinitamente buono e degno per se stesso di essere amato.
+
+D. Perchè chiamate voi perfetto il dolore di contrizione?
+
+R. Chiamo perfetto il dolore di contrizione per due ragioni: 1.º perchè riguarda esclusivamente la bontà di Dio, e non il nostro vantaggio o danno; 2.º perchè ci fa subito ottenere il perdono dei peccati, restandoci però l’obbligo di confessarci.
+
+D. Dunque il dolore perfetto ci ottiene il perdono dei peccati indipendentemente dalla confessione?
+
+R. Il dolore perfetto non ci ottiene il perdono dei peccati indipendentemente dalla confessione, perchè sempre include la volontà di confessarsi.
+
+D. Perchè il dolore perfetto, o contrizione, produce questo effetto di rimetterci in grazia di Dio?
+
+R. Il dolore perfetto, o contrizione produce questo effetto, perchè nasce dalla carità la quale non può trovarsi nell’anima insieme col peccato mortale.
+
+D. Qual’è il dolore imperfetto o di attrizione?
+
+R. Il dolore imperfetto o di attrizione e quello per cui ci pentiamo di avere offeso Dio, come sommo Giudice, cioè per timore dei castighi meritati in questa o nell’altra vita o per la stessa bruttezza del peccato.
+
+D. Quali condizioni deve avere il dolore, per essere buono?
+
+R. Il dolore per essere buono, deve avere quattro condizioni: deve essere interno, soprannaturale, sommo e universale .
+
+D. Che cosa vuol dire che il dolore deve essere interno?
+
+R. Vuol dire che deve essere nel cuore e nella volontà e non nelle sole parole.
+
+D. Perchè il dolore dev’essere interno?
+
+R. Il dolore deve essere interno, perchè la volontà che si è allontanata da Dio col peccato, deve ritornare a Dio detestando il peccato commesso.
+
+D. Che cosa vuol dire che il dolore deve essere soprannaturale?
+
+R. Vuol dire che deve essere eccitato in noi dalla grazia del Signore e concepito per motivi di fede.
+
+D. Perchè il dolore dev’essere soprannaturale?
+
+R. Il dolore deve essere soprannaturale, per chè è soprannaturale il fine a cui si dirige, cioè il perdono di Dio, l’acquisto della grazia santificante ed il diritto alla gloria eterna.
+
+D. Spiegate meglio la differenza tra il dolore soprannaturale e il naturale?
+
+R. Chi si pente per avere offeso Dio infinitamente buono e degno per se stesso di essere amato, per aver perduto il paradiso e meritato l’inferno, ovvero per la malizia intrinseca del peccato, ha un dolore soprannaturale perchè questi sono motivi di fede: chi invece si pentisse solo pel disonore, o castigo che gli viene dagli uomini, o per qualche danno puramente temporale, avrebbe un dolore naturale, perchè si pentirebbe solo per motivi umani.
+
+D. Perchè il dolore deve essere sommo?
+
+R. Il dolore deve essere sommo, perchè dobbiamo riguardare e odiare il peccato come sommo di tutti i mali, essendo offesa di Dio sommo Bene.
+
+D. Pel dolore dei peccati è forse necessario piangere, come alle volte si piange per le disgrazie di questa vita?
+
+R. Non è necessario che materialmente si pianga pel dolore dei peccati; ma basta che nel cuore si faccia più gran caso di avere offeso Dio, che di qualunque altra disgrazia.
+
+D. Che vuol dire che il dolore deve essere universale?
+
+R. Vuol dire che deve estendersi a tutti i peccati mortali commessi.
+
+D. Perchè il dolore deve estendersi a tutti i peccati mortali commessi?
+
+R. Perchè chi non si pente anche di un solo peccato mortale, rimane nemico di Dio.
+
+D. Che cosa dobbiamo fare per avere il dolore dei nostri peccati?
+
+R. Per avere il dolore dei nostri peccati dobbiamo dimandarlo di cuore a Dio, ed eccitarlo in noi con la considerazione del gran male che abbiamo fatto peccando.
+
+D. Come farete per eccitarvi a detestare i peccati?
+
+R. Per eccitarmi a detestare i peccati: 1.º considererò il rigore della infinita giustizia di Dio e la deformità del peccato che ha deturpato l’anima mia e mi ha reso meritevole delle pene eterne dell’inferno; 2.º considererò che ho perduta la grazia, l’amicizia, la figliuolanza di Dio e l’eredità del paradiso; 3.º che ho offeso il mio Redentore che è morto per me, e che i miei peccati sono stati la cagione della sua morte; 4.º che ho disprezzato il mio Creatore, il mio Dio; che ho voltato le spalle a lui, mio sommo bene degno di essere amato sopra ogni cosa e servito fedelmente.
+
+D. Dobbiamo noi essere grandemente solleciti, quando andiamo a confessarci, d’avere un vero dolore de’ nostri peccati?
+
+R. Quando noi andiamo a confessarci, dobbiamo essere certamente molto solleciti di avere un vero dolore de’ nostri peccati, perchè questa è la cosa più importante di tutte: e se manca il dolore, la confessione non vale.
+
+D. Chi si confessa di soli peccati veniali deve avere il dolore di tutti?
+
+R. Chi si confessa di soli peccati veniali, per confessarsi validamente basta che sia pentito di alcuno di essi; ma per ottenere il perdono di tutti è necessario che si penta di tutti quelli che riconosce di aver commesso.
+
+D. Chi si confessa di soli peccati veniali, e non è pentito neppure di un solo, fa una buona confessione?
+
+R. Chi si confessa di soli peccati veniali e non è pentito neppure di un solo, fa una confessione di nessun valore; la quale è inoltre sacrilega, se la mancanza del dolore è avvertita.
+
+D. Che cosa convien fare per rendere più sicura la confessione di soli peccati veniali?
+
+R. Per rendere più sicura la confessione di soli peccati veniali, è cosa prudente accusare, con vero dolore, anche qualche peccato più grave della vita passata, benchè già confessato altre volte.
+
+D. È cosa buona fare spesso l’atto di contrizione?
+
+R: È cosa buona ed utilissima il fare spesso l’atto di contrizione, massime prima di andare a dormire, e quando uno si accorge o dubita di essere caduto in peccato mortale, per rimettersi più presto in grazia di Dio; e giova sopratutto per ottenere più facilmente da Dio la grazia di fare simile atto nel maggior bisogno, cioè nel pericolo di morte.
+
+§ 5 . - Del proponimento.
+
+D. In che consiste il proponimento?
+
+R. Il proponimento consiste in una volontà risoluta di non commettere mai più il peccato e di usare tutti i mezzi necessari per fuggirlo.
+
+D. Quali condizioni deve avere il proponimento per essere buono?
+
+R. Il proponimento, affinchè sia buono, deve avere principalmente tre condizioni: deve essere assoluto, universale ed efficace .
+
+D. Che cosa vuol dire: proponimento assoluto?
+
+R. Vuol dire che il proponimento deve essere senza alcuna condizione di tempo, di luogo, o di persona.
+
+D. Che cosa vuol dire: il proponimento deve essere universale?
+
+R. Il proponimento deve essere universale , vuol dire che dobbiamo voler fuggire tutti i peccati mortali, tanto quelli già altre volte commessi, quanto altri che potremmo commettere.
+
+D. Che cosa vuol dire: il proponimento deve essere efficace?
+
+R. Il proponimento deve essere efficace , vuol dire che bisogna avere una volontà risoluta di perdere prima ogni cosa che commettere un nuovo peccato, di fuggire le occasioni pericolose di peccare, di distruggere gli abiti cattivi, e di adempiere gli obblighi contratti in conseguenza dei nostri peccati.
+
+D. Che s’intende per abito cattivo?
+
+R. Per abito cattivo s’intende la disposizione acquistata a cadere con facilità in quei peccati ai quali ci siamo assuefatti.
+
+D. Che cosa si deve fare per correggere gli abiti cattivi?
+
+R. Per correggere gli abiti cattivi dobbiamo stare vigilanti sopra di noi, fare molta orazione, frequentare la confessione, avere un buon direttore stabile, e mettere in pratica i consigli e i rimedi che egli ci propone.
+
+D. Che cosa s’intende per occasioni pericolose di peccare?
+
+R. Per occasioni pericolose di tendono tutte quelle circostanze di tempo, di luogo, di persone, o di cose che per propria natura, o per la nostra fragilità ci inducono a commettere il peccato.
+
+D. Siamo noi gravemente obbligati a schivare tutte le occasioni pericolose?
+
+R. Noi siamo gravemente obbligati a schivare quelle occasioni pericolose che d’ordinario ci inducono a commettere peccato mortale, le quali si chiamano le occasioni prossime del peccato.
+
+D. Che cosa deve fare chi non può fuggire qualche occasione di peccato?
+
+R. Chi non può fuggire qualche occasione di peccato, lo dica al confessore e stia ai consigli di lui.
+
+D. Quali considerazioni servono per fare il proponimento?
+
+R. Per fare il proponimento servono le stesse considerazioni, che valgono ad eccitare il dolore; cioè la considerazione dei motivi che abbiamo di temere la giustizia di Dio e di amare la sua infinità bontà.
+
+§ 6 . - Dell’accusa dei peccati al confessore.
+
+D. Dopo di esservi ben disposto alla confessione con l’esame, col dolore e col proponimento, che cosa farete?
+
+R. Dopo di essermi ben disposto coll’esame, col dolore e col proponimento, andrò a fare al confessore l’accusa de’ miei peccati per averne l’assoluzione.
+
+D. Di quali peccati siamo obbligati a confessarci?
+
+R. Siamo obbligati a confessarci di tutti i peccati mortali; è bene però confessare anche i veniali.
+
+D. Quali sono le condizioni che deve avere l’accusa dei peccati o confessione?
+
+R. Le condizioni principali che deve avere l’accusa dei peccati sono cinque: deve essere umile, intiera, sincera, prudente e breve .
+
+D. Che vuol dire: l’accusa deve esser umile?
+
+R. L’accusa deve esser umile , vuol dire che il penitente deve accusarsi dinanzi al suo confessore, senza alterigia di animo o di parole, ma coi sentimenti di un reo, che riconosce la sua colpa e comparisce davanti al giudice.
+
+D. Che vuol dire: l’accusa dev’essere intiera?
+
+R. L’accusa dev’essere intiera , vuol dire che si debbono manifestare con le loro circostanze e nel loro numero tutti i peccati mortali commessi dopo l’ultima confessione ben fatta e dei quali si ha coscienza.
+
+D. Quali circostanze si devono manifestare, perchè l’accusa sia intiera?
+
+R. Perchè l’accusa sia intiera, si devono manifestare le circostanze che mutano la specie del peccato.
+
+D. Quali sono le circostanze che mutano la specie del peccato?
+
+R. Le circostanze che mutano la specie del peccato, sono: 1.º quelle per le quali un’azione peccaminosa da veniale diventa mortale; 2.º quelle per le quali un’azione peccaminosa contiene la malizia di due o più peccati mortali.
+
+D. Datemi l’esempio di una circostanza che faccia diventar mortale un peccato veniale?
+
+R. Chi per iscusarsi dicesse una bugia dalla quale venisse grave danno al prossimo, dovrebbe manifestare questa circostanza che cambia la bugia da officiosa in gravemente dannosa.
+
+D. Datemi ora l’esempio di una circostanza per la quale una stessa azione peccaminosa contiene la malizia di due o più peccati.
+
+R. Chi avesse rubato una cosa sacra do vrebbe accusare questa circostanza che aggiunge al furto la malizia del sacrilegio.
+
+D. Se taluno non fosse certo di aver commesso un peccato, deve confessarsene?
+
+R. Se taluno non fosse certo di aver commesso un peccato, non è obbligato a confessarsene; se però volesse accusarlo, dovrà aggiungere che non è certo di averlo commesso.
+
+D. Chi non ricorda precisamente il numero de’ suoi peccati, che cosa deve fare?
+
+R. Chi non ricorda precisamente il numero dei suoi peccati, deve accusarne il numero approssimativo.
+
+D. Chi ha taciuto per pura dimenticanza un peccato mortale, o una circostanza necessaria, ha fatto una buona confessione?
+
+R. Chi ha taciuto per pura dimenticanza un peccato mortale, o una circostanza necessaria, ha fatto una buona confessione purchè abbia usata la debita diligenza per ricordarsene.
+
+D. Se un peccato mortale dimenticato nella confessione torna poi in mente, siamo obbligati ad accusarcene in un’altra confessione?
+
+R. Se un peccato mortale dimenticato nella confessione torna poi in mente, siamo obbligati senza dubbio ad accusarlo la prima volta che di nuovo ci confessiamo.
+
+D. Chi per vergogna, o per qualche altro motivo tace colpevolmente nella confessione qualche peccato mortale, che cosa commette?
+
+R. Colui che per vergogna o per qualche altro motivo tace colpevolmente qualche peccato mortale in confessione, profana il sacramento e perciò si fa reo di un gravissimo sacrilegio.
+
+D. Chi ha taciuto colpevolmente qualche peccato mortale nella confessione, come deve provvedere alla propria coscienza?
+
+R. Chi ha taciuto colpevolmente qualche peccato mortale nella confessione, deve esporre al confessore il peccato taciuto, dire in quante confessioni l’abbia taciuto e rifare tutte le confessioni dall’ultima ben fatta.
+
+D. Che cosa deve considerare chi fosse tentato a tacere qualche peccato in confessione?
+
+R. Chi fosse tentato a tacere un peccato grave in confessione deve considerare:
+
+1.º che non ha avuto rossore di peccare alla presenza di Dio, che tutto vede;
+
+2.º che è meglio manifestare i propri peccati al confessore in segreto, che vivere in quieto nel peccato, fare una morte infelice ed essere perciò svergognato nel dì del giudizio universale in faccia a tutto il mondo;
+
+3.º che il confessore è obbligato al sigillo sacramentale sotto gravissimo peccato e con la minaccia di severissime pene temporali ed eterne.
+
+D. Che cosa vuol dire: l’accusa deve essere sincera?
+
+R. L’accusa deve essere sincera , vuol dire che bisogna dichiarare i propri peccati quali sono, senza scusarli, diminuirli o accrescerli.
+
+D. Che vuol dire: la confessione deve essere prudente?
+
+R. La confessione deve essere prudente , vuol dire che nel confessare i peccati dobbiamo servirci dei termini più modesti, e che dobbiamo guardarci dallo scoprire i peccati degli altri.
+
+D. Che cosa significa: la confessione deve essere breve?
+
+R. La confessione deve essere breve , significa che non dobbiamo dire niente d’inutile al confessore.
+
+D. Non è egli gravoso il dover confessare ad un altro i propri peccati, massimamente se sono assai vergognosi?
+
+R. Sebbene il confessare ad un altro i propri peccati possa essere gravoso, bisogna farlo, perchè è di precetto divino e altrimenti non si può ottenere il perdono dei peccati commessi, e inoltre perchè la difficoltà di confessarsi è compensata da molti vantaggi e da grandi consolazioni.
+
+§ 7 . - Del modo di confessarsi.
+
+D. Come vi presenterete al confessore?
+
+R. Mi inginocchierò ai piedi del confessore e dirò: beneditemi, padre, perchè ho peccato.
+
+D. Che cosa farete mentre il confessore vi darà la benedizione?
+
+R. Mi inchinerò umilmente a ricevere la benedizione, e farò il segno della Croce.
+
+D. Fatto il segno della Croce, che cosa deve dirsi?
+
+R. Fatto il segno della Croce, si deve dire: mi confesso a Dio onnipotente, alla beata Vergine Maria, a tutti i Santi, ed a voi, padre mio spirituale, perchè ho peccato.
+
+D. E poi che cosa bisogna dire?
+
+R. Poi bisogna dire: mi sono confessato nel tal tempo; per grazia di Dio ho ricevuto l’assoluzione, ho fatto la penitenza, e sono andato alla Comunione. Quindi si fa l’accusa dei peccati.
+
+D. Finita l’accusa dei peccati che cosa farete?
+
+R. Finita l’accusa dei peccati dirò: mi accuso ancora di tutti i peccati della vita passata, specialmente contro la tale, o tale virtù – p. es. contro la purità, contro il quarto comandamento, ecc.
+
+D. Dopo questa accusa che cosa si deve dire?
+
+R. Si deve dire: di tutti questi peccati e di quelli che non ricordo, domando perdono a Dio con tutto il cuore; ed a voi, mio padre spirituale, domando la penitenza e l’assoluzione.
+
+D. Compita così l’accusa dei peccati che cosa resta a farsi?
+
+R. Compita l’accusa dei peccati, bisogna ascoltare con rispetto quello che dirà il confessore; accettare la penitenza con sincera volontà di farla; e mentre egli darà l’assoluzione, rinnovare di cuore l’atto di contrizione.
+
+D. Ricevuta l’assoluzione, che resta a fare?
+
+R. Ricevuta l’assoluzione, bisogna ringraziare il Signore; fare al più presto la penitenza; e mettere in pratica gli avvisi del confessore.
+
+§ 8 . - Dell’assoluzione.
+
+D. Debbono i confessori dar sempre l’assoluzione a quelli che si confessano?
+
+R. I confessori debbono dare l’assoluzione solamente a quelli che essi giudicano ben disposti a riceverla.
+
+D. Possono i confessori differire o negare qualche volta l’assoluzione?
+
+R. I confessori non solamente possono, nè debbono differire o negare l’assoluzione in certi casi, per non profanare il sacramento.
+
+D. Quali sono i penitenti che debbono ritenersi mal disposti, e ai quali si deve d’ordinario negare o differire l’assoluzione?
+
+R. I penitenti che debbono ritenersi mal disposti sono questi principalmente:
+
+1.º coloro che non sanno i misteri principali della fede o trascurano d’imparare le altre cose della Dottrina cristiana, che sono obbligati a sapere secondo il loro stato;
+
+2.º coloro che sono gravemente negligenti nel fare l’esame di coscienza o non dànno segni di dolore e di pentimento;
+
+3.º coloro che non vogliono restituire, potendo, la roba altrui, o la riputazione tolta;
+
+4.º coloro che non perdonano di cuore ai loro nemici.
+
+5.º coloro che non vogliono praticare i mezzi necessari per emendarsi dei loro abiti cattivi;
+
+6.º coloro che non vogliono lasciare le occasioni prossime del peccato.
+
+D. Non è egli troppo rigoroso il confessore che differisce l’assoluzione al penitente, perchè non lo crede ancora ben disposto?
+
+R. Il confessore che differisce l’assoluzione al penitente, perchè non lo crede ancora ben disposto, non è troppo rigoroso, ma anzi molto caritatevole, regolandosi come un buon medico, che tenta tutti i rimedi, anche disgustosi e dolorosi, per salvare la vita all’ammalato.
+
+D. Il peccatore al quale si differisce o si nega l’assoluzione, dovrà disperarsi, o affatto ritirarsi dalla confessione?
+
+R. Il peccatore, al quale si differisce, o si nega l’assoluzione, non deve disperarsi, o ritirarsi affatto dalla confessione; ma deve umiliarsi, riconoscere il suo deplorabile stato, profittare dei buoni consigli che il confessore gli dà, e così mettersi al più presto possibile in istato di meritare l’assoluzione.
+
+D. Che cosa deve fare il penitente, quanto alla scelta del confessore?
+
+R. Il vero penitente deve raccomandarsi molto a Dio per la scelta di un confessore pio, dotto e prudente, poi mettersi nelle sue mani, e sottomettersi a lui, come a suo giudice e medico.
+
+§ 9 . - Della soddisfazione ossia penitenza.
+
+D. Che cosa è la soddisfazione?
+
+R. La soddisfazione, che chiamasi anche pe nitenza sacramentale, è uno degli atti del penitente, col quale egli dà un qualche risarcimento alla giustizia di Dio per i peccati commessi, eseguendo quelle opere che il confessore gli impone.
+
+D. Il penitente è obbligato ad accettare la penitenza ingiuntagli dal confessore?
+
+R. Il penitente è obbligato ad accettare la penitenza ingiuntagli dal confessore, se può farla; e se non può farla, deve dirlo umilmente al confessore stesso, e domandarne un’altra.
+
+D. Quando si deve fare la penitenza?
+
+R. Se il confessore non ha prescritto verun tempo, la penitenza si deve fare al più presto, e procurare di farla in istato di grazia.
+
+D. Come si deve fare la penitenza?
+
+R. La penitenza si deve fare intiera e con divozione.
+
+D. Perchè nella confessione s’ingiunge la penitenza?
+
+R. La penitenza s’ingiunge perchè d’ordinario, dopo l’assoluzione sacramentale che rimette la colpa e la pena eterna, resta una pena temporale da scontarsi in questo mondo o nel purgatorio.
+
+D. Per qual ragione ha voluto il Signore nel sacramento del Battesimo rimettere tutta la pena dovuta ai peccati e non nel sacramento della Penitenza?
+
+R. Il Signore ha voluto nel sacramento del Battesimo rimettere tutta la pena dovuta ai peccati, e non nel sacramento della Penitenza, perchè i peccati dopo il Battesimo sono assai più gravi, essendo commessi con maggior cognizione e ingratitudine ai beneficî di Dio, e anche perchè l’obbligo di soddisfarli sia freno a non ricadere nel peccato.
+
+D. Possiamo noi soddisfare da noi stessi a Dio?
+
+R. Noi, da noi stessi, non possiamo soddisfare a Dio; ma ben lo possiamo con l’unirci a Gesù Cristo, che col merito della sua passione e morte dà valore alle nostre azioni.
+
+D. La penitenza che dà il confessore basta essa sempre a cancellare la pena che rimane dovuta ai peccati?
+
+R. La penitenza che dà il confessore d’ordinario non basta per scontare la pena che rimane dovuta ai peccati; perciò bisogna procurare di supplire con altre penitenze volontarie.
+
+D. Quali sono le opere di penitenza?
+
+R. Le opere di penitenza si possono ridurre a tre specie: alla preghiera, al digiuno, alla limosina.
+
+D. Che cosa intendete per preghiera?
+
+R. Per la preghiera s’intende ogni sorta di esercizi di pietà.
+
+D. Che cosa s’intende per digiuno?
+
+R. Per digiuno s’intende ogni sorta di mortificazione.
+
+D. Che s’intende per limosina?
+
+R. Per limosina s’intende qualunque opera di misericordia spirituale e corporale.
+
+D. Quale penitenza è più meritoria, quella che dà il confessore, o quella che facciamo di nostra elezione?
+
+R. La penitenza che ci dà il confessore è la più meritoria, perchè, essendo parte del sacramento, riceve maggior virtù dai meriti della passione di Gesù Cristo.
+
+D. Quelli che muoiono dopo d’avere ricevuta l’assoluzione, ma prima d’avere pienamente soddisfatto alla giustizia di Dio, vanno subito in paradiso?
+
+R. No; vanno in purgatorio per ivi soddisfare alla giustizia di Dio, e purificarsi interamente.
+
+D. Le anime che sono nel purgatorio possono essere da noi sollevate nelle loro pene?
+
+R. Sì, le anime, che sono nel purgatorio, possono essere sollevate con le preghiere, con le limosine, con tutte le altre buone opere e con le indulgenze, ma sopratutto col santo sacrificio della Messa.
+
+D. Oltre la penitenza, che altro deve fare il penitente dopo la confessione?
+
+R. Il penitente, dopo la confessione, oltre la penitenza, se ha danneggiato ingiustamente il prossimo nella roba o nell’onore, o se gli ha dato scandalo, deve per quanto gli è possibile al più presto restituirgli la roba, ripararne l’onore e rimediare allo scandalo.
+
+D. Come si può rimediare allo scandalo che si è cagionato?
+
+R. Si può rimediare allo scandalo che si è cagionato, facendone cessare l’occasione, ed edificando con le parole e col buon esempio quelli che abbiamo scandalizzati.
+
+D. In qual maniera si dovrà soddisfare al prossimo, quando è stato da noi offeso?
+
+R. Si dovrà soddisfare al prossimo, quando è stato da noi offeso, con domandargli perdono o con dargli qualche altra conveniente riparazione.
+
+D. Quali frutti produce in noi una buona confessione?
+
+R. Una buona confessione: 1.º ci rimette i peccati commessi, e ci dà la grazia di Dio; 2.º ci restituisce la pace e la quiete della coscienza; 3.º ci riapre le porte del paradiso, e cambia la pena eterna dell’inferno in pena temporale; 4.º ci preserva dalle ricadute e ci rende capaci del tesoro delle indulgenze.
+
+§ 10 . - Delle indulgenze.
+
+D. Che cosa è l’indulgenza?
+
+R. L’indulgenza è la remissione della pena temporale dovuta per i nostri peccati, già rimessi quanto alla colpa; remissione che la Chiesa accorda fuori del sacramento della Penitenza.
+
+D. Da chi ha ricevuto la Chiesa la facoltà di dare le indulgenze?
+
+R. La Chiesa ha ricevuto la facoltà di dare le indulgenze da Gesù Cristo.
+
+D. In qual modo la Chiesa ci rimette la pena temporale per mezzo delle indulgenze?
+
+R. La Chiesa ci rimette la pena temporale per mezzo delle indulgenze, applicandoci le soddisfazioni sovrabbondanti di Gesù Cristo, di Maria SSm̃a, e dei Santi, le quali formano ciò che dicesi il tesoro della Chiesa .
+
+D. Chi ha il potere di concedere le indulgenze?
+
+R. Il potere di concedere le indulgenze lo ha solo il Papa in tutta la Chiesa, e il Vescovo nella sua diocesi, secondo la facoltà concessagli dal Papa.
+
+D. Di quante specie sono le indulgenze?
+
+R. Le indulgenze sono di due specie: l’indulgenza plenaria e l’indulgenza parziale.
+
+D. Qual’è l’indulgenza plenaria?
+
+R. L’indulgenza plenaria è quella con cui ci viene rimessa tutta la pena temporale dovuta per i nostri peccati. Perciò se taluno morisse dopo aver ricevuto tale Indulgenza, andrebbe subito in Paradiso, esente affatto dalle pene del purgatorio.
+
+D. Qual’è l’indulgenza parziale?
+
+R. L’indulgenza parziale è quella con la quale ci viene rimessa soltanto una parte della pena temporale dovuta per i nostri peccati.
+
+D. Che cosa intende di fare la Chiesa nel concedere le indulgenze?
+
+R. Nel concedere le indulgenze la Chiesa intende venire in aiuto alla nostra incapacità di espiare in questo mondo tutta la pena temporale, facendoci conseguire per mezzo di opere di pietà e di carità cristiana quello che nei primi secoli procurava che si ottenesse col rigore dei canoni penitenziali.
+
+D. Che cosa s’intende per indulgenza di quaranta o cento giorni, ovvero di sette anni, e simili?
+
+R. Per indulgenza di quaranta o cento giorni ovvero di sette anni e simili, s’intende la remissione di tanta pena temporale, quanta se ne sconterebbe con quaranta o cento giorni ovvero sette anni della penitenza anticamente stabilita dalla Chiesa.
+
+D. Che conto dobbiamo fare delle indulgenze?
+
+R. Delle indulgenze dobbiamo fare grandissimo conto, perchè con esse si soddisfa alla giustizia di Dio e più presto e più facilmente si ottiene il possesso del cielo.
+
+D. Che cosa si ricerca per acquistare le indulgenze?
+
+R. Per acquistare le indulgenze si ricerca: 1.º lo stato di grazia (almeno nell’ultima opera che si compie) e la mondezza anche da quelle colpe veniali, di cui vuolsi cancellare la pena; 2.º l’adempimento delle opere che la Chiesa prescrive per acquistare l’indulgenza; 3.º l’intenzione di acquistarla.
+
+D. Le indulgenze possono applicarsi anche alle anime del purgatorio?
+
+R. Sì, le indulgenze possono applicarsi anche alle anime del purgatorio, quando chi le accorda dichiari che si possono ad esse applicare.
+
+D. Che cosa è il Giubileo?
+
+R. Il Giubileo, che ordinariamente si concede ogni venticinque anni, è un’indulgenza plenaria a cui sono annessi molti privilegi e particolari concessioni, come di poter ottenere l’assoluzione di alcuni peccati riservati e delle censure, e la commutazione di alcuni voti.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-vii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-vii.txt
@@ -1,0 +1,28 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quarta/Capo_VII ===
+=== TITLE: Parte IV — Dei sacramenti — Compendio della dottrina cristiana/Catechismo maggiore/Parte quarta/Capo VII ===
+
+Capo VII. Dell’Estrema Unzione.
+
+D. Che cosa è il sacramento dell’Estrema Unzione detto pure Olio Santo?
+
+R. L’Estrema Unzione detta pure Olio Santo, è il sacramento istituito per sollievo spirituale ed anche temporale degli infermi, in pericolo di morte.
+
+D. Quali effetti produce il sacramento dell’Estrema Unzione?
+
+R. Il sacramento dell’Estrema Unzione produce i seguenti effetti: 1.º accresce la grazia santificante; 2.º cancella i peccati veniali, e anche i mortali che l’infermo pentito non potesse più confessare; 3.º toglie quella debolezza e languidezza pel bene, la quale rimane anche dopo di aver ottenuto il perdono dei peccati; 4.º dà la forza di sopportare pazientemente il male, di resistere alle tentazioni e di morire santamente; 5.º aiuta a ricuperare la sanità del corpo, se sia utile alla salute dell’anima.
+
+D. In qual tempo si deve ricevere l’Olio Santo?
+
+R. L’Olio Santo si deve ricevere quando la malattia è pericolosa, e dopo che l’infermo ha ricevuto, se può, i sacramenti della Penitenza e dell’Eucaristia; anzi è bene riceverlo quando si è ancora sano di mente e con qualche speranza di vita.
+
+D. Perchè è bene ricevere l’Olio Santo, quando si è ancora di mente sana e con qualche speranza di vita?
+
+R. È bene ricevere l’Olio Santo, quando si è ancora di mente sana e con qualche speranza di vita, perchè ricevendolo con miglior disposizione si può riceverne maggior frutto, e ancora perchè, dando questo sacramento la sanità del corpo, se è espediente all’anima, con aiutare le forze della natura, non si deve aspettare che la salute sia disperata.
+
+D. Con quali disposizioni si deve ricevere l’Olio Santo?
+
+R. Le principali disposizioni per ricevere l’Olio Santo sono: essere in grazia di Dio, confidare nella virtù del sacramento e nella divina misericordia, e rassegnarsi alla volontà del Signore.
+
+D. Quali sentimenti deve provare l’infermo alla vista del sacerdote?
+
+R. Alla vista del sacerdote l’infermo deve provare sentimento di gratitudine a Dio per averglielo mandato, deve ricevere volentieri e chiedere, se può da sè stesso, i conforti della religione.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-viii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quarta-capo-viii.txt
@@ -1,0 +1,74 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quarta/Capo_VIII ===
+=== TITLE: Parte IV — Dei sacramenti — Compendio della dottrina cristiana/Catechismo maggiore/Parte quarta/Capo VIII ===
+
+Capo VIII. Dell’Ordine Sacro.
+
+D. Che cosa è il sacramento dell’Ordine Sacro?
+
+R. L’Ordine Sacro è il sacramento che dà la potestà di esercitare i sacri ministeri che riguardano il culto di Dio e la salute delle anime, e che imprime nell’anima di chi lo riceve il carattere di ministro di Dio.
+
+D. Perchè si chiama Ordine?
+
+R. Si chiama Ordine perchè consiste in vari gradi, l’uno subordinato all’altro, dai quali risulta la sacra Gerarchia.
+
+D. Quali sono questi gradi?
+
+R. Supremo tra essi è l’ Episcopato , che con tiene la pienezza del sacerdozio; quindi il Presbiterato o Sacerdozio semplice ; poi il Diaconato , e gli Ordini che diconsi minori .
+
+D. Ha Gesù Cristo istituito immediatamente tutti i gradi dell’Ordine Sacro?
+
+R. Gesù Cristo ha istituito immediatamente i due gradi superiori dell’Ordine Sacro, che sono l’ Episcopato e il Sacerdozio semplice ; per mezzo degli Apostoli poi istituì il Diaconato , dal quale derivano gli altri Ordini inferiori.
+
+D. Quando Gesù Cristo ha istituito l’Ordine Sacerdotale?
+
+R. Gesù Cristo ha istituito l’Ordine Sacerdotale nell’ultima Cena, quando conferì agli Apostoli e ai loro successori la potestà di consa crare la SSm̃a Eucaristia. Il giorno poi della sua resurrezione conferì ai medesimi il potere di rimettere e di ritenere i peccati, costituendoli così i primi sacerdoti della nuova legge in tutta la pienezza della loro potestả.
+
+D. Chi è il ministro di questo sacramento?
+
+R. Il ministro di questo sacramento è il solo Vescovo.
+
+D. È dunque grande la dignità del Sacerdozio cristiano?
+
+R. La dignità del Sacerdozio cristiano è grandissima per la doppia potestà che ad esso ha conferito Gesù Cristo sul suo Corpo reale e sul suo Corpo mistico, che è la Chiesa; e per la divina missione affidata ai sacerdoti di condurre tutti gli uomini alla vita eterna.
+
+D. Il Sacerdozio cattolico è necessario nella Chiesa?
+
+R. Il Sacerdozio cattolico è necessario nella Chiesa; perchè senza di esso i fedeli sarebbero privi del santo sacrificio della Messa e della maggior parte dei sacramenti, non avrebbero chi li ammaestrasse nella fede, e resterebbero come pecore senza pastore in balia dei lupi, a dir breve non esisterebbe più la Chiesa come Gesù Cristo l’ha istituita.
+
+D. Dunque il Sacerdozio cattolico non cesserà mai sulla terra?
+
+R. Il Sacerdozio cattolico, non ostante la guerra che gli muove contro l’inferno, durerà fino alla fine dei secoli; avendo Gesù Cristo promesso che le potestà dell’inferno non prevarranno giammai contro la sua Chiesa.
+
+D. È peccato disprezzare i sacerdoti?
+
+R. È peccato gravissimo, perchè il disprezzo e le ingiurie che si rivolgono contro i sacerdoti, ricadono sopra Gesù Cristo stesso, il quale ha detto ai suoi Apostoli: chi disprezza voi, disprezza me .
+
+D. Quale deve essere il fine di chi abbraccia lo stato ecclesiastico?
+
+R. Il fine di chi abbraccia lo stato ecclesiastico deve essere unicamente la gloria di Dio e la salute delle anime.
+
+D. Che cosa è necessario per entrare nello stato ecclesiastico?
+
+R. Per entrare nello stato ecclesiastico è necessaria, prima di tutto, la vocazione divina.
+
+D. Che cosa si deve fare per conoscere se Dio chiama allo stato ecclesiastico?
+
+R. Per conoscere se Dio chiama allo stato ecclesiastico si deve: 1.º pregare con fervore il Signore che manifesti qual’è la sua volontà; 2.º prendere consiglio dal proprio Vescovo o da un savio e prudente direttore; 3.º esaminare con diligenza se si abbia l’abilità necessaria agli studi, ai ministeri, ed agli obblighi di questo stato.
+
+D. Chi entrasse nello stato ecclesiastico senza vocazione divina farebbe male?
+
+R. Chi entrasse nello stato ecclesiastico senza vocazione divina farebbe un grave male e si metterebbe in pericolo di perdizione.
+
+D. Fanno male i genitori che per motivi temporali inducono i figliuoli ad abbracciare senza vocazione lo stato ecclesiastico?
+
+R. I genitori che per motivi temporali, inducono i figliuoli ad abbracciare senza vocazione lo stato ecclesiastico, commettono essi pure gravissima colpa, perchè con ciò usurpano il diritto che Dio ha riservato a sè solo di scegliere i suoi ministri, e mettono i figliuoli in pericolo di eterna dannazione.
+
+D. Quali sono i doveri dei fedeli verso coloro che sono chiamati agli Ordini sacri?
+
+R. I fedeli devono:
+
+1.º lasciare ai loro figliuoli e dipendenti piena libertà di seguire la vocazione di Dio;
+
+2.º pregar Iddio che si degni di concedere alla sua Chiesa buoni pastori e zelanti ministri, essendo anche a tal fine istituiti i digiuni delle quattro tempora;
+
+3.º avere un singolare rispetto verso tutti quelli che sono, per mezzo degli Ordini, consacrati al servizio di Dio.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quinta-capo-i.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quinta-capo-i.txt
@@ -1,0 +1,264 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quinta/Capo_I ===
+=== TITLE: Parte V — Delle virtù principali e delle altre cose necessarie a sapersi del cristiano — Compendio della dottrina cristiana/Catechismo maggiore/Parte quinta/Capo I ===
+
+Capo I. Delle virtù principali.
+
+§ 1 . - Delle virtù teologali.
+
+D. Che cosa è la virtù?
+
+R. La virtù è una qualità dell’anima, per la quale si ha propensione, facilità e prontezza a conoscere ed operare il bene.
+
+D. Quante sono le principali virtù soprannaturali?
+
+R. Le principali virtù soprannaturali sono sette: cioè tre teologali e quattro cardinali.
+
+D. Quali sono le virtù teologali?
+
+R. Le virtù teologali sono: la Fede, la Speranza e la Carità.
+
+D. Perchè la Fede, la Speranza e la Carità si chiamano virtù teologali?
+
+R. La Fede, la Speranza e la Carità si chiamano virtù teologali, perchè hanno Dio per oggetto immediato e principale, e ci sono infuse da Lui.
+
+D. In qual modo le virtù teologali hanno Dio per oggetto immediato?
+
+R. Le virtù teologali hanno Dio per oggetto immediato, perchè con la Fede noi crediamo in Dio, e crediamo tutto ciò che Egli ha rivelato; con la Speranza speriamo di possedere Dio; con la Carità amiamo Dio e in Lui amiamo noi stessi e il prossimo.
+
+D. Quando è che Dio ci infonde nell’anima le virtù teologali?
+
+R. Iddio per sua bontà ci infonde nell’anima le virtù teologali quando ci adorna della sua grazia santificante, e perciò quando ricevemmo il Battesimo fummo arricchiti di queste virtù, e con esse, dei doni dello Spirito Santo.
+
+D. Basta per salvarsi, aver ricevuto nel Battesimo le virtù teologali?
+
+R. Per chi ha l’uso della ragione, non basta aver ricevuto nel Battesimo le virtù teologali; ma è necessario farne spesso gli atti.
+
+D. Quando siamo obbligati di fare gli atti di Fede, di Speranza e di Carità?
+
+R. Siamo obbligati di fare gli atti di Fede, di Speranza e di Carità: 1.º giunti all’uso della ragione: 2.º spesse volte nel decorso della vita; 3.º in pericolo di morte.
+
+§ 2 . - Della Fede.
+
+D. Che cosa è la Fede?
+
+R. La Fede è una virtù soprannaturale, infusa da Dio nell’anima nostra, per la quale noi, appoggiati all’autorità di Dio stesso, crediamo esser vero tutto quello che Egli ha rivelato, e che per mezzo della Chiesa ci propone a credere.
+
+D. In quale maniera sappiamo noi le verità rivelate da Dio?
+
+R. Noi sappiamo le verità rivelate da Dio per mezzo della santa Chiesa che è infallibile; cioè, per mezzo del Papa, successore di san Pietro e per mezzo dei Vescovi successori degli Apostoli, i quali furono ammaestrati da Gesù Cristo medesimo.
+
+D. Siamo noi sicuri di quelle cose che la santa Chiesa c’insegna?
+
+R. Di quelle cose che la santa Chiesa c’insegna, noi siamo sicurissimi, perchè Gesù Cristo ha impegnato la sua parola, che la Chiesa non si sarebbe mai ingannata.
+
+D. Con qual peccato si perde la Fede?
+
+R. La Fede si perde con negare o dubitare volontariamente anche di un solo articolo propostoci a credere.
+
+D. Come si riacquista la Fede perduta?
+
+R. La Fede perduta si riacquista con pentirsi del peccato commesso e con credere di nuovo tutto quello che crede la santa Chiesa.
+
+§ 3 . - Dei misteri.
+
+D. Possiamo noi capire tutte le verità della Fede?
+
+R. No, noi non possiamo capire tutte le verità della Fede, perchè alcune di queste verità sono misteri.
+
+D. Che cosa sono i misteri?
+
+R. I misteri sono verità superiori alla ragione, che noi dobbiamo credere quantunque non le possiamo comprendere.
+
+D. Perchè dobbiamo credere i misteri?
+
+R. Dobbiamo credere i misteri, perchè li ha rivelati Iddio, il quale essendo Verità e Bontà infinita, non può nè ingannarsi nè ingannare.
+
+D. I misteri sono essi contrari alla ragione?
+
+R. I misteri sono superiori, ma non contrari alla ragione; è anzi la stessa ragione che ci persuade ad ammettere i misteri.
+
+D. Perchè i misteri non possono essere contrari alla ragione?
+
+R. I misteri non possono essere contrari alla ragione, perchè è lo stesso Dio che ci ha dato il lume della ragione e rivelato i misteri, nè Egli può contraddire a se stesso.
+
+§ 4 . - Della Sacra Scrittura.
+
+D. Dove si contengono le verità che Dio ha rivelato?
+
+R. Le verità che Dio ha rivelato si con tengono nella Sacra Scrittura e nella Tradizione.
+
+D. Che cosa è la Sacra Scrittura?
+
+R. La Sacra Scrittura è la collezione dei libri scritti dai Profeti ed Agiografi, dagli Apostoli, e dagli Evangelisti per ispirazione dello Spirito Santo, e ricevuti dalla Chiesa come ispirati.
+
+D. In quante parti si divide la Sacra Scrittura?
+
+R. La Sacra Scrittura si divide in due parti: nell’antico e nel nuovo Testamento.
+
+D. Che cosa contiene l’antico Testamento?
+
+R. L’antico Testamento contiene i libri ispirati, scritti innanzi alla venuta di Gesù Cristo.
+
+D. Che cosa contiene il nuovo Testamento?
+
+R. Il nuovo Testamento contiene i libri ispirati, scritti dopo la venuta di Gesù Cristo.
+
+D. Con qual nome si chiama comunemente la Sacra Scrittura?
+
+R. La Sacra Scrittura chiamasi comunemente col nome di Sacra Bibbia.
+
+D. Che cosa vuol dire la parola Bibbia?
+
+R. La parola Bibbia vuol dire la collezione dei libri santi, il libro per eccellenza, il libro dei libri, il libro ispirato da Dio.
+
+D. Perchè la Sacra Scrittura dicesi il libro per eccellenza?
+
+R. La Sacra Scrittura dicesi il libro per eccellenza, a motivo dell’eccellenza della materia di cui tratta e dell’Autore della medesima.
+
+D. Non vi può essere errore nella Sacra Scrittura?
+
+R. Nella Sacra Scrittura non vi può essere errore alcuno, perchè, essendo tutta ispirata, autore di tutte le sue parti è Dio medesimo. Ciò non toglie che nelle copie e traduzioni della stessa possa essere occorso qualche sbaglio o dei copisti o dei traduttori. Però nelle edizioni rivedute ed approvate dalla Chiesa cattolica non vi può essere errore in ciò che riguarda la fede o la morale.
+
+D. È necessaria a tutti i cristiani la lettura della Bibbia?
+
+R. La lettura della Bibbia non è necessaria a tutti i cristiani, ammaestrati come sono dalla Chiesa, ma però è molto utile e raccomandata a tutti.
+
+D. Si può leggere qualunque traduzione volgare della Bibbia?
+
+R. Si possono leggere quelle traduzioni volgari della Bibbia, che sono riconosciute fedeli dalla Chiesa cattolica, e sono accompagnate da spiegazioni approvate dalla Chiesa medesima.
+
+D. Perchè si possono leggere le sole traduzioni della Bibbia, che sono approvate dalla Chiesa?
+
+R. Si possono leggere le sole traduzioni della Bibbia che sono approvate dalla Chiesa, perchè essa sola è legittima custode della Bibbia.
+
+D. Per mezzo di chi possiamo noi conoscere il vero senso delle Sacre Scritture?
+
+R. Il vero senso delle Sacre Scritture noi possiamo conoscerlo solo per mezzo della Chiesa, perchè solo la Chiesa non può errare nell’interpretarle.
+
+D. Che dovrebbe fare il cristiano se gli venisse offerta la Bibbia da un protestante o da qualche emissario dei protestanti?
+
+R. Se ad un cristiano venisse offerta la Bibbia da un protestante, o da qualche emissario dei protestanti, egli dovrebbe rigettarla con orrore, perchè proibita dalla Chiesa; che se l’avesse ricevuta senza badarvi, dovrebbe tosto gettarla alle fiamme, o consegnarla al proprio parroco.
+
+D. Perchè la Chiesa proibisce le Bibbie protestanti?
+
+R. La Chiesa proibisce la Bibbie protestanti perchè o sono alterate e contengono errori, oppure, mancando della sua approvazione e delle note dichiarative dei sensi oscuri, possono nuocere alla Fede. Per questo, la Chiesa proibisce eziandio le traduzioni della Sacra Scrittura già approvate da essa, ma ristampate senza le spiegazioni dalla medesima approvate.
+
+§ 5 . - Della Tradizione.
+
+D. Ditemi: che cosa è la Tradizione?
+
+R. La Tradizione e la parola di Dio non scritta, ma comunicata a viva voce da Gesù Cristo e dagli Apostoli, e giunta inalterata, di secolo in secolo per mezzo della Chiesa fino a noi.
+
+D. Dove si contengono gl’insegnamenti della Tradizione?
+
+R. Gl’insegnamenti della Tradizione si contengono principalmente nei decreti dei Concilî, negli scritti dei santi Padri, negli atti della Santa Sede, nelle parole e negli usi della sacra Liturgia.
+
+D. In qual conto si deve tenere la Tradizione?
+
+R. La Tradizione si deve tenere in quel medesimo conto in che si tiene la parola di Dio rivelata, contenuta nella Sacra Scrittura.
+
+§ 6 . - Della Speranza.
+
+D. Che cosa è la Speranza ?
+
+R. La Speranza è una virtù soprannaturale, infusa da Dio nell’anima nostra, per la quale desideriamo ed aspettiamo la vita eterna che Dio ha promesso ai suoi servi, e gli aiuti necessari per ottenerla.
+
+D. Per qual motivo dobbiamo noi sperare da Dio il paradiso e gli aiuti necessari per con seguirlo?
+
+R. Noi dobbiamo sperare da Dio il paradiso e gli aiuti necessari per conseguirlo, perchè Dio misericordiosissimo, pei meriti di N. S. Gesù Cristo, lo ha promesso a chi lo serve di cuore; ed essendo fedelissimo ed onnipotente, mantiene sempre la sua promessa.
+
+D. Quali sono le condizioni necessarie per ottenere il paradiso?
+
+R. Le condizioni necessarie per ottenere il paradiso, sono la grazia di Dio, l’esercizio delle buone opere e la perseveranza nel santo amore di Lui fino alla morte.
+
+D. Come si perde la Speranza?
+
+R. Si perde la Speranza ogni qual volta si perde la Fede: si perde ancora per il peccato di disperazione o di presunzione.
+
+D. Come si riacquista la Speranza perduta?
+
+R. La Speranza perduta si riacquista con pentirsi del peccato commesso, eccitando di nuovo la fiducia nella bontà divina.
+
+§ 7 . - Della Carità.
+
+D. Che cosa è la Carità?
+
+R. La Carità è una virtù soprannaturale, infusa da Dio nell’anima nostra, per la quale amiamo Dio per se stesso sopra ogni cosa, e il prossimo come noi stessi per amor di Dio.
+
+D. Per quali motivi dobbiamo noi amare Dio?
+
+R. Noi dobbiamo amare Iddio perchè Egli è il sommo bene, infinitamente buono e perfetto; e inoltre per il comando che Egli ce ne fa, e per i tanti beneficî che da Lui riceviamo.
+
+D. Come si deve amare Iddio?
+
+R. Dio si deve amare sopra tutte le cose, con tutto il cuore, con tutta la mente, con tutta l’anima e con tutte le forze.
+
+D. Che vuol dire amare Iddio sopra tutte le cose?
+
+R. Amare Iddio sopra tutte le cose vuol dire preferirlo a tutte le creature più care e più perfette, ed essere disposti a perdere tutto piuttosto che offenderlo e cessare di amarlo.
+
+D. Che vuol dire amare Iddio con tutto il cuore?
+
+R. Amare Iddio con tutto il cuore vuol dire consacrare a Lui tutti i nostri affetti.
+
+D. Che vuol dire amare Iddio con tutta la mente?
+
+R. Amare Iddio con tutta la mente vuol dire indirizzare a Lui tutti i nostri pensieri.
+
+D. Che vuol dire amare Iddio con tutta l’anima?
+
+R. Amare Iddio con tutta l’anima vuol dire consacrare a Lui l’uso di tutte le potenze dell’anima nostra.
+
+D. Che vuol dire amare Iddio con tutte le nostre forze?
+
+R. Amare Iddio con tutte le nostre forze vuol dire procurare di crescere sempre più nell’amore di Lui e fare in modo che tutte le nostre azioni abbiano per motivo e per fine l’amore di Lui, ed il desiderio di piacergli.
+
+D. Perchè dobbiamo noi amare il prossimo?
+
+R. Noi dobbiamo amare il prossimo per amor di Dio, perchè Egli ce lo comanda, e perchè ogni uomo è immagine di Lui.
+
+D. Siamo obbligati ad amare anche i nemici?
+
+R. Sì, siamo obbligati ad amare anche i nemici, perchè sono anch’essi nostro prossimo, e perchè Gesù Cristo ce ne ha fatto un espresso comando.
+
+D. Che vuol dire amare il prossimo come se stesso?
+
+R. Amare il prossimo come se stesso vuol dire desiderargli e fargli, per quanto si può, quel bene che dobbiamo desiderare a noi stessi, e non desiderargli nè fargli alcun male.
+
+D. Quando è che noi amiamo noi stessi come si deve?
+
+R. Noi amiamo noi stessi come si deve, quando cerchiamo di servir Dio e mettere in Lui ogni nostra felicità.
+
+D. Come si perde la Carità?
+
+R. La Carità si perde con qualunque peccato mortale.
+
+D. Come si riacquista la Carità?
+
+R. La Carità si riacquista facendo atti di amor di Dio, pentendosi e confessandosi come si deve.
+
+§ 8 . - Delle virtù cardinali.
+
+D. Quali sono le virtù cardinali?
+
+R. Le virtù cardinali sono la Prudenza, la Giustizia, la Fortezza e la Temperanza.
+
+D. Perchè la Prudenza, la Giustizia, la Fortezza, e la Temperanza si chiamano virtù cardinali?
+
+R. La Prudenza, la Giustizia, la Fortezza, e la Temperanza si chiamano virtù cardinali, perchè sono il cardine, e il fondamento delle virtù morali.
+
+D. Che cosa è la Prudenza?
+
+R. La Prudenza e la virtù che dirige ogni azione al debito fine, e però cerca i mezzi convenienti affinchè l’opera riesca in tutto ben fatta, e quindi accetta al Signore.
+
+D. Che cosa è la Giustizia?
+
+R. La Giustizia è la virtù per cui diamo a ciascuno quello che gli si deve.
+
+D. Che cosa è la Fortezza?
+
+R. La Fortezza è la virtù che ci rende coraggiosi a non temere alcun pericolo, neppure l’istessa morte, per servizio di Dio.
+
+D. Che cosa è la Temperanza?
+
+R. La Temperanza è la virtù per la quale raffreniamo i desideri disordinati dei piaceri sensibili, e usiamo con moderazione dei beni temporali.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quinta-capo-ii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quinta-capo-ii.txt
@@ -1,0 +1,40 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quinta/Capo_II ===
+=== TITLE: Parte V — Delle virtù principali e delle altre cose necessarie a sapersi del cristiano — Compendio della dottrina cristiana/Catechismo maggiore/Parte quinta/Capo II ===
+
+Capo II. Dei doni dello Spirito Santo.
+
+D. Quanti e quali sono i doni dello Spirito Santo?
+
+R. I doni dello Spirito Santo sono sette: 1.º il dono della Sapienza; 2.º dell’Intelletto; 3.º del Consiglio; 4.º della Fortezza; 5.º della Scienza; 6.º della Pietà; 7.º del Timor di Dio.
+
+D. A che servono i doni dello Spirito Santo?
+
+R. I doni dello Spirito Santo servono a stabilirci nella Fede, nella Speranza e nella Carità; e a renderci pronti agli atti delle virtù necessarie per conseguire la perfezione della vita cristiana.
+
+D. Che cosa è la Sapienza?
+
+R. La Sapienza è un dono col quale noi alzando la mente da queste cose terrene e fragili, contempliamo le eterne, cioè l’eterna Verità che è Dio, gustando ed amando Lui, nel quale consiste ogni nostro bene.
+
+D. Che cosa è l’Intelletto?
+
+R. L’Intelletto è un dono col quale ci viene facilitata, per quanto si può da uomo mortale, l’intelligenza delle verità della Fede e dei divini misteri, i quali col lume naturale dell’intelletto nostro non possiamo conoscere.
+
+D. Che cosa è il Consiglio?
+
+R. Il Consiglio è un dono col quale nei dubbi ed incertezze dell’umana vita conosciamo ciò che torna più alla gloria di Dio, alla salute nostra e del prossimo.
+
+D. Che cosa è la Fortezza?
+
+R. La Fortezza è un dono che c’inspira valore e coraggio per osservare fedelmente la santa legge di Dio e della Chiesa, superando tutti gli ostacoli e gli assalti dei nostri nemici.
+
+D. Che cosa è la Scienza?
+
+R. La Scienza è un dono col quale giudichiamo rettamente delle cose create, è conosciamo il modo di ben usarle e indirizzarle all’ultimo fine che è Dio.
+
+D. Che cosa è la Pietà?
+
+R. La Pietà è un dono col quale veneriamo ed amiamo Dio e i Santi, e conserviamo un animo pio e benevolo verso il prossimo per amor di Dio.
+
+D. Che cosa è il Timor di Dio?
+
+R. Il Timor di Dio è un dono che ci fa riverire Dio e temere di offendere la sua divina Maestà, e ci distoglie dal male incitandoci al bene.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quinta-capo-iii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quinta-capo-iii.txt
@@ -1,0 +1,80 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quinta/Capo_III ===
+=== TITLE: Parte V — Delle virtù principali e delle altre cose necessarie a sapersi del cristiano — Compendio della dottrina cristiana/Catechismo maggiore/Parte quinta/Capo III ===
+
+Capo III. Delle Beatitudini evangeliche.
+
+D. Quante e quali sono le Beatitudini evangeliche?
+
+R. Le Beatitudini evangeliche sono otto:
+
+1.ª Beati i poveri di spirito, perchè di questi è il regno de’ cieli.
+
+2.ª Beati i mansueti, perchè questi possederanno la terra.
+
+3.ª Beati quelli che piangono, perchè saranno consolati.
+
+4.ª Beati quelli che hanno fame e sete della giustizia, perchè saranno saziati.
+
+5.ª Beati i misericordiosi, perchè troveranno misericordia.
+
+6.ª Beati i mondi di cuore, perchè vedranno Dio.
+
+7.ª Beati i pacifici, perchè saranno chiamati figli di Dio.
+
+8.ª Beati quelli che soffrono persecuzioni per amor della giustizia, perchè di essi è il regno de’ cieli.
+
+D. Perchè Gesù Cristo ci ha proposto le Beatitudini?
+
+R. Gesù Cristo ci ha proposto le Beatitudini per farci detestare le massime del mondo, e per invitarci ad amare e praticare le massime del suo Vangelo.
+
+D. Chi sono quelli che il mondo chiama beati?
+
+R. Il mondo chiama beati quelli che abbondano di ricchezze e di onori, che vivono allegramente, e che non hanno alcuna occasione di patire.
+
+D. Chi sono i poveri di spirito, che Gesù Cristo chiama beati?
+
+R. I poveri di spirito, secondo il Vangelo, sono quelli che hanno il cuore distaccato dalle ricchezze; ne fanno buon uso, se le posseggono; non le cercano con sollecitudine, se ne sono privi; ne soffrono con rassegnazione la perdita, se loro vengono tolte.
+
+D. Chi sono i mansueti?
+
+R. I mansueti sono quelli che trattano il prossimo con dolcezza, e ne soffrono con pazienza i difetti e i torti che da essi ricevono, senza querele, risentimenti o vendette.
+
+D. Chi sono quelli che piangono, eppure sono detti beati?
+
+R. Quelli che piangono, eppure sono detti beati, sono coloro che soffrono rassegnati le tribolazioni, e che si affliggono per i peccati commessi, pei mali e per gli scandali che si vedono nel mondo, per la lontananza dal paradiso e pel pericolo di perderlo.
+
+D. Chi sono quelli che hanno fame e sete della giustizia?
+
+R. Quelli che hanno fame e sete della giustizia sono coloro che desiderano ardentemente di crescere sempre più nella divina grazia e nell’esercizio delle opere buone e virtuose.
+
+D. Chi sono i misericordiosi?
+
+R. I misericordiosi, sono quelli che amano in Dio e per amor di Dio il loro prossimo, ne compassionano le miserie si spirituali, che corporali, e procurano di sollevarlo secondo le loro forze e il loro stato.
+
+D. Chi sono i mondi di cuore?
+
+R. I mondi di cuore sono quelli che non hanno veruno affetto al peccato e ne stanno lontani, e schivano sopratutto ogni sorta d’impurità.
+
+D. Chi sono i pacifici?
+
+R. I pacifici sono quelli che conservano la pace col prossimo e con se stessi, e procurano di mettere la pace tra quelli che sono in discordia.
+
+D. Chi sono quelli che soffrono persecuzione per amore della giustizia?
+
+R. Quelli che soffrono persecuzione per amore della giustizia sono coloro che sopportano con pazienza le derisioni, i rimproveri e le persecuzioni per causa della fede e della legge di Gesù Cristo.
+
+D. Che cosa significano i diversi premi promessi da Gesù Cristo nelle Beatitudini?
+
+R. I diversi premi promessi da Gesù Cristo nelle Beatitudini significano tutti, sotto diversi nomi, la gloria eterna del cielo.
+
+D. Le Beatitudini ci procurano solo l’eterna gloria del paradiso?
+
+R. Le Beatitudini non ci procurano solo l’eterna gloria del paradiso, ma sono anche i mezzi per condurre una vita felice, per quanto è possibile, in questo mondo.
+
+D. Coloro che seguono le Beatitudini, ne ricevono già qualche ricompensa in questa vita?
+
+R. Sì, certamente, coloro che seguono le Beatitudini, ne ricevono già qualche ricompensa anche in questa vita, perchè già godono un’interna pace e contentezza, che è principio, benchè imperfetto, della eterna felicità.
+
+D. Quelli che seguono le massime del mondo potranno dirsi felici?
+
+R. No, quelli che seguono le massime del mondo, non sono felici, perchè non hanno la vera pace dell’anima, e corrono pericolo di dannarsi.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quinta-capo-iv.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quinta-capo-iv.txt
@@ -1,0 +1,48 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quinta/Capo_IV ===
+=== TITLE: Parte V — Delle virtù principali e delle altre cose necessarie a sapersi del cristiano — Compendio della dottrina cristiana/Catechismo maggiore/Parte quinta/Capo IV ===
+
+Capo IV. Delle opere di misericordia.
+
+D. Quali sono le opere buone delle quali ci sarà domandato conto particolare nel dì del Giudizio?
+
+R. Le opere buone delle quali ci sarà domandato conto particolare nel dì del Giudizio sono le opere di misericordia.
+
+D. Che cosa s’intende per opera di misericordia?
+
+R. Opera di misericordia è quella con la quale si soccorre ai bisogni corporali o spirituali del nostro prossimo.
+
+D. Quali sono le opere di misericordia corporali?
+
+R. Le opere di misericordia corporali sono:
+
+1.ª Dar da mangiare agli affamati.
+
+2.ª Dar da bere agli assetati.
+
+3.ª Vestire gl’ignudi.
+
+4.ª Alloggiare i pellegrini.
+
+5.ª Visitare gli infermi.
+
+6.ª Visitare i carcerati.
+
+7.ª Seppellire i morti.
+
+D. Quali sono le opere di misericordia spirituali?
+
+R. Le opere di misericordia spirituali sono:
+
+1.ª Consigliare i dubbiosi.
+
+2.ª Istruire gli ignoranti.
+
+3.ª Ammonire i peccatori.
+
+4.ª Consolare gli afflitti.
+
+5.ª Perdonare le offese.
+
+6.ª Sopportare pazientemente le persone moleste.
+
+7.ª Pregare Dio per i vivi e per i morti.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quinta-capo-v.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quinta-capo-v.txt
@@ -1,0 +1,60 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quinta/Capo_V ===
+=== TITLE: Parte V — Delle virtù principali e delle altre cose necessarie a sapersi del cristiano — Compendio della dottrina cristiana/Catechismo maggiore/Parte quinta/Capo V ===
+
+Capo V. Dei peccati e delle loro specie principali.
+
+D. Quante sorta di peccati vi sono?
+
+R. Vi sono due sorta di peccati: il peccato originale ed il peccato attuale .
+
+D. Qual’è il peccato originale?
+
+R. Il peccato originale è quello col quale tutti nasciamo, e che abbiamo contratto per la disubbidienza del nostro primo padre Adamo.
+
+D. Quali danni ci ha cagionati il peccato di Adamo?
+
+R. I danni del peccato di Adamo sono: la privazione della grazia, la perdita del paradiso, l’ignoranza, l’inclinazione al male, la morte e tutte le altre miserie.
+
+D. Come si cancella il peccato originale?
+
+R. Il peccato originale si cancella col santo Battesimo.
+
+D. Qual’è il peccato attuale?
+
+R. Il peccato attuale è quello che l’uomo, arrivato all’uso della ragione, commette con la sua libera volontà.
+
+D. Quante sorta di peccato attuale vi sono?
+
+R. Vi sono due sorta di peccato attuale: il mortale ed il veniale.
+
+D. Qual’è il peccato mortale?
+
+R. Il peccato mortale è una trasgressione della divina legge, per la quale si manca gravemente ai doveri verso Dio, verso il prossimo, verso noi stessi.
+
+D. Perchè si dice mortale?
+
+R. Si dice mortale perchè dà morte all’anima, col far perdere la grazia santificante, che è la vita dell’anima, come l’anima è la vita dal corpo.
+
+D. Quali danni fa all’anima il peccato mortale?
+
+R. 1.º Il peccato mortale priva l’anima della grazia e dell’amicizia di Dio; 2.º le fa perdere il paradiso; 3.º la priva dei meriti acquistati, e la rende incapace di acquistarne dei nuovi; 4.º la fa schiava del demonio; 5.º le fa meritare l’inferno, ed anche i castighi di questa vita.
+
+D. Oltre la gravità della materia che cosa si richiede per costituire un peccato mortale?
+
+R. Oltre la gravità della materia per costituire un peccato mortale si richiede la piena avvertenza di tale gravità e la deliberata volontà di commettere il peccato.
+
+D. Qual è il peccato veniale?
+
+R. Il peccato veniale è una lieve trasgressione della divina legge, per la quale si manca solo leggermente a qualche dovere verso Dio, verso il prossimo e verso noi stessi.
+
+D. Perchè si chiama veniale?
+
+R. Perchè è leggiero rispetto al peccato mortale, non ci fa perdere la divina grazia; e perchè Dio più facilmente lo perdona.
+
+D. Dunque non è da fare gran caso del peccato veniale?
+
+R. Ciò sarebbe un inganno grandissimo, sia perchè il peccato veniale contiene sempre una qualche offesa di Dio, sia perchè reca danni non piccoli all’anima.
+
+D. Quali danni reca il peccato veniale?
+
+R. Il peccato veniale: 1.º indebolisce e raffredda in noi la carità; 2.º ci dispone al peccato mortale; 3.º ci rende meritevoli di grandi pene temporali in questo mondo o nell’altro.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quinta-capo-vi.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quinta-capo-vi.txt
@@ -1,0 +1,40 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quinta/Capo_VI ===
+=== TITLE: Parte V — Delle virtù principali e delle altre cose necessarie a sapersi del cristiano — Compendio della dottrina cristiana/Catechismo maggiore/Parte quinta/Capo VI ===
+
+Capo VI. Dei vizi capitali e di altri peccati più gravi.
+
+D. Che cosa è il vizio?
+
+R. Il vizio è una cattiva disposizione dell’animo a fuggire il bene e a fare il male, causata dal frequente ripetersi degli atti cattivi.
+
+D. Che differenza v’è tra peccato e vizio?
+
+R. Tra peccato e vizio v’è questa differenza, che il peccato è un atto che passa, mentre il vizio è la cattiva abitudine contratta di cadere in qualche peccato.
+
+D. Quali sono i vizi che si chiamano capitali?
+
+R. I vizi che si chiamano capitali sono sette: 1.º Superbia; 2.º Avarizia; 3.º Lussuria; 4.º Ira; 5.º Gola; 6.º Invidia; 7.º Accidia.
+
+D. I vizi capitali come si vincono?
+
+R. I vizi capitali si vincono con l’esercizio delle virtù opposte. Così la superbia si vince con l’umiltà; l’avarizia con la liberalità; la lussuria con la castità; l’ira con la pazienza; la gola con l’astinenza; l’invidia con l’amor fraterno; l’accidia con la diligenza e col fervore nel servizio di Dio.
+
+D. Perchè questi vizi si chiamano capitali?
+
+R. Questi vizi si chiamano capitali, perchè sono la sorgente e la cagione di molti altri vizi e peccati.
+
+D. Quanti sono i peccati contro lo Spirito Santo?
+
+R. I peccati contro lo Spirito Santo sono sei: 1.º disperazione delle salute; 2.º presunzione di salvarsi senza merito; 3.º impugnare la verità conosciuta; 4.º invidia della altrui grazia; 5.º ostinazione nei peccati; 6.º impenitenza finale.
+
+D. Perchè questi peccati si dicono in particolare contro lo Spirito Santo?
+
+R. Questi peccati si dicono in particolare contro lo Spirito Santo, perchè si commettono per pura malizia, la quale è contraria alla bontà, che si attribuisce allo Spirito Santo.
+
+D. Quali sono i peccati che si dicono gridare vendetta nel cospetto di Dio?
+
+R. I peccati che diconsi gridar vendetta nel cospetto di Dio sono quattro: 1.º omicidio volontario; 2.º peccato impuro contro l’ordine della natura; 3.º oppressione dei poveri; 4.º fraudare la mercede agli operai.
+
+D. Perchè si dice che questi peccati gridano vendetta al cospetto di Dio?
+
+R. Questi peccati diconsi gridare vendetta al cospetto di Dio, perchè lo dice lo Spirito Santo e perchè la loro iniquità è così grave e manifesta che provoca Dio a punirli con più severi castighi.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quinta-capo-vii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quinta-capo-vii.txt
@@ -1,0 +1,20 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quinta/Capo_VII ===
+=== TITLE: Parte V — Delle virtù principali e delle altre cose necessarie a sapersi del cristiano — Compendio della dottrina cristiana/Catechismo maggiore/Parte quinta/Capo VII ===
+
+Capo VII. Dei Novissimi e di altri mezzi principali per evitare il peccato.
+
+D. Che cosa intendete per Novissimi?
+
+R. Novissimi sono chiamate nei Libri santi le cose ultime che accadranno all’uomo.
+
+D. Quanti sono i Novissimi, o cose ultime dell’uomo?
+
+R. I Novissimi, o cose ultime dell’uomo, sono quattro: Morte, Giudizio, Inferno e Paradiso.
+
+D. Perchè i Novissimi si dicono cose ultime dell’uomo?
+
+R. I Novissimi si dicono cose ultime dell’uomo, perchè la Morte è l’ultima cosa che ci accade in questo mondo; il Giudizio di Dio è l’ultimo fra i giudizi che dobbiamo sostenere; l’Inferno è l’estremo male che avranno i cattivi; il Paradiso il sommo bene che avranno i buoni.
+
+D. Quando dobbiamo noi pensare ai Novissimi?
+
+R. È bene pensare ai Novissimi ogni giorno, e massimamente nel fare orazione alla mattina subito svegliati, alla sera prima di andare a riposo e tutte le volte che siamo tentati a far male, perchè questo pensiero è validissimo a farci evitare il peccato.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-quinta-capo-viii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-quinta-capo-viii.txt
@@ -1,0 +1,92 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_quinta/Capo_VIII ===
+=== TITLE: Parte V — Delle virtù principali e delle altre cose necessarie a sapersi del cristiano — Compendio della dottrina cristiana/Catechismo maggiore/Parte quinta/Capo VIII ===
+
+Capo VIII. Degli esercizi divoti che si consigliano al cristiano per ogni giorno.
+
+D. Che cosa deve fare un buon cristiano la mattina subito svegliato?
+
+R. Un buon cristiano , la mattina appena svegliato, deve fare il segno della santa Croce ed offrire il cuore a Dio, dicendo queste o altre simili parole: Mio Dio, io vi dono il mio cuore e l’anima mia.
+
+D. A che cosa si dovrebbe pensare levandosi dal letto e vestendosi?
+
+R. Levandosi dal letto e vestendosi, si dovrebbe pensare che Dio è presente, che quel giorno può esser l’ultimo della nostra vita; e levarsi e vestirsi con ogni possibile modestia.
+
+D. Levato e vestito, che cosa deve fare un buon cristiano?
+
+R. Un buon cristiano, appena levato e vestito, deve mettersi alla presenza di Dio, e ing nocchiarsi, se può, innanzi a qualche divota immagine, dicendo con divozione: «Vi adoro, mio Dio, e vi amo con tutto il cuore; vi ringrazio di avermi creato, fatto cristiano e conservato in questa notte; vi offerisco tutte le mie azioni, e vi prego di preservarmi in questo giorno dal peccato, e di liberarmi da ogni male. Così sia». Reciti quindi il Pater Noster , l’ Ave Maria , il Credo e gli atti di Fede, di Speranza e di Carità, accompagnandoli con vivo affetto del cuore.
+
+D. Quali pratiche di pietà dovrebbe ogni giorno compiere il cristiano?
+
+R. Il cristiano, potendolo, dovrebbe ogni giorno: 1.º assistere con divozione alla santa Messa; 2.º fare una visita, anche brevissima, al SS. Sacramento; 3.º recitare la terza parte del santo Rosario.
+
+D. Che cosa si deve fare prima di lavorare?
+
+R. Prima di lavorare, si deve offrire il lavoro a Dio, dicendo di cuore: «Signore vi offerisco questo lavoro: datemi la vostra benedizione».
+
+D. Per qual fine si deve lavorare?
+
+R. Si deve lavorare per la gloria di Dio e per fare la sua volontà.
+
+D. Che cosa convien fare prima di prender cibo?
+
+R. Prima di prender cibo, stando in piedi, conviene fare il segno della santa Croce e poi dire con divozione: «Signore Iddio, date la vostra benedizione a noi e al cibo che ora prenderemo per mantenerci nel vostro servizio».
+
+D. Avendo finito di prender cibo, che cosa convien fare?
+
+R. Finito di prender cibo convien fare il segno della santa Croce, e dire; «Signore vi ringrazio del cibo che mi avete dato; fatemi degno di partecipare alla mensa celeste».
+
+D. Quando uno si accorge di qualche tentazione che cosa dovrebbe fare?
+
+R. Quando uno si accorge di qualche tentazione dovrebbe invocare con fede il SS. Nome di Gesù, o di Maria, o dire fervorosamente qualche giaculatoria, come p. e. «datemi grazia, o Signore, che non vi offenda giammai», oppure fare il segno della Croce; evitando però che da segni esterni si accorgano gli altri delle sue tentazioni.
+
+D. Quando uno conosce o dubita d’aver commesso qualche peccato, che cosa deve fare?
+
+R. Quando alcuno conosce o dubita d’aver peccato, deve fare subito un atto di contrizione, e procurare di confessarsene al più presto.
+
+D. Quando, fuori di chiesa, si sente il segno dell’elevazione dell’ostia alla Messa solenne, o della benedizione del SS. Sacramento, che cosa si deve fare?
+
+R. Si deve fare, almeno col cuore, un atto di adorazione dicendo p. e.: «Sia lodato e rin graziato ogni momento il santissimo e divinissimo Sacramento».
+
+D. Che cosa si deve dire quando suona l’ Ave Maria , all’alba, al mezzodì e alla sera?
+
+R. Al suono dell’ Ave Maria , il buon cristiano recita l’ Angelus Domini , con tre volte l’ Ave Maria .
+
+D. La sera, prima di andare a riposo che cosa convien fare?
+
+R. La sera prima del riposo, convien mettersi, come al mattino, alla presenza di Dio, recitare divotamente le stesse orazioni, fare un breve esame di coscienza e domandare perdono a Dio dei peccati commessi nella giornata.
+
+D. Che cosa farete prima di addormentarvi?
+
+R. Prima di addormentarmi farò il segno della santa Croce, penserò che posso morire in quella notte, e darò il cuore a Dio, dicendo: «Signore e Dio mio, io vi dono tutto il mio cuore; Santissima Trinità, datemi grazia di ben vivere e di ben morire; Gesù, Giuseppe e Maria, io raccomando a voi l’anima mia».
+
+D. Oltre alle orazioni della mattina e della sera, in quale altra maniera si può ricorrere a Dio nel corso della giornata?
+
+R. Nel corso della giornata si può pregare Iddio frequentemente con altre brevi orazioni che si chiamano giaculatorie .
+
+D. Dite qualche giaculatoria.
+
+R. Signore aiutatemi — Signore sia fatta la vostra santissima volontà — Gesù mio, io voglio essere tutto vostro — Gesù mio, misericordia — Dolce Cuor del mio Gesù, fa ch’io t’ami sempre più.
+
+D. È utile dire durante il giorno molte giaculatorie?
+
+R. È cosa utilissima dire durante il giorno molte orazioni giaculatorie, e si possono dire anche col cuore senza proferir parola, camminando, lavorando, ecc.
+
+D. Oltre alle orazioni giaculatorie, in quale altra cosa si dovrebbe esercitare sovente il cristiano?
+
+R. Oltrechè nelle orazioni giaculatorie il cristiano si dovrebbe esercitare nella cristiana mortificazione.
+
+D. Che cosa vuol dire mortificarsi?
+
+R. Mortificarsi, vuol dire lasciare, per amore di Dio, quello che piace, ed accettare quello che dispiace secondo i sensi, o l’amor proprio.
+
+D. Quando si porta il Santissimo Sacramento ad un infermo, che cosa si deve fare?
+
+R. Quando si porta il SSm̃o Sacramento a qualche infermo, si deve procurare, potendo, di accompagnarlo con modestia e raccoglimento; e se non si può, fare un atto di adorazione in qualunque luogo uno si trovi, e poi dire: «Consolate, o Signore, questo infermo, e dategli grazia di uniformarsi alla vostra santissima volontà e di conseguire la sua salute».
+
+D. Sentendo suonare l’agonia di qualche moribondo, che cosa farete?
+
+R. Sentendo suonare l’agonia di un mori bondo, mi porterò, potendo, alla Chiesa a pregare per lui, e non potendo, raccomanderò al Signore l’anima sua, pensando che fra breve tempo avrò da trovarmi io pure in questo stato.
+
+D. Sentendo il segno della morte di qualcheduno, che cosa farete?
+
+R. Sentendo il segno della morte di qualcheduno, procurerò di dire un De profundis o un Requiem per l’anima di quel defunto, e rinnoverò il pensiero della morte.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-seconda-capo-i.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-seconda-capo-i.txt
@@ -1,0 +1,108 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_seconda/Capo_I ===
+=== TITLE: Parte II — Dell'orazione — Compendio della dottrina cristiana/Catechismo maggiore/Parte seconda/Capo I ===
+
+Capo I. Dell’orazione in generale.
+
+D. Di che cosa si tratta nella seconda parte della Dottrina cristiana?
+
+R. Nella seconda parte della Dottrina cristiana si tratta dell’orazione in generale e del Pater Noster in particolare.
+
+D. Che cosa è l’orazione?
+
+R. L’orazione e una elevazione della mente a Dio per adorarlo, per ringraziarlo, e per domandargli quello che ci abbisogna.
+
+D. Come si distingue l’orazione?
+
+R. L’orazione si distingue in mentale e vocale. L’orazione mentale è quella che si fa con la sola mente; l’orazione vocale è quella che si fa con le parole accompagnate dall’attenzione della mente e dalla divozione del cuore.
+
+D. Si può distinguere in altro modo l’orazione?
+
+R. L’orazione si può anche distinguere in privata e pubblica.
+
+D. Qual’è l’orazione privata?
+
+R. L’orazione privata è quella che ciascuno fa in particolare per sè o per altri.
+
+D. Qual’è l’orazione pubblica?
+
+R. L’orazione pubblica è quella che si fa dai sacri ministri, a nome della Chiesa, e per la salvezza del popolo fedele. Si può chiamar pubblica anche l’orazione fatta in comune e pubblicamente dai fedeli, come nelle processioni, nei pellegrinaggi e nel tempio.
+
+D. Abbiamo noi speranza fondata di ottenere per mezzo della orazione, gli aiuti e le grazie di cui abbiamo bisogno?
+
+R. La speranza di ottenere da Dio le grazie, di cui abbiamo bisogno, è fondata nelle promesse di Dio Onnipotente, misericordioso e fedelissimo, e nei meriti di Gesù Cristo.
+
+D. In nome di chi dobbiamo domandare a Dio le grazie che ci sono necessarie?
+
+R. Noi dobbiamo domandare a Dio le grazie che ci sono necessarie in nome di Gesù Cristo, come Egli medesimo ci ha insegnato e come pratica la Chiesa la quale termina sempre le sue preghiere con queste parole: per Dominum nostrum Iesum Christum , cioè: per il nostro Signore Gesù Cristo.
+
+D. Perchè dobbiamo domandare a Dio le grazie in nome di Gesù Cristo?
+
+R. Noi dobbiamo domandare le grazie in nome di Gesù Cristo, perchè essendo Egli il nostro mediatore, solo per mezzo di lui noi possiamo avvicinarci al trono di Dio.
+
+D. Se l’orazione ha tanta virtù, che vuol dire che molte volte non sono esaudite le nostre preghiere?
+
+R. Molte volte le nostre preghiere non sono esaudite, o perchè domandiamo cose che non convengono alla nostra eterna salute, o perchè non preghiamo come si deve.
+
+D. Quali sono le cose che dobbiamo principalmente domandare a Dio?
+
+R. Dobbiamo principalmente domandare a Dio la sua gloria, la nostra eterna salute e i mezzi per conseguirla.
+
+D. Non è lecito il domandare anche beni temporali?
+
+R. Sì, è lecito domandare a Dio anche i beni temporali, ma sempre con la condizione che siano conformi alla sua santissima volontà, e non siano d’impedimento alla nostra eterna salute.
+
+D. Se Iddio sa tutto ciò che ci è necessario, perchè si deve pregare?
+
+R. Sebbene Iddio sappia tutto ciò che ci è necessario, pure vuole che noi lo preghiamo, per riconoscerlo come datore d’ogni bene, per attestargli la nostra umile sommissione e per meritarci i suoi favori.
+
+D. Qual’è la prima e migliore disposizione per rendere efficaci le nostre preghiere?
+
+R. La prima e miglior disposizione per ren dere efficaci le nostre preghiere è di essere in istato di grazia, o non essendovi, almeno desiderare di rimettersi in tale stato.
+
+D. Quali altre disposizioni si richiedono per ben pregare?
+
+R. Per ben pregare si richiedono specialmente il raccoglimento, l’umiltà, la fiducia, la perseveranza e la rassegnazione.
+
+D. Che vuol dire pregare con raccoglimento?
+
+R. Vuol dire pensare che parliamo con Dio, e perciò dobbiamo pregare con tutto il rispetto e la divozione, evitando per quanto è possibile le distrazioni, cioè ogni pensiero estraneo all’orazione.
+
+D. Le distrazioni diminuiscono il merito dell’orazione?
+
+R. Sì, quando noi stessi le procuriamo, ovvero non le respingiamo con diligenza. Se poi facciamo quanto è possibile per essere raccolti in Dio, allora le distrazioni non diminuiscono il merito della nostra orazione, ma anzi lo possono accrescere.
+
+D. Che cosa si richiede per fare orazione con raccoglimento?
+
+R. Dobbiamo prima della preghiera allontanare tutte le occasioni di distrazione, e dobbiamo durante la preghiera pensare che siamo alla presenza di Dio il quale ci vede e ci ascolta.
+
+D. Che vuol dire pregare con umiltà?
+
+R. Vuol dire riconoscere sinceramente la propria indegnità, impotenza e miseria, accom pagnando la preghiera con la compostezza del corpo.
+
+D. Che vuol dire pregare con fiducia?
+
+R. Vuol dire che dobbiamo avere ferma speranza di essere esauditi, se da ciò deriva la gloria di Dio ed il nostro vero bene.
+
+D. Che vuol dire pregare con perseveranza?
+
+R. Vuol dire che non dobbiamo stancarci di pregare, se Iddio subito non ci esaudisce, ma che dobbiamo seguitare anzi a pregare con più fervore.
+
+D. Che vuol dire pregare con rassegnazione?
+
+R. Vuol dire che dobbiamo conformarci al volere di Dio, il quale conosce meglio di noi quanto è necessario alla nostra eterna salute, pur anche nel caso in cui le nostre preghiere non fossero esaudite.
+
+D. Dio esaudisce sempre le orazioni ben fatte?
+
+R. Sì, Dio esaudisce sempre le orazioni ben fatte; ma nella maniera che egli sa essere più utile per la nostra eterna salute, e non sempre secondo la nostra volontà.
+
+D. Quali effetti produce in noi l’orazione?
+
+R. L’orazione ci fa riconoscere la nostra dipendenza da Dio supremo Signore in tutte le cose, ci fa pensare alle cose celesti, ci fa progredire nella virtù, ci ottiene da Dio misericordia, ci fortifica contro le tentazioni, ci conforta nelle tribolazioni, ci aiuta nei nostri bisogni, e ci ottiene la grazia della perseveranza finale.
+
+D. Quand’è che noi dobbiamo specialmente pregare?
+
+R. Noi dobbiamo pregare specialmente nei pericoli, nelle tentazioni e in punto di morte; inoltre dobbiamo pregare frequentemente, ed è bene che ciò si faccia la mattina e la sera e al principio delle azioni importanti della giornata.
+
+D. Per chi dobbiamo pregare?
+
+R. Dobbiamo pregare per tutti; cioè per noi stessi, per i nostri parenti, superiori, benefattori, amici e nemici; per la conversione dei poveri peccatori, di quelli che sono fuori della vera Chiesa, e per le anime sante del purgatorio.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-seconda-capo-ii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-seconda-capo-ii.txt
@@ -1,0 +1,214 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_seconda/Capo_II ===
+=== TITLE: Parte II — Dell'orazione — Compendio della dottrina cristiana/Catechismo maggiore/Parte seconda/Capo II ===
+
+Capo II. Dell’orazione domenicale.
+
+§ 1 . - Dell’orazione domenicale in genere.
+
+D. Qual’è l’orazione vocale più eccellente?
+
+R. L’orazione vocale più eccellente è quella che Gesù Cristo medesimo ci ha insegnato, cioè il Pater noster .
+
+D. Perchè il Pater noster è l’orazione più eccellente?
+
+R. Il Pater noster è l’orazione più eccellente perchè l’ha composta e ce l’ha insegnata Gesù Cristo medesimo; perchè contiene chiaramente in poche parole tutto quello che possiamo sperare da Dio; ed è la regola e il modello di tutte le altre orazioni.
+
+D. Il Pater noster è anche l’orazione più efficace?
+
+R. Il Pater noster è anche l’orazione più efficace, perchè è la più accetta a Dio, facendo noi orazione con le stesse parole che ci ha dettate il suo divin Figliuolo.
+
+D. Perchè il Pater noster si chiama orazione domenicale?
+
+R. Il Pater noster si chiama orazione domenicale, che vuol dire preghiera del Signore, appunto perchè ce l’ha insegnata Gesù Cristo di propria bocca.
+
+D. Quante domande sono nel Pater noster?
+
+R. Nel Pater noster sono sette domande, precedute da un proemio.
+
+D. Recitate il Pater noster.
+
+R. Padre nostro, che sei nei cieli:
+
+1.ª Sia santificato il nome tuo.
+
+2.ª Venga il regno tuo.
+
+3.ª Sia fatta la volontà tua, come in cielo, così in terra.
+
+4.ª Dacci oggi il nostro pane quotidiano.
+
+5.ª E rimetti a noi i nostri debiti, siccome noi li rimettiamo ai nostri debitori.
+
+6.ª E non c’indurre in tentazione.
+
+7.ª Ma liberaci dal male. Così sia.
+
+D. Perchè, invocando Dio in principio dell’orazione domenicale, lo chiamiamo nostro Padre?
+
+R. In principio dell’orazione domenicale chiamiamo Dio nostro Padre per risvegliare la nostra fiducia nella sua infinita bontà, essendo noi suoi figliuoli.
+
+D. Perchè possiamo noi dire che siamo figliuoli di Dio?
+
+R. Noi siamo figliuoli di Dio: 1.º Perchè Egli ci ha creato a imagine sua e ci conserva e governa colla sua provvidenza; 2.º Perchè ci ha, per ispeciale benevolenza, adottati nel Battesimo come fratelli di Gesù Cristo e coeredi insieme con lui dell’eterna gloria.
+
+D. Perchè chiamiamo Dio Padre nostro e non Padre mio?
+
+R. Chiamiamo Dio Padre nostro e non Padre mio, perchè tutti siamo suoi figliuoli e però dobbiamo riguardarci ed amarci tutti come fratelli, e pregare gli uni per gli altri.
+
+D. Essendo Dio in ogni luogo, perchè gli diciamo: che sei ne’ cieli?
+
+R. Dio è in ogni luogo; ma diciamo: Padre nostro, che sei ne’ cieli , per sollevare i nostri cuori al cielo, dove Dio si manifesta nella gloria a’ suoi figliuoli.
+
+§ 2 . - Della prima petizione.
+
+D. Che cosa chiediamo noi nella prima domanda: Sia santificato il nome tuo?
+
+R. Nella prima domanda: Sia santificato il nome tuo noi chiediamo che Dio sia conosciuto, amato, onorato e servito da tutto il mondo, e da noi in particolare.
+
+D. Che cosa intendiamo chiedendo che Dio sia conosciuto, amato e servito da tutto il mondo?
+
+R. Noi intendiamo di chiedere che gli infedeli giungano alla cognizione del vero Dio, gli eretici riconoscano i loro errori, gli scismatici ritornino all’unità della Chiesa, che i peccatori si ravvedano e che i giusti siano perseveranti nel bene.
+
+D. Perchè prima d’ogni altra cosa domandiamo che sia santificato il nome di Dio?
+
+R. Prima d’ogni altra cosa domandiamo che sia santificato il nome di Dio, perchè la gloria di Dio ci deve stare più a cuore che tutti i nostri beni e vantaggi.
+
+D. In qual modo possiamo noi procurare la gloria di Dio?
+
+R. Noi possiamo procurare la gloria di Dio con la preghiera, col buon esempio, e con l’indirizzare a Lui tutti i pensieri, gli affetti e le opere nostre.
+
+§ 3 . - Della seconda petizione.
+
+D. Che cosa intendiamo noi per regno di Dio?
+
+R. Per regno di Dio intendiamo un triplice regno spirituale; cioè il regno di Dio in noi, ossia il regno della grazia; il regno di Dio in terra, cioè la santa Chiesa cattolica; e il regno di Dio nei cieli, ovvero il paradiso.
+
+D. Che cosa chiediamo noi con le parole: venga il regno tuo, in ordine alla grazia?
+
+R. In ordine alla grazia noi chiediamo che Dio regni in noi con la sua grazia santificante per la quale Egli si compiace di risiedere in noi come re nella sua reggia; e di tenerci uniti a Lui con le virtù della fede, della speranza e della carità per le quali regna sul nostro intelletto, sul nostro cuore, e sulla nostra volontà.
+
+D. Che cosa chiediamo con le parole: venga il regno tuo , in ordine alla Chiesa?
+
+R. In ordine alla Chiesa chiediamo che questa sempre più si dilati e si propaghi per tutto il mondo a salvezza degli uomini.
+
+D. Che cosa chiediamo con le parole: venga il regno tuo in ordine alla gloria?
+
+R. In ordine alla gloria noi chiediamo di potere un giorno essere ammessi nel santo paradiso, per il quale fummo creati, dove saremo pienamente felici.
+
+§ 4 . - Della terza petizione.
+
+D. Che cosa chiediamo nella terza domanda: sia fatta la volontà tua, come in cielo, così in terra?
+
+R. Nella terza domanda: sia fatta la volontà tua, come in cielo, così in terra , chiediamo la grazia di fare in ogni cosa la volontà di Dio con ubbidire ai suoi santi comandamenti così prontamente, come gli angeli e i santi gli ubbidiscono in cielo. Chiediamo inoltre la grazia di corrispondere alle divine ispirazioni, e di vivere rassegnati alla volontà di Dio quando Egli ci manda delle tribolazioni.
+
+D. È necessario eseguire la volontà di Dio?
+
+R. È necessario eseguire la volontà di Dio quanto è necessario il conseguire l’eterna salute, perchè Gesù Cristo ha detto che entrerà nel regno dei cieli soltanto chi avrà fatto la volontà del Padre suo.
+
+D. In qual modo possiamo conoscere la volontà di Dio?
+
+R. Noi possiamo conoscere la volontà di Dio specialmente per mezzo della Chiesa e dei nostri superiori spirituali stabiliti da Dio per guidarci nella via della salute. Possiamo anche conoscere questa santissima volontà dalle divine ispirazioni e dalle stesse circostanze nelle quali il Signore ci ha posti.
+
+D. Dobbiamo sempre riconoscere la volontà di Dio nelle cose prospere od avverse della vita?
+
+R. Nelle cose sì prospere che avverse della vita presente dobbiamo sempre riconoscere anche la volontà di Dio, il quale tutto dispone o permette per il nostro bene.
+
+§ 5 . - Della quarta petizione.
+
+D. Che cosa chiediamo nella quarta domanda: dacci oggi il nostro pane quotidiano?
+
+R. Nella quarta domanda: dacci oggi il nostro pane quotidiano , chiediamo a Dio ciò che ci è necessario ciascun giorno e per l’anima e pel corpo.
+
+D. Che cosa domandiamo a Dio per l’anima nostra?
+
+R. Per l’anima nostra domandiamo a Dio il sostentamento della vita spirituale: cioè preghiamo il Signore che ci doni la sua grazia, di cui abbiamo continuamente bisogno.
+
+D. Come si nutrisce la vita dell’anima nostra?
+
+R. La vita dell’anima si nutrisce specialmente col cibo della divina parola e col Santissimo Sacramento dell’altare.
+
+D. Che cosa domandiamo a Dio pel nostro corpo?
+
+R. Pel nostro corpo domandiamo ciò che è necessario al sostentamento della vita temporale.
+
+D. Perchè diciamo: dacci oggi il nostro pane, e non piuttosto: dacci oggi il pane?
+
+R. Diciamo dacci oggi il nostro pane , e non piuttosto: dacci oggi il pane , per escludere ogni desiderio della roba d’altri; perciò preghiamo il Signore che ci aiuti nei guadagni giusti e leciti, affinchè ci procuriamo il vitto con le nostre fatiche, senza furti ed inganni.
+
+D. Perchè diciamo: dacci il pane, e non dammi?
+
+R. Diciamo: dacci invece di dammi per rammentarci che, siccome le sostanze ci vengono da Dio, così se Egli ce ne dà in abbondanza, lo fa a questo fine che ne dispensiamo il superfluo ai poveri.
+
+D. Perchè aggiungiamo quotidiano?
+
+R. Aggiungiamo quotidiano , perchè dobbiamo desiderare quello che ci è necessario alla vita, e non l’abbondanza dei cibi e dei beni della terra.
+
+D. Che cosa significa di più la parola oggi nella quarta domanda?
+
+R. La parola oggi significa che non dobbiamo essere troppo solleciti dell’avvenire, ma domandare quello che ci è necessario al presente.
+
+§ 6 . - Della quinta petizione.
+
+D. Che cosa chiediamo nella quinta domanda: e rimetti a noi i nostri debiti, siccome noi li rimettiamo ai nostri debitori?
+
+R. Nella quinta domanda: e rimetti a noi i nostri debiti, siccome noi li rimettiamo ai nostri debitori , chiediamo a Dio che ci perdoni i nostri peccati, siccome noi perdoniamo ai nostri offensori.
+
+D. Perchè i nostri peccati si chiamano debiti?
+
+R. I nostri peccati si chiamano debiti perchè per essi dobbiamo soddisfare alla divina giustizia o in questa vita o nell’altra.
+
+D. Quelli che non perdonano al prossimo, possono sperare che Dio loro perdoni ?
+
+R. Quelli che non perdonano al prossimo non hanno nessuna ragione di sperare che Dio loro perdoni, tanto più che si condannano da se stessi, dicendo a Dio, che perdoni loro, come essi perdonano al prossimo.
+
+§ 7 . - Della sesta petizione.
+
+D. Che cosa chiediamo nella sesta domanda: e non c’indurre in tentazione?
+
+R. Nella sesta domanda: e non c’indurre in tentazione , chiediamo a Dio che ci liberi dalle tentazioni, o non permettendo che siamo tentati, o dandoci grazia di non essere vinti.
+
+D. Che cosa sono le tentazioni?
+
+R. Le tentazioni sono un incitamento al peccato che ci viene dal demonio, o dai cattivi, o dalle nostre passioni.
+
+D. È peccato aver tentazioni?
+
+R. No, non è peccato aver tentazioni, ma è peccato acconsentirvi, o esporsi volontariamente al pericolo di acconsentirvi.
+
+D. Perchè Iddio permette che siamo tentati?
+
+R. Iddio permette che siamo tentati per provare la nostra fedeltà, per far aumentare le nostre virtù e per accrescere i nostri meriti.
+
+D. Che cosa dobbiamo fare per evitare le tentazioni?
+
+R. Per evitare le tentazioni dobbiamo fuggire le occasioni pericolose, custodire i nostri sensi, ricevere spesso i santi sacramenti, e far uso della preghiera.
+
+§ 8 . - Della settima petizione.
+
+D. Che cosa chiediamo nella settima domanda: ma liberaci dal male?
+
+R. Nella settima domanda, ma liberaci dal male , chiediamo a Dio, che ci liberi dai mali passati, presenti e futuri, e specialmente dal sommo male che è il peccato e dall’eterna dannazione, che ne è la pena.
+
+D. Perchè diciamo: liberaci dal male e non dai mali?
+
+R. Diciamo: liberaci dal male e non dai mali , perchè non dobbiamo desiderare di andare esenti da tutti i mali di questa vita, ma solamente da quelli, che non sono espedienti all’anima nostra, e perciò domandiamo la liberazione dal male in genere, cioè da tutto ciò che Dio vede essere per noi male.
+
+D. Non è lecito domandare la liberazione da qualche male in particolare, per esempio da una malattia?
+
+R. Sì, è lecito domandare la liberazione da qualche male in particolare, ma sempre rimettendoci alla volontà di Dio, il quale può anche ordinare quella tribolazione a vantaggio dell’anima nostra.
+
+D. A che cosa ci giovano le tribolazioni che Dio ci manda?
+
+R. Le tribolazioni ci giovano per fare penitenza delle nostre colpe, per esercitare le virtù, e sopratutto per imitare Gesù Cristo nostro capo, al quale è giusto che ci conformiamo nei patimenti, se vogliamo aver parte nella sua gloria.
+
+D. Che vuol dire Amen in fine del Pater?
+
+R. Amen vuol dire: così sia, così desidero, così prego il Signore e così spero.
+
+D. Per ottenere le grazie domandate nel Pater noster basta recitarlo in qualsivoglia maniera?
+
+R. Per ottenere le grazie domandate nel Pater noster bisogna recitarlo senza fretta, con attenzione e accompagnarlo col cuore.
+
+D. Quando dobbiamo noi dire il Pater?
+
+R. Il Pater dobbiamo dirlo ogni giorno, perchè abbiamo bisogno ogni giorno dell’aiuto di Dio.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-seconda-capo-iii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-seconda-capo-iii.txt
@@ -1,0 +1,64 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_seconda/Capo_III ===
+=== TITLE: Parte II — Dell'orazione — Compendio della dottrina cristiana/Catechismo maggiore/Parte seconda/Capo III ===
+
+Capo III. Dell’«Ave Maria».
+
+D. Quale orazione siamo noi soliti dire dopo il Pater?
+
+R. Dopo il Pater , diciamo la salutazione angelica, cioè l’ Ave Maria , per mezzo della quale ricorriamo alla santissima Vergine.
+
+D. Perchè l’ Ave Maria si chiama salutazione angelica?
+
+R. L’ Ave Maria si chiama salutazione angelica perchè comincia col saluto che fece a Maria Vergine l’arcangelo Gabriele.
+
+D. Di chi sono le parole dell’ Ave Maria?
+
+R. Le parole dell’ Ave Maria parte sono dell’arcangelo Gabriele, parte di S. Elisabetta, e parte della Chiesa.
+
+D. Quali sono le parole dell’arcangelo Gabriele?
+
+R. Le parole dell’arcangelo Gabriele sono: «Dio ti salvi, piena di grazia: il Signore è teco: tu sei benedetta fra le donne».
+
+D. Quando fu che l’Angelo disse a Maria queste parole?
+
+R. L’Angelo disse a Maria queste parole, quando andò ad annunziarle da parte di Dio il mistero dell’Incarnazione che in lei doveva operarsi.
+
+D. Che intendiamo noi di fare nel salutare la santissima Vergine con le stesse parole dell’Arcangelo?
+
+R. Nel salutare la santissima Vergine con le parole dell’Arcangelo, noi ci rallegriamo con lei, facendo memoria dei singolari privilegi e doni, che Iddio le ha conceduti a preferenza di tutte le altre creature.
+
+D. Quali sono le parole di santa Elisabetta?
+
+R. Le parole di santa Elisabetta sono: «Tu sei benedetta fra le donne, e benedetto il frutto del tuo seno».
+
+D. Quando fu che santa Elisabetta disse queste parole?
+
+R. Santa Elisabetta disse queste parole, inspirata da Dio, quando tre mesi prima che desse alla luce S. Giovanni Battista, fu visitata dalla santissima Vergine, che già portava nel seno il suo divin Figliuolo.
+
+D. Che cosa facciamo noi nel dire queste parole?
+
+R. Nel dire le parole di santa Elisabetta ci rallegriamo con Maria SSm̃a della sua eccelsa dignità di Madre di Dio, e benediciamo Dio e lo ringraziamo di averci dato Gesù Cristo per mezzo di Maria.
+
+D. Di chi sono le altre parole dell’ Ave Maria?
+
+R. Tutte le altre parole dell’ Ave Maria sono state aggiunte dalla Chiesa.
+
+D. Che cosa domandiamo noi con le ultime parole dell’ Ave Maria?
+
+R. Con le ultime parole dell’ Ave Maria , domandiamo la protezione della santissima Vergine nel corso di questa vita, e specialmente nel l’ora della nostra morte, nella quale ne avremo maggior bisogno.
+
+D. Perchè dopo il Pater diciamo piuttosto l’ Ave Maria , che qualunque altra orazione?
+
+R. Perchè la SSm̃a Vergine è l’Avvocata più potente appresso Gesù Cristo, epperciò dopo avere detta l’orazione insegnataci da Gesù Cristo, preghiamo la SSm̃a Vergine che ci ottenga le grazie, che abbiamo domandate.
+
+D. Per qual motivo la Vergine santissima è così potente?
+
+R. La santissima Vergine è così potente perchè è Madre di Dio, ed è impossibile che non sia da Lui esaudita.
+
+D. Che c’insegnano i Santi sulla devozione a Maria?
+
+R. Sulla devozione a Maria i Santi c’insegnano che i veri suoi devoti sono da Lei amati e protetti con amore di tenerissima Madre e per mezzo di Lei sono certi di trovare Gesù e di ottenere il paradiso.
+
+D. Qual divozione a Maria la Chiesa ci raccomanda in modo speciale?
+
+R. La divozione che la Chiesa ci raccomanda in modo speciale verso Maria santissima è la recita del santo Rosario.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-seconda-capo-iv.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-seconda-capo-iv.txt
@@ -1,0 +1,16 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_seconda/Capo_IV ===
+=== TITLE: Parte II — Dell'orazione — Compendio della dottrina cristiana/Catechismo maggiore/Parte seconda/Capo IV ===
+
+Capo IV. Dell’invocazione dei Santi.
+
+D. È cosa buona ed utile il ricorrere alla intercessione dei Santi?
+
+R. È cosa utilissima pregare i Santi, e deve farsi da ogni cristiano. Dobbiamo pregare particolarmente i nostri Angeli Custodi, S. Giuseppe Patrono della Chiesa, i santi Apostoli, i Santi di cui portiamo il nome, e i Santi Protettori della diocesi e della parrocchia.
+
+D. Che differenza passa tra le preghiere che facciamo a Dio e quelle che facciamo ai Santi?
+
+R. Tra le preghiere che facciamo a Dio e quelle che facciamo ai Santi passa questa differenza, che Dio lo preghiamo affinchè, come autore delle grazie, ci dia i beni e ci liberi dai mali, e i Santi li preghiamo perchè, come avvocati presso Dio, intercedano per noi.
+
+D. Quando diciamo che un Santo ha fatto una grazia, che cosa intendiamo dire?
+
+R. Quando diciamo che un Santo ha fatto una grazia, intendiamo dire che quel Santo ha ottenuto da Dio quella grazia.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-terza-capo-i.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-terza-capo-i.txt
@@ -1,0 +1,58 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_terza/Capo_I ===
+=== TITLE: Parte III — Dei comandamenti di Dio e della Chiesa — Compendio della dottrina cristiana/Catechismo maggiore/Parte terza/Capo I ===
+
+Capo I. Dei comandamenti di Dio in generale.
+
+D. Di che cosa si tratta nella terza parte della Dottrina cristiana?
+
+R. Nella terza parte della Dottrina cristiana si tratta dei comandamenti di Dio e della Chiesa.
+
+D. Quanti sono i comandamenti della legge di Dio?
+
+R. I comandamenti della legge di Dio sono dieci:
+
+Io sono il Signore Iddio tuo:
+
+1.º Non avrai altro Dio avanti di me.
+
+2.º Non nominare il nome di Dio invano.
+
+3.º Ricordati di santificare le feste.
+
+4.º Onora il padre e la madre.
+
+5.º Non ammazzare.
+
+6.º Non fornicare.
+
+7.º Non rubare.
+
+8.º Non dire il falso testimonio.
+
+9.º Non desiderare la donna d’altri.
+
+10.º Non desiderare la roba d’altri.
+
+D. I comandamenti di Dio perchè hanno questo nome?
+
+R. I comandamenti di Dio hanno questo nome perchè lo stesso Dio li ha impressi nell’anima di ogni uomo, li ha promulgati sul monte Sinai nell’antica legge scolpiti sopra due tavole di pietra, e Gesù Cristo li ha confermati nella legge nuova.
+
+D. Quali sono i comandamenti della prima tavola?
+
+R. I comandamenti della prima tavola sono i primi tre, che riguardano direttamente Dio, e i doveri che abbiamo verso di Lui.
+
+D. Quali sono i comandamenti della seconda tavola?
+
+R. I comandamenti della seconda tavola sono i sette ultimi, che riguardano il prossimo e i doveri che abbiamo verso di esso.
+
+D. Siamo noi obbligati ad osservare i comandamenti?
+
+R. Sì, siamo tutti obbligati ad osservare i comandamenti, perchè tutti dobbiamo vivere secondo la volontà di Dio che ci ha creati, e basta trasgredirne gravemente uno solo per meritare l’inferno.
+
+D. Possiamo noi osservare i comandamenti?
+
+R. Noi possiamo senza dubbio osservare i comandamenti di Dio, perchè Iddio non ci co manda alcuna cosa impossibile e dà la grazia di osservarli a chi la domanda come si deve.
+
+D. Che cosa si deve considerare generalmente in ciascun comandamento?
+
+R. In ciascun comandamento si deve considerare la parte positiva e la parte negativa; cioè quello che ci viene comandato e quello che ci viene proibito.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-terza-capo-ii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-terza-capo-ii.txt
@@ -1,0 +1,206 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_terza/Capo_II ===
+=== TITLE: Parte III — Dei comandamenti di Dio e della Chiesa — Compendio della dottrina cristiana/Catechismo maggiore/Parte terza/Capo II ===
+
+Capo II. Dei comandamenti che riguardano Dio.
+
+§ 1 . - Del primo comandamento.
+
+D. Perchè si dice in principio: Io sono il Signore Iddio tuo?
+
+R. In principio dei comandamenti si dice: Io sono il Signore Iddio tuo , perchè conosciamo che Dio, essendo il nostro Creatore e Signore, può comandare quello che vuole, e noi, sue creature, siamo tenuti ad obbedirgli.
+
+D. Che cosa Iddio ci ordina colle parole del primo comandamento: Non avrai altro Dio avanti di me?
+
+R. Con le parole del primo comandamento: Non avrai altro Dio avanti di me , Iddio ci ordina di riconoscere, di adorare, di amare e servire Lui solo, come nostro supremo Signore.
+
+D. Come si adempie il primo comandamento?
+
+R. Il primo comandamento si adempie coll’esercizio del culto interno ed esterno.
+
+D. Che cosa è il culto interno?
+
+R. Il culto interno è l’onore che si rende a Dio con le sole facoltà dello spirito, ossia con la mente e con la volontà.
+
+D. Che cosa è il culto esterno?
+
+R. Il culto esterno è l’omaggio che si rende a Dio per mezzo di atti esteriori e di oggetti sensibili.
+
+D. Non basta adorar Dio solo col cuore internamente?
+
+R. No, non basta adorar Dio solo col cuore internamente, ma bisogna adorarlo anche esternamente, collo spirito insieme e col corpo, perchè Egli è Creatore e Signore assoluto dell’uno e dell’altro.
+
+D. Può stare il culto esterno, senza l’interno?
+
+R. No, non può stare in verun modo il culto esterno senza l’interno, perchè quello scompagnato da questo rimane privo di vita, di merito e di efficacia, come corpo senz’anima.
+
+D. Che cosa ci proibisce il primo comandamento?
+
+R. Il primo comandamento ci proibisce l’idolatria, la superstizione, il sacrilegio, l’eresia ed ogni altro peccato contro la religione.
+
+D. Che cosa è l’idolatria?
+
+R. Si chiama idolatria il dare a qualche creatura, per esempio ad una statua, ad un’imagine, ad un uomo, il culto supremo di adorazione dovuto a Dio solo.
+
+D. Come si trova espressa nella Sacra Scrittura questa proibizione?
+
+R. Nella Sacra Scrittura si trova espressa questa proibizione con le parole: Tu non ti farai scultura, nè rappresentazione alcuna di quel che è lassù nel cielo e quaggiù in terra. E non adorerai tali cose, nè ad esse presterai culto.
+
+D. Proibiscono queste parole ogni sorta d’imagini?
+
+R. No certamente; ma soltanto quelle delle false divinità, fatte a scopo di adorazione, come facevano gl’idolatri. Ciò è tanto vero che Iddio stesso comandò a Mosè di farne alcune, come le due statue di cherubini sull’arca, e il serpente di bronzo nel deserto.
+
+D. Che cosa è la superstizione?
+
+R. Si chiama superstizione qualunque devozione contraria alla dottrina e all’uso della Chiesa, come anche l’attribuire ad un’azione o ad una cosa qualunque una virtù soprannaturale che non ha.
+
+D. Che cosa è il sacrilegio?
+
+R. Il sacrilegio è la profanazione di un luogo, di una persona o di una cosa consacrata a Dio e destinata al suo culto.
+
+D. Che cosa è l’eresia?
+
+R. L’eresia è un errore colpevole dell’intelletto, per cui si nega con pertinacia qualche verità della fede.
+
+D. Quali altre cose proibisce il primo comandamento?
+
+R. Il primo comandamento ci proibisce altresì qualunque commercio col demonio e l’aggregarsi alle sette anticristiane.
+
+D. Chi ricorresse al demonio o lo invocasse, commetterebbe grave peccato?
+
+R. Chi ricorresse al demonio o lo invocasse commetterebbe un peccato enorme, perchè il demonio è il più perverso nemico di Dio e dell’uomo.
+
+D. È lecito interrogare le tavole così dette parlanti o scriventi, o consultare in qualunque modo le anime dei trapassati mediante lo spiritismo?
+
+R. Tutte le pratiche dello spiritismo sono illecite, perchè superstiziose, e spesso non immuni da intervento diabolico, e perciò furono dalla Chiesa giustamente proibite.
+
+D. Il primo comandamento proibisce forse di onorare ed invocare gli Angeli e i Santi?
+
+R. No, non è proibito onorare ed invocare gli Angeli e i Santi; anzi dobbiamo farlo, perchè è cosa buona e utile, e dalla Chiesa altamente raccomandata, essendo essi gli amici di Dio e i nostri intercessori presso di Lui.
+
+D. Essendo Gesù Cristo il nostro unico Mediatore presso Dio, perchè ricorriamo anche alla mediazione di Maria santissima e dei Santi?
+
+R. Gesù Cristo è il nostro Mediatore presso Dio, inquantochè, essendo vero Dio e vero Uomo, Egli solo in virtù dei proprî meriti ci ha riconciliati con Dio e ce ne ottiene tutte le grazie. La Vergine poi e i Santi in virtù dei meriti di Gesù Cristo e per la carità che li unisce a Dio ed a noi, ci aiutano con la loro intercessione ad ottenere le grazie che domandiamo. E questo è uno dei grandi beni della comunione dei Santi.
+
+D. Possiamo onorare anche le sacre imagini di Gesù Cristo e dei Santi?
+
+R. Sì, perchè l’onore che si rende alle sacre imagini di Gesù Cristo e dei Santi si riferisce alle loro stesse persone.
+
+D. E le reliquie dei Santi si possono onorare?
+
+R. Sì, anche le reliquie dei Santi si debbono onorare, perchè i loro corpi furono vivi membri di Gesù Cristo, e templi dello Spirito Santo, e debbono risorgere gloriosi all’eterna vita.
+
+D. Che differenza vi è tra il culto che rendiamo a Dio e il culto che rendiamo ai Santi?
+
+R. Tra il culto che rendiamo a Dio e il culto che rendiamo ai Santi vi è questa differenza, che Iddio lo adoriamo per la sua infinita eccellenza, e i Santi invece non li adoriamo, ma li onoriamo e veneriamo come amici di Dio e nostri intercessori presso di Lui. Il culto che si rende a Dio si chiama latria cioè di adorazione , ed il culto che si rende ai Santi si chiama dulia cioè di venerazione a’ servi di Dio ; il culto poi particolare, che prestiamo a Maria santissima, si chiama iperdulia , cioè di specialissima venerazione , come a Madre di Dio.
+
+§ 2 . - Del secondo comandamento.
+
+D. Che cosa ci proibisce il secondo comandamento: Non nominare il nome di Dio invano?
+
+R. Il secondo comandamento: Non nominare il nome di Dio invano , ci proibisce: 1.º di nominare il nome di Dio senza rispetto; 2.º di bestemmiare contro Dio, contro la santissima Vergine e contro i Santi; 3.º di fare giuramenti falsi o non necessari, o in qualunque modo illeciti.
+
+D. Che vuol dire nominare il nome di Dio senza rispetto?
+
+R. Nominare il nome di Dio senza rispetto vuol dire pronunziare questo santo nome e tutto ciò che si riferisce in modo speciale a Dio stesso, come il nome di Gesù, di Maria e dei Santi, nella collera, per ischerzo, o in altro modo poco riverente.
+
+D. Che cosa è la bestemmia?
+
+R. La bestemmia è un orribile peccato che consiste in parole o atti di disprezzo o di maledizione contro Dio, la Vergine, i Santi, o contro le cose sante.
+
+D. Vi è differenza tra la bestemmia e l’imprecazione?
+
+R. V’è differenza perchè con la bestemmia si maledice, o si desidera il male a Dio, alla Madonna, ai Santi: mentre con la imprecazione si maledice o si desidera il male a sè stesso, o al prossimo.
+
+D. Che cosa è il giuramento?
+
+R. Il giuramento è il chiamare Dio in testimonio della verità di ciò che si dice, o si promette.
+
+D. È sempre proibito il giurare?
+
+R. Non è sempre proibito il giurare, ma è lecito anzi onorevole a Dio quando vi sia necessità e il giuramento sia fatto con verità, con giudizio e con giustizia.
+
+D. Quando non si giura con verità?
+
+R. Quando si afferma con giuramento ciò che si sa, o si crede che sia falso, e quando con giuramento si promette di fare ciò che non si ha intenzione di eseguire.
+
+D. Quando non si giura con giudizio?
+
+R. Quando si giura senza prudenza e senza matura considerazione, ovvero per cose di poca importanza.
+
+D. Quando non si giura con giustizia?
+
+R. Quando si giura di fare una cosa che non sia giusta o lecita, come vendicarsi, rubare ed altre cose simili.
+
+D. Siamo noi obbligati di mantenere il giuramento di fare cose ingiuste od illecite?
+
+R. Non solo non siamo obbligati, ma peccheremmo facendole, perchè proibite dalla legge di Dio, o della Chiesa.
+
+D. Chi giura il falso che peccato commette?
+
+R. Chi giura il falso commette peccato mortale, perchè disonora gravemente Dio verità infinita, chiamandolo in testimonio del falso.
+
+D. Che cosa ci ordina il secondo comandamento?
+
+R. Il secondo comandamento ci ordina di onorare il nome santo di Dio e di adempiere oltre i giuramenti anche i voti.
+
+D. Che cosa è il voto?
+
+R. Il voto è una promessa che si fa a Dio di una cosa buona e a noi possibile e migliore della cosa contraria, alla quale ci obblighiamo come se ci fosse comandata.
+
+D. Se la osservanza del voto riuscisse in tutto o in parte molto difficile, che si dovrebbe fare?
+
+R. Si può domandare la commutazione o la dispensa al proprio Vescovo, od al Sommo Pontefice, secondo la qualità del voto.
+
+D. È peccato trasgredire i voti?
+
+R. Il trasgredire i voti è peccato, e perciò non dobbiamo far voti senza matura riflessione e, ordinariamente, senza il consiglio del confessore, o d’altra persona prudente, per non esporci al pericolo di peccare.
+
+D. Si possono fare i voti alla Madonna ed ai Santi?
+
+R. I voti si fanno solamente a Dio: si può però promettere a Dio di far qualche cosa in onore della Madonna, o dei Santi.
+
+§ 3 . - Del terzo comandamento.
+
+D. Che cosa ci ordina il terzo comandamento: Ricordati di santificare le feste?
+
+R. Il terzo comandamento: Ricordati di santificare le feste , ci ordina di onorare Dio con opere di culto nei giorni di festa.
+
+D. Quali sono i giorni di festa?
+
+R. Nell’antica legge erano i sabati ed altri giorni particolarmente solenni per il popolo ebreo; nella legge nuova sono le domeniche ed altre festività stabilite dalla Chiesa.
+
+D. Perchè nella legge nuova si santifica la domenica invece del sabato?
+
+R. La domenica, che significa giorno del Signore, fu sostituita al sabato perchè in tal giorno Gesù Cristo Signor nostro risuscitò.
+
+D. Quale opera di culto ci viene comandata nei giorni di festa?
+
+R. Ci viene comandato di assistere divotamente al santo sacrificio della Messa.
+
+D. Con quali altre opere un buon cristiano santifica le feste?
+
+R. Il buon cristiano santifica le feste: 1.º coll’intervenire alla Dottrina cristiana, alle prediche ed ai divini uffizî; 2.º col ricevere spesso, con le dovute disposizioni i sacramenti della Penitenza e dell’Eucaristia; 3.º coll’esercitarsi nell’orazione e nelle opere di cristiana carità verso il prossimo.
+
+D. Che cosa ci proibisce il terzo comandamento?
+
+R. Il terzo comandamento ci proibisce le opere servili e qualunque opera che ci impedisca il culto di Dio.
+
+D. Quali sono le opere servili proibite nei giorni di festa?
+
+R. Le opere servili proibite nei giorni di festa sono le opere dette manuali, cioè quei lavori materiali in cui ha parte più il corpo che lo spirito; come quelle che ordinariamente si fanno dai servi, dagli operai e dagli artieri.
+
+D. Quale peccato si commette lavorando in giorno di festa?
+
+R. Lavorando in giorno di festa si commette peccato mortale: scusa però dalla colpa grave la brevità del tempo che si occupa.
+
+D. Non vi è alcuna opera servile che sia permessa nei giorni di festa?
+
+R. Nei giorni di festa sono permesse quelle opere che sono necessarie alla vita, o al servizio di Dio; e quelle che si fanno per una causa grave domandando licenza, se si può, al proprio parroco.
+
+D. Per qual fine nelle feste sono proibite le opere servili?
+
+R. Sono proibite nelle feste le opere servili, affinchè possiamo meglio attendere al divin culto e alla salute dell’anima nostra; e riposarci dalle fatiche. Per questo non è proibito qualche onesto divertimento.
+
+D. Quali altre cose dobbiamo schivare sovrattutto nelle feste?
+
+R. Nelle feste dobbiamo schivare sopra tutto il peccato e tutto ciò che può indurci al peccato, come i divertimenti e i ritrovi pericolosi.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-terza-capo-iii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-terza-capo-iii.txt
@@ -1,0 +1,296 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_terza/Capo_III ===
+=== TITLE: Parte III — Dei comandamenti di Dio e della Chiesa — Compendio della dottrina cristiana/Catechismo maggiore/Parte terza/Capo III ===
+
+Capo III. Dei comandamenti che riguardano il prossimo.
+
+§ 1. - Del quarto comandamento.
+
+D. Che cosa ci ordina il quarto comandamento: Onora il padre e la madre?
+
+R. Il quarto comandamento: Onora il padre e la madre , ci ordina di rispettare il padre e la madre, di obbedire loro in tutto ciò che non è peccato, e di aiutarli nei loro bisogni spirituali e temporali.
+
+D. Che cosa ci proibisce il quarto comanda mento?
+
+R. Il quarto comandamento ci proibisce di offendere i genitori con le parole, con le opere e in qualsiasi altro modo.
+
+D. Sotto il nome di padre e di madre, quali altre persone comprende questo comandamento?
+
+R. Questo comandamento, sotto il nome di padre e di madre comprende ancora tutti i superiori, così ecclesiastici, come secolari, ai quali perciò dobbiamo obbedire e portare rispetto.
+
+D. Donde viene ai genitori l’autorità di comandare ai figliuoli, e l’obbligo ai figliuoli di obbedire loro?
+
+R. L’autorità che i genitori hanno di comandare ai figliuoli, e l’obbligo ai figliuoli di obbedire, viene da Dio che costituì ed ordinò la famiglia, acciocchè in essa l’uomo trovi i primi mezzi necessari al suo perfezionamento materiale e spirituale.
+
+D. I genitori hanno dei doveri verso i loro figli?
+
+R. I genitori hanno il dovere di amare, alimentare e mantenere i loro figliuoli, di provvedere alla loro educazione religiosa e civile, di dar loro buono esempio, di allontanarli dall’occasione di peccato, correggerli delle loro mancanze, ed aiutarli ad abbracciare lo stato al quale sano chiamati da Dio.
+
+D. Ci diede Iddio l’esempio di famiglia perfetta?
+
+R. Iddio ci diede l’esempio di famiglia perfetta nella Sacra Famiglia, nella quale Gesù Cristo visse soggetto a Maria santissima e a S. Giuseppe fino ai trent’anni, cioè fino a quando incominciò ad esercitare la missione affidatagli dall’Eterno Padre di predicare il Vangelo.
+
+D. Se le famiglie vivessero da sole, separate una dall’altra, potrebbero provvedere a tutti i propri bisogni materiali e morali?
+
+R. Se le famiglie vivessero da sole, separate una dall’altra, non potrebbero provvedere ai propri bisogni, ed è necessario che si siano unite in società civile, a fine di aiutarsi a vicenda per il perfezionamento e la felicità comune.
+
+D. Che cosa è la società civile?
+
+R. La società civile è l’unione di molte famiglie dipendenti dall’autorità di un capo, per aiutarsi scambievolmente a conseguire il mutuo perfezionamento e la felicità temporale.
+
+D. Donde viene alla società civile l’autorità che la governa?
+
+R. L’autorità che governa la società civile viene da Dio, che la vuole costituita a bene comune.
+
+D. Vi è obbligo di rispettare e di obbedire l’autorità che governa la società civile?
+
+R. Sì, tutti quelli che appartengono alla società civile hanno l’obbligo di rispettare e di obbedire l’autorità perchè viene da Dio, e perchè così è richiesto dal bene comune.
+
+D. Si debbono rispettare tutte le leggi che sono imposte dall’autorità civile?
+
+R. Si debbono rispettare tutte le leggi che l’autorità civile impone, purchè esse non siano contrarie alla legge di Dio, secondo il comando e l’esempio di nostro Signor Gesù Cristo.
+
+D. Oltre il rispetto e l’obbedienza alle leggi imposte dall’autorità, coloro che fanno parte della società civile hanno altri doveri?
+
+R. Coloro che fanno parte della società civile, hanno, oltre l’obbligo del rispetto e dell’obbedienza alle leggi, il dovere di vivere concordi e di adoperarsi ciascuno coi mezzi e con le forze proprie affinchè essa sia virtuosa, pacifica, ordinata e prospera a comune vantaggio.
+
+§ 2 . - Del quinto comandamento.
+
+D. Che cosa proibisce il quinto comandamento: Non ammazzare?
+
+R. Il quinto comandamento: Non ammazzare , proibisce di dar morte, battere, ferire o fare qualunque altro danno al prossimo nel corpo, sia per sè, sia per mezzo d’altri; come pure di offenderlo con parole ingiuriose e di volergli male. In questo comandamento Iddio proibisce anche il dar morte a se stesso, ossia il suicidio .
+
+D. Perchè è peccato grave uccidere il prossimo?
+
+R. Perchè l’uccisore si usurpa temerariamente il diritto che ha Dio solo sulla vita dell’uomo; perchè distrugge la sicurezza dell’umano consorzio, e perchè perchè toglie al prossimo la vita, che è il più gran bene naturale che ha sulla terra.
+
+D. Vi sono dei casi nei quali sia lecito uccidere il prossimo?
+
+R. È lecito uccidere il prossimo quando si combatte in una guerra giusta, quando si eseguisce per ordine dell’autorità suprema la condanna di morte in pena di qualche delitto; e finalmente quando trattasi di necessaria e legittima difesa della vita contro un ingiusto aggressore.
+
+D. Dio, nel quinto comandamento, proibisce anche di nuocere alla vita spirituale del prossimo?
+
+R. Sì, Iddio nel quinto comandamento proibisce anche di nuocere alla vita spirituale del prossimo con lo scandalo.
+
+D. Che cosa è lo scandalo?
+
+R. Lo scandalo è qualunque detto, fatto o omissione, che è occasione ad altri di commettere peccati.
+
+D. È peccato grave lo scandalo?
+
+R. Lo scandalo è un peccato grave, perchè tende a distruggere la più grande opera di Dio, che è la redenzione, con la perdita delle anime; dà al prossimo la morte dell’anima togliendogli la vita della grazia, che è più preziosa della vita del corpo; è causa di una moltitudine di peccati. Perciò Iddio minaccia agli scandalosi i più severi castighi.
+
+D. Perchè nel quinto comandamento, Dio proibisce il dar morte a se stesso, ossia il suicidio?
+
+R. Nel quinto comandamento, Dio proibisce il suicidio perchè l’uomo non è padrone della sua vita, come non lo è di quella degli altri. La Chiesa poi punisce il suicida colla privazione della sepoltura ecclesiastica.
+
+D. È proibito nel quinto comandamento anche il duello?
+
+R. Sì, nel quinto comandamento è proibito anche il duello, perchè il duello partecipa della malizia del suicidio e dell’omicidio, ed è scomu nicato chiunque volontariamente vi ha parte, anche di semplice spettatore.
+
+D. È anche proibito il duello quando sia escluso il pericolo di morte?
+
+R. È anche proibito questo duello perchè non solamente non possiamo uccidere, ma neanche ferire volontariamente noi stessi e gli altri.
+
+D. La difesa dell’onore può scusare il duello?
+
+R. No: perchè non è vero, che nel duello si ripara l’offesa; e perchè non si può riparare l’onore con un’azione ingiusta, irragionevole e barbara, quale è il duello.
+
+D. Che cosa ci ordina il quinto comandamento?
+
+R. Il quinto comandamento ci ordina di per donare ai nostri nemici, e di voler bene a tutti.
+
+D. Che cosa deve fare chi ha danneggiato il prossimo nella vita del corpo, o in quella dell’anima?
+
+R. Chi ha danneggiato il prossimo non basta che si confessi, ma deve anche riparare al male che ha fatto col risarcire al prossimo i danni arrecati, col ritrattare gli errori insegnati, e col dar buoni esempi.
+
+§ 3 . - Del sesto e del nono comandamento.
+
+D. Che cosa ci proibisce il sesto comandamento: Non fornicare?
+
+R. Il sesto comandamento: Non fornicare , ci proibisce ogni atto, ogni sguardo, ogni di scorso contrario alla castità, e l’infedeltà nel matrimonio.
+
+D. Che cosa proibisce il nono comandamento?
+
+R. Il nono comandamento proibisce espressamente ogni desiderio contrario alla fedeltà che i coniugi si sono giurata nel contrarre matrimonio: e proibisce pure ogni colpevole pensiero o desiderio di azione vietata dal sesto comandamento.
+
+D. È un gran peccato l’impurità?
+
+R. È un peccato gravissimo ed abominevole innanzi a Dio ed agli uomini; avvilisce l’uomo alla condizione dei bruti, lo trascina a molti altri peccati e vizi, e provoca i più terribili castighi in questa vita e nell’altra.
+
+D. Sono peccati tutti i pensieri che ci vengono in mente contro la purità?
+
+R. I pensieri che ci vengono in mente contro la purità, per se stessi non sono peccati, ma piuttosto tentazioni e incentivi al peccato.
+
+D. Quando è che sono peccati i pensieri cattivi?
+
+R. I pensieri cattivi, ancorchè siano inefficaci, sono peccati quando colpevolmente diamo loro motivo, o vi acconsentiamo, o ci esponiamo al pericolo prossimo di acconsentirvi.
+
+D. Che cosa ci ordinano il sesto e nono comandamento?
+
+R. Il sesto comandamento ci ordina di essere casti e modesti negli atti, negli sguardi, nel portamento e nelle parole. Il nono comandamento ci ordina di essere casti e puri anche nell’interno, cioè nella mente e nel cuore.
+
+D. Che cosa ci convien fare per osservare il sesto e il nono comandamento?
+
+R. Per ben osservare il sesto e il nono comandamento, dobbiamo pregare spesso e di cuore Iddio, essere divoti di Maria Vergine Madre della purità, ricordarci che Dio ci vede, pensare alla morte, ai divini castighi, alla passione di Gesù Cristo, custodire i nostri sensi, praticare la mortificazione cristiana e frequentare colle dovute disposizioni i sacramenti.
+
+D. Che cosa dobbiamo fuggire per mantenerci casti?
+
+R. Per mantenerci casti conviene fuggire l’ozio, i cattivi compagni, la lettura dei libri e dei giornali cattivi, l’intemperanza, il guardare le immagini indecenti, gli spettacoli licenziosi, le conversazioni pericolose, e tutte le altre occasioni di peccato.
+
+§ 4 . - Del settimo comandamento.
+
+D. Che cosa ci proibisce il settimo comandamento: Non rubare?
+
+R. Il settimo comandamento: Non rubare , proibisce di prendere e di ritenere ingiustamente la roba altrui e di recar danno al prossimo nella roba in qualunque altro modo.
+
+D. Che cosa vuol dire rubare?
+
+R. Vuol dire prendere ingiustamente la roba altrui contro la volontà del padrone, quando cioè egli ha tutta la ragione ed il diritto di non volerne essere privato.
+
+D. Perchè si proibisce il rubare?
+
+R. Perchè si pecca contro la giustizia, e si fa ingiuria al prossimo, prendendo e ritenendo contro il suo diritto e la sua volontà ciò che gli appartiene.
+
+D. Che cosa è la roba d’altri?
+
+R. È tutto ciò che appartiene al prossimo, che ne ha la proprietà o l’uso, o lo tiene in deposito.
+
+D. In quanti modi si prende ingiustamente la roba degli altri?
+
+R. In due modi: col furto e con la rapina.
+
+D. Il furto come si commette?
+
+R. Il furto si commette prendendo occultamente la roba degli altri.
+
+D. La rapina come si commette?
+
+R. La rapina si commette prendendo con violenza e manifestamente la roba degli altri.
+
+D. In quali casi si può prendere la roba de gli altri senza far peccato?
+
+R. Quando il padrone non fosse contrario, ovvero quando ingiustamente non volesse, come accadrebbe di uno che avesse estrema necessità, purchè prendesse soltanto quanto gli è strettamente necessario per sovvenire all’urgente ed estremo bisogno.
+
+D. Solamente col furto e con la rapina si danneggia il prossimo nella roba?
+
+R. Si danneggia anche con la frode, con l’usura e con qualunque altra ingiustizia contro i suoi beni.
+
+D. Come si commette la frode?
+
+R. La frode si commette ingannando il prossimo nel commercio con pesi, misure o monete false e con merci cattive; falsificando scritture e documenti; in somma facendo inganni nelle compre, nelle vendite ed in qualsiasi altro contratto ed anche quando non si vuol dare il giusto ed il convenuto.
+
+D. In qual modo si commette l’usura?
+
+R. L’usura si commette con l’esigere senza legittimo titolo un illecito interesse per una somma prestata, abusando del bisogno e dell’ignoranza altrui.
+
+D. Quali altre ingiustizie si commettono contro i beni del prossimo?
+
+R. Col fargli perdere ingiustamente ciò che ha, col danneggiarlo nelle possessioni, non lavorare conforme al dovere, non pagare per malizia i debiti e le dovute mercedi, col ferire od uccidere animali che gli appartengono, col mandare a male le cose avute in custodia, con l’impedire ad alcuno di fare un giusto guadagno, col tenere mano ai ladri, col ricevere, nascondere o comprare la roba rubata.
+
+D. È peccato grave rubare?
+
+R. È un peccato grave contro la giustizia quando trattasi di materia grave, essendo cosa molto importante che sia rispettato il diritto che ciascuno ha sulla roba propria, e ciò per il bene degli individui, delle famiglie e della società.
+
+D. Quando è grave la materia del furto?
+
+R. È grave quando si toglie cosa rilevante, ed anche quando, togliendosi cosa di poco momento, il prossimo ne patisce grave danno.
+
+D. Che cosa ci ordina il settimo comandamento?
+
+R. Il settimo comandamento ci ordina di rispettare la roba degli altri, dare la giusta mercede agli operai, ed osservare la giustizia in tutto quello che riguarda la proprietà altrui.
+
+D. Chi ha peccato contro il settimo comandamento basta che se ne confessi?
+
+R. Chi ha peccato contro il settimo comandamento non basta che se ne confessi, ma bisogna che faccia quello che può per restituire la roba d’altri e risarcire i danni.
+
+D. Che cosa è il risarcimento dei danni?
+
+R. Il risarcimento dei danni è il compenso che si deve dare al prossimo dei frutti e dei guadagni perduti a cagione del furto e delle altre ingiustizie commesse a suo danno.
+
+D. A chi si deve restituire la roba rubata?
+
+R. A chi si è rubato; ai suoi eredi, se egli fosse morto; e se ciò fosse veramente impossibile, si deve erogarne il valore a beneficio dei poveri e di pie opere.
+
+D. Che cosa si deve fare quando si trova qualche cosa di grande valore?
+
+R. Devesi usare grande diligenza per trovarne il padrone, e restituirgliela fedelmente.
+
+§ 5 . - Dell’ottavo comandamento.
+
+D. Che cosa ci proibisce l’ottavo comandamento: Non dire falso testimonio?
+
+R. L’ottavo comandamento: Non dire il falso testimonio , ci proibisce di attestare il falso in giudizio: e proibisce ancora la detrazione o mormorazione, la calunnia, l’adulazione, il giudizio ed il sospetto temerario ed ogni sorta di bugia.
+
+D. Che cos’è la detrazione o mormorazione?
+
+R. La detrazione o mormorazione è un peccato che consiste nel manifestare, senza giusto motivo, i peccati e difetti altrui.
+
+D. Che cos’è la calunnia?
+
+R. La calunnia è un peccato che consiste nell’attribuire malignamente al prossimo colpe e difetti che non ha.
+
+D. Che cos’è l’adulazione?
+
+R. L’adulazione è un peccato che consiste nell’ingannare taluno col dire falsamente bene di lui o di altri, allo scopo di averne vantaggio.
+
+D. Che cos’è il giudizio o sospetto temerario?
+
+R. Il giudizio o sospetto temerario è un peccato che consiste nel giudicare o sospettar male degli altri senza un giusto fondamento.
+
+D. Che cos’è la bugia?
+
+R. La bugia è un peccato che consiste nell’asserire per vero o per falso, con parole o con fatti, ciò che non si crede tale.
+
+D. Di quante specie è la bugia?
+
+R. La bugia è di tre specie: giocosa, officiosa e dannosa.
+
+D. Qual’è la bugia giocosa?
+
+R. La bugia giocosa è quella con cui si mentisce per giuoco, e senza pregiudizio di alcuno.
+
+D. Qual’è la bugia officiosa?
+
+R. La bugia officiosa è l’asserzione del falso per la propria o per l’altrui utilità, senza pregiudizio di alcuno.
+
+D. Qual’è la bugia dannosa?
+
+R. La bugia dannosa è l’asserzione del falso con pregiudizio del prossimo.
+
+D. È mai lecito dir la bugia?
+
+R. Non è mai lecito dir la bugia nè per giuoco, nè per proprio, nè per altrui vantaggio, essendo cosa per se stessa cattiva.
+
+D. Che peccato è la bugia ?
+
+R. La bugia quando è giocosa od officiosa è peccato veniale; quando poi è dannosa è peccato mortale, se il danno che reca è grave.
+
+D. È necessario sempre dir tutto come si pensa?
+
+R. Non è sempre necessario, specialmente quando chi interroga non ha il diritto di sapere ciò che domanda.
+
+D. Chi ha peccato contro l’ottavo comandamento, basta che se ne confessi?
+
+R. Chi ha peccato contro l’ottavo comandamento, non basta che se ne confessi, ma è obbligato anche a ritrattare quanto disse calun niando il prossimo, e a riparare, nel miglior modo che può, i danni che gli ha cagionato.
+
+D. Che cosa ci ordina l’ottavo comandamento?
+
+R. L’ottavo comandamento ci ordina di dire a tempo e luogo la verità, e di interpretare in bene, per quanto possiamo, le azioni del nostro prossimo.
+
+§ 6 . - Del decimo comandamento.
+
+D. Che cosa ci proibisce il decimo comandamento: Non desiderare la roba d’altri?
+
+R. Il decimo comandamento: Non desiderare la roba d’altri , proibisce il desiderio di privare altri della sua roba e il desiderio di acquistar roba con mezzi ingiusti.
+
+D. Perchè proibisce Iddio anche il desiderio della roba altrui?
+
+R. Dio ci proibisce i desiderî sregolati della roba altrui, perchè Egli vuole che noi anche internamente siamo giusti e ci teniamo sempre più lontani dalle opere ingiuste.
+
+D. Il decimo comandamento che cosa ci ordina?
+
+R. Il decimo comandamento ci ordina di contentarci dello stato in cui Dio ci ha posti e di soffrire con pazienza la povertà, quando Iddio ci voglia in tale stato.
+
+D. Come può il cristiano essere contento nello stato di povertà?
+
+R. Il cristiano può essere contento anche nello stato di povertà, considerando che mas simo bene è la coscienza pura e tranquilla, che la nostra vera patria è il cielo, e che Gesù Cristo si fece povero per amor nostro e ha promesso un premio speciale a tutti quelli che sopportano con pazienza la povertà.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-terza-capo-iv.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-terza-capo-iv.txt
@@ -1,0 +1,182 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_terza/Capo_IV ===
+=== TITLE: Parte III — Dei comandamenti di Dio e della Chiesa — Compendio della dottrina cristiana/Catechismo maggiore/Parte terza/Capo IV ===
+
+Capo IV. Dei precetti della Chiesa.
+
+§ 1 . - Dei precetti della Chiesa in generale.
+
+D. Oltre i comandamenti di Dio, che altro dobbiamo noi osservare?
+
+R. Oltre i comandamenti di Dio noi dobbiamo osservare i precetti della Chiesa.
+
+D. Siamo noi obbligati ad obbedire alla Chiesa?
+
+R. Senza dubbio siamo obbligati ad obbedire alla Chiesa, perchè Gesù Cristo medesimo lo comanda, e perchè i precetti della Chiesa aiutano ad osservare i comandamenti di Dio.
+
+D. Quando comincia l’obbligo di osservare i precetti della Chiesa?
+
+R. L’obbligo di osservare i precetti della Chiesa generalmente incomincia dall’uso di ragione.
+
+D. È peccato trasgredire un precetto della Chiesa?
+
+R. Il trasgredire avvertitamente un precetto della Chiesa in materia grave è peccato mortale.
+
+D. Chi può dispensare da un precetto della Chiesa?
+
+R. Da un precetto della Chiesa può dispensare solamente il Papa, e chi da lui ne ha ricevute le facoltà.
+
+D. Quanti e quali sono i precetti della Chiesa?
+
+R. I Precetti della Chiesa sono cinque:
+
+1.º Udir la Messa tutte le domeniche e le altre feste comandate.
+
+2.º Digiunare la Quaresima, le quattro tempora e le vigilie comandate; non mangiar carne nei giorni proibiti.
+
+3.º Confessarsi almeno una volta l’anno, e comunicarsi alla Pasqua di Risurrezione, ciascuno alla propria parrocchia.
+
+4.º Pagare le decime dovute alla Chiesa, secondo le usanze.
+
+5.º Non celebrare le nozze ne’ tempi vietati, cioè dalla prima domenica dell’Avvento fino all’Epifania, e dal primo giorno di Quaresima fino all’ottava di Pasqua.
+
+§ 2 . - Del primo precetto della Chiesa.
+
+D. Che cosa ci ordina il primo precetto o comandamento della Chiesa: Ascoltare la Messa tutte le domeniche e le altre feste comandate?
+
+R. Il primo precetto della Chiesa: Ascoltare la Messa tutte le domeniche e le altre feste comandate , ci ordina di assistere con divozione alla santa Messa in tutte le domeniche e nelle altre feste di precetto.
+
+D. Qual’è la Messa alla quale la Chiesa desidera che si assista nelle domeniche e nelle altre feste di precetto?
+
+R. La Messa alla quale la Chiesa desidera che possibilmente si assista nelle domeniche e nelle altre feste di precetto è la Messa parrocchiale.
+
+D. Perchè la Chiesa raccomanda ai fedeli di assistere alla Messa parrocchiale?
+
+R. La Chiesa raccomanda ai fedeli di assistere alla Messa parrocchiale: 1.º affinchè quelli che appartengono alla stessa parrocchia si uniscano a pregare insieme col parroco che è loro capo; 2.º affinchè i parrocchiani partecipino maggiormente al santo sacrificio, che è applicato principalmente per loro; 3.º affinchè ascoltino le verità del Vangelo che i parrochi hanno obbligo di esporre nella santa Messa; 4.º affinchè vengano a conoscere le prescrizioni e gli avvisi che si pubblicano in detta Messa.
+
+D. Che cosa vuol dire: domenica?
+
+R. Domenica vuol dire giorno del Signore, cioè giorno specialmente consacrato al divino servizio.
+
+D. Perchè nel primo comandamento della Chiesa si fa menzione speciale della domenica?
+
+R. Nel primo comandamento della Chiesa si fa menzione speciale della domenica, perchè essa è la festa principale presso i cristiani, come il sabato era la festa principale presso gli ebrei, istituita da Dio stesso.
+
+D. Quali altre feste ha istituito la Chiesa?
+
+R. La Chiesa ha istituito anche le feste di nostro Signore, della SSm̃a Vergine, degli Angeli e dei Santi.
+
+D. Perchè la Chiesa ha istituito altre feste di nostro Signore?
+
+R. La Chiesa ha istituito altre feste di nostro Signore in memoria de’ suoi divini misteri.
+
+D. Le feste della SSm̃a Vergine, degli Angeli e dei Santi perchè sono state istituite?
+
+R. Le feste della santissima Vergine, degli Angeli e dei Santi, sono state istituite 1.º in memoria delle grazie che Dio loro ha fatte, e per ringraziarne la divina bontà; 2.º affinchè noi li onoriamo, imitiamo i loro esempi e siamo aiutati dalle loro preghiere.
+
+§ 3 . - Del secondo precetto della Chiesa.
+
+D. Che cosa ci ordina il secondo precetto della Chiesa con le parole: Digiunare i giorni comandati?
+
+R. Il secondo precetto della Chiesa con le parole: Digiunare i giorni comandati , ci ordina di osservare il digiuno: 1.º nella Quaresima; 2.º in alcuni giorni dell’Avvento, dove ciò è prescritto; 3.º nelle quattro tempora; 4.º in alcune vigilie.
+
+D. In che consiste il digiuno?
+
+R. Il digiuno consiste nel fare un solo pasto al giorno e nell’astenersi dai cibi vietati.
+
+D. Nei giorni di digiuno, si può fare la sera una piccola refezione?
+
+R. Per condiscendenza della Chiesa si può, nei giorni di digiuno, fare un po’ di refezione alla sera.
+
+D. A che serve il digiuno?
+
+R. Il digiuno serve a meglio disporci all’orazione, a fare penitenza dei peccati commessi e preservarci dal commetterne dei nuovi.
+
+D. Chi è obbligato al digiuno?
+
+R. Al digiuno sono obbligati tutti i cristiani, che hanno compiuto ventun anno e che non sono o dispensati o scusati da legittimo impedimento.
+
+D. Quelli che non hanno l’obbligo del digiuno sono affatto esenti dalla mortificazione?
+
+R. Quelli che non hanno l’obbligo del digiuno non sono affatto esenti dalla mortificazione, perchè siamo tutti obbligati a fare penitenza.
+
+D. Per qual fine è stata istituita la Quaresima?
+
+R. La Quaresima è stata istituita per imitare in qualche modo il rigoroso digiuno di quaranta giorni che Gesù Cristo fece nel deserto, e per prepararci col mezzo della penitenza a celebrare santamente la Pasqua.
+
+D. Per qual fine è stato istituito il digiuno dell’Avvento?
+
+R. Il digiuno dell’Avvento è stato istituito per disporci a celebrare santamente il Natale di N. S. Gesù Cristo.
+
+D. Per qual fine è stato istituito il digiuno delle quattro tempora?
+
+R. Il digiuno delle quattro tempora, è stato istituito per consacrare ogni stagione dell’anno con la penitenza di alcuni giorni; per domandare a Dio la conservazione dei frutti della terra; per ringraziarlo dei frutti già dati, e per pregarlo di dare alla sua Chiesa dei buoni ministri, dei quali si fa l’ordinazione nei sabati delle quattro tempora.
+
+D. Per qual fine è stato istituito il digiuno delle vigilie?
+
+R. Il digiuno delle vigilie è stato istituito per prepararci a celebrare santamente le feste principali.
+
+D. Che cosa ci è proibito nel venerdì e nel sabato non dispensato?
+
+R. Nel venerdì e nel sabato non dispensato, ci è proibito il mangiar carne, eccettuato il caso di necessità.
+
+D. Perchè la Chiesa ha voluto che ci asteniamo dal mangiar carne in questi giorni?
+
+R. Acciocchè facciamo penitenza in ogni settimana, e massime il venerdì in onore della Passione, ed il sabato in memoria della sepoltura di Gesù Cristo, e in onore di Maria SSm̃a.
+
+§ 4 . - Del terzo precetto della Chiesa.
+
+D. Che cosa ci comanda la Chiesa colle parole del terzo precetto: Confessarsi almeno una volta l’anno?
+
+R. Con le parole del terzo precetto: Confessarsi almeno una volta l’anno , la Chiesa obbliga tutti i cristiani, che sono giunti all’uso di ragione, ad accostarsi almeno una volta l’anno al sacramento della Penitenza.
+
+D. Qual è il tempo più opportuno per soddisfare al precetto della Confessione annuale?
+
+R. Il tempo più opportuno per soddisfare al precetto della confessione annuale è la Quaresima secondo l’uso introdotto e approvato da tutta la Chiesa.
+
+D. Perchè la Chiesa dice che ci confessiamo almeno una volta l’anno?
+
+R. La Chiesa dice: almeno , per farci conoscere il suo desiderio che ci accostiamo più spesso ai santi sacramenti.
+
+D. È dunque cosa utile confessarsi spesso?
+
+R. È cosa utilissima confessarsi spesso, massimamente perchè è difficile che si confessi bene e si tenga lontano dal peccato mortale chi si confessa di rado.
+
+D. Che cosa ci prescrive la Chiesa con le altre parole del terzo precetto: Comunicarsi almeno alla Pasqua di Risurrezione, ciascuno nella propria parrocchia?
+
+R. Con le altre parole del terzo precetto: Comunicarsi almeno alla Pasqua di Risurrezione, ciascuno nella propria parrocchia , la Chiesa obbliga tutti i cristiani che sono arrivati all’età della discrezione, a ricevere ogni anno la santissima Eucaristia nella propria parrocchia durante il tempo pasquale.
+
+D. Siamo in altro tempo, fuori di Pasqua, obbligati a comunicarci?
+
+R. Siamo obbligati a comunicarci anche in pericolo di morte.
+
+D. Perchè si dice che ci comunichiamo almeno alla Pasqua?
+
+R. Perchè la Chiesa desidera vivamente che non solo alla Pasqua di Risurrezione; ma il più spesso possibile ci accostiamo alla santa Comunione, che è il divino nutrimento delle anime nostre.
+
+D. Si soddisfa questo precetto con una confessione, o comunione sacrilega.
+
+R. Chi facesse una confessione e comunione sacrilega non soddisfa al terzo precetto della Chiesa, perchè l’intenzione della Chiesa è che si ricevano questi sacramenti pel fine per cui furono istituiti, cioè per la nostra santificazione.
+
+§ 5. - Del quarto precetto della Chiesa .
+
+D. Come si osserva il quarto precetto della Chiesa: Pagar le decime dovute alla Chiesa?
+
+R. Il quarto precetto: ' Pagar le decime dovute alla Chiesa , si osserva col pagare quelle offerte o prestazioni che sono state stabilite per riconoscere il supremo dominio che Iddio ha sopra tutte le cose, e per provvedere all’onesta sussistenza de’ suoi ministri.
+
+D. Come si devono pagare le decime?
+
+R. Le decime si devono pagare di quelle cose e in quel modo che porta la consuetudine dei luoghi.
+
+§ 6 . - Del quinto precetto della Chiesa.
+
+D. Che cosa ci proibisce la Chiesa nel quinto precetto: Non celebrare le nozze nei tempi proibiti?
+
+R. Nel quinto precetto la Chiesa non vieta la celebrazione del sacramento del Matrimonio; ma soltanto la solennità delle nozze dalla prima domenica dell’Avvento sino all’Epifania, e dal primo giorno di Quaresima sino all’ottava di Pasqua.
+
+D. Quale è la solennità delle nozze proibita?
+
+R. La solennità proibita da questo precetto consiste nella Messa propria degli sposi, nella benedizione nuziale, e nella pompa straordinaria delle nozze.
+
+D. Perchè le dimostrazioni di pompa non convengono nell’Avvento e nella Quaresima?
+
+R. Le dimostrazioni di pompa non convengono nell’Avvento e nella Quaresima, perchè questi sono tempi specialmente consacrati alla penitenza e all’orazione.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/parte-terza-capo-v.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/parte-terza-capo-v.txt
@@ -1,0 +1,44 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Catechismo_maggiore/Parte_terza/Capo_V ===
+=== TITLE: Parte III — Dei comandamenti di Dio e della Chiesa — Compendio della dottrina cristiana/Catechismo maggiore/Parte terza/Capo V ===
+
+Capo V. Dei doveri particolari del proprio stato e dei consigli evangelici.
+
+§ 1 . - Dei doveri del proprio stato.
+
+D. Che cosa sono i doveri del proprio stato?
+
+R. Per doveri del proprio stato s’intendono quelle particolari obbligazioni che ciascuno ha per causa dello stato, della condizione e dell’officio in cui si trova.
+
+D. Chi ha imposto ai vari stati i particolari loro doveri?
+
+R. Dio stesso ha imposto ai vari stati i particolari loro doveri, perchè questi derivano da’ suoi divini comandamenti.
+
+D. Spiegatemi con qualche esempio come i doveri particolari derivino dai dieci comandamenti?
+
+R. Nel quarto comandamento sotto il nome di padre e di madre, s’intendono anche tutti i nostri superiori, e perciò da quel comandamento derivano tutti i doveri di obbedienza, di amore e di rispetto degli inferiori verso i loro superiori, e tutti i doveri di vigilanza che hanno i superiori verso i loro inferiori.
+
+D. Da quali comandamenti derivano i doveri degli artigiani, dei commercianti, degli amministratori di roba altrui e simili?
+
+R. I doveri di fedeltà, di sincerità, di giustizia, di equità, che essi hanno, derivano dal settimo, dall’ottavo e dal decimo comandamento che proibiscono ogni frode, ingiustizia, negligenza e doppiezza.
+
+D. I doveri delle persone consacrate a Dio, da quale comandamento derivano?
+
+R. I doveri delle persone consacrate a Dio derivano dal secondo comandamento che ordina di adempiere i voti e le promesse fatte a Dio, essendosi tali persone obbligate in tal modo alla osservanza di tutti o di alcuni consigli evangelici.
+
+§ 2 . - Dei consigli evangelici.
+
+D. Che cosa sono i consigli evangelici?
+
+R. I consigli evangelici sono alcuni mezzi suggeriti da Gesù Cristo nel santo Vangelo per giungere alla cristiana perfezione.
+
+D. Quali sono i consigli evangelici?
+
+R. I consigli evangelici sono: la povertà volontaria, la castità perpetua, e l’obbedienza in ogni cosa che non sia peccato.
+
+D. A che servono i consigli evangelici?
+
+R. I consigli evangelici servono a facilitare l’osservanza dei comandamenti e ad assicurar meglio la eterna salute.
+
+D. Perchè i consigli evangelici facilitano l’osservanza dei comandamenti?
+
+R. I consigli evangelici facilitano l’osservanza dei comandamenti, perchè ci aiutano a distaccare il cuore dall’amor della roba, dai piaceri, e dagli onori, e così ci allontanano dal peccato.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/prime-nozioni-capo-i.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/prime-nozioni-capo-i.txt
@@ -1,0 +1,104 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Prime_nozioni_di_catechismo/Capo_I ===
+=== TITLE: Prime nozioni di catechismo — Capo I (Delle verità principali di nostra santa Fede) ===
+
+Capo I. Delle verità principali di nostra santa Fede.
+
+D. Fatevi il segno della Croce.
+
+R. Nel nome del Padre e del Figliuolo e dello Spirito Santo. Così sia.
+
+D. Ditelo in latino.
+
+R. In nomine Patris et Filii et Spiritus Sancti. Amen.
+
+D. Chi vi ha creato?
+
+R. Mi ha creato Iddio.
+
+D. Per qual fine Dio vi ha creato?
+
+R. Dio mi ha creato per conoscerlo, amarlo e servirlo in questa vita, e poi goderlo per sempre nell’altra.
+
+D. Chi è Dio?
+
+R. Dio è l’Essere perfettissimo, Creatore e Signore del cielo e della terra.
+
+D. Vi è un solo Dio?
+
+R. Sì, vi è un solo Dio.
+
+D. Dove è Dio?
+
+R. Dio è in cielo, in terra e in ogni luogo.
+
+D. Dio vede tutto?
+
+R. Sì, Dio vede tutto, anche i nostri pensieri.
+
+D. Dio è sempre stato?
+
+R. Dio è sempre stato e sempre sarà, perchè è eterno.
+
+D. Dio ha il corpo come noi?
+
+R. Dio non ha corpo, perchè è un purissimo spirito.
+
+D. Quante Persone sono in Dio?
+
+R. In Dio sono tre Persone realmente distinte.
+
+D. Come si chiamano le tre Persone divine?
+
+R. Le tre Persone divine si chiamano il Padre, il Figliuolo e lo Spirito Santo.
+
+D. Le Persone della SSm̃a Trinità sono uguali o disuguali fra loro?
+
+R. Le Persone della SSm̃a Trinità sono perfettamente uguali, perchè hanno la stessa essenza o natura divina.
+
+D. Delle tre Persone divine quale si è fatta uomo?
+
+R. Delle tre Persone divine si è fatta uomo la seconda, cioè il Figliuolo.
+
+D. In qual modo il Figliuolo di Dio si fece uomo?
+
+R. Il Figliuolo di Dio si fece uomo prendendo un corpo ed un’anima, come abbiamo noi, nel purissimo seno di Maria Vergine, per opera dello Spirito Santo.
+
+D. Come si chiama il Figliuolo di Dio fatto uomo?
+
+R. Il Figliuolo di Dio fatto uomo si chiama Gesù Cristo.
+
+D. Chi è dunque Gesù Cristo?
+
+R. Gesù Cristo è il Figliuolo di Dio fatto uomo.
+
+D. Perchè il Figliuolo di Dio si fece uomo?
+
+R. Il Figliuolo di Dio si fece uomo per salvarci.
+
+D. Che vuol dire: per salvarci?
+
+R. Per salvarci vuol dire per liberarci dal peccato e dall’Inferno e per meritarci la gloria del Paradiso.
+
+D. Che cosa si gode in paradiso?
+
+R. In paradiso si gode per sempre la vista di Dio e ogni bene, senza patire alcuna sorta di male.
+
+D. A chi concede Iddio il paradiso?
+
+R. Dio concede il paradiso come premio a coloro che in questa vita lo amano e lo servono.
+
+D. Che cosa si soffre nell’inferno ?
+
+R. Nell’inferno si soffre per sempre la privazione della vista di Dio, il fuoco eterno ed ogni male, senza aver mai alcuna sorta di bene.
+
+D. Chi è condannato all inferno?
+
+R. All’inferno sono condannati coloro che in questa vita non vollero amare nè servire Iddio e muoiono impenitenti.
+
+D. Che cosa ha fatto Gesù Cristo per salvarci?
+
+R. Gesù Cristo per salvarci ha patito ed è morto in croce.
+
+D. Dopo la sua morte risuscitò Gesù Cristo?
+
+R. Gesù Cristo tre giorni dopo la sua morte risuscitò glorioso e trionfante per non mai più morire.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/prime-nozioni-capo-ii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/prime-nozioni-capo-ii.txt
@@ -1,0 +1,136 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Prime_nozioni_di_catechismo/Capo_II ===
+=== TITLE: Prime nozioni di catechismo — Capo II (Parti principali della Dottrina cristiana) ===
+
+Capo II. Parti principali della Dottrina cristiana.
+
+D. Quali sono le parti principali della Dottrina cristiana?
+
+R. Le parti principali della Dottrina cristiana sono quattro; cioè il Credo , il Pater noster , i Comandamenti e i Sacramenti .
+
+D. Dite il Credo.
+
+R. 1.º Io credo in Dio Padre onnipotente creatore del cielo e della terra.
+
+2.º E in Gesù Cristo, suo figliuolo unico, Signor nostro.
+
+3.º Il quale fu concepito di Spirito Santo: nacque da Maria Vergine.
+
+4.º Patì sotto Ponzio Pilato: fu crocifisso, morto e sepolto.
+
+5.º Discese all’inferno: il terzo giorno risuscitò da morte.
+
+6.º Salì al Cielo: siede alla destra di Dio Padre onnipotente.
+
+7.º Di là ha da venire a giudicare i vivi e i morti.
+
+8.º Credo nello Spirito Santo.
+
+9.º La santa Chiesa Cattolica: la comunione dei santi.
+
+10.º La remissione de’ peccati.
+
+11.º La risurrezione della carne.
+
+12.º La vita eterna. Amen.
+
+D. Dite il Pater noster in italiano.
+
+R. Padre nostro, che sei ne’ cieli,
+
+1.º Sia santificato il nome tuo.
+
+2.º Venga il regno tuo.
+
+3.º Sia fatta la volontà tua, come in cielo, così in terra.
+
+4.º Dacci oggi il nostro pane quotidiano.
+
+5.º E rimetti a noi i nostri debiti, siccome noi li rimettiamo ai nostri debitori.
+
+6.º E non c’indurre in tentazione.
+
+7.º Ma liberaci dal male. Così sia.
+
+D. Dite il Pater noster in latino.
+
+R. Pater noster qui es in coelis,
+
+1.º Sanctificetur nomen tuum.
+
+2.º Adveniat regnum tuum.
+
+3.º Fiat voluntas tua, sicut in coelo et in terra.
+
+4.º Panem nostrum quotidianum da nobis hodie;
+
+5.º Et dimitte nobis debita nostra, sicut et nos dimittimus debitoribus nostris;
+
+6.º Et ne nos inducas in tentationem;
+
+7.º Sed libera nos a malo. Amen.
+
+D. Dite l’ Ave Maria in italiano.
+
+R. Dio ti salvi, o Maria, piena di grazia. Il Signore è teco. Tu sei benedetta fra le donne, e benedetto è il frutto del tuo seno Gesù. Santa Maria, Madre di Dio, prega per noi peccatori, adesso e nell’ora della morte nostra. Così sia.
+
+D. Dite l’ Ave Maria in latino.
+
+R. Ave, Maria, gratia plena. Dominus tecum. Benedicta tu in mulieribus et benedictus fructus ventris tui, Iesus. Sancta Maria, Mater Dei, ora pro nobis peccatoribus, nunc et in hora mortis nostrae. Amen.
+
+D. Dite il Gloria in italiano.
+
+R. Gloria al Padre, al Figlio e allo Spirito Santo, come era nel principio, adesso e sempre e nei secoli dei secoli. Così sia.
+
+D. Dite il Gloria in latino.
+
+R. Gloria Patri et Filio et Spiritui Sancto, sicut erat in principio et nunc et semper et in saecula saeculorum. Amen.
+
+D. Quanti e quali sono i comandamenti di Dio?
+
+R. I comandamenti di Dio sono dieci.
+
+Io sono il Signore Iddio tuo:
+
+1.º Non avrai altro Dio avanti di me.
+
+2.º Non nominare il nome di Dio invano.
+
+3.º Ricordati di santificare le feste.
+
+4.º Onora il padre e la madre.
+
+5.º Non ammazzare.
+
+6.º Non fornicare.
+
+7.º Non rubare.
+
+8.º Non dire il falso testimonio.
+
+9.º Non desiderare la donna d’altri.
+
+10.º Non desiderare la roba d’altri.
+
+D. Quanti e quali sono i precetti della Chiesa?
+
+R. I Precetti della Chiesa sono cinque:
+
+1.º Udir la Messa tutte le domeniche e le altre feste comandate.
+
+2.º Digiunare la quaresima, le quattro tempora e le vigilie comandate: non mangiar carne nei giorni proibiti.
+
+3.º Confessarsi almeno una volta l’anno, e comunicarsi nella Pasqua di Risurrezione, alla propria parrocchia.
+
+4.º Pagare le decime dovute alla Chiesa, secondo le usanze.
+
+5.º Non celebrare le nozze ne’ tempi vietati, cioè dalla prima domenica dell’Avvento fino all’Epifania, e dal primo giorno di Quaresima fino all’ottava di Pasqua.
+
+D. Quanti e quali sono i sacramenti?
+
+R. I Sacramenti sono sette:
+
+1.º Battesimo; 2.º Cresima; 3.º Eucaristia; 4.º Penitenza; 5.º Estrema unzione; 6.º Ordine sacro; 7.º Matrimonio.
+
+D. Chi ha istituito questi sacramenti?
+
+R. Li ha istituiti il nostro Signor Gesù Cristo.

--- a/content/books/pius-x-greater-catechism/sources/it-originals/prime-nozioni-capo-iii.txt
+++ b/content/books/pius-x-greater-catechism/sources/it-originals/prime-nozioni-capo-iii.txt
@@ -1,0 +1,24 @@
+=== URL: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana/Prime_nozioni_di_catechismo/Capo_III ===
+=== TITLE: Prime nozioni di catechismo — Capo III (Atti di Fede, di Speranza, di Carità e di Contrizione) ===
+
+Capo III. Atti di Fede, di Speranza, di Carità e di Contrizione.
+
+D. Dite l’Atto di Fede.
+
+R. Io credo fermamente, perchè così ha rivelato Dio, infallibile verità, alla santa Chiesa cattolica, e per mezzo di essa lo rivela anche a noi, che vi è un solo Dio in tre Persone Divine, uguali e distinte, che si chiamano Padre, Figliuolo e Spirito Santo; che il Figliuolo si fece uomo, prendendo, per opera dello Spirito Santo, carne ed anima umana nel seno della purissima Vergine Maria: morì per noi in croce, risuscitò, salì al cielo, e di là ha da venire alla fine del mondo a giudicare tutti i vivi ed i morti, per dare per sempre ai buoni il paradiso ed ai cattivi l’inferno. E di più per l’istesso motivo credo tutto quello che crede ed insegna la medesima santa Chiesa.
+
+D. Dite l’Atto di Speranza.
+
+R. Dio mio, perchè siete onnipotente ed infinitamente buono e misericordioso, io spero che, per i meriti della passione e morte di Gesù Cristo nostro Salvatore, mi darete la vita eterna, la quale Voi fedelissimo avete promessa a chi farà opere da buon cristiano, come propongo di fare col vostro santo aiuto.
+
+D. Dite l’Atto di Carità.
+
+R. Dio mio, perchè siete sommo e perfettissimo Bene, vi amo con tutto il cuore e sopra ogni altra cosa, e, piuttosto che offendervi, sono disposto a perdere ogni altra cosa e per amor vostro amo ancora e voglio amare il prossimo mio come me medesimo.
+
+D. Dite l’Atto di Contrizione.
+
+R. Dio mio, per esser Voi somma Bontà, e perchè vi amo sopra ogni cosa, mi pento e mi dolgo di vero cuore di avervi offeso, e propongo fermamente, col vostro santo aiuto, di non peccare mai più nell’avvenire, ed in particolare di fuggire le occasioni prossime del peccato.
+
+D. Dite l’Atto di Attrizione e Contrizione?
+
+R. O mio Dio, mi pento e mi dolgo di vero cuore di avervi offeso. Me ne pento per l’inferno che ho meritato e per il paradiso che ho perduto; ma molto più mi pento perchè peccando ho offeso un Dio così buono, così grande come siete Voi. Vorrei prima esser morto che avervi offeso; e propongo fermamente di non peccare più per l’avvenire e di fuggire le occasioni prossime del peccato.

--- a/scripts/build-pius-x-greater-catechism-md.py
+++ b/scripts/build-pius-x-greater-catechism-md.py
@@ -29,11 +29,22 @@ OUT_DIR = BOOK_DIR / "it"
 # Some source files don't have a "D. ... R. ..." structure — they're just prose.
 # Listed here so we render them as plain markdown paragraphs instead of trying
 # to match a Q&A pattern.
-PROSE_FILES = {"lettera-promulgazione.txt"}
+PROSE_FILES = {
+    "avvertenza.txt",
+    "lettera-promulgazione.txt",
+    "orazioni-quotidiane.txt",
+}
+
+# These prose chapters have non-trivial sub-heading structure that the
+# generic prose renderer can't infer. The committed .md is hand-authored;
+# the builder skips them on re-run so manual edits aren't clobbered.
+HAND_AUTHORED = {"orazioni-quotidiane.txt"}
 
 # Chapter title map: source filename → markdown H1.
 TITLES: dict[str, str] = {
+    "avvertenza.txt": "Avvertenza",
     "lettera-promulgazione.txt": "Lettera di S.S. Papa Pio X al Cardinale Pietro Respighi",
+    "orazioni-quotidiane.txt": "Orazioni quotidiane ed altre preci",
     "prime-nozioni-capo-i.txt": "Prime nozioni — Capo I. Delle verità principali di nostra santa Fede",
     "prime-nozioni-capo-ii.txt": "Prime nozioni — Capo II. Parti principali della Dottrina cristiana",
     "prime-nozioni-capo-iii.txt": "Prime nozioni — Capo III. Atti di Fede, di Speranza, di Carità e di Contrizione",
@@ -199,6 +210,9 @@ def main() -> None:
     if not files:
         raise SystemExit(f"no .txt sources in {SRC_DIR}")
     for src in files:
+        if src.name in HAND_AUTHORED:
+            print(f"  · {src.name}: hand-authored, skipped")
+            continue
         body = strip_header(src.read_text(encoding="utf-8"))
         body = normalize_spacing(body)
         paragraphs = split_paragraphs(body)

--- a/scripts/build-pius-x-greater-catechism-md.py
+++ b/scripts/build-pius-x-greater-catechism-md.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Convert downloaded Wikisource .txt sources to authored Markdown chapter files.
+
+Reads content/books/pius-x-greater-catechism/sources/it-originals/*.txt and
+writes content/books/pius-x-greater-catechism/it/*.md, one md per source.
+
+Format follows the existing pius-x-catechism (1912) book:
+  # Chapter title
+  ## § N. - subsection heading (when present)
+  **1.** Question?
+  *Answer.*
+
+Q&A numbering restarts per chapter. The Wikisource transcription uses `D.` /
+`R.` markers (no numbers) since the canonical 1905 numbering wasn't preserved
+on Wikisource; per-chapter numbering keeps the visual style consistent with
+the 1912 sibling and gives readers a useful local index.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+BOOK_DIR = ROOT / "content" / "books" / "pius-x-greater-catechism"
+SRC_DIR = BOOK_DIR / "sources" / "it-originals"
+OUT_DIR = BOOK_DIR / "it"
+
+# Some source files don't have a "D. ... R. ..." structure — they're just prose.
+# Listed here so we render them as plain markdown paragraphs instead of trying
+# to match a Q&A pattern.
+PROSE_FILES = {"lettera-promulgazione.txt"}
+
+# Chapter title map: source filename → markdown H1.
+TITLES: dict[str, str] = {
+    "lettera-promulgazione.txt": "Lettera di S.S. Papa Pio X al Cardinale Pietro Respighi",
+    "prime-nozioni-capo-i.txt": "Prime nozioni — Capo I. Delle verità principali di nostra santa Fede",
+    "prime-nozioni-capo-ii.txt": "Prime nozioni — Capo II. Parti principali della Dottrina cristiana",
+    "prime-nozioni-capo-iii.txt": "Prime nozioni — Capo III. Atti di Fede, di Speranza, di Carità e di Contrizione",
+    "lezione-preliminare.txt": "Lezione preliminare — Della dottrina cristiana e delle sue parti principali",
+}
+
+
+def strip_header(body: str) -> str:
+    """Remove the === URL / === TITLE lines added by the crawler."""
+    lines = body.split("\n")
+    out: list[str] = []
+    skipping = True
+    for ln in lines:
+        if skipping and (ln.startswith("=== ") or ln.strip() == ""):
+            continue
+        skipping = False
+        out.append(ln)
+    return "\n".join(out)
+
+
+def normalize_spacing(text: str) -> str:
+    """Fix the spurious spaces left by inline-element extraction.
+
+    The crawler used `get_text(separator=' ')`, which inserts a space whenever
+    an inline `<i>` / `<b>` boundary is crossed. That leaves artifacts like
+    `il Credo .` or `parola Credo , che`. Tighten those up.
+    """
+    text = re.sub(r"\s+([,.;:!?»])", r"\1", text)
+    text = re.sub(r"([«])\s+", r"\1", text)
+    # Convert a stray non-breaking space to a regular one
+    text = text.replace(" ", " ")
+    text = re.sub(r" {2,}", " ", text)
+    return text
+
+
+def split_paragraphs(text: str) -> list[str]:
+    paras: list[str] = []
+    current: list[str] = []
+    for ln in text.split("\n"):
+        if ln.strip() == "":
+            if current:
+                paras.append(" ".join(current).strip())
+                current = []
+        else:
+            current.append(ln.strip())
+    if current:
+        paras.append(" ".join(current).strip())
+    return paras
+
+
+def is_question(p: str) -> bool:
+    return p.startswith("D.") and (len(p) <= 2 or p[2] == " ")
+
+
+def is_answer(p: str) -> bool:
+    return p.startswith("R.") and (len(p) <= 2 or p[2] == " ")
+
+
+def is_section_divider(p: str) -> bool:
+    # `§ 1 . - Della Chiesa in generale.`
+    return p.startswith("§")
+
+
+def strip_qr_prefix(p: str) -> str:
+    return re.sub(r"^[DR]\.\s*", "", p).strip()
+
+
+def render_qa(paragraphs: list[str], chapter_title: str) -> str:
+    """Walk paragraphs and assemble markdown.
+
+    Pattern: chapter heading, then alternating Q (D.) / A (R.) blocks. An
+    answer may be followed by un-prefixed continuation paragraphs (e.g. the
+    numbered articles of the Credo recitation); those get rendered as their
+    own italic paragraphs immediately after the answer.
+    """
+    out: list[str] = [f"# {chapter_title}", ""]
+    n = 0
+    state = "header"  # header → q → a → (q | continuation | section)
+
+    # The first non-empty paragraph is usually the chapter's own "Capo X. ..."
+    # heading that the source page repeats — we drop it since the markdown H1
+    # already carries that information.
+    i = 0
+    if paragraphs and not is_question(paragraphs[0]) and not is_section_divider(paragraphs[0]):
+        i = 1
+
+    while i < len(paragraphs):
+        p = paragraphs[i]
+        if is_section_divider(p):
+            # Section dividers (`§ 1. - ...`) become H2 subheadings.
+            heading = p.lstrip("§ ").rstrip(".").strip()
+            heading = re.sub(r"^\d+\s*\.\s*-?\s*", "", heading).strip(" .-")
+            section_num_match = re.match(r"§\s*(\d+)", p)
+            if section_num_match:
+                heading = f"§ {section_num_match.group(1)}. {heading}"
+            out.append(f"## {heading}")
+            out.append("")
+            state = "header"
+            i += 1
+            continue
+
+        if is_question(p):
+            n += 1
+            q = strip_qr_prefix(p)
+            out.append(f"**{n}.** {q}")
+            out.append("")
+            state = "q"
+            i += 1
+            continue
+
+        if is_answer(p):
+            a = strip_qr_prefix(p)
+            out.append(f"*{a}*")
+            out.append("")
+            state = "a"
+            i += 1
+            continue
+
+        # Continuation paragraph (e.g., numbered list items inside an answer).
+        # Render as italic so it visually belongs to the preceding answer.
+        if state == "a":
+            out.append(f"*{p}*")
+            out.append("")
+            i += 1
+            continue
+
+        # Floating prose before any Q/A — emit as plain paragraph.
+        out.append(p)
+        out.append("")
+        i += 1
+
+    while out and out[-1] == "":
+        out.pop()
+    out.append("")
+    return "\n".join(out)
+
+
+def render_prose(paragraphs: list[str], chapter_title: str) -> str:
+    out: list[str] = [f"# {chapter_title}", ""]
+    for p in paragraphs:
+        out.append(p)
+        out.append("")
+    while out and out[-1] == "":
+        out.pop()
+    out.append("")
+    return "\n".join(out)
+
+
+def chapter_title_for(filename: str, paragraphs: list[str]) -> str:
+    if filename in TITLES:
+        return TITLES[filename]
+    # Default: take the first paragraph, normalize spacing/punctuation
+    raw = paragraphs[0] if paragraphs else filename
+    # Convert "Capo I.  Del «Credo» in generale." → "Capo I — Del «Credo» in generale"
+    raw = raw.strip().rstrip(".")
+    raw = re.sub(r"^(Capo\s+[IVXLCDM]+)\s*[.\s]+", r"\1 — ", raw)
+    return raw
+
+
+def main() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    files = sorted(SRC_DIR.glob("*.txt"))
+    if not files:
+        raise SystemExit(f"no .txt sources in {SRC_DIR}")
+    for src in files:
+        body = strip_header(src.read_text(encoding="utf-8"))
+        body = normalize_spacing(body)
+        paragraphs = split_paragraphs(body)
+        if not paragraphs:
+            print(f"  ! {src.name}: empty after parsing — skipped")
+            continue
+        title = chapter_title_for(src.name, paragraphs)
+        if src.name in PROSE_FILES:
+            md = render_prose(paragraphs, title)
+        else:
+            md = render_qa(paragraphs, title)
+        out_path = OUT_DIR / (src.stem + ".md")
+        out_path.write_text(md, encoding="utf-8")
+        qa_count = md.count("**") // 2
+        print(f"  → {out_path.relative_to(ROOT)}  ({qa_count} Q&A)")
+
+    print(f"\nWrote {sum(1 for _ in OUT_DIR.glob('*.md'))} markdown chapters to {OUT_DIR.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/crawl-pius-x-greater-catechism-it.py
+++ b/scripts/crawl-pius-x-greater-catechism-it.py
@@ -46,9 +46,19 @@ COMPENDIO = "/wiki/Compendio_della_dottrina_cristiana"
 # Standalone front-matter pages — fetched directly into individual .txt files.
 FRONT_MATTER: list[tuple[str, str, str]] = [
     (
+        "avvertenza.txt",
+        f"{COMPENDIO}/Avvertenza",
+        "Avvertenza",
+    ),
+    (
         "lettera-promulgazione.txt",
         f"{COMPENDIO}/Lettera_di_S.S._Papa_Pio_X",
         "Lettera di S.S. Papa Pio X",
+    ),
+    (
+        "orazioni-quotidiane.txt",
+        f"{COMPENDIO}/Orazioni_quotidiane_ed_altre_preci",
+        "Orazioni quotidiane ed altre preci",
     ),
     (
         "prime-nozioni-capo-i.txt",

--- a/scripts/crawl-pius-x-greater-catechism-it.py
+++ b/scripts/crawl-pius-x-greater-catechism-it.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Download the 1905 Catechismo Maggiore di Pio X from Italian Wikisource.
+
+Outputs one .txt per logical section into
+content/books/pius-x-greater-catechism/sources/it-originals/, with --- page
+separators wrapping each Wikisource subpage.
+
+Source: https://it.wikisource.org/wiki/Compendio_della_dottrina_cristiana
+The Wikisource transcription is the canonical proofread edition (100% quality).
+The 1905 text itself is public domain.
+
+What we fetch:
+  - Promulgation letter (Lettera di S.S. Papa Pio X)
+  - Prime nozioni di catechismo — Capo I, II, III (the daily-prayers/acts block
+    that the Hagan English translation omits)
+  - Catechismo Maggiore — Lezione preliminare + 5 parts, each split into
+    multiple "Capo" subpages
+
+The script first fetches each Parte index page, parses out the Capo subpage
+links, and walks them. We don't hardcode chapter counts so a future Wikisource
+revision is picked up automatically.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+
+ROOT = Path(__file__).resolve().parent.parent
+OUT_DIR = (
+    ROOT
+    / "content"
+    / "books"
+    / "pius-x-greater-catechism"
+    / "sources"
+    / "it-originals"
+)
+BASE = "https://it.wikisource.org"
+COMPENDIO = "/wiki/Compendio_della_dottrina_cristiana"
+
+# Standalone front-matter pages — fetched directly into individual .txt files.
+FRONT_MATTER: list[tuple[str, str, str]] = [
+    (
+        "lettera-promulgazione.txt",
+        f"{COMPENDIO}/Lettera_di_S.S._Papa_Pio_X",
+        "Lettera di S.S. Papa Pio X",
+    ),
+    (
+        "prime-nozioni-capo-i.txt",
+        f"{COMPENDIO}/Prime_nozioni_di_catechismo/Capo_I",
+        "Prime nozioni di catechismo — Capo I (Delle verità principali di nostra santa Fede)",
+    ),
+    (
+        "prime-nozioni-capo-ii.txt",
+        f"{COMPENDIO}/Prime_nozioni_di_catechismo/Capo_II",
+        "Prime nozioni di catechismo — Capo II (Parti principali della Dottrina cristiana)",
+    ),
+    (
+        "prime-nozioni-capo-iii.txt",
+        f"{COMPENDIO}/Prime_nozioni_di_catechismo/Capo_III",
+        "Prime nozioni di catechismo — Capo III (Atti di Fede, di Speranza, di Carità e di Contrizione)",
+    ),
+    (
+        "lezione-preliminare.txt",
+        f"{COMPENDIO}/Catechismo_maggiore/Lezione_preliminare",
+        "Catechismo Maggiore — Lezione preliminare (Della dottrina cristiana e delle sue parti principali)",
+    ),
+]
+
+# Each part of the Catechismo Maggiore is an index page that links to per-Capo
+# subpages. The script walks each Parte and writes one .txt per Capo.
+PARTI: list[tuple[str, str, str]] = [
+    ("parte-prima", "Parte_prima", "Parte I — Il Credo o Simbolo apostolico"),
+    ("parte-seconda", "Parte_seconda", "Parte II — Dell'orazione"),
+    (
+        "parte-terza",
+        "Parte_terza",
+        "Parte III — Dei comandamenti di Dio e della Chiesa",
+    ),
+    ("parte-quarta", "Parte_quarta", "Parte IV — Dei sacramenti"),
+    (
+        "parte-quinta",
+        "Parte_quinta",
+        "Parte V — Delle virtù principali e delle altre cose necessarie a sapersi del cristiano",
+    ),
+]
+
+HEADERS = {
+    "User-Agent": (
+        "Ember corpus importer (https://github.com/gustavo-depaula/ember) - "
+        "fetching public-domain Catechismo Maggiore 1905 from it.wikisource.org"
+    )
+}
+
+
+def fetch(url: str) -> BeautifulSoup:
+    resp = requests.get(url, headers=HEADERS, timeout=30)
+    resp.raise_for_status()
+    return BeautifulSoup(resp.text, "html.parser")
+
+
+def extract_body_text(soup: BeautifulSoup) -> str:
+    """Strip Wikisource chrome and return clean paragraph-flow text.
+
+    The real content lives in `div.testi.cristianesimo`. Everything else
+    (`span.metadata`, `span.numeropagina`, header/footer tables, edit links)
+    is chrome and gets removed before extraction. We then walk paragraph-level
+    elements one at a time and collapse their inline content with spaces so
+    that `<i>`/`<b>`/`<span>` don't fragment lines.
+    """
+    content = soup.select_one("div.testi") or soup.select_one("div.mw-parser-output") or soup
+
+    for sel in [
+        "span.metadata",
+        "span.numeropagina",
+        "table",
+        "div.ws-noexport",
+        ".ws-noexport",
+        ".noprint",
+        "div.printfooter",
+        "span.mw-editsection",
+        "div.thumb",
+        "sup.reference",
+        "div#siteSub",
+        "div#jump-to-nav",
+        "div.mw-indicators",
+        "div.mw-empty-elt",
+        "style",
+        "script",
+    ]:
+        for el in content.select(sel):
+            el.decompose()
+
+    blocks: list[str] = []
+    block_tags = ["p", "div", "h1", "h2", "h3", "h4", "li", "dt", "dd", "blockquote"]
+    for el in content.find_all(block_tags):
+        has_block_child = any(
+            d.name in block_tags for d in el.descendants if getattr(d, "name", None)
+        )
+        if has_block_child:
+            continue
+        text = el.get_text(separator=" ", strip=True)
+        # Normalize whitespace runs and the leftover non-breaking spaces
+        text = re.sub(r"[ \s]+", " ", text).strip()
+        if not text:
+            continue
+        blocks.append(text)
+    return "\n\n".join(blocks)
+
+
+def discover_capi(parte_slug: str) -> list[tuple[str, str]]:
+    """Return [(capo_slug, full_url), ...] for the Capi linked from a Parte index."""
+    url = f"{BASE}{COMPENDIO}/Catechismo_maggiore/{parte_slug}"
+    soup = fetch(url)
+    content = soup.select_one("div.mw-parser-output") or soup
+    capi: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    prefix = f"{COMPENDIO}/Catechismo_maggiore/{parte_slug}/"
+    for a in content.select("a[href]"):
+        href = a["href"]
+        if not href.startswith(prefix):
+            continue
+        # Skip in-page anchors / fragments
+        clean_href = href.split("#", 1)[0]
+        if clean_href in seen:
+            continue
+        seen.add(clean_href)
+        # Slug = the bit after the last slash, e.g. "Capo_I"
+        slug = clean_href.rsplit("/", 1)[-1]
+        capi.append((slug, urljoin(BASE, clean_href)))
+    return capi
+
+
+def write_page(out_path: Path, url: str, title: str, body: str) -> None:
+    header = f"=== URL: {url} ===\n=== TITLE: {title} ==="
+    out_path.write_text(header + "\n\n" + body + "\n", encoding="utf-8")
+    words = len(body.split())
+    print(f"  → {out_path.relative_to(ROOT)}  ({words:,} words)")
+
+
+def slugify_capo(parte: str, capo: str) -> str:
+    # "Capo_I" → "capo-i"
+    s = capo.lower().replace("_", "-")
+    return f"{parte}-{s}"
+
+
+def title_for_capo(parte_title: str, capo_slug: str, soup: BeautifulSoup) -> str:
+    h1 = soup.select_one("h1#firstHeading")
+    page_title = h1.get_text(strip=True) if h1 else capo_slug.replace("_", " ")
+    return f"{parte_title} — {page_title}"
+
+
+def main() -> None:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    print("Front matter:")
+    for filename, path, title in FRONT_MATTER:
+        url = urljoin(BASE, path)
+        print(f"  fetching {url}")
+        soup = fetch(url)
+        body = extract_body_text(soup)
+        write_page(OUT_DIR / filename, url, title, body)
+        time.sleep(0.5)
+
+    for parte_slug, parte_path, parte_title in PARTI:
+        print(f"\n{parte_title}:")
+        capi = discover_capi(parte_path)
+        if not capi:
+            raise SystemExit(f"no Capi discovered for {parte_path}")
+        for capo_slug_raw, capo_url in capi:
+            soup = fetch(capo_url)
+            body = extract_body_text(soup)
+            filename = slugify_capo(parte_slug, capo_slug_raw) + ".txt"
+            title = title_for_capo(parte_title, capo_slug_raw, soup)
+            write_page(OUT_DIR / filename, capo_url, title, body)
+            time.sleep(0.5)
+
+    total = sum(1 for _ in OUT_DIR.glob("*.txt"))
+    total_words = 0
+    for p in OUT_DIR.glob("*.txt"):
+        total_words += len(p.read_text(encoding="utf-8").split())
+    print(f"\nWrote {total} files, {total_words:,} words total to {OUT_DIR.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `book/pius-x-greater-catechism` — the 1905 *Catechismo Maggiore* di San Pio X, sibling to the existing 1912 `pius-x-catechism` (which is the *shorter* one). 44 chapters / ~44k words, Italian only first pass.
- Sourced from the 100%-proofread Wikisource transcription of the *Compendio della dottrina cristiana* (`it.wikisource.org`). Includes promulgation letter, **Prime nozioni di catechismo** (daily prayers in IT/LA, Commandments, Precepts, Acts of Faith/Hope/Charity/Contrition — the front matter the Hagan 1910 English translation drops), Lezione preliminare, and all five canonical Parts.
- Two reusable scripts: `crawl-pius-x-greater-catechism-it.py` (BS4 Wikisource crawler with leaf-block text extraction) and `build-pius-x-greater-catechism-md.py` (source → markdown converter matching the 1912 sibling's `**N.** Q? / *A.*` format).

## Notes / followups
- Per-chapter numbering (1–N within each Capo) — Wikisource didn't preserve the canonical 1905 cross-book numbering (~993). Easy to renumber later if we find a numbered edition.
- A couple of OCR-era artifacts inherited from the Wikisource transcription (`si rife risce`, `i i vivi`) — present in the canonical source, not introduced here.
- pt-BR and EN translations deferred. The CIN.org Hagan EN translation is incomplete (missing the daily-prayers block), so English will need a fuller source or a translation from the Italian canonical.

## Test plan
- [ ] `pnpm build:corpus` registers `book/pius-x-greater-catechism` in `catalog.json` with `langs: ["it"]` and all 44 chapter blobs (verified locally — 10,710-byte manifest, all blobs present).
- [ ] Spot-check a chapter blob renders the expected markdown (verified: parte-prima-capo-i has the full 12-article Credo).
- [ ] Open in the app book reader, navigate the nested TOC (Lettera → Prime nozioni → Lezione preliminare → 5 Parts), verify Q&A formatting and `§` subheadings render correctly.