### PR TITLE
Fix oversized celebration description on the home carousel

### DIFF
--- a/apps/app/src/features/home/components/CelebrationOfDay.tsx
+++ b/apps/app/src/features/home/components/CelebrationOfDay.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { Text, XStack, YStack } from 'tamagui'
 
 import { AnimatedPressable } from '@/components'
-import { ProseBlock } from '@/components/prayer'
+import { InlineMarkdown } from '@/components/prayer'
 import { useYearCalendar } from '@/features/calendar'
 import { localizeContent } from '@/lib/i18n'
 import { getCelebrationsForDate, type ResolvedCelebration } from '@/lib/liturgical'
@@ -34,7 +34,11 @@ function CelebrationRow({
           {rankLabel(celebration, t).toUpperCase()}
         </Text>
       </XStack>
-      {description && <ProseBlock text={{ primary: description }} />}
+      {description && (
+        <Text fontFamily="$body" fontSize="$2" color="$colorSecondary">
+          <InlineMarkdown source={description} />
+        </Text>
+      )}
       {celebration.entry.holyDayOfObligation && (
         <Text fontFamily="$body" fontSize="$1" color="$accent">
           {t('calendar.holyDay')}

--- a/apps/app/src/features/home/components/SeasonalContext.tsx
+++ b/apps/app/src/features/home/components/SeasonalContext.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { Text, YStack } from 'tamagui'
 
 import { AnimatedPressable } from '@/components'
-import { ProseBlock } from '@/components/prayer'
+import { InlineMarkdown } from '@/components/prayer'
 import { useUpcomingCelebration } from '@/features/calendar'
 import { localizeContent } from '@/lib/i18n'
 import { normalizeDate } from '@/lib/liturgical'
@@ -53,9 +53,9 @@ export function SeasonalContext({ date }: { date: Date }) {
           {when}
         </Text>
         {description && (
-          <YStack maxWidth={520}>
-            <ProseBlock text={{ primary: description }} />
-          </YStack>
+          <Text fontFamily="$body" fontSize="$2" color="$colorSecondary" maxWidth={520}>
+            <InlineMarkdown source={description} />
+          </Text>
         )}
       </YStack>
     </AnimatedPressable>


### PR DESCRIPTION
## Summary

The "Celebração de Hoje" card on the home carousel was rendering its description (e.g. *"Doutor da Igreja, diácono, teólogo e compositor de hinos (m. 373)"*) in the reader's body type — far too large for a compact card subtitle. The "Próxima Festa" / SeasonalContext card had the same regression.

**Root cause.** PR #246 (Render markdown in detail-page narrative text) replaced the original sized `<Text fontSize="\$2">` with `<ProseBlock>` so the description could pick up bold/italic markdown. But `ProseBlock` runs through `useReadingStyle()`, which is the reader-page font/size/leading hook — appropriate for long-form prose like books and the catechism, not for a card subtitle wrapped in the home carousel's illuminated dark theme. Result: the description balloons.

**Fix.** Switch to `InlineMarkdown`, the lightweight helper PR #246 itself introduced for exactly this case ("compact metadata… inherits font size and color from the parent"). The parent `<Text>` controls size/color; markdown emphasis still renders. The two home carousel components touched:

- `CelebrationOfDay` — the burgundy "Celebração de Hoje" card (the one in the screenshot)
- `SeasonalContext` — the green "Próxima Festa" card (same regression path)

`DayDetail` (calendar tab) and `ProseBlock` itself (which other detail pages legitimately use for long-form narrative) are intentionally left alone.

## Test plan

- [ ] On the home screen, today (2026-06-09) shows the Santo Efrém card with the description "*Doutor da Igreja, diácono, teólogo e compositor de hinos (m. 373)*" in the same compact body size as the saint-of-the-day reflection card, not the reader's body font
- [ ] If a description contains `*italic*` or `**bold**` markdown, emphasis still renders correctly within the description line
- [ ] The "Próxima Festa" (SeasonalContext) card subtitle also renders at compact body size
- [ ] Light + dark themes both look right; long descriptions still soft-wrap within the card