### PR TITLE
Empty rule-of-life CTA: point to templates, not practices

### DIFF
--- a/apps/app/src/features/plan-of-life/components/RuleOfLifeSections.tsx
+++ b/apps/app/src/features/plan-of-life/components/RuleOfLifeSections.tsx
@@ -222,7 +222,7 @@ export function RuleOfLifeSections({ belowWall }: { belowWall?: ReactNode }) {
 
       {slots.length === 0 ? (
         <AnimatedPressable
-          onPress={() => router.push('/practices')}
+          onPress={() => router.push('/templates' as never)}
           accessibilityRole="button"
           accessibilityLabel={t('plan.emptyStateAction')}
         >

--- a/apps/app/src/lib/i18n/locales/en-US.ts
+++ b/apps/app/src/lib/i18n/locales/en-US.ts
@@ -707,7 +707,7 @@ export default {
     emptyState: 'Your rule of life is still a blank page.',
     emptyStateDescription:
       'Add practices to begin shaping the shape of your days — prayer, reading, silence, almsgiving.',
-    emptyStateAction: 'Browse practices →',
+    emptyStateAction: 'Browse traditions →',
     pinAll: 'Make plan available offline',
     pinAllInProgress: 'Saving for offline… {{done}} of {{total}}',
     planOffline: 'Plan is available offline',

--- a/apps/app/src/lib/i18n/locales/pt-BR.ts
+++ b/apps/app/src/lib/i18n/locales/pt-BR.ts
@@ -715,7 +715,7 @@ export default {
     emptyState: 'Sua regra de vida ainda é uma página em branco.',
     emptyStateDescription:
       'Adicione práticas para começar a moldar seus dias — oração, leitura, silêncio, caridade.',
-    emptyStateAction: 'Ver práticas →',
+    emptyStateAction: 'Ver tradições →',
     pinAll: 'Tornar plano disponível offline',
     pinAllInProgress: 'Salvando para offline… {{done}} de {{total}}',
     planOffline: 'Plano disponível offline',


### PR DESCRIPTION
## Summary
- The empty-state card on the Plan tab ("Sua regra de vida ainda é uma página em branco.") now navigates to `/templates` instead of `/practices` — better first step for users with a blank rule.
- Updated CTA label in both locales: `Ver práticas →` → `Ver tradições →` / `Browse practices →` → `Browse traditions →`.

## Test plan
- [ ] Open the Plan tab with no practices in the rule
- [ ] Tap the empty-state card → lands on Traditions, not Practices
- [ ] Verify label reads "Ver tradições →" in pt-BR and "Browse traditions →" in en-US