### PR TITLE
Fix PillSelector overflow: wrap pills to multiple rows

### DIFF
--- a/apps/app/src/components/PillSelector.tsx
+++ b/apps/app/src/components/PillSelector.tsx
@@ -17,7 +17,7 @@ export function PillSelector<T extends string>({
       <Text fontFamily="$body" fontSize="$2" color="$color">
         {label}
       </Text>
-      <XStack gap="$sm">
+      <XStack gap="$sm" flexWrap="wrap">
         {options.map((opt) => {
           const selected = value === opt.value
           return (


### PR DESCRIPTION
## Problem

The rubric-version selector in Settings (`Rúbricas do Breviário e Missa EF`) has **11 options**, but `PillSelector` laid them out in a single, non-scrolling `XStack`. Only the first ~3 fit on screen (Tridentine 1570/1888/1906); the remaining 8 — Divino Afflatu, Reduced 1955, Rubrics 1960, the Monastic family — ran off the right edge and were unreachable (no horizontal scroll).

## Fix

Add `flexWrap="wrap"` so the pills wrap onto multiple rows. All 11 versions are now visible. Harmless for the other selectors (language, calendar form, region) which have 2–3 options and already fit on one line.

One-line change.