### PR TITLE
Fix variant practices never marking complete on home

### DIFF
--- a/apps/app/src/app/(tabs)/(today,explore,library,you,search)/index.tsx
+++ b/apps/app/src/app/(tabs)/(today,explore,library,you,search)/index.tsx
@@ -113,7 +113,9 @@ export default function HomeScreen() {
       }
       router.push({
         pathname: '/pray/[practiceId]',
-        params: { practiceId: resolvedId, slotId },
+        // Pray the resolved variant's content, but track completion against the
+        // base practice id so it matches this plan slot.
+        params: { practiceId: resolvedId, slotId, completionId: practiceId },
       })
     },
     [router],

--- a/apps/app/src/app/(tabs)/(today,explore,library,you,search)/pray/[practiceId].tsx
+++ b/apps/app/src/app/(tabs)/(today,explore,library,you,search)/pray/[practiceId].tsx
@@ -2,13 +2,19 @@ import { useLocalSearchParams } from 'expo-router'
 import { PracticeFlow } from '@/features/practices/components/PracticeFlow'
 
 export default function PrayScreen() {
-  const { practiceId, programDay, slotId } = useLocalSearchParams<{
+  const { practiceId, programDay, slotId, completionId } = useLocalSearchParams<{
     practiceId: string
     programDay?: string
     slotId?: string
+    completionId?: string
   }>()
   const parsedProgramDay = programDay !== undefined ? Number(programDay) : undefined
   return (
-    <PracticeFlow practiceId={practiceId ?? ''} programDay={parsedProgramDay} slotId={slotId} />
+    <PracticeFlow
+      practiceId={practiceId ?? ''}
+      programDay={parsedProgramDay}
+      slotId={slotId}
+      completionId={completionId}
+    />
   )
 }

--- a/apps/app/src/features/practices/components/PracticeFlow/hooks/usePracticeCompletion.ts
+++ b/apps/app/src/features/practices/components/PracticeFlow/hooks/usePracticeCompletion.ts
@@ -26,6 +26,11 @@ export function usePracticeCompletion(
   renderedSections: RenderedSection[],
   selectOverrides: Record<string, string>,
   slotId?: string,
+  // When a variant is being prayed, `practiceId` is the variant's content id
+  // but the plan slot (and thus the completion record) is keyed on the base
+  // practice id. Log against that base id so the completion matches the slot;
+  // cursors/program progress still key on the variant `practiceId`.
+  completionId?: string,
 ) {
   const { t } = useTranslation()
   const router = useRouter()
@@ -42,7 +47,7 @@ export function usePracticeCompletion(
     const subId = slotId ?? parseSlotKey(currentSlot?.id ?? `${practiceId}::default`).slotId
 
     logCompletionMutation.mutate(
-      { practiceId, date: today, subId },
+      { practiceId: completionId ?? practiceId, date: today, subId },
       {
         onSuccess: async () => {
           successBuzz()
@@ -84,6 +89,7 @@ export function usePracticeCompletion(
     )
   }, [
     practiceId,
+    completionId,
     slotId,
     currentSlot?.id,
     logCompletionMutation,

--- a/apps/app/src/features/practices/components/PracticeFlow/index.tsx
+++ b/apps/app/src/features/practices/components/PracticeFlow/index.tsx
@@ -8,10 +8,12 @@ export function PracticeFlow({
   practiceId,
   programDay: programDayProp,
   slotId,
+  completionId,
 }: {
   practiceId: string
   programDay?: number
   slotId?: string
+  completionId?: string
 }) {
   const { selectOverrides, handleSelectOverride } = useSelectOverrides(practiceId, programDayProp)
   const contentQuery = usePracticeContent(practiceId, programDayProp)
@@ -21,6 +23,7 @@ export function PracticeFlow({
     contentQuery.data?.renderedSections ?? [],
     selectOverrides,
     slotId,
+    completionId,
   )
   const thresholdElapsed = useMinElapsed(900)
 


### PR DESCRIPTION
When a plan practice has an active_variant, the home screen navigated to
the pray flow with the variant's content id as practiceId, so the
completion was logged under the variant id. But the plan slot, home
checklist, streaks, and wall heatmap all key completions on the base
practice_id via composeSlotKey(completion.practice_id, ...), so the keys
never matched and the practice stayed incomplete after praying.

Thread a separate completionId (the base practice id) used only for the
completion log; content resolution and reading-track cursors keep using
the variant id (cursors are intentionally variant-keyed). All other
/pray entry points pass no completionId and are unaffected.