### PR TITLE
DO: make suppressAlleluia Hermes-safe (drop regex lookbehind)

### DIFF
--- a/packages/divinum-officium/src/hours/helpers.ts
+++ b/packages/divinum-officium/src/hours/helpers.ts
@@ -161,18 +161,22 @@ export async function processInlineAlleluias(
 // has already wrapped the red abbreviation markers (Ant., V., R., …) in
 // markup, so the regex's optional leading `[,.]` can never swallow a marker's
 // terminating dot — `Ant. Allelúja, …` becomes `Ant., …`, not `Ant, …`. Our
-// pipeline keeps markers as plain text, so we guard the marker dot with a
-// negative lookbehind (anchored to line-start or whitespace so it can't fire
-// mid-word). The space before the alleluia is still consumed via `\s*`.
-const alleluiaMarkerGuard = '(?<!(?:^|\\s)(?:Ant|Ps|[AVRSOMCDP]|v|r))'
+// pipeline keeps markers as plain text, so we protect a line-initial marker
+// dot in a first pass (re-emitting the captured `Ant.`/`V.`/… and dropping
+// only the following whitespace + alleluia), then strip the rest. Done with a
+// capture group rather than a lookbehind — Hermes (the on-device JS engine)
+// does not reliably support lookbehind assertions.
+const alleluiaMarker = '(?:^|\\s)(?:Ant|Ps|[AVRSOMCDP]|v|r)\\.'
 
 export async function suppressAlleluia(
   state: HoursState,
   text: string,
   lang: string,
 ): Promise<string> {
-  const regex = await alleluiaRegexp(state, lang)
-  return text.replace(new RegExp(`${alleluiaMarkerGuard}[,.]?\\s*${regex.source}`, 'gim'), '')
+  const a = (await alleluiaRegexp(state, lang)).source
+  return text
+    .replace(new RegExp(`(${alleluiaMarker})\\s*${a}`, 'gim'), '$1')
+    .replace(new RegExp(`[,.]?\\s*${a}`, 'gi'), '')
 }
 
 // Port of alleluia_ant.


### PR DESCRIPTION
## Problem

The marker-dot guard added with the votive offices (#279) used a **negative lookbehind** `(?<!…)` in `suppressAlleluia`. Hermes (React Native's on-device JS engine) does not reliably support lookbehind assertions — constructing that `RegExp` can throw, which would break the hour on device whenever `suppressAlleluia` runs (Lent dates), while every Node-based test still passes.

## Fix

Replace the lookbehind with a two-pass capture-group approach:
1. Re-emit a captured line-initial marker (`Ant.`, `V.`, …) while dropping the following whitespace + alleluia (so the marker's dot is preserved, matching how the Perl reds the marker before suppressing).
2. Strip the remaining alleluias.

Char-for-char identical output: the full hours differential (11 versions + Portugues + votive offices, 13 tests) stays green, including the Lenten votive case that exercises this path.

## Note

This is **not** the cause of the current production breviary/Mass failure — that's a stale app bundle (predates the DO producers); an OTA `eas update` resolves it. This is a separate latent on-device bug worth shipping regardless.