### PR TITLE
Fix OF Mass Gospel Acclamation rendering and "Palavra" typo

### DIFF
--- a/apps/app/src/components/prayer/ChoiceRichTextBlock.tsx
+++ b/apps/app/src/components/prayer/ChoiceRichTextBlock.tsx
@@ -86,7 +86,14 @@ export function ChoiceRichTextBlock({
           {opt.introduction.primary}
         </PrayerText>
       )}
-      {precedingResponse && <PrayerText>{precedingResponse.primary}</PrayerText>}
+      {precedingResponse && (
+        <XStack gap={4} alignItems="baseline">
+          <ResponseMark value="℟" width={18} />
+          <PrayerText flex={1} fontWeight="600">
+            {precedingResponse.primary}
+          </PrayerText>
+        </XStack>
+      )}
       <RichTextBody body={opt.body} />
       {opt.conclusion && (
         <PrayerText color="$colorBurgundy" fontStyle="italic">

--- a/apps/app/src/sources/of/blocks/readings.test.ts
+++ b/apps/app/src/sources/of/blocks/readings.test.ts
@@ -46,4 +46,39 @@ describe('renderReadingSet — multiple options', () => {
     expect(s).toContain('Aleluia.') // the alternate refrain is not dropped
     expect(s).toContain('"role":"r"')
   })
+
+  it('renders the Gospel Acclamation as its own headed section, not a ℟ reply', () => {
+    const set: ReadingSet = {
+      secondReading: { options: [reading('Texto da segunda leitura.', '5, 6-11')] },
+      gospelAcclamation: {
+        options: [
+          {
+            mode: 'alleluia',
+            acclamation: { lines: { 'pt-BR': [line('Aleluia, aleluia.')] } },
+            verse: {
+              lines: { 'pt-BR': [line('Aleluia, aleluia. O Reino do céu está perto! Aleluia.')] },
+            },
+          },
+        ],
+      },
+    }
+    const flat = renderReadingSet(set, lang)
+    // The acclamation gets its own heading like every other slot.
+    expect(
+      flat.some(
+        (p) => p.type === 'heading' && JSON.stringify(p).includes('Aclamação ao Evangelho'),
+      ),
+    ).toBe(true)
+    // The refrain is plain text, never a ℟ versicle/response item that would
+    // read as a second reply to the Second Reading.
+    const acc = flat.find((p) => JSON.stringify(p).includes('Aleluia, aleluia.'))
+    expect(acc?.type).toBe('text')
+    expect(JSON.stringify(acc)).not.toContain('"role":"r"')
+    // The proper verse is kept (leading refrain stripped) and shown italic.
+    const verse = flat.find(
+      (p) => p.type === 'text' && JSON.stringify(p).includes('O Reino do céu está perto!'),
+    )
+    expect(JSON.stringify(verse)).toContain('"style":"italic"')
+    expect(JSON.stringify(verse)).not.toContain('Aleluia, aleluia. O Reino')
+  })
 })

--- a/apps/app/src/sources/of/blocks/readings.ts
+++ b/apps/app/src/sources/of/blocks/readings.ts
@@ -165,7 +165,19 @@ export function renderReadingSet(set: ReadingSet, lang: LangPrefs): Primitive[] 
     // The Alleluia refrain (sung by all), then the proper verse — the upstream
     // verse field repeats the refrain glued to its front, so strip it.
     const accText = acc ? flattenRt(acc) : undefined
