### PR TITLE
DO rendering: style inline markup (verse numbers, pointing marks, small caps)

### DIFF
--- a/apps/app/src/components/PrayerText.tsx
+++ b/apps/app/src/components/PrayerText.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react'
 import { Text, YStack } from 'tamagui'
 
 import { useReadingStyle } from '@/hooks/useReadingStyle'
+import { DoInlineLine } from './prayer/DoInline'
 import { InlineMarkdownLine } from './prayer/InlineMarkdown'
 import { ResponseMark } from './prayer/ResponseMark'
 
@@ -18,6 +19,7 @@ export function PrayerLines({
   fontStyle,
   language,
   prefix,
+  markup,
 }: {
   text: string
   fontWeight?: ComponentProps<typeof Text>['fontWeight']
@@ -27,6 +29,9 @@ export function PrayerLines({
   // for people responses). Rendered through `ResponseMark` so styling
   // stays in sync with versicle/response markers across the app.
   prefix?: string
+  // 'do' renders each line with the Divinum Officium inline renderer (verse
+  // numbers, pointing marks, small caps) instead of the markdown one.
+  markup?: 'do'
 }) {
   const reading = useReadingStyle()
   const baseFamily = reading.fontFamily as unknown as string
@@ -37,7 +42,11 @@ export function PrayerLines({
       {lines.map((line, i) => (
         <PrayerText key={`${i}`} fontWeight={fontWeight} fontStyle={fontStyle}>
           {i === 0 && prefix && <ResponseMark value={prefix} />}
-          <InlineMarkdownLine text={line} baseFamily={baseFamily} language={language} />
+          {markup === 'do' ? (
+            <DoInlineLine text={line} language={language} reading={reading} />
+          ) : (
+            <InlineMarkdownLine text={line} baseFamily={baseFamily} language={language} />
+          )}
         </PrayerText>
       ))}
     </YStack>

--- a/apps/app/src/components/PrimitiveBlock.tsx
+++ b/apps/app/src/components/PrimitiveBlock.tsx
@@ -59,6 +59,7 @@ export const PrimitiveBlock = memo(function PrimitiveBlock({
         <PrayerTextBlock
           text={primitive.text}
           fontStyle={primitive.style === 'italic' ? 'italic' : undefined}
+          markup={primitive.markup}
         />
       )
 

--- a/apps/app/src/components/prayer/DoInline.test.ts
+++ b/apps/app/src/components/prayer/DoInline.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { parseDoInline } from './DoInline'
+
+describe('parseDoInline', () => {
+  it('splits a verse number from the verse body', () => {
+    expect(parseDoInline('/:24:1:/ Ad te, Dómine, levávi ánimam meam:')).toEqual([
+      { kind: 'mark', text: '24:1' },
+      { kind: 'body', text: ' Ad te, Dómine, levávi ánimam meam:' },
+    ])
+  })
+
+  it('marks the mediant asterisk distinctly from body text', () => {
+    expect(parseDoInline('viam iustificatiónum tuárum: * et exquíram eam semper.')).toEqual([
+      { kind: 'body', text: 'viam iustificatiónum tuárum: ' },
+      { kind: 'mediant', text: '*' },
+      { kind: 'body', text: ' et exquíram eam semper.' },
+    ])
+  })
+
+  it('treats Hebrew-letter headings and inline directions as marks', () => {
+    expect(parseDoInline('/:(He):/ Legem pone mihi')).toEqual([
+      { kind: 'mark', text: '(He)' },
+      { kind: 'body', text: ' Legem pone mihi' },
+    ])
+    expect(parseDoInline('/:(genuflectitur):/')).toEqual([
+      { kind: 'mark', text: '(genuflectitur)' },
+    ])
+  })
+
+  it('handles flexa and genuflection-cross pointing marks', () => {
+    expect(parseDoInline('Veníte adorémus †')).toEqual([
+      { kind: 'body', text: 'Veníte adorémus ' },
+      { kind: 'point', text: '†' },
+    ])
+    expect(parseDoInline('‡ et procidámus')).toEqual([
+      { kind: 'point', text: '‡' },
+      { kind: 'body', text: ' et procidámus' },
+    ])
+  })
+
+  it('extracts small caps', () => {
+    expect(parseDoInline('%Dóminus% regnávit')).toEqual([
+      { kind: 'smallcaps', text: 'Dóminus' },
+      { kind: 'body', text: ' regnávit' },
+    ])
+  })
+
+  it('returns plain text as a single body run', () => {
+    expect(parseDoInline('Deo grátias.')).toEqual([{ kind: 'body', text: 'Deo grátias.' }])
+  })
+
+  it('combines a verse number, a Hebrew letter and a mediant in one line', () => {
+    expect(parseDoInline('/:118:1:/ /:(Aleph):/ Beáti immaculáti: * qui ámbulant.')).toEqual([
+      { kind: 'mark', text: '118:1' },
+      { kind: 'body', text: ' ' },
+      { kind: 'mark', text: '(Aleph)' },
+      { kind: 'body', text: ' Beáti immaculáti: ' },
+      { kind: 'mediant', text: '*' },
+      { kind: 'body', text: ' qui ámbulant.' },
+    ])
+  })
+})

--- a/apps/app/src/components/prayer/DoInline.tsx
+++ b/apps/app/src/components/prayer/DoInline.tsx
@@ -1,0 +1,88 @@
+// biome-ignore-all lint/suspicious/noArrayIndexKey: parsed inline runs never reorder
+import { Fragment } from 'react'
+import { Text as RNText } from 'react-native'
+import { Text } from 'tamagui'
+
+import type { useReadingStyle } from '@/hooks/useReadingStyle'
+import { hyphenate } from '@/lib/hyphenate'
+
+// Divinum Officium leaves its own inline markup in the assembled text (the
+// engine deliberately doesn't flatten it — rendering is the app's job). One
+// line of that markup tokenizes into styled runs:
+//   /:X:/   small rubric-toned inline — psalm verse numbers (24:1), the Ps 118
+//           Hebrew-letter headings, and inline directions like (genuflectitur).
+//           DO renders these as <FONT SIZE=1 COLOR=red>.
+//   *       the mediant pause that bisects every psalm verse
+//   † ‡     flexa / genuflection-cross pointing marks
+//   %…%     small caps (divine names)
+// Anything else is body text.
+export type DoRunKind = 'body' | 'mark' | 'mediant' | 'point' | 'smallcaps'
+export type DoRun = { kind: DoRunKind; text: string }
+
+const tokenRe = /\/:(.*?):\/|%(.+?)%|([*†‡])/g
+
+export function parseDoInline(line: string): DoRun[] {
+  const runs: DoRun[] = []
+  let last = 0
+  for (const m of line.matchAll(tokenRe)) {
+    const idx = m.index ?? 0
+    if (idx > last) runs.push({ kind: 'body', text: line.slice(last, idx) })
+    if (m[1] !== undefined) runs.push({ kind: 'mark', text: m[1] })
+    else if (m[2] !== undefined) runs.push({ kind: 'smallcaps', text: m[2] })
+    else runs.push({ kind: m[3] === '*' ? 'mediant' : 'point', text: m[3] })
+    last = idx + m[0].length
+  }
+  if (last < line.length) runs.push({ kind: 'body', text: line.slice(last) })
+  return runs.length > 0 ? runs : [{ kind: 'body', text: line }]
+}
+
+// The single place to tune DO inline typography. `color` is a theme token;
+// `scale` shrinks the run relative to body size (verse numbers ride small).
+// `body` and `smallcaps` render differently and are handled outside this map.
+const runStyle: Partial<Record<DoRunKind, { color: string; scale?: number }>> = {
+  mark: { color: '$colorBurgundy', scale: 0.72 },
+  point: { color: '$colorBurgundy' },
+  mediant: { color: '$colorSecondary' },
+}
+
+// Renders one line of DO markup. `reading` is threaded in from PrayerLines so
+// the hook runs once per block, not once per line.
+export function DoInlineLine({
+  text,
+  language,
+  reading,
+}: {
+  text: string
+  language?: string
+  reading: ReturnType<typeof useReadingStyle>
+}) {
+  const baseFamily = reading.fontFamily as unknown as string
+  return (
+    <>
+      {parseDoInline(text).map((run, i) => {
+        if (run.kind === 'smallcaps') {
+          return (
+            <RNText
+              key={i}
+              style={{ fontFamily: baseFamily, textTransform: 'uppercase', letterSpacing: 0.5 }}
+            >
+              {run.text}
+            </RNText>
+          )
+        }
+        const style = runStyle[run.kind]
+        if (!style) return <Fragment key={i}>{hyphenate(run.text, language)}</Fragment>
+        return (
+          <Text
+            key={i}
+            color={style.color}
+            fontSize={style.scale ? Math.round(reading.fontSize * style.scale) : undefined}
+            lineHeight={style.scale ? reading.lineHeight : undefined}
+          >
+            {run.text}
+          </Text>
+        )
+      })}
+    </>
+  )
+}

--- a/apps/app/src/components/prayer/PrayerTextBlock.tsx
+++ b/apps/app/src/components/prayer/PrayerTextBlock.tsx
@@ -7,14 +7,16 @@ import { BilingualBlock } from './BilingualBlock'
 export function PrayerTextBlock({
   text,
   fontStyle,
+  markup,
 }: {
   text: BilingualText
   fontStyle?: ComponentProps<typeof Text>['fontStyle']
+  markup?: 'do'
 }) {
   return (
     <BilingualBlock
       content={text}
-      renderText={(t) => <PrayerLines text={t} fontStyle={fontStyle} />}
+      renderText={(t) => <PrayerLines text={t} fontStyle={fontStyle} markup={markup} />}
     />
   )
 }

--- a/apps/app/src/content/primitives.ts
+++ b/apps/app/src/content/primitives.ts
@@ -21,6 +21,10 @@ export type TextPrimitive = {
   text: BilingualText
   voice?: 'priest' | 'people' | 'all'
   style?: 'normal' | 'italic'
+  // 'do' routes the text through the Divinum Officium inline renderer, which
+  // styles verse numbers, mediant/pointing marks and small caps. Default
+  // (undefined) uses the standard markdown inline renderer.
+  markup?: 'do'
 }
 
 export type HeadingPrimitive = {

--- a/apps/app/src/sources/divinum-officium/blocks.test.ts
+++ b/apps/app/src/sources/divinum-officium/blocks.test.ts
@@ -52,6 +52,7 @@ describe('mapItemsToPrimitives', () => {
     expect(out).toEqual([
       {
         type: 'text',
+        markup: 'do',
         text: { primary: 'One line only.', secondary: 'Linea una.\nLinea altera.' },
       },
     ])
@@ -61,7 +62,7 @@ describe('mapItemsToPrimitives', () => {
     const out = mapItemsToPrimitives(['#Canon', 'Te ígitur, clementíssime Pater.'])
     expect(out).toEqual([
       { type: 'heading', text: { primary: 'Canon' }, size: 'h1' },
-      { type: 'text', text: { primary: 'Te ígitur, clementíssime Pater.' } },
+      { type: 'text', markup: 'do', text: { primary: 'Te ígitur, clementíssime Pater.' } },
     ])
   })
 })

--- a/apps/app/src/sources/divinum-officium/blocks.ts
+++ b/apps/app/src/sources/divinum-officium/blocks.ts
@@ -97,6 +97,9 @@ export function mapItemsToPrimitives(primaryItems: string[], latinItems?: string
     if (textBuffer.length === 0) return
     out.push({
       type: 'text',
+      // DO body text carries inline markup (verse numbers, mediant/pointing
+      // marks, small caps); the DO inline renderer styles it.
+      markup: 'do',
       text: {
         primary: textBuffer.map((t) => t.primary).join('\n'),
         ...(textBuffer.some((t) => t.secondary !== undefined)

--- a/docs/features/divinum-officium.md
+++ b/docs/features/divinum-officium.md
@@ -97,6 +97,19 @@ Contracts: `assembleHour(hora, date, version, lang, loader)`, `assembleMass(date
 - **Sources** (`apps/app/src/sources/divinum-officium/`): `loader.ts` (corpus-backed DoLoader + per-file lang fallback), `do-hour.ts` (`producer/do-hour`, `dateScoped`, params `{hour}`), `do-mass.ts` (`producer/do-mass` — emits the complete resolved Mass: ordinary + propers inline + Full/Propers/Readings view select). DoBlock → existing primitives only; no new renderer blocks. This removes the deferred `proper`-slot seam (`ProperSlot`, `useProperForSlot`).
 - **Practices:** one `practice/breviary` whose `flow.json` is a top-level hour `select` (auto-dispatched to the current hour via a clock `map`) with a ninth **Votive Office** tab; that tab holds a `pickerStyle: 'cards'` votive picker (no default), each card carrying its own hour picker that calls `producer/do-hour` with `{hour, votive}`. `practice/mass` EF branch becomes `{"type":"include","ref":"producer/do-mass"}`.
 
+## Rendering — inline DO markup
+
+The engine deliberately does **not** flatten DO's inline markup; it ships in the assembled text and the app interprets it at render time (the same split as markdown elsewhere — content carries the markup, the renderer styles it). The markers, all left intact by `cleanItemMarkers`:
+
+| Marker | Meaning | Style |
+|---|---|---|
+| `/:X:/` | small rubric-toned inline — psalm verse numbers (`24:1`), Ps 118 Hebrew-letter headings (`(He)`), inline directions (`(genuflectitur)`). DO renders `<FONT SIZE=1 COLOR=red>`. | `$colorBurgundy`, ~0.72× body size |
+| `*` | the mediant pause bisecting every psalm verse | `$colorSecondary` |
+| `†` `‡` | flexa / genuflection-cross pointing marks | `$colorBurgundy` |
+| `%…%` | small caps (divine names) | uppercase + tracking |
+
+`TextPrimitive` carries `markup?: 'do'`; the DO→primitive mapper (`blocks.ts`) sets it on the text it emits, and `PrayerLines` routes those lines through `DoInline.tsx` (`parseDoInline` → styled runs) instead of the markdown inline renderer. **All inline typography lives in one `runStyle` table in `DoInline.tsx`** — the single place to tune it. Scoped to `text` primitives for now (psalms/body); `rubric`/`heading`/`verses` can opt in with the same flag when they carry markup.
+
 ## Teardown (at Mass cutover)
 
 Deleted: `packages/mass/src/buildEFFlow.ts` + `packages/mass/src/ef/*`, EF branch of `apps/app/src/sources/mass-flow.ts`, `apps/app/src/lib/mass-propers/*`, `ProperSlot.tsx` + `proper` primitive handling (after grep for OF stragglers), `ef-*` fragments (after side-by-side parity review — they are the quality baseline), `apps/app/scripts/parse-do-propers.ts`, `scripts/build-ef-ranks.mjs`, `content/propers/`, the `propers` aux entry in `copy-hearth-aux.mjs` and the deploy workflow, the `parse-propers` root script.


### PR DESCRIPTION
## Problem

Divinum Officium leaves its own inline markup in the assembled text — and intentionally so: the engine doesn't flatten it because rendering is the app's job. But the app fed that text to the **markdown** inline renderer, which doesn't understand DO markup. So psalm verse numbers rendered as literal `/:24:1:/`, and the mediant/pointing marks weren't styled at all.

Markers in play (all left intact by the engine's `cleanItemMarkers`):

| Marker | Meaning |
|---|---|
| `/:X:/` | small rubric-toned inline — verse numbers (`24:1`), Ps 118 Hebrew-letter headings (`(He)`), inline directions (`(genuflectitur)`) |
| `*` | mediant pause |
| `†` `‡` | flexa / genuflection-cross pointing marks |
| `%…%` | small caps (divine names) |

## Change

- **`DoInline.tsx`** — a DO-aware inline renderer: `parseDoInline(line)` tokenizes into styled runs (`mark` / `mediant` / `point` / `smallcaps` / `body`), and `DoInlineLine` renders them. **All inline typography lives in one `runStyle` table** — the single place to tune it going forward (verse numbers ride small + `$colorBurgundy`, pointing marks tinted, etc.).
- **`markup?: 'do'`** on `TextPrimitive`. The DO→primitive mapper (`blocks.ts`) sets it; `PrayerLines` routes those lines through `DoInline` instead of the markdown renderer. Default (undefined) is unchanged → no effect on prayers/books.
- `reading` style is threaded from `PrayerLines` into `DoInlineLine` (one hook call per block, not per line).

Scoped to `text` primitives (psalms/body) for now — `rubric`/`heading`/`verses` can opt in with the same flag when they carry markup.

## Tests

- `DoInline.test.ts` — 7 cases over the tokenizer (verse numbers, mediant, Hebrew letters, directions, flexa/cross, small caps, combined line, plain text).
- `blocks.test.ts` updated for the new `markup: 'do'` field.
- Full app suite otherwise unchanged; typecheck clean on touched files.

> Note: `main` currently has 9 pre-existing test failures from an unmocked `ExpoWebBrowser` native module in the render harness — unrelated to this PR (they fail with this branch's changes stashed). Flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)