### PR TITLE
Clamp upcoming-feast card blurb so it stops inflating the home carousel

### DIFF
--- a/apps/app/src/features/home/components/SeasonalContext.tsx
+++ b/apps/app/src/features/home/components/SeasonalContext.tsx
@@ -51,7 +51,13 @@ export function SeasonalContext({ date }: { date: Date }) {
           {when}
         </Text>
         {description && (
-          <Text fontFamily="$body" fontSize="$2" color="$colorSecondary" maxWidth={520}>
+          <Text
+            fontFamily="$body"
+            fontSize="$2"
+            color="$colorSecondary"
+            maxWidth={520}
+            numberOfLines={3}
+          >
             <InlineMarkdown source={description} />
           </Text>
         )}


### PR DESCRIPTION
## Problem

On the Home ("Hoje") tab, the "EM BREVE" upcoming-feast card (`SeasonalContext`) rendered the feast description with **no line clamp**. A long blurb (e.g. *Natividade de São João Batista*, ~13 lines) made that one card huge. Since the daily carousel sizes to its **tallest** slide and centers each slide vertically, every shorter card (e.g. "SANTO DO DIA") was then surrounded by large empty top/bottom margins.

## Fix

Every sibling card already clamps its description — `CelebrationOfDay` (`numberOfLines={3}`), `SaintOfDayCard` (`numberOfLines={3}`), `DiesDevotion` (`numberOfLines={4}`). `SeasonalContext` was the only one missing it.

This adds `numberOfLines={3}` to the `SeasonalContext` description so the upcoming-feast card stays comparable in height to the others, eliminating the oversized card and the empty-margin disparity. The clamp works correctly through `InlineMarkdown` (it renders nested `RNText`/string nodes that the parent `Text`'s `numberOfLines` clamps).

## Verification

- Open the Home tab on a date with a long-description upcoming feast (e.g. ~June 16, "Natividade de São João Batista" within 14 days).
- Confirm the "EM BREVE" card now clips to 3 lines with an ellipsis, is no longer oversized, and other carousel cards no longer show large empty margins.

https://claude.ai/code/session_013xdRKGAQPz79NwwvTTAUsa

---
_Generated by [Claude Code](https://claude.ai/code/session_013xdRKGAQPz79NwwvTTAUsa)_