-    if (accText) out.push({ type: 'verses', style: 'vr', items: [{ role: 'r', text: accText }] })
+    // The acclamation is its own section, not a reply to the Second Reading: it
+    // gets a heading like every other slot, and the refrain is an acclamation
+    // sung by all — not a versicle/response dialogue, so no ℟ mark.
+    if (accText || verse)
+      out.push(
+        heading(
+          bt(
+            { 'pt-BR': slotLabels.gospelAcclamation.pt, 'en-US': slotLabels.gospelAcclamation.en },
+            lang,
+          ) ?? { primary: slotLabels.gospelAcclamation.pt },
+        ),
+      )
+    if (accText) out.push(text(accText))
     if (verse) {
       const v = flattenRt(verse)
       const strip = (s: string | undefined, prefix: string | undefined) =>

--- a/content/of/formularies/tempore/ordinary-time/week-11/sunday.json
+++ b/content/of/formularies/tempore/ordinary-time/week-11/sunday.json
@@ -1056,7 +1056,7 @@
               "la": "Verbum Dómini.",
               "es": "Palabra de Dios.",
               "en-US": "The Word of the Lord.",
-              "pt-BR": "Parlavra do Senhor.",
+              "pt-BR": "Palavra do Senhor.",
               "it": "Parola di Dio.",
               "fr": "Parole du Seigneur.",
               "de": "Wort des lebendigen Gottes."

--- a/content/of/formularies/tempore/ordinary-time/week-19/wednesday.json
+++ b/content/of/formularies/tempore/ordinary-time/week-19/wednesday.json
@@ -968,7 +968,7 @@
               "la": "Verbum Dómini.",
               "es": "Palabra del Señor.",
               "en-US": "The Gospel of the Lord.",
-              "pt-BR": "Parlavra da Salvação.",
+              "pt-BR": "Palavra da Salvação.",
               "it": "Parola del Signore.",
               "fr": "Acclamons la Parole de Dieu !",
               "de": "Evangelium unseres Herrn Jesus Christus."
@@ -1896,7 +1896,7 @@
               "la": "Verbum Dómini.",
               "es": "Palabra del Señor.",
               "en-US": "The Gospel of the Lord.",
-              "pt-BR": "Parlavra da Salvação.",
+              "pt-BR": "Palavra da Salvação.",
               "it": "Parola del Signore.",
               "fr": "Acclamons la Parole de Dieu !",
               "de": "Evangelium unseres Herrn Jesus Christus."

--- a/content/of/formularies/tempore/ordinary-time/week-23/wednesday.json
+++ b/content/of/formularies/tempore/ordinary-time/week-23/wednesday.json
@@ -1060,7 +1060,7 @@
               "la": "Verbum Dómini.",
               "es": "Palabra de Dios.",
               "en-US": "The Word of the Lord.",
-              "pt-BR": "Parlavra do Senhor.",
+              "pt-BR": "Palavra do Senhor.",
               "it": "Parola di Dio.",
               "fr": "Parole du Seigneur.",
               "de": "Wort des lebendigen Gottes."


### PR DESCRIPTION
## Context

In the OF Mass practice (screenshot: Sunday, Week 11 Ordinary Time, Year A), the Liturgy of the Word rendered the Gospel Acclamation as if it were a second reply to the Second Reading. This fixes that plus a data typo.

## Findings & fixes

**1. "Parlavra" typo → "Palavra"**
Hard-coded in the corpus (`secondReading.options[].conclusion`), in 3 ordinary-time formularies. Corrected.

**2. Gospel Acclamation had no heading**
Every other slot (Primeira Leitura, Salmo Responsorial, Segunda Leitura, Evangelho) gets a heading; the Alleluia did not — even though an `Aclamação ao Evangelho` label already existed in `readings.ts` and was never used. It now emits that heading, mirroring the psalm pattern.

**3. Alleluia tagged as a bold ℟ response**
The refrain was pushed as a `role: 'r'` versicle/response item (rendered bold), so stacked under `℟ Graças a Deus.` it read as a second reply to the reading. Liturgically the acclamation is sung by all — not a versicle/response dialogue — so it now renders as plain text under its heading.

**4. Inconsistent people's replies**
The Gospel's "Glória a vós, Senhor." (`precedingResponse`) rendered as plain text while the identical "Graças a Deus." got a bold ℟. `precedingResponse` now renders with a ℟ mark for consistency.

**Deliberate call:** the verse's trailing "Aleluia." is left inline rather than split onto its own line — robust extraction is mode-dependent (Lent's *versus ante Evangelium* has no Alleluia), and the core defect is fully resolved by the heading + dropping the ℟.

## Verification
- `readings.test.ts` passes (3/3, incl. a new test locking in the headed, non-℟ acclamation rendering)
- Biome clean; edited files typecheck with no errors
- The 3 formulary JSON files re-parse with accents intact