### PR TITLE
CI: install snowballstemmer before building corpus

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,9 @@ jobs:
           done
           rm -rf _site_hearth
 
+      - name: Install corpus builder deps
+        run: pip install snowballstemmer
+
       - name: Build content corpus (Hearth v2)
         run: python3 scripts/build-corpus.py _site/hearth/v2
 


### PR DESCRIPTION
## Summary
- PR #255 added `snowballstemmer` for the in-book search stemmer but didn't update the Hearth deploy workflow, breaking deploys with `ModuleNotFoundError: No module named 'snowballstemmer'`.
- Adds a `pip install snowballstemmer` step before the corpus build.

## Test plan
- [ ] Watch the next deploy run finish successfully.