### PR TITLE
Fix Hearth deploy: drop dead build-mass-fragments step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,9 +44,6 @@ jobs:
       - name: Generate OF liturgical calendar from ember-extra
         run: node scripts/build-of-calendar.mjs
 
-      - name: Merge Mass fragments for producer/mass
-        run: node scripts/build-mass-fragments.mjs
-
       - name: Stage Hearth files
         run: |
           cp -r content _site_hearth


### PR DESCRIPTION
## Problem

The Hearth deploy job is failing:

```
Error: Cannot find module '/home/runner/work/ember/ember/scripts/build-mass-fragments.mjs'
```

## Cause

The **"Merge Mass fragments for producer/mass"** step in `deploy.yml` still ran `scripts/build-mass-fragments.mjs`, which was deleted in the Divinum Officium rebuild (#276) as part of the EF Mass teardown. `producer/do-mass` now emits the fully-resolved Mass inline, so `mass-fragments.json` is neither produced nor consumed anywhere — `grep` finds zero references outside this one workflow step.

## Fix

Remove the dead step. No other changes; the local `pnpm build:corpus` never invoked it (it was CI-only).