### PR TITLE
Fix two distinct bottom-clip bugs: audio player + Saints grid

### DIFF
--- a/apps/app/src/components/ScreenLayout.tsx
+++ b/apps/app/src/components/ScreenLayout.tsx
@@ -18,6 +18,7 @@ export function ScreenLayout({
   padded = true,
   refreshing,
   onRefresh,
+  modal = false,
 }: {
   children: ReactNode
   scroll?: boolean
@@ -25,12 +26,16 @@ export function ScreenLayout({
   /** Pull-to-refresh: when provided, the scroll view shows a RefreshControl. */
   refreshing?: boolean
   onRefresh?: () => void | Promise<void>
+  /** fullScreenModal route — the modal covers the tab bar and the
+   * now-playing accessory, so skip the manual bottom clearance. Without
+   * this, modals reserve ~128pt of empty padding at the bottom. */
+  modal?: boolean
 }) {
   const insets = useSafeAreaInsets()
   const nowPlayingClearance = useNowPlayingClearance()
   // The tabs disable automatic content insets so this manual padding is the
   // single source of truth (lets the home flourish bleed into the notch).
-  const bottomClearance = nativeTabBarClearance + nowPlayingClearance
+  const bottomClearance = modal ? 0 : nativeTabBarClearance + nowPlayingClearance
 
   const inner = (
     <YStack

--- a/apps/app/src/features/creators/audio/AudioPlayerScreen.tsx
+++ b/apps/app/src/features/creators/audio/AudioPlayerScreen.tsx
@@ -37,7 +37,7 @@ export function AudioPlayerScreen({ onBack }: { onBack: () => void }) {
 
   if (!nowPlaying) {
     return (
-      <ScreenLayout>
+      <ScreenLayout modal>
         <YStack flex={1} alignItems="center" justifyContent="center" padding="$lg">
           <Text fontFamily="$body" color="$colorSecondary">
             {t('creators.nothingPlaying')}
@@ -59,7 +59,7 @@ export function AudioPlayerScreen({ onBack }: { onBack: () => void }) {
   const artworkSize = hasDescription ? 180 : 240
 
   return (
-    <ScreenLayout scroll={false}>
+    <ScreenLayout scroll={false} modal>
       <YStack flex={1} gap="$md" paddingVertical="$lg">
         <Pressable
           onPress={onBack}
@@ -199,7 +199,7 @@ export function AudioPlayerScreen({ onBack }: { onBack: () => void }) {
               {t('creators.description')}
             </Text>
             <YStack flex={1}>
-              <RichDescription html={nowPlaying.summary ?? ''} />
+              <RichDescription html={nowPlaying.summary ?? ''} scrollEnabled />
             </YStack>
           </YStack>
         )}

--- a/apps/app/src/features/creators/components/HtmlWebView.tsx
+++ b/apps/app/src/features/creators/components/HtmlWebView.tsx
@@ -3,7 +3,16 @@ import { Platform, View } from 'react-native'
 // biome-ignore lint/suspicious/noExplicitAny: WebView type not exported from react-native-webview
 const WebView: any = Platform.OS !== 'web' ? require('react-native-webview').default : undefined
 
-export function HtmlWebView({ html }: { html: string }) {
+export function HtmlWebView({
+  html,
+  scrollEnabled = false,
+}: {
+  html: string
+  /** Let the WebView own its own scroll. Opt-in: keep off when the parent is
+   * already a ScrollView (avoids nested scrolling), turn on for fixed-height
+   * containers like the audio player description. */
+  scrollEnabled?: boolean
+}) {
   if (Platform.OS === 'web') {
     return (
       <View style={{ flex: 1 }}>
@@ -30,9 +39,9 @@ export function HtmlWebView({ html }: { html: string }) {
       originWhitelist={['*']}
       javaScriptEnabled
       showsVerticalScrollIndicator={false}
-      scrollEnabled={false}
-      bounces={false}
-      overScrollMode="never"
+      scrollEnabled={scrollEnabled}
+      bounces={scrollEnabled}
+      overScrollMode={scrollEnabled ? 'auto' : 'never'}
     />
   )
 }

--- a/apps/app/src/features/creators/components/RichDescription.tsx
+++ b/apps/app/src/features/creators/components/RichDescription.tsx
@@ -25,10 +25,16 @@ function doc(body: string, color: string, link: string): string {
 </style></head><body>${body}</body></html>`
 }
 
-export function RichDescription({ html }: { html: string }) {
+export function RichDescription({
+  html,
+  scrollEnabled = false,
+}: {
+  html: string
+  scrollEnabled?: boolean
+}) {
   const theme = useTheme()
   const color = theme.color.val
   const link = theme.accent.val
   const doc_ = useMemo(() => doc(html, color, link), [html, color, link])
-  return <HtmlWebView html={doc_} />
+  return <HtmlWebView html={doc_} scrollEnabled={scrollEnabled} />
 }

--- a/apps/app/src/features/saints/components/SaintCardGrid.tsx
+++ b/apps/app/src/features/saints/components/SaintCardGrid.tsx
@@ -76,6 +76,7 @@ export function SaintCardGrid() {
 
   return (
     <FlatList
+      style={styles.flex}
       data={saints}
       renderItem={renderItem}
       keyExtractor={keyExtractor}
@@ -88,6 +89,12 @@ export function SaintCardGrid() {
 }
 
 const styles = StyleSheet.create({
+  // Without flex:1, the FlatList sizes to its full content height (all rows
+  // stacked) — the parent YStack overflows ScreenLayout's bounded area and
+  // the grid stops scrolling: any row past the first ~2.2 is clipped and
+  // unreachable. flex:1 binds the list to the remaining parent height so
+  // the inner ScrollView has a finite viewport to scroll within.
+  flex: { flex: 1 },
   list: {
     paddingBottom: 24,
     gap: 12,

--- a/apps/app/src/stores/creatorsStore.ts
+++ b/apps/app/src/stores/creatorsStore.ts
@@ -4,6 +4,7 @@
  * module scope, not in a route component.
  */
 
+import { usePathname } from 'expo-router'
 import { create } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
 
@@ -89,10 +90,16 @@ const NOW_PLAYING_BAR_GAP = 16
 
 /**
  * Vertical space ScrollViews must reserve so the mini-bar doesn't occlude
- * their last items. Zero when nothing is playing.
+ * their last items. Zero when nothing is playing, or when on the now-playing
+ * item's own page — the tabs layout hides the accessory there (the full
+ * player IS the surface), so reserving space leaves a dead black band.
  */
 export function useNowPlayingClearance(): number {
-  return useCreatorsStore((s) => (s.nowPlaying ? NOW_PLAYING_BAR_HEIGHT + NOW_PLAYING_BAR_GAP : 0))
+  const pathname = usePathname()
+  const nowPlaying = useCreatorsStore((s) => s.nowPlaying)
+  if (!nowPlaying) return 0
+  if (pathname?.endsWith(`/episode/${nowPlaying.itemId}`)) return 0
+  return NOW_PLAYING_BAR_HEIGHT + NOW_PLAYING_BAR_GAP
 }
 
 export const useCreatorsStore = create<CreatorsState>()(


### PR DESCRIPTION
## Summary

Two unrelated screens were clipping content into a dead black band at the bottom — same symptom, different causes.

### Audio player (fullScreenModal) — phantom clearance

`ScreenLayout` reserves \`nativeTabBarClearance (56) + nowPlayingClearance (72)\` ≈ 128pt of bottom padding for the tab bar and now-playing accessory. But the audio player is a \`fullScreenModal\` route, so the tab bar is covered by the modal and \`(tabs)/_layout.tsx\` already hides the accessory on the playing item's own page. The reservation was for UI that doesn't render — clipping the description mid-paragraph.

- \`ScreenLayout\`: new \`modal\` prop skips the manual bottom clearance for modal routes.
- \`useNowPlayingClearance\`: pathname-aware — returns 0 on \`/episode/[itemId]\` for the playing item, mirroring the \`showPlayer\` gate in \`(tabs)/_layout.tsx\`. Every other surface (collections, books, templates, …) also stops reserving space for a bar that's been hidden.
- \`AudioPlayerScreen\`: opts into \`modal\` and turns on scroll on the description WebView (new opt-in \`scrollEnabled\` prop on \`RichDescription\` / \`HtmlWebView\`) so long summaries no longer clip silently in their fixed-height container.

### Saints grid — FlatList missing flex:1

The grid sat inside a YStack with PageHeader as a sibling. The FlatList had no \`flex={1}\`, so it sized to its full content height — the parent overflowed \`ScreenLayout\`'s bounded area and the inner ScrollView never got a finite viewport. Result: rows past ~2.2 were clipped and unreachable (no scrolling possible). \`practices/index.tsx\` doesn't hit this because there the FlatList is a direct child of \`ScreenLayout\`'s bounded YStack and inherits the bound.

- \`SaintCardGrid\`: adds \`style={{ flex: 1 }}\` so the list scrolls within its parent instead of overflowing.

## Test plan

- [ ] Open the audio player → description fills down to the safe area instead of fading into a black band; long summaries scroll inside their panel.
- [ ] Mini-player on other tabs (Today, Library, etc.) still floats above the tab bar with breathing room; clearance unchanged when not on the player's own page.
- [ ] When nothing is playing, no clearance is added.
- [ ] Open Saints (Santos) → can scroll past row 2; all 14 saints are reachable.
- [ ] Article reader unaffected (\`scrollEnabled\` defaults to false on \`HtmlWebView\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)