### PR TITLE
Render inline markdown in practice flow text

### DIFF
--- a/apps/app/src/components/PrayerText.tsx
+++ b/apps/app/src/components/PrayerText.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import { Text, YStack } from 'tamagui'
 
 import { useReadingStyle } from '@/hooks/useReadingStyle'
-import { hyphenate } from '@/lib/hyphenate'
+import { InlineMarkdownLine } from './prayer/InlineMarkdown'
 import { ResponseMark } from './prayer/ResponseMark'
 
 export function PrayerText(props: ComponentProps<typeof Text>) {
@@ -15,28 +15,29 @@ export function PrayerText(props: ComponentProps<typeof Text>) {
 export function PrayerLines({
   text,
   fontWeight,
+  fontStyle,
   language,
   prefix,
 }: {
   text: string
   fontWeight?: ComponentProps<typeof Text>['fontWeight']
+  fontStyle?: ComponentProps<typeof Text>['fontStyle']
   language?: string
   // Inline missal mark placed at the start of the first line (e.g. "℟. "
   // for people responses). Rendered through `ResponseMark` so styling
   // stays in sync with versicle/response markers across the app.
   prefix?: string
 }) {
-  const lines = useMemo(
-    () => text.split('\n').map((line) => hyphenate(line, language)),
-    [text, language],
-  )
+  const reading = useReadingStyle()
+  const baseFamily = reading.fontFamily as unknown as string
+  const lines = useMemo(() => text.split('\n'), [text])
 
   return (
     <YStack gap="$xs">
       {lines.map((line, i) => (
-        <PrayerText key={`${i}`} fontWeight={fontWeight}>
+        <PrayerText key={`${i}`} fontWeight={fontWeight} fontStyle={fontStyle}>
           {i === 0 && prefix && <ResponseMark value={prefix} />}
-          {line}
+          <InlineMarkdownLine text={line} baseFamily={baseFamily} language={language} />
         </PrayerText>
       ))}
     </YStack>

--- a/apps/app/src/components/PrimitiveBlock.tsx
+++ b/apps/app/src/components/PrimitiveBlock.tsx
@@ -9,7 +9,6 @@ import {
   RenderedReviewResolutionBlock,
 } from '@/features/resolutions'
 import { ProducerHtmlBlock } from './include/ProducerHtmlBlock'
-import { PrayerText } from './PrayerText'
 import { CelebrationBanner } from './prayer/CelebrationBanner'
 import { ChoiceRichTextBlock } from './prayer/ChoiceRichTextBlock'
 import { CollapsibleBlock } from './prayer/CollapsibleBlock'
@@ -56,12 +55,11 @@ export const PrimitiveBlock = memo(function PrimitiveBlock({
 
   switch (primitive.type) {
     case 'text':
-      return primitive.style === 'italic' ? (
-        <PrayerText fontStyle="italic" color="$color">
-          {primitive.text.primary}
-        </PrayerText>
-      ) : (
-        <PrayerTextBlock text={primitive.text} />
+      return (
+        <PrayerTextBlock
+          text={primitive.text}
+          fontStyle={primitive.style === 'italic' ? 'italic' : undefined}
+        />
       )
 
     case 'heading':

--- a/apps/app/src/components/prayer/InlineMarkdown.tsx
+++ b/apps/app/src/components/prayer/InlineMarkdown.tsx
@@ -1,55 +1,82 @@
+// biome-ignore-all lint/suspicious/noArrayIndexKey: parsed inline nodes never reorder
 import { Fragment } from 'react'
-import { Text as RNText } from 'react-native'
+import { Text as RNText, type TextStyle } from 'react-native'
 
 import { bodyFont } from '@/config/fonts'
+import { hyphenate } from '@/lib/hyphenate'
 
-import { parseInline } from './parseMarkdown'
+import { type InlineNode, parseInline } from './parseMarkdown'
 
-/**
- * Inline markdown renderer for short text fields that live inside a parent
- * `<Text>` wrapper (annotation rows, todo notes, compact metadata). Renders
- * only inline emphasis (bold, italic, bold-italic) — block-level constructs
- * pass through as plain text. Inherits font size and color from the parent;
- * swaps the concrete font face for emphasis since RN's Text drops inherited
- * fontWeight/fontStyle when fontFamily is set.
- */
-function bodyFace(weight: 400 | 700, italic: boolean): string {
-  const variants = bodyFont.face?.[weight]
-  return (italic ? variants?.italic : variants?.normal) ?? bodyFont.family
+// React Native's Text ignores inherited fontWeight/fontStyle when fontFamily is
+// set, so nested emphasis must resolve a concrete font face. EB Garamond ships
+// dedicated bold/italic faces; other reading fonts load only Regular, so fall
+// back to synthetic weight/style on the base family.
+export function emphasisStyle(baseFamily: string, weight: 400 | 700, italic: boolean): TextStyle {
+  if (baseFamily.startsWith('EBGaramond')) {
+    const variants = bodyFont.face?.[weight]
+    return { fontFamily: (italic ? variants?.italic : variants?.normal) ?? baseFamily }
+  }
+  return {
+    fontFamily: baseFamily,
+    ...(weight === 700 ? { fontWeight: '700' } : {}),
+    ...(italic ? { fontStyle: 'italic' } : {}),
+  }
 }
 
-export function InlineMarkdown({ source }: { source: string }) {
-  const nodes = parseInline(source)
+export function InlineText({ nodes, baseFamily }: { nodes: InlineNode[]; baseFamily: string }) {
   return (
     <>
       {nodes.map((node, i) => {
         switch (node.type) {
           case 'bold':
-            // biome-ignore lint/suspicious/noArrayIndexKey: parsed nodes never reorder
             return (
-              <RNText key={i} style={{ fontFamily: bodyFace(700, false) }}>
+              <RNText key={i} style={emphasisStyle(baseFamily, 700, false)}>
                 {node.text}
               </RNText>
             )
           case 'italic':
-            // biome-ignore lint/suspicious/noArrayIndexKey: parsed nodes never reorder
             return (
-              <RNText key={i} style={{ fontFamily: bodyFace(400, true) }}>
+              <RNText key={i} style={emphasisStyle(baseFamily, 400, true)}>
                 {node.text}
               </RNText>
             )
           case 'bolditalic':
-            // biome-ignore lint/suspicious/noArrayIndexKey: parsed nodes never reorder
             return (
-              <RNText key={i} style={{ fontFamily: bodyFace(700, true) }}>
+              <RNText key={i} style={emphasisStyle(baseFamily, 700, true)}>
                 {node.text}
               </RNText>
             )
           default:
-            // biome-ignore lint/suspicious/noArrayIndexKey: parsed nodes never reorder
             return <Fragment key={i}>{node.text}</Fragment>
         }
       })}
     </>
   )
+}
+
+// Inline markdown for a single line of prayer text. Parses `*italic*` /
+// `**bold**` / `***bolditalic***`, then hyphenates each segment so long words
+// soft-wrap at the same boundaries as in plain text.
+export function InlineMarkdownLine({
+  text,
+  baseFamily,
+  language,
+}: {
+  text: string
+  baseFamily: string
+  language?: string
+}) {
+  const nodes = parseInline(text).map((n) => ({ ...n, text: hyphenate(n.text, language) }))
+  return <InlineText nodes={nodes} baseFamily={baseFamily} />
+}
+
+/**
+ * Inline markdown renderer for short text fields that live inside a parent
+ * `<Text>` wrapper (annotation rows, todo notes, compact metadata). Renders
+ * only inline emphasis (bold, italic, bold-italic) — block-level constructs
+ * pass through as plain text. Inherits font size and color from the parent.
+ */
+export function InlineMarkdown({ source }: { source: string }) {
+  const nodes = parseInline(source)
+  return <InlineText nodes={nodes} baseFamily={bodyFont.family ?? ''} />
 }

--- a/apps/app/src/components/prayer/PrayerTextBlock.tsx
+++ b/apps/app/src/components/prayer/PrayerTextBlock.tsx
@@ -1,7 +1,20 @@
 import type { BilingualText } from '@ember/content-engine'
+import type { ComponentProps } from 'react'
+import type { Text } from 'tamagui'
 import { PrayerLines } from '../PrayerText'
 import { BilingualBlock } from './BilingualBlock'
 
-export function PrayerTextBlock({ text }: { text: BilingualText }) {
-  return <BilingualBlock content={text} renderText={(t) => <PrayerLines text={t} />} />
+export function PrayerTextBlock({
+  text,
+  fontStyle,
+}: {
+  text: BilingualText
+  fontStyle?: ComponentProps<typeof Text>['fontStyle']
+}) {
+  return (
+    <BilingualBlock
+      content={text}
+      renderText={(t) => <PrayerLines text={t} fontStyle={fontStyle} />}
+    />
+  )
 }

--- a/apps/app/src/components/prayer/ProseBlock.tsx
+++ b/apps/app/src/components/prayer/ProseBlock.tsx
@@ -1,63 +1,14 @@
 // biome-ignore-all lint/suspicious/noArrayIndexKey: static parsed markdown nodes never reorder
 import type { BilingualText } from '@ember/content-engine'
-import { Fragment } from 'react'
-import { Text as RNText, type TextStyle } from 'react-native'
 import { Text, YStack } from 'tamagui'
-import { bodyFont } from '@/config/fonts'
 import { useReadingStyle } from '@/hooks/useReadingStyle'
 import { Typography } from '../typography'
 import { ImageBlock } from './ImageBlock'
+import { InlineText } from './InlineMarkdown'
 import type { InlineNode } from './parseMarkdown'
 import { parseMarkdown } from './parseMarkdown'
 
 export { parseMarkdown }
-
-// React Native's Text ignores inherited fontWeight/fontStyle when fontFamily is
-// set, so nested emphasis must resolve a concrete face. EB Garamond ships
-// bold/italic faces; the other reading fonts load only Regular, so fall back to
-// synthetic weight/style on the base family.
-function emphasisStyle(baseFamily: string, weight: 400 | 700, italic: boolean): TextStyle {
-  if (baseFamily.startsWith('EBGaramond')) {
-    const variants = bodyFont.face?.[weight]
-    return { fontFamily: (italic ? variants?.italic : variants?.normal) ?? baseFamily }
-  }
-  return {
-    fontFamily: baseFamily,
-    ...(weight === 700 ? { fontWeight: '700' } : {}),
-    ...(italic ? { fontStyle: 'italic' } : {}),
-  }
-}
-
-function InlineText({ nodes, baseFamily }: { nodes: InlineNode[]; baseFamily: string }) {
-  return (
-    <>
-      {nodes.map((node, i) => {
-        switch (node.type) {
-          case 'bold':
-            return (
-              <RNText key={i} style={emphasisStyle(baseFamily, 700, false)}>
-                {node.text}
-              </RNText>
-            )
-          case 'italic':
-            return (
-              <RNText key={i} style={emphasisStyle(baseFamily, 400, true)}>
-                {node.text}
-              </RNText>
-            )
-          case 'bolditalic':
-            return (
-              <RNText key={i} style={emphasisStyle(baseFamily, 700, true)}>
-                {node.text}
-              </RNText>
-            )
-          default:
-            return <Fragment key={i}>{node.text}</Fragment>
-        }
-      })}
-    </>
-  )
-}
 
 export function ProseBlock({ text }: { text: BilingualText }) {
   const nodes = parseMarkdown(text.primary)


### PR DESCRIPTION
## Summary
- The `text` primitive (used by `prayer.inline`, `meditation`, canticle subtitle) routed through `PrayerLines`, which only split on newlines and never parsed inline emphasis — so authored `*italic*` / `**bold**` markup leaked through as literal asterisks. Repro: morning-offering-opus-dei → "Tudo para a glória de Deus. *Deo omnis gloria!*".
- Only `ProseBlock` parsed inline emphasis (`parseInline` + a private `InlineText`). Lift that renderer into the shared `InlineMarkdown` module and route `PrayerLines` through it, hyphenating each parsed segment so wrapping still matches plain text.
- Fold the italic-style text branch through `PrayerTextBlock` so meditation and canticle-subtitle text gain bilingual support + markdown parsing too (previously they used only `primary`, no line splitting).

## Test plan
- [ ] Open Morning Offering (Opus Dei) — last sealing line renders with "Deo omnis gloria!" in italic, no literal asterisks
- [ ] Switch language to EN — secondary side renders italic too
- [ ] Side-by-side bilingual mode also renders italic on both columns
- [ ] Practices that use `meditation` and `canticle` subtitles still render correctly (now via `PrayerTextBlock`)
- [ ] Book reader / prose content (catechism, etc.) still renders unchanged — same renderer, just imported from `InlineMarkdown` now

🤖 Generated with [Claude Code](https://claude.com/claude-code)