### PR TITLE
First-run onboarding flow

### DIFF
--- a/apps/app/src/app/(tabs)/(today,explore,library,you,search)/settings/index.tsx
+++ b/apps/app/src/app/(tabs)/(today,explore,library,you,search)/settings/index.tsx
@@ -2,6 +2,7 @@ import { type DoVersionId, doVersionOrder } from '@ember/divinum-officium'
 import DateTimePicker from '@react-native-community/datetimepicker'
 import { format, parseISO } from 'date-fns'
 import Constants from 'expo-constants'
+import { useRouter } from 'expo-router'
 import * as Updates from 'expo-updates'
 import { useUpdates } from 'expo-updates'
 import { useState } from 'react'
@@ -49,6 +50,7 @@ const themeOptions = [
 
 export default function SettingsScreen() {
   const { t } = useTranslation()
+  const router = useRouter()
   const translation = usePreferencesStore((s) => s.translation)
   const liturgicalCalendar = usePreferencesStore((s) => s.liturgicalCalendar)
   const setLiturgicalCalendar = usePreferencesStore((s) => s.setLiturgicalCalendar)
@@ -67,6 +69,34 @@ export default function SettingsScreen() {
     <ScreenLayout>
       <YStack gap="$lg" paddingVertical="$lg">
         <PageHeader title={t('settings.title')} />
+
+        <Pressable
+          onPress={() => router.push('/tour')}
+          accessibilityRole="button"
+          accessibilityLabel={t('settings.tour')}
+        >
+          <XStack
+            backgroundColor="$backgroundSurface"
+            borderRadius="$lg"
+            padding="$md"
+            alignItems="center"
+            justifyContent="space-between"
+          >
+            <YStack flex={1}>
+              <Text fontFamily="$body" fontSize="$2" color="$color">
+                {t('settings.tour')}
+              </Text>
+              <Text fontFamily="$body" fontSize="$1" color="$colorSecondary">
+                {t('settings.tourDescription')}
+              </Text>
+            </YStack>
+            <Text fontFamily="$body" fontSize="$2" color="$accent">
+              {t('settings.view')}
+            </Text>
+          </XStack>
+        </Pressable>
+
+        <SectionDivider />
 
         <YStack gap="$md">
           <Text fontFamily="$heading" fontSize="$3" color="$color">

--- a/apps/app/src/app/(tabs)/(today,explore,library,you,search)/tour.tsx
+++ b/apps/app/src/app/(tabs)/(today,explore,library,you,search)/tour.tsx
@@ -1,0 +1,9 @@
+import { useRouter } from 'expo-router'
+
+import { IntroSlides } from '@/features/onboarding'
+
+/** The features overview, revisitable from Settings — Done returns to where you were. */
+export default function TourScreen() {
+  const router = useRouter()
+  return <IntroSlides revisit onDone={() => router.back()} />
+}

--- a/apps/app/src/app/_layout.tsx
+++ b/apps/app/src/app/_layout.tsx
@@ -148,6 +148,7 @@ export default function RootLayout() {
     theme: themePreference,
     hydrated: prefsHydrated,
     hydrate: hydratePrefs,
+    hasOnboarded,
   } = usePreferencesStore()
   const { hydrated: bibleHydrated, hydrate: hydrateBible } = useBibleStore()
   const { hydrated: catechismHydrated, hydrate: hydrateCatechism } = useCatechismStore()
@@ -375,7 +376,15 @@ export default function RootLayout() {
                   contentStyle: { backgroundColor: rootBg },
                 }}
               >
-                <Stack.Screen name="(tabs)" options={{ title: i18n.t('a11y.home') }} />
+                {/* First run: route to onboarding until the user completes (or
+                    skips) it. The guard flips the moment `hasOnboarded` is set,
+                    revealing the tabs — no manual navigation, no flash. */}
+                <Stack.Protected guard={!hasOnboarded}>
+                  <Stack.Screen name="onboarding" />
+                </Stack.Protected>
+                <Stack.Protected guard={hasOnboarded}>
+                  <Stack.Screen name="(tabs)" options={{ title: i18n.t('a11y.home') }} />
+                </Stack.Protected>
               </Stack>
             </ThemeProvider>
             <FloatingOfflineChip />

--- a/apps/app/src/app/onboarding/_layout.tsx
+++ b/apps/app/src/app/onboarding/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router'
+
+export default function OnboardingLayout() {
+  return <Stack screenOptions={{ headerShown: false, gestureEnabled: false }} />
+}

--- a/apps/app/src/app/onboarding/done.tsx
+++ b/apps/app/src/app/onboarding/done.tsx
@@ -1,10 +1,9 @@
 import { useTranslation } from 'react-i18next'
 import { YStack } from 'tamagui'
 
-import { AnimatedPressable } from '@/components/AnimatedPressable'
 import { ScreenLayout } from '@/components/ScreenLayout'
 import { Typography } from '@/components/typography'
-import { completeOnboarding } from '@/features/onboarding'
+import { completeOnboarding, PrimaryButton } from '@/features/onboarding'
 
 export default function OnboardingDoneScreen() {
   const { t } = useTranslation()
@@ -30,17 +29,7 @@ export default function OnboardingDoneScreen() {
           </Typography>
         </YStack>
 
-        <AnimatedPressable
-          onPress={completeOnboarding}
-          accessibilityRole="button"
-          accessibilityLabel={t('onboarding.done.begin')}
-        >
-          <YStack backgroundColor="$accent" borderRadius="$md" padding="$md" alignItems="center">
-            <Typography variant="label" fontSize="$3" color="$background">
-              {t('onboarding.done.begin')}
-            </Typography>
-          </YStack>
-        </AnimatedPressable>
+        <PrimaryButton label={t('onboarding.done.begin')} onPress={completeOnboarding} />
       </YStack>
     </ScreenLayout>
   )

--- a/apps/app/src/app/onboarding/done.tsx
+++ b/apps/app/src/app/onboarding/done.tsx
@@ -29,7 +29,11 @@ export default function OnboardingDoneScreen() {
           </Typography>
         </YStack>
 
-        <PrimaryButton label={t('onboarding.done.begin')} onPress={completeOnboarding} />
+        <PrimaryButton
+          label={t('onboarding.done.begin')}
+          onPress={completeOnboarding}
+          haptic="success"
+        />
       </YStack>
     </ScreenLayout>
   )

--- a/apps/app/src/app/onboarding/done.tsx
+++ b/apps/app/src/app/onboarding/done.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from 'react-i18next'
+import { YStack } from 'tamagui'
+
+import { AnimatedPressable } from '@/components/AnimatedPressable'
+import { ScreenLayout } from '@/components/ScreenLayout'
+import { Typography } from '@/components/typography'
+import { completeOnboarding } from '@/features/onboarding'
+
+export default function OnboardingDoneScreen() {
+  const { t } = useTranslation()
+
+  return (
+    <ScreenLayout scroll={false} modal>
+      <YStack flex={1} paddingVertical="$lg" gap="$lg">
+        <YStack
+          flex={1}
+          alignItems="center"
+          justifyContent="center"
+          gap="$lg"
+          paddingHorizontal="$md"
+        >
+          <Typography variant="ceremonial" fontSize={64} lineHeight={72}>
+            ✠
+          </Typography>
+          <Typography variant="sacred-title" fontSize={30} textAlign="center">
+            {t('onboarding.done.title')}
+          </Typography>
+          <Typography variant="whisper" textAlign="center" fontSize="$3" maxWidth={360}>
+            {t('onboarding.done.body')}
+          </Typography>
+        </YStack>
+
+        <AnimatedPressable
+          onPress={completeOnboarding}
+          accessibilityRole="button"
+          accessibilityLabel={t('onboarding.done.begin')}
+        >
+          <YStack backgroundColor="$accent" borderRadius="$md" padding="$md" alignItems="center">
+            <Typography variant="label" fontSize="$3" color="$background">
+              {t('onboarding.done.begin')}
+            </Typography>
+          </YStack>
+        </AnimatedPressable>
+      </YStack>
+    </ScreenLayout>
+  )
+}

--- a/apps/app/src/app/onboarding/formation.tsx
+++ b/apps/app/src/app/onboarding/formation.tsx
@@ -18,6 +18,7 @@ import {
   useOnboardingState,
 } from '@/features/onboarding'
 import { useCreatePractice, useEnableSlotsForPractice } from '@/features/plan-of-life'
+import { selectionTick } from '@/lib/haptics'
 
 const dailySchedule = JSON.stringify({ type: 'daily' })
 
@@ -75,7 +76,10 @@ export default function OnboardingFormationScreen() {
           return (
             <AnimatedPressable
               key={opt.id}
-              onPress={() => setSelected(opt.id)}
+              onPress={() => {
+                selectionTick()
+                setSelected(opt.id)
+              }}
               accessibilityRole="radio"
               accessibilityState={{ selected: isSelected }}
               accessibilityLabel={t(`onboarding.formation.options.${opt.id}.name`)}

--- a/apps/app/src/app/onboarding/formation.tsx
+++ b/apps/app/src/app/onboarding/formation.tsx
@@ -1,0 +1,114 @@
+import { useRouter } from 'expo-router'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { XStack, YStack } from 'tamagui'
+
+import { AnimatedPressable } from '@/components/AnimatedPressable'
+import { Card } from '@/components/Card'
+import { Typography } from '@/components/typography'
+import { saveItem } from '@/db/repositories/savedItems'
+import {
+  completeOnboarding,
+  type FormationOption,
+  formationOptions,
+  nextRoute,
+  OnboardingScaffold,
+  recommendFormation,
+  stepProgress,
+  useOnboardingState,
+} from '@/features/onboarding'
+import { useCreatePractice, useEnableSlotsForPractice } from '@/features/plan-of-life'
+
+const dailySchedule = JSON.stringify({ type: 'daily' })
+
+function tagKey(opt: FormationOption): string {
+  if (opt.kind === 'book') return 'onboarding.formation.tag.book'
+  if (opt.kind === 'ccc') return 'onboarding.formation.tag.reader'
+  return 'onboarding.formation.tag.program'
+}
+
+export default function OnboardingFormationScreen() {
+  const { t } = useTranslation()
+  const router = useRouter()
+  const { prayerStage, formationStage, time } = useOnboardingState()
+  const enableSlots = useEnableSlotsForPractice()
+  const createPractice = useCreatePractice()
+
+  const recommended = recommendFormation({ prayerStage, formationStage, time })
+  const [selected, setSelected] = useState(recommended)
+  const busy = enableSlots.isPending || createPractice.isPending
+
+  async function enroll(opt: FormationOption) {
+    if (opt.kind === 'program-enroll') {
+      await enableSlots.mutateAsync(opt.practiceId)
+    } else if (opt.kind === 'program-create') {
+      await createPractice.mutateAsync({
+        id: opt.practiceId,
+        slot: { tier: 'ideal', time: '07:00', schedule: dailySchedule },
+      })
+    } else if (opt.kind === 'book') {
+      // Lightweight record — adds to the library without a full offline download.
+      await saveItem(opt.bookId, 'book')
+    }
+    // ccc: nothing to enroll — the Catechism reader is always available.
+  }
+
+  async function onContinue() {
+    if (busy) return
+    const opt = formationOptions.find((o) => o.id === selected)
+    if (opt) await enroll(opt)
+    router.push(nextRoute('formation'))
+  }
+
+  return (
+    <OnboardingScaffold
+      title={t('onboarding.formation.title')}
+      subtitle={t('onboarding.formation.subtitle')}
+      progress={stepProgress('formation')}
+      onContinue={onContinue}
+      continueDisabled={busy}
+      onSkip={completeOnboarding}
+    >
+      <YStack gap="$md">
+        {formationOptions.map((opt) => {
+          const isSelected = opt.id === selected
+          return (
+            <AnimatedPressable
+              key={opt.id}
+              onPress={() => setSelected(opt.id)}
+              accessibilityRole="radio"
+              accessibilityState={{ selected: isSelected }}
+              accessibilityLabel={t(`onboarding.formation.options.${opt.id}.name`)}
+            >
+              <Card ornate={isSelected}>
+                <YStack gap="$xs">
+                  <XStack justifyContent="space-between" alignItems="center" gap="$sm">
+                    <Typography
+                      variant="label"
+                      fontSize="$3"
+                      color={isSelected ? '$accent' : undefined}
+                      flex={1}
+                    >
+                      {t(`onboarding.formation.options.${opt.id}.name`)}
+                    </Typography>
+                    <Typography variant="reference" tone="muted">
+                      {t(tagKey(opt))}
+                    </Typography>
+                  </XStack>
+                  <Typography variant="whisper">
+                    {t(`onboarding.formation.options.${opt.id}.desc`)}
+                  </Typography>
+                  {opt.id === recommended ? (
+                    <Typography variant="reference" color="$accent">
+                      {t('onboarding.formation.recommended')}
+                    </Typography>
+                  ) : null}
+                </YStack>
+              </Card>
+            </AnimatedPressable>
+          )
+        })}
+      </YStack>
+    </OnboardingScaffold>
+  )
+}

--- a/apps/app/src/app/onboarding/index.tsx
+++ b/apps/app/src/app/onboarding/index.tsx
@@ -1,0 +1,8 @@
+import { useRouter } from 'expo-router'
+
+import { completeOnboarding, IntroSlides, nextRoute } from '@/features/onboarding'
+
+export default function OnboardingIntroScreen() {
+  const router = useRouter()
+  return <IntroSlides onDone={() => router.push(nextRoute('index'))} onSkip={completeOnboarding} />
+}

--- a/apps/app/src/app/onboarding/language.tsx
+++ b/apps/app/src/app/onboarding/language.tsx
@@ -13,6 +13,7 @@ import {
   OnboardingScaffold,
   stepProgress,
 } from '@/features/onboarding'
+import { selectionTick } from '@/lib/haptics'
 import { supportedLanguages } from '@/lib/i18n'
 import { usePreferencesStore } from '@/stores/preferencesStore'
 
@@ -35,6 +36,7 @@ export default function OnboardingLanguageScreen() {
   function toggle(lang: ContentLanguage) {
     // The interface language stays known — you can read what the app speaks to you.
     if (lang === interfaceContent) return
+    selectionTick()
     setKnown((prev) => {
       const next = new Set(prev)
       if (next.has(lang)) next.delete(lang)

--- a/apps/app/src/app/onboarding/language.tsx
+++ b/apps/app/src/app/onboarding/language.tsx
@@ -1,0 +1,106 @@
+import type { ContentLanguage } from '@ember/content-engine'
+import { useRouter } from 'expo-router'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { XStack, YStack } from 'tamagui'
+
+import { AnimatedCheckbox } from '@/components/AnimatedCheckbox'
+import { PillSelector } from '@/components/PillSelector'
+import { Typography } from '@/components/typography'
+import {
+  completeOnboarding,
+  nextRoute,
+  OnboardingScaffold,
+  stepProgress,
+} from '@/features/onboarding'
+import { supportedLanguages } from '@/lib/i18n'
+import { usePreferencesStore } from '@/stores/preferencesStore'
+
+const allContentLanguages: ContentLanguage[] = ['en-US', 'pt-BR', 'la']
+
+export default function OnboardingLanguageScreen() {
+  const { t } = useTranslation()
+  const router = useRouter()
+  const language = usePreferencesStore((s) => s.language)
+  const setLanguage = usePreferencesStore((s) => s.setLanguage)
+  const storedKnown = usePreferencesStore((s) => s.knownLanguages)
+  const setKnownLanguages = usePreferencesStore((s) => s.setKnownLanguages)
+  const setContentLanguage = usePreferencesStore((s) => s.setContentLanguage)
+  const setSecondaryLanguage = usePreferencesStore((s) => s.setSecondaryLanguage)
+
+  // The interface language is always one you know; seed the pool with it.
+  const interfaceContent = language as ContentLanguage
+  const [known, setKnown] = useState<Set<ContentLanguage>>(
+    () => new Set(storedKnown.length ? storedKnown : [interfaceContent]),
+  )
+
+  function toggle(lang: ContentLanguage) {
+    // The interface language stays known — you can read what the app speaks to you.
+    if (lang === interfaceContent) return
+    setKnown((prev) => {
+      const next = new Set(prev)
+      if (next.has(lang)) next.delete(lang)
+      else next.add(lang)
+      return next
+    })
+  }
+
+  function persistAndAdvance() {
+    const list = allContentLanguages.filter((l) => known.has(l) || l === interfaceContent)
+    setKnownLanguages(list)
+    // The renderer shows two languages today: primary + one secondary, derived
+    // from the pool (interface language leads; first other known language pairs).
+    const primary = allContentLanguages.includes(interfaceContent) ? interfaceContent : list[0]
+    setContentLanguage(primary)
+    setSecondaryLanguage(list.find((l) => l !== primary))
+    router.push(nextRoute('language'))
+  }
+
+  return (
+    <OnboardingScaffold
+      title={t('onboarding.language.title')}
+      subtitle={t('onboarding.language.subtitle')}
+      progress={stepProgress('language')}
+      onContinue={persistAndAdvance}
+      onSkip={completeOnboarding}
+    >
+      <YStack gap="$lg">
+        <PillSelector
+          label={t('onboarding.language.interface')}
+          options={supportedLanguages.map((l) => ({ value: l.code, label: l.label }))}
+          value={language}
+          onChange={setLanguage}
+        />
+
+        <YStack gap="$sm">
+          <Typography variant="interface" fontSize="$2">
+            {t('onboarding.language.known')}
+          </Typography>
+          <Typography variant="whisper">{t('onboarding.language.knownHint')}</Typography>
+          <YStack gap="$xs" paddingTop="$xs">
+            {allContentLanguages.map((lang) => {
+              const checked = known.has(lang) || lang === interfaceContent
+              const locked = lang === interfaceContent
+              return (
+                <XStack
+                  key={lang}
+                  alignItems="center"
+                  gap="$md"
+                  paddingVertical="$sm"
+                  opacity={locked ? 0.7 : 1}
+                >
+                  <AnimatedCheckbox
+                    checked={checked}
+                    onToggle={() => toggle(lang)}
+                    accessibilityLabel={t(`languages.${lang}`)}
+                  />
+                  <Typography variant="interface">{t(`languages.${lang}`)}</Typography>
+                </XStack>
+              )
+            })}
+          </YStack>
+        </YStack>
+      </YStack>
+    </OnboardingScaffold>
+  )
+}

--- a/apps/app/src/app/onboarding/language.tsx
+++ b/apps/app/src/app/onboarding/language.tsx
@@ -25,8 +25,6 @@ export default function OnboardingLanguageScreen() {
   const setLanguage = usePreferencesStore((s) => s.setLanguage)
   const storedKnown = usePreferencesStore((s) => s.knownLanguages)
   const setKnownLanguages = usePreferencesStore((s) => s.setKnownLanguages)
-  const setContentLanguage = usePreferencesStore((s) => s.setContentLanguage)
-  const setSecondaryLanguage = usePreferencesStore((s) => s.setSecondaryLanguage)
 
   // The interface language is always one you know; seed the pool with it.
   const interfaceContent = language as ContentLanguage
@@ -46,13 +44,9 @@ export default function OnboardingLanguageScreen() {
   }
 
   function persistAndAdvance() {
+    // setKnownLanguages also derives the primary + secondary display languages.
     const list = allContentLanguages.filter((l) => known.has(l) || l === interfaceContent)
     setKnownLanguages(list)
-    // The renderer shows two languages today: primary + one secondary, derived
-    // from the pool (interface language leads; first other known language pairs).
-    const primary = allContentLanguages.includes(interfaceContent) ? interfaceContent : list[0]
-    setContentLanguage(primary)
-    setSecondaryLanguage(list.find((l) => l !== primary))
     router.push(nextRoute('language'))
   }
 

--- a/apps/app/src/app/onboarding/notifications.tsx
+++ b/apps/app/src/app/onboarding/notifications.tsx
@@ -1,0 +1,76 @@
+import { useRouter } from 'expo-router'
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { YStack } from 'tamagui'
+
+import { Card } from '@/components/Card'
+import { Typography } from '@/components/typography'
+import { nextRoute, OnboardingScaffold, stepProgress } from '@/features/onboarding'
+import { useSlots, useUpdateSlot } from '@/features/plan-of-life'
+import { requestNotificationPermission } from '@/lib/notifications'
+
+const notifyOn = JSON.stringify({ enabled: true, reminders: [{ offset: 0 }] })
+
+export default function OnboardingNotificationsScreen() {
+  const { t } = useTranslation()
+  const router = useRouter()
+  const slots = useSlots()
+  const updateSlot = useUpdateSlot()
+  const [busy, setBusy] = useState(false)
+
+  // useSlots() already returns enabled, non-archived slots; keep those with a time.
+  const timed = useMemo(() => slots.filter((s) => s.time), [slots])
+  const times = useMemo(
+    () => [...new Set(timed.map((s) => s.time).filter(Boolean))].sort(),
+    [timed],
+  ) as string[]
+
+  const advance = () => router.push(nextRoute('notifications'))
+
+  async function enable() {
+    if (busy) return
+    setBusy(true)
+    try {
+      const granted = await requestNotificationPermission()
+      if (granted) {
+        // Writing notify config triggers resyncReminders (useUpdateSlot.onSuccess).
+        for (const slot of timed) {
+          await updateSlot.mutateAsync({ id: slot.id, data: { notify: notifyOn } })
+        }
+      }
+    } finally {
+      setBusy(false)
+      advance()
+    }
+  }
+
+  return (
+    <OnboardingScaffold
+      title={t('onboarding.notifications.title')}
+      subtitle={t('onboarding.notifications.subtitle')}
+      progress={stepProgress('notifications')}
+      continueLabel={t('onboarding.notifications.enable')}
+      onContinue={enable}
+      continueDisabled={busy}
+      onSkip={advance}
+      skipLabel={t('common.notNow')}
+    >
+      <YStack gap="$md">
+        {times.length > 0 ? (
+          <Card>
+            <YStack gap="$xs">
+              <Typography variant="reference" tone="muted">
+                {t('onboarding.notifications.timesLabel')}
+              </Typography>
+              <Typography variant="interface" fontSize="$3">
+                {times.join('  ·  ')}
+              </Typography>
+            </YStack>
+          </Card>
+        ) : (
+          <Typography variant="whisper">{t('onboarding.notifications.noTimes')}</Typography>
+        )}
+      </YStack>
+    </OnboardingScaffold>
+  )
+}

--- a/apps/app/src/app/onboarding/plan.tsx
+++ b/apps/app/src/app/onboarding/plan.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/features/onboarding'
 import { AdoptSheet } from '@/features/templates/AdoptSheet'
 import { useTemplateList, useTemplateManifest } from '@/features/templates/hooks'
+import { lightTap, selectionTick } from '@/lib/haptics'
 import { localizeContent } from '@/lib/i18n'
 
 function bareTemplateId(id: string): string {
@@ -70,7 +71,10 @@ export default function OnboardingPlanScreen() {
           return (
             <AnimatedPressable
               key={id}
-              onPress={() => setSelected(id)}
+              onPress={() => {
+                selectionTick()
+                setSelected(id)
+              }}
               accessibilityRole="radio"
               accessibilityState={{ selected: isSelected }}
               accessibilityLabel={name}
@@ -97,7 +101,11 @@ export default function OnboardingPlanScreen() {
         })}
 
         <AnimatedPressable
-          onPress={() => manifest.data && setSheetOpen(true)}
+          onPress={() => {
+            if (!manifest.data) return
+            lightTap()
+            setSheetOpen(true)
+          }}
           accessibilityRole="button"
           accessibilityState={{ disabled: !manifest.data }}
           accessibilityLabel={t('onboarding.plan.preview')}

--- a/apps/app/src/app/onboarding/plan.tsx
+++ b/apps/app/src/app/onboarding/plan.tsx
@@ -1,0 +1,130 @@
+import { useRouter } from 'expo-router'
+import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { YStack } from 'tamagui'
+
+import { AnimatedPressable } from '@/components/AnimatedPressable'
+import { Card } from '@/components/Card'
+import { Typography } from '@/components/typography'
+import {
+  completeOnboarding,
+  nextRoute,
+  OnboardingScaffold,
+  recommendTemplates,
+  stepProgress,
+  useOnboardingState,
+} from '@/features/onboarding'
+import { AdoptSheet } from '@/features/templates/AdoptSheet'
+import { useTemplateList, useTemplateManifest } from '@/features/templates/hooks'
+import { localizeContent } from '@/lib/i18n'
+
+function bareTemplateId(id: string): string {
+  return id.slice(id.indexOf('/') + 1)
+}
+
+export default function OnboardingPlanScreen() {
+  const { t } = useTranslation()
+  const router = useRouter()
+  const { prayerStage, formationStage, time } = useOnboardingState()
+  const templates = useTemplateList()
+
+  const rec = useMemo(
+    () => recommendTemplates({ prayerStage, formationStage, time }),
+    [prayerStage, formationStage, time],
+  )
+
+  // Show the recommended template first, then the others worth considering.
+  const order = useMemo(() => {
+    const ids = [rec.primary, ...rec.alsoConsider]
+    return [...new Set(ids)]
+  }, [rec])
+
+  const byBareId = useMemo(() => {
+    const map = new Map<string, (typeof templates)[number]>()
+    for (const item of templates) map.set(bareTemplateId(item.id), item)
+    return map
+  }, [templates])
+
+  const [selected, setSelected] = useState(rec.primary)
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const manifest = useTemplateManifest(selected)
+
+  const advance = () => router.push(nextRoute('plan'))
+
+  return (
+    <OnboardingScaffold
+      title={t('onboarding.plan.title')}
+      subtitle={t('onboarding.plan.subtitle')}
+      progress={stepProgress('plan')}
+      continueLabel={t('common.continue')}
+      onContinue={advance}
+      onSkip={completeOnboarding}
+    >
+      <YStack gap="$md">
+        {order.map((id) => {
+          const item = byBareId.get(id)
+          if (!item) return null
+          const isSelected = id === selected
+          const name = item.entry.name ? localizeContent(item.entry.name) : id
+          const description = item.entry.description ? localizeContent(item.entry.description) : ''
+          return (
+            <AnimatedPressable
+              key={id}
+              onPress={() => setSelected(id)}
+              accessibilityRole="radio"
+              accessibilityState={{ selected: isSelected }}
+              accessibilityLabel={name}
+            >
+              <Card ornate={isSelected}>
+                <YStack gap="$xs">
+                  <Typography
+                    variant="label"
+                    fontSize="$3"
+                    color={isSelected ? '$accent' : undefined}
+                  >
+                    {name}
+                  </Typography>
+                  <Typography variant="whisper">{description}</Typography>
+                  {id === rec.primary ? (
+                    <Typography variant="reference" color="$accent">
+                      {t('onboarding.plan.recommended')}
+                    </Typography>
+                  ) : null}
+                </YStack>
+              </Card>
+            </AnimatedPressable>
+          )
+        })}
+
+        <AnimatedPressable
+          onPress={() => manifest.data && setSheetOpen(true)}
+          accessibilityRole="button"
+          accessibilityState={{ disabled: !manifest.data }}
+          accessibilityLabel={t('onboarding.plan.preview')}
+        >
+          <YStack
+            borderWidth={1}
+            borderColor="$accent"
+            borderRadius="$md"
+            padding="$md"
+            alignItems="center"
+            opacity={manifest.data ? 1 : 0.45}
+          >
+            <Typography variant="label" fontSize="$3" color="$accent">
+              {t('onboarding.plan.preview')}
+            </Typography>
+          </YStack>
+        </AnimatedPressable>
+      </YStack>
+
+      {manifest.data ? (
+        <AdoptSheet
+          template={manifest.data}
+          open={sheetOpen}
+          onClose={() => setSheetOpen(false)}
+          onAdopted={advance}
+        />
+      ) : null}
+    </OnboardingScaffold>
+  )
+}

--- a/apps/app/src/app/onboarding/profiler.tsx
+++ b/apps/app/src/app/onboarding/profiler.tsx
@@ -1,0 +1,68 @@
+import { useRouter } from 'expo-router'
+import { useTranslation } from 'react-i18next'
+import { YStack } from 'tamagui'
+
+import { PillSelector } from '@/components/PillSelector'
+import {
+  completeOnboarding,
+  type FormationStage,
+  nextRoute,
+  OnboardingScaffold,
+  type PrayerStage,
+  stepProgress,
+  type TimeAvailable,
+  useOnboardingState,
+} from '@/features/onboarding'
+
+export default function OnboardingProfilerScreen() {
+  const { t } = useTranslation()
+  const router = useRouter()
+  const { prayerStage, formationStage, time, setAnswers } = useOnboardingState()
+
+  const prayerOptions: { value: PrayerStage; label: string }[] = [
+    { value: 'new', label: t('onboarding.profiler.prayer.new') },
+    { value: 'some', label: t('onboarding.profiler.prayer.some') },
+    { value: 'experienced', label: t('onboarding.profiler.prayer.experienced') },
+  ]
+  const formationOptions: { value: FormationStage; label: string }[] = [
+    { value: 'new', label: t('onboarding.profiler.formation.new') },
+    { value: 'some', label: t('onboarding.profiler.formation.some') },
+    { value: 'formed', label: t('onboarding.profiler.formation.formed') },
+  ]
+  const timeOptions: { value: TimeAvailable; label: string }[] = [
+    { value: 'short', label: t('onboarding.profiler.time.short') },
+    { value: 'medium', label: t('onboarding.profiler.time.medium') },
+    { value: 'long', label: t('onboarding.profiler.time.long') },
+  ]
+
+  return (
+    <OnboardingScaffold
+      title={t('onboarding.profiler.title')}
+      subtitle={t('onboarding.profiler.subtitle')}
+      progress={stepProgress('profiler')}
+      onContinue={() => router.push(nextRoute('profiler'))}
+      onSkip={completeOnboarding}
+    >
+      <YStack gap="$lg">
+        <PillSelector
+          label={t('onboarding.profiler.prayer.question')}
+          options={prayerOptions}
+          value={prayerStage ?? ('' as PrayerStage)}
+          onChange={(v) => setAnswers({ prayerStage: v })}
+        />
+        <PillSelector
+          label={t('onboarding.profiler.formation.question')}
+          options={formationOptions}
+          value={formationStage ?? ('' as FormationStage)}
+          onChange={(v) => setAnswers({ formationStage: v })}
+        />
+        <PillSelector
+          label={t('onboarding.profiler.time.question')}
+          options={timeOptions}
+          value={time ?? ('' as TimeAvailable)}
+          onChange={(v) => setAnswers({ time: v })}
+        />
+      </YStack>
+    </OnboardingScaffold>
+  )
+}

--- a/apps/app/src/components/PillSelector.tsx
+++ b/apps/app/src/components/PillSelector.tsx
@@ -1,5 +1,7 @@
-import { Pressable } from 'react-native'
 import { Text, XStack, YStack } from 'tamagui'
+
+import { AnimatedPressable } from '@/components/AnimatedPressable'
+import { selectionTick } from '@/lib/haptics'
 
 export function PillSelector<T extends string>({
   label,
@@ -21,9 +23,12 @@ export function PillSelector<T extends string>({
         {options.map((opt) => {
           const selected = value === opt.value
           return (
-            <Pressable
+            <AnimatedPressable
               key={opt.value}
-              onPress={() => onChange(opt.value)}
+              onPress={() => {
+                selectionTick()
+                onChange(opt.value)
+              }}
               accessibilityRole="radio"
               accessibilityLabel={opt.label}
               accessibilityState={{ selected }}
@@ -39,7 +44,7 @@ export function PillSelector<T extends string>({
                   {opt.label}
                 </Text>
               </YStack>
-            </Pressable>
+            </AnimatedPressable>
           )
         })}
       </XStack>

--- a/apps/app/src/features/onboarding/IntroSlides.tsx
+++ b/apps/app/src/features/onboarding/IntroSlides.tsx
@@ -5,6 +5,7 @@ import { YStack } from 'tamagui'
 
 import { ScreenLayout } from '@/components/ScreenLayout'
 import { Typography } from '@/components/typography'
+import { selectionTick } from '@/lib/haptics'
 import { PrimaryButton, SkipButton } from './OnboardingButtons'
 import { Dots } from './OnboardingProgress'
 
@@ -32,6 +33,10 @@ export function IntroSlides({
   const [width, setWidth] = useState(0)
   const [active, setActive] = useState(0)
   const listRef = useRef<FlatList<Slide>>(null)
+  // Tracks the last index we reacted to, and whether the move was button-driven
+  // (so a page turn ticks only on a real swipe — the Continue button already taps).
+  const lastIndex = useRef(0)
+  const buttonDriven = useRef(false)
   const isLast = active >= slides.length - 1
 
   const onLayout = useCallback((e: LayoutChangeEvent) => {
@@ -41,14 +46,22 @@ export function IntroSlides({
   const onScroll = useCallback(
     (e: { nativeEvent: { contentOffset: { x: number } } }) => {
       if (width <= 0) return
-      const i = Math.round(e.nativeEvent.contentOffset.x / width)
-      setActive(Math.max(0, Math.min(i, slides.length - 1)))
+      const i = Math.max(
+        0,
+        Math.min(Math.round(e.nativeEvent.contentOffset.x / width), slides.length - 1),
+      )
+      if (i === lastIndex.current) return
+      lastIndex.current = i
+      setActive(i)
+      if (buttonDriven.current) buttonDriven.current = false
+      else selectionTick()
     },
     [width, slides.length],
   )
 
   const primary = () => {
     if (isLast) return onDone()
+    buttonDriven.current = true
     listRef.current?.scrollToOffset({ offset: (active + 1) * width, animated: true })
   }
 

--- a/apps/app/src/features/onboarding/IntroSlides.tsx
+++ b/apps/app/src/features/onboarding/IntroSlides.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { FlatList, type LayoutChangeEvent } from 'react-native'
+import { View, XStack, YStack } from 'tamagui'
+
+import { AnimatedPressable } from '@/components/AnimatedPressable'
+import { ScreenLayout } from '@/components/ScreenLayout'
+import { Typography } from '@/components/typography'
+
+type Slide = { title: string; body: string }
+
+// Decorative manuscript glyphs, one per slide (rationed gold ceremonial rung).
+const glyphs = ['✦', '❦', '✠', '✣', '❧']
+
+/**
+ * The features-overview carousel — a few reverent, swipeable slides. Used both as
+ * the first onboarding step and, in `revisit` mode, from Settings (Done returns,
+ * no skip, no flow advance).
+ */
+export function IntroSlides({
+  onDone,
+  onSkip,
+  revisit = false,
+}: {
+  onDone: () => void
+  onSkip?: () => void
+  revisit?: boolean
+}) {
+  const { t } = useTranslation()
+  const slides = t('onboarding.intro.slides', { returnObjects: true }) as Slide[]
+  const [width, setWidth] = useState(0)
+  const [active, setActive] = useState(0)
+  const listRef = useRef<FlatList<Slide>>(null)
+  const isLast = active >= slides.length - 1
+
+  const onLayout = useCallback((e: LayoutChangeEvent) => {
+    setWidth(e.nativeEvent.layout.width)
+  }, [])
+
+  const onScroll = useCallback(
+    (e: { nativeEvent: { contentOffset: { x: number } } }) => {
+      if (width <= 0) return
+      const i = Math.round(e.nativeEvent.contentOffset.x / width)
+      setActive(Math.max(0, Math.min(i, slides.length - 1)))
+    },
+    [width, slides.length],
+  )
+
+  const primary = () => {
+    if (isLast) return onDone()
+    listRef.current?.scrollToOffset({ offset: (active + 1) * width, animated: true })
+  }
+
+  const primaryLabel = isLast
+    ? revisit
+      ? t('common.done')
+      : t('onboarding.intro.getStarted')
+    : t('common.continue')
+
+  return (
+    <ScreenLayout scroll={false} modal>
+      <YStack flex={1} paddingVertical="$lg" gap="$lg">
+        <YStack flex={1} onLayout={onLayout}>
+          {width > 0 ? (
+            <FlatList
+              ref={listRef}
+              data={slides}
+              keyExtractor={(_, i) => String(i)}
+              horizontal
+              pagingEnabled
+              showsHorizontalScrollIndicator={false}
+              onScroll={onScroll}
+              scrollEventThrottle={16}
+              renderItem={({ item, index }) => (
+                <YStack
+                  width={width}
+                  flex={1}
+                  alignItems="center"
+                  justifyContent="center"
+                  gap="$lg"
+                  paddingHorizontal="$md"
+                >
+                  <Typography variant="ceremonial" fontSize={56} lineHeight={64}>
+                    {glyphs[index % glyphs.length]}
+                  </Typography>
+                  <Typography variant="sacred-title" fontSize={30} textAlign="center">
+                    {item.title}
+                  </Typography>
+                  <Typography variant="whisper" textAlign="center" fontSize="$3" maxWidth={360}>
+                    {item.body}
+                  </Typography>
+                </YStack>
+              )}
+            />
+          ) : null}
+        </YStack>
+
+        <XStack gap="$xs" justifyContent="center" alignItems="center">
+          {slides.map((_, i) => (
+            <View
+              // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length static dots
+              key={i}
+              width={i === active ? 18 : 6}
+              height={6}
+              borderRadius={3}
+              backgroundColor={i === active ? '$accent' : '$accentSubtle'}
+            />
+          ))}
+        </XStack>
+
+        <YStack gap="$sm">
+          <AnimatedPressable
+            onPress={primary}
+            accessibilityRole="button"
+            accessibilityLabel={primaryLabel}
+          >
+            <YStack backgroundColor="$accent" borderRadius="$md" padding="$md" alignItems="center">
+              <Typography variant="label" fontSize="$3" color="$background">
+                {primaryLabel}
+              </Typography>
+            </YStack>
+          </AnimatedPressable>
+
+          {!revisit && onSkip ? (
+            <AnimatedPressable
+              onPress={onSkip}
+              accessibilityRole="button"
+              accessibilityLabel={t('common.skip')}
+            >
+              <YStack padding="$sm" alignItems="center">
+                <Typography variant="whisper">{t('common.skip')}</Typography>
+              </YStack>
+            </AnimatedPressable>
+          ) : null}
+        </YStack>
+      </YStack>
+    </ScreenLayout>
+  )
+}

--- a/apps/app/src/features/onboarding/IntroSlides.tsx
+++ b/apps/app/src/features/onboarding/IntroSlides.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { FlatList, type LayoutChangeEvent } from 'react-native'
-import { View, XStack, YStack } from 'tamagui'
+import { YStack } from 'tamagui'
 
-import { AnimatedPressable } from '@/components/AnimatedPressable'
 import { ScreenLayout } from '@/components/ScreenLayout'
 import { Typography } from '@/components/typography'
+import { PrimaryButton, SkipButton } from './OnboardingButtons'
+import { Dots } from './OnboardingProgress'
 
 type Slide = { title: string; body: string }
 
@@ -95,43 +96,11 @@ export function IntroSlides({
           ) : null}
         </YStack>
 
-        <XStack gap="$xs" justifyContent="center" alignItems="center">
-          {slides.map((_, i) => (
-            <View
-              // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length static dots
-              key={i}
-              width={i === active ? 18 : 6}
-              height={6}
-              borderRadius={3}
-              backgroundColor={i === active ? '$accent' : '$accentSubtle'}
-            />
-          ))}
-        </XStack>
+        <Dots count={slides.length} activeIndex={active} fill={false} />
 
         <YStack gap="$sm">
-          <AnimatedPressable
-            onPress={primary}
-            accessibilityRole="button"
-            accessibilityLabel={primaryLabel}
-          >
-            <YStack backgroundColor="$accent" borderRadius="$md" padding="$md" alignItems="center">
-              <Typography variant="label" fontSize="$3" color="$background">
-                {primaryLabel}
-              </Typography>
-            </YStack>
-          </AnimatedPressable>
-
-          {!revisit && onSkip ? (
-            <AnimatedPressable
-              onPress={onSkip}
-              accessibilityRole="button"
-              accessibilityLabel={t('common.skip')}
-            >
-              <YStack padding="$sm" alignItems="center">
-                <Typography variant="whisper">{t('common.skip')}</Typography>
-              </YStack>
-            </AnimatedPressable>
-          ) : null}
+          <PrimaryButton label={primaryLabel} onPress={primary} />
+          {!revisit && onSkip ? <SkipButton onPress={onSkip} /> : null}
         </YStack>
       </YStack>
     </ScreenLayout>

--- a/apps/app/src/features/onboarding/OnboardingButtons.tsx
+++ b/apps/app/src/features/onboarding/OnboardingButtons.tsx
@@ -3,20 +3,34 @@ import { YStack } from 'tamagui'
 
 import { AnimatedPressable } from '@/components/AnimatedPressable'
 import { Typography } from '@/components/typography'
+import { lightTap, selectionTick, successBuzz } from '@/lib/haptics'
 
-/** The gold primary CTA shared across every onboarding step. */
+/**
+ * The gold primary CTA shared across every onboarding step. Fires a light tap on
+ * press; the final "Begin" step passes `haptic="success"` for a heavier flourish.
+ */
 export function PrimaryButton({
   label,
   onPress,
   disabled,
+  haptic = 'tap',
 }: {
   label: string
   onPress: () => void
   disabled?: boolean
+  haptic?: 'tap' | 'success'
 }) {
   return (
     <AnimatedPressable
-      onPress={disabled ? undefined : onPress}
+      onPress={
+        disabled
+          ? undefined
+          : () => {
+              if (haptic === 'success') successBuzz()
+              else lightTap()
+              onPress()
+            }
+      }
       accessibilityRole="button"
       accessibilityState={{ disabled: !!disabled }}
       accessibilityLabel={label}
@@ -41,7 +55,14 @@ export function SkipButton({ label, onPress }: { label?: string; onPress: () => 
   const { t } = useTranslation()
   const text = label ?? t('common.skip')
   return (
-    <AnimatedPressable onPress={onPress} accessibilityRole="button" accessibilityLabel={text}>
+    <AnimatedPressable
+      onPress={() => {
+        selectionTick()
+        onPress()
+      }}
+      accessibilityRole="button"
+      accessibilityLabel={text}
+    >
       <YStack padding="$sm" alignItems="center">
         <Typography variant="whisper">{text}</Typography>
       </YStack>

--- a/apps/app/src/features/onboarding/OnboardingButtons.tsx
+++ b/apps/app/src/features/onboarding/OnboardingButtons.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from 'react-i18next'
+import { YStack } from 'tamagui'
+
+import { AnimatedPressable } from '@/components/AnimatedPressable'
+import { Typography } from '@/components/typography'
+
+/** The gold primary CTA shared across every onboarding step. */
+export function PrimaryButton({
+  label,
+  onPress,
+  disabled,
+}: {
+  label: string
+  onPress: () => void
+  disabled?: boolean
+}) {
+  return (
+    <AnimatedPressable
+      onPress={disabled ? undefined : onPress}
+      accessibilityRole="button"
+      accessibilityState={{ disabled: !!disabled }}
+      accessibilityLabel={label}
+    >
+      <YStack
+        backgroundColor="$accent"
+        borderRadius="$md"
+        padding="$md"
+        alignItems="center"
+        opacity={disabled ? 0.45 : 1}
+      >
+        <Typography variant="label" fontSize="$3" color="$background">
+          {label}
+        </Typography>
+      </YStack>
+    </AnimatedPressable>
+  )
+}
+
+/** The quiet secondary action (Skip / Not now). Defaults its label to "Skip". */
+export function SkipButton({ label, onPress }: { label?: string; onPress: () => void }) {
+  const { t } = useTranslation()
+  const text = label ?? t('common.skip')
+  return (
+    <AnimatedPressable onPress={onPress} accessibilityRole="button" accessibilityLabel={text}>
+      <YStack padding="$sm" alignItems="center">
+        <Typography variant="whisper">{text}</Typography>
+      </YStack>
+    </AnimatedPressable>
+  )
+}

--- a/apps/app/src/features/onboarding/OnboardingProgress.tsx
+++ b/apps/app/src/features/onboarding/OnboardingProgress.tsx
@@ -1,11 +1,24 @@
 import { View, XStack } from 'tamagui'
 
-/** A quiet row of dots marking position in the onboarding flow. */
-export function OnboardingProgress({ index, total }: { index: number; total: number }) {
+/**
+ * A row of dots. `fill` (default) lights every dot up to the active one — a
+ * progress bar; with `fill={false}` only the active dot lights — a carousel
+ * position indicator. The active dot is always widened.
+ */
+export function Dots({
+  count,
+  activeIndex,
+  fill = true,
+}: {
+  count: number
+  activeIndex: number
+  fill?: boolean
+}) {
   return (
     <XStack gap="$xs" justifyContent="center" alignItems="center" accessibilityRole="progressbar">
-      {Array.from({ length: total }, (_, i) => {
-        const active = i + 1 === index
+      {Array.from({ length: count }, (_, i) => {
+        const active = i === activeIndex
+        const on = fill ? i <= activeIndex : active
         return (
           <View
             // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length static dots
@@ -13,10 +26,15 @@ export function OnboardingProgress({ index, total }: { index: number; total: num
             width={active ? 18 : 6}
             height={6}
             borderRadius={3}
-            backgroundColor={i + 1 <= index ? '$accent' : '$accentSubtle'}
+            backgroundColor={on ? '$accent' : '$accentSubtle'}
           />
         )
       })}
     </XStack>
   )
+}
+
+/** Step progress for the onboarding scaffold (1-based step of total). */
+export function OnboardingProgress({ index, total }: { index: number; total: number }) {
+  return <Dots count={total} activeIndex={index - 1} />
 }

--- a/apps/app/src/features/onboarding/OnboardingProgress.tsx
+++ b/apps/app/src/features/onboarding/OnboardingProgress.tsx
@@ -1,4 +1,44 @@
-import { View, XStack } from 'tamagui'
+import { useEffect } from 'react'
+import Animated, {
+  interpolateColor,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from 'react-native-reanimated'
+import { useTheme, XStack } from 'tamagui'
+
+import { calmSpring } from '@/config/animation'
+
+/** A single dot that springs its width and tweens its fill as state changes. */
+function Dot({
+  active,
+  on,
+  onColor,
+  offColor,
+}: {
+  active: boolean
+  on: boolean
+  onColor: string
+  offColor: string
+}) {
+  const width = useSharedValue(active ? 18 : 6)
+  const progress = useSharedValue(on ? 1 : 0)
+
+  useEffect(() => {
+    width.value = withSpring(active ? 18 : 6, calmSpring)
+  }, [active, width])
+  useEffect(() => {
+    progress.value = withTiming(on ? 1 : 0, { duration: 200 })
+  }, [on, progress])
+
+  const style = useAnimatedStyle(() => ({
+    width: width.value,
+    backgroundColor: interpolateColor(progress.value, [0, 1], [offColor, onColor]),
+  }))
+
+  return <Animated.View style={[{ height: 6, borderRadius: 3 }, style]} />
+}
 
 /**
  * A row of dots. `fill` (default) lights every dot up to the active one — a
@@ -14,22 +54,22 @@ export function Dots({
   activeIndex: number
   fill?: boolean
 }) {
+  const theme = useTheme()
+  const onColor = theme.accent.val
+  const offColor = theme.accentSubtle.val
+
   return (
     <XStack gap="$xs" justifyContent="center" alignItems="center" accessibilityRole="progressbar">
-      {Array.from({ length: count }, (_, i) => {
-        const active = i === activeIndex
-        const on = fill ? i <= activeIndex : active
-        return (
-          <View
-            // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length static dots
-            key={i}
-            width={active ? 18 : 6}
-            height={6}
-            borderRadius={3}
-            backgroundColor={on ? '$accent' : '$accentSubtle'}
-          />
-        )
-      })}
+      {Array.from({ length: count }, (_, i) => (
+        <Dot
+          // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length static dots
+          key={i}
+          active={i === activeIndex}
+          on={fill ? i <= activeIndex : i === activeIndex}
+          onColor={onColor}
+          offColor={offColor}
+        />
+      ))}
     </XStack>
   )
 }

--- a/apps/app/src/features/onboarding/OnboardingProgress.tsx
+++ b/apps/app/src/features/onboarding/OnboardingProgress.tsx
@@ -1,0 +1,22 @@
+import { View, XStack } from 'tamagui'
+
+/** A quiet row of dots marking position in the onboarding flow. */
+export function OnboardingProgress({ index, total }: { index: number; total: number }) {
+  return (
+    <XStack gap="$xs" justifyContent="center" alignItems="center" accessibilityRole="progressbar">
+      {Array.from({ length: total }, (_, i) => {
+        const active = i + 1 === index
+        return (
+          <View
+            // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length static dots
+            key={i}
+            width={active ? 18 : 6}
+            height={6}
+            borderRadius={3}
+            backgroundColor={i + 1 <= index ? '$accent' : '$accentSubtle'}
+          />
+        )
+      })}
+    </XStack>
+  )
+}

--- a/apps/app/src/features/onboarding/OnboardingScaffold.tsx
+++ b/apps/app/src/features/onboarding/OnboardingScaffold.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ScrollView, YStack } from 'tamagui'
+
+import { AnimatedPressable } from '@/components/AnimatedPressable'
+import { PageHeader } from '@/components/PageHeader'
+import { ScreenLayout } from '@/components/ScreenLayout'
+import { Typography } from '@/components/typography'
+
+import { OnboardingProgress } from './OnboardingProgress'
+
+/**
+ * Shared chrome for the onboarding input steps: progress dots, a left-aligned
+ * title + optional subtitle, a scrollable content area, and a fixed footer with
+ * a primary Continue and a quiet Skip. The intro and done screens render their
+ * own full-bleed layout instead.
+ */
+export function OnboardingScaffold({
+  title,
+  subtitle,
+  progress,
+  children,
+  continueLabel,
+  onContinue,
+  continueDisabled,
+  onSkip,
+  skipLabel,
+}: {
+  title: string
+  subtitle?: string
+  progress?: { index: number; total: number }
+  children: ReactNode
+  continueLabel?: string
+  onContinue: () => void
+  continueDisabled?: boolean
+  onSkip: () => void
+  skipLabel?: string
+}) {
+  const { t } = useTranslation()
+
+  return (
+    <ScreenLayout scroll={false} modal>
+      <YStack flex={1} paddingVertical="$lg" gap="$lg">
+        {progress ? <OnboardingProgress index={progress.index} total={progress.total} /> : null}
+
+        <ScrollView flex={1} showsVerticalScrollIndicator={false}>
+          <YStack gap="$lg" paddingBottom="$lg">
+            <YStack gap="$sm">
+              <PageHeader title={title} />
+              {subtitle ? <Typography variant="whisper">{subtitle}</Typography> : null}
+            </YStack>
+            {children}
+          </YStack>
+        </ScrollView>
+
+        <YStack gap="$sm">
+          <AnimatedPressable
+            onPress={continueDisabled ? undefined : onContinue}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: !!continueDisabled }}
+            accessibilityLabel={continueLabel ?? t('common.continue')}
+          >
+            <YStack
+              backgroundColor="$accent"
+              borderRadius="$md"
+              padding="$md"
+              alignItems="center"
+              opacity={continueDisabled ? 0.45 : 1}
+            >
+              <Typography variant="label" fontSize="$3" color="$background">
+                {continueLabel ?? t('common.continue')}
+              </Typography>
+            </YStack>
+          </AnimatedPressable>
+
+          <AnimatedPressable
+            onPress={onSkip}
+            accessibilityRole="button"
+            accessibilityLabel={skipLabel ?? t('common.skip')}
+          >
+            <YStack padding="$sm" alignItems="center">
+              <Typography variant="whisper">{skipLabel ?? t('common.skip')}</Typography>
+            </YStack>
+          </AnimatedPressable>
+        </YStack>
+      </YStack>
+    </ScreenLayout>
+  )
+}

--- a/apps/app/src/features/onboarding/OnboardingScaffold.tsx
+++ b/apps/app/src/features/onboarding/OnboardingScaffold.tsx
@@ -2,11 +2,10 @@ import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, YStack } from 'tamagui'
 
-import { AnimatedPressable } from '@/components/AnimatedPressable'
 import { PageHeader } from '@/components/PageHeader'
 import { ScreenLayout } from '@/components/ScreenLayout'
 import { Typography } from '@/components/typography'
-
+import { PrimaryButton, SkipButton } from './OnboardingButtons'
 import { OnboardingProgress } from './OnboardingProgress'
 
 /**
@@ -54,34 +53,12 @@ export function OnboardingScaffold({
         </ScrollView>
 
         <YStack gap="$sm">
-          <AnimatedPressable
-            onPress={continueDisabled ? undefined : onContinue}
-            accessibilityRole="button"
-            accessibilityState={{ disabled: !!continueDisabled }}
-            accessibilityLabel={continueLabel ?? t('common.continue')}
-          >
-            <YStack
-              backgroundColor="$accent"
-              borderRadius="$md"
-              padding="$md"
-              alignItems="center"
-              opacity={continueDisabled ? 0.45 : 1}
-            >
-              <Typography variant="label" fontSize="$3" color="$background">
-                {continueLabel ?? t('common.continue')}
-              </Typography>
-            </YStack>
-          </AnimatedPressable>
-
-          <AnimatedPressable
-            onPress={onSkip}
-            accessibilityRole="button"
-            accessibilityLabel={skipLabel ?? t('common.skip')}
-          >
-            <YStack padding="$sm" alignItems="center">
-              <Typography variant="whisper">{skipLabel ?? t('common.skip')}</Typography>
-            </YStack>
-          </AnimatedPressable>
+          <PrimaryButton
+            label={continueLabel ?? t('common.continue')}
+            onPress={onContinue}
+            disabled={continueDisabled}
+          />
+          <SkipButton label={skipLabel} onPress={onSkip} />
         </YStack>
       </YStack>
     </ScreenLayout>

--- a/apps/app/src/features/onboarding/index.ts
+++ b/apps/app/src/features/onboarding/index.ts
@@ -1,0 +1,16 @@
+export { IntroSlides } from './IntroSlides'
+export { OnboardingProgress } from './OnboardingProgress'
+export { OnboardingScaffold } from './OnboardingScaffold'
+export {
+  type FormationOption,
+  type FormationOptionId,
+  type FormationStage,
+  formationOptions,
+  type PrayerStage,
+  type ProfilerAnswers,
+  recommendFormation,
+  recommendTemplates,
+  type TimeAvailable,
+} from './recommendations'
+export { completeOnboarding, nextRoute, type OnboardingStep, stepProgress } from './steps'
+export { useOnboardingState } from './useOnboardingState'

--- a/apps/app/src/features/onboarding/index.ts
+++ b/apps/app/src/features/onboarding/index.ts
@@ -1,5 +1,6 @@
 export { IntroSlides } from './IntroSlides'
-export { OnboardingProgress } from './OnboardingProgress'
+export { PrimaryButton, SkipButton } from './OnboardingButtons'
+export { Dots, OnboardingProgress } from './OnboardingProgress'
 export { OnboardingScaffold } from './OnboardingScaffold'
 export {
   type FormationOption,

--- a/apps/app/src/features/onboarding/recommendations.ts
+++ b/apps/app/src/features/onboarding/recommendations.ts
@@ -1,0 +1,84 @@
+// Maps the light profiler answers to a recommended starter template and a
+// default formation reading. Everyone can override — these only set sensible
+// defaults so the first screen isn't a blank catalog.
+
+export type PrayerStage = 'new' | 'some' | 'experienced'
+export type FormationStage = 'new' | 'some' | 'formed'
+export type TimeAvailable = 'short' | 'medium' | 'long'
+
+export type ProfilerAnswers = {
+  prayerStage?: PrayerStage
+  formationStage?: FormationStage
+  time?: TimeAvailable
+}
+
+export type TemplateRecommendation = {
+  /** Bare template id pre-selected for the user (always offered; never forced). */
+  primary: string
+  /** A few other bare template ids worth a look, in priority order. */
+  alsoConsider: string[]
+}
+
+const beginner = 'beginner-minimum'
+
+/**
+ * The beginner's minimum is the default for everyone new; the more a soul has an
+ * established prayer life (and time), the richer the primary suggestion. The full
+ * template browser is always one tap away regardless.
+ */
+export function recommendTemplates(a: ProfilerAnswers): TemplateRecommendation {
+  const stage = a.prayerStage ?? 'new'
+
+  if (stage === 'new') {
+    return { primary: beginner, alsoConsider: ['salesian', 'little-way'] }
+  }
+
+  if (stage === 'some') {
+    return {
+      primary: 'salesian',
+      alsoConsider: [beginner, 'little-way', a.time === 'long' ? 'ignatian' : 'sacred-heart'],
+    }
+  }
+
+  // experienced
+  const rich =
+    a.time === 'long'
+      ? ['opus-dei', 'carmelite', 'ignatian']
+      : ['ignatian', 'sacred-heart', 'salesian']
+  return { primary: rich[0], alsoConsider: [beginner, ...rich.slice(1)] }
+}
+
+// The formation reading options. Morrow + Compendium are real day-by-day programs;
+// the catechisms are plain books (read at your own pace); the CCC is its own reader.
+export type FormationOptionId =
+  | 'catechetical-formation'
+  | 'compendium'
+  | 'ccc'
+  | 'trent-catechism'
+  | 'pius-x-catechism'
+  | 'pius-x-greater-catechism'
+
+export type FormationOption =
+  // Seeded-disabled program practice — enroll = enable its slot.
+  | { id: FormationOptionId; kind: 'program-enroll'; practiceId: string }
+  // Program practice with no seeded slot — enroll = create practice + slot.
+  | { id: FormationOptionId; kind: 'program-create'; practiceId: string }
+  // Plain book — pin for offline; no day-by-day plan yet.
+  | { id: FormationOptionId; kind: 'book'; bookId: string }
+  // The Catechism reader — deep-link, no plan.
+  | { id: FormationOptionId; kind: 'ccc' }
+
+export const formationOptions: FormationOption[] = [
+  { id: 'catechetical-formation', kind: 'program-enroll', practiceId: 'catechetical-formation' },
+  { id: 'compendium', kind: 'program-create', practiceId: 'compendium' },
+  { id: 'ccc', kind: 'ccc' },
+  { id: 'pius-x-catechism', kind: 'book', bookId: 'book/pius-x-catechism' },
+  { id: 'pius-x-greater-catechism', kind: 'book', bookId: 'book/pius-x-greater-catechism' },
+  { id: 'trent-catechism', kind: 'book', bookId: 'book/trent-catechism' },
+]
+
+/** The default-nudged formation reading. Morrow for beginners; Compendium once formed. */
+export function recommendFormation(a: ProfilerAnswers): FormationOptionId {
+  if (a.formationStage === 'formed') return 'compendium'
+  return 'catechetical-formation'
+}

--- a/apps/app/src/features/onboarding/steps.ts
+++ b/apps/app/src/features/onboarding/steps.ts
@@ -16,35 +16,27 @@ export const onboardingSteps = [
 
 export type OnboardingStep = (typeof onboardingSteps)[number]
 
-const isWeb = Platform.OS === 'web'
-
-function activeSteps(): OnboardingStep[] {
-  return onboardingSteps.filter((s) => !(isWeb && s === 'notifications'))
-}
-
-function routeFor(step: OnboardingStep): string {
-  return step === 'index' ? '/onboarding' : `/onboarding/${step}`
-}
+// Resolved once: web has no OS notifications, so that step drops out of the flow.
+const activeSteps = onboardingSteps.filter((s) => !(Platform.OS === 'web' && s === 'notifications'))
+// The dot-indicator steps — everything between the intro and the closing screen.
+const contentSteps: OnboardingStep[] = activeSteps.filter((s) => s !== 'index' && s !== 'done')
 
 /** The route to advance to after `current` (skips notifications on web). */
 export function nextRoute(current: OnboardingStep): string {
-  const steps = activeSteps()
-  const i = steps.indexOf(current)
-  const next = steps[i + 1] ?? 'done'
-  return routeFor(next)
+  const next = activeSteps[activeSteps.indexOf(current) + 1] ?? 'done'
+  return next === 'index' ? '/onboarding' : `/onboarding/${next}`
 }
 
 /**
- * Progress for the dot indicator. Shown on the input steps (language → the last
- * step before done); the intro and done screens return undefined (no dots).
+ * Progress for the dot indicator. Shown on the input steps; the intro and done
+ * screens have no dots (returns undefined).
  */
 export function stepProgress(
   current: OnboardingStep,
 ): { index: number; total: number } | undefined {
-  const content: OnboardingStep[] = activeSteps().filter((s) => s !== 'index' && s !== 'done')
-  const i = content.indexOf(current)
+  const i = contentSteps.indexOf(current)
   if (i === -1) return undefined
-  return { index: i + 1, total: content.length }
+  return { index: i + 1, total: contentSteps.length }
 }
 
 /** Marks onboarding complete; the Stack.Protected guard then reveals the tabs. */

--- a/apps/app/src/features/onboarding/steps.ts
+++ b/apps/app/src/features/onboarding/steps.ts
@@ -1,0 +1,54 @@
+import { Platform } from 'react-native'
+import { usePreferencesStore } from '@/stores/preferencesStore'
+import { useOnboardingState } from './useOnboardingState'
+
+// The linear step order. `index` is the intro; `done` closes the flow. The
+// notifications step is native-only (web has no OS notifications).
+export const onboardingSteps = [
+  'index',
+  'language',
+  'profiler',
+  'plan',
+  'formation',
+  'notifications',
+  'done',
+] as const
+
+export type OnboardingStep = (typeof onboardingSteps)[number]
+
+const isWeb = Platform.OS === 'web'
+
+function activeSteps(): OnboardingStep[] {
+  return onboardingSteps.filter((s) => !(isWeb && s === 'notifications'))
+}
+
+function routeFor(step: OnboardingStep): string {
+  return step === 'index' ? '/onboarding' : `/onboarding/${step}`
+}
+
+/** The route to advance to after `current` (skips notifications on web). */
+export function nextRoute(current: OnboardingStep): string {
+  const steps = activeSteps()
+  const i = steps.indexOf(current)
+  const next = steps[i + 1] ?? 'done'
+  return routeFor(next)
+}
+
+/**
+ * Progress for the dot indicator. Shown on the input steps (language → the last
+ * step before done); the intro and done screens return undefined (no dots).
+ */
+export function stepProgress(
+  current: OnboardingStep,
+): { index: number; total: number } | undefined {
+  const content: OnboardingStep[] = activeSteps().filter((s) => s !== 'index' && s !== 'done')
+  const i = content.indexOf(current)
+  if (i === -1) return undefined
+  return { index: i + 1, total: content.length }
+}
+
+/** Marks onboarding complete; the Stack.Protected guard then reveals the tabs. */
+export function completeOnboarding() {
+  useOnboardingState.getState().reset()
+  usePreferencesStore.getState().setHasOnboarded(true)
+}

--- a/apps/app/src/features/onboarding/useOnboardingState.ts
+++ b/apps/app/src/features/onboarding/useOnboardingState.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand'
+
+import type { FormationStage, PrayerStage, TimeAvailable } from './recommendations'
+
+// In-flow state carried across the onboarding step screens (each step is its own
+// route). Ephemeral by design — only the resulting plan, language, and formation
+// choices are persisted, via the preferences store and plan-of-life mutations.
+type OnboardingState = {
+  prayerStage?: PrayerStage
+  formationStage?: FormationStage
+  time?: TimeAvailable
+  setAnswers: (
+    patch: Partial<Pick<OnboardingState, 'prayerStage' | 'formationStage' | 'time'>>,
+  ) => void
+  reset: () => void
+}
+
+export const useOnboardingState = create<OnboardingState>((set) => ({
+  prayerStage: undefined,
+  formationStage: undefined,
+  time: undefined,
+  setAnswers: (patch) => set(patch),
+  reset: () => set({ prayerStage: undefined, formationStage: undefined, time: undefined }),
+}))

--- a/apps/app/src/features/onboarding/useOnboardingState.ts
+++ b/apps/app/src/features/onboarding/useOnboardingState.ts
@@ -15,10 +15,14 @@ type OnboardingState = {
   reset: () => void
 }
 
-export const useOnboardingState = create<OnboardingState>((set) => ({
+const initialAnswers = {
   prayerStage: undefined,
   formationStage: undefined,
   time: undefined,
+} satisfies Partial<OnboardingState>
+
+export const useOnboardingState = create<OnboardingState>((set) => ({
+  ...initialAnswers,
   setAnswers: (patch) => set(patch),
-  reset: () => set({ prayerStage: undefined, formationStage: undefined, time: undefined }),
+  reset: () => set(initialAnswers),
 }))

--- a/apps/app/src/lib/i18n/locales/en-US.ts
+++ b/apps/app/src/lib/i18n/locales/en-US.ts
@@ -802,6 +802,9 @@ export default {
     readingProgress: 'Reading Progress',
     bibleTranslation: 'Bible Translation',
     change: 'Change',
+    view: 'View',
+    tour: 'What is Ember?',
+    tourDescription: 'A short tour of what Ember can do',
     markBooks: 'Mark Books as Already Read',
     updatePosition: 'Update your starting position',
     theme: 'Theme',
@@ -1458,6 +1461,7 @@ export default {
     show: 'Show',
     hide: 'Hide',
     skip: 'Skip',
+    continue: 'Continue',
     done: 'Done',
     notNow: 'Not now',
     justNow: 'just now',
@@ -1469,6 +1473,115 @@ export default {
   error: {
     somethingWrong: 'Something went wrong.',
     tryAgainLater: 'Please try again.',
+  },
+
+  onboarding: {
+    intro: {
+      getStarted: 'Get started',
+      slides: [
+        {
+          title: 'Welcome to Ember',
+          body: 'A companion for the Catholic life of prayer — walking with you, one day at a time.',
+        },
+        {
+          title: 'Build your rule of life',
+          body: 'Shape a daily plan of prayer and devotion, and watch your fidelity grow over time.',
+        },
+        {
+          title: 'Pray, beautifully',
+          body: 'Guided prayers and devotions — from a single Hail Mary to the whole of the Mass.',
+        },
+        {
+          title: 'The whole tradition',
+          body: 'Scripture, the Catechism, the saints, and spiritual classics — in English, Portuguese, and Latin, fully offline.',
+        },
+      ],
+    },
+    language: {
+      title: 'Your languages',
+      subtitle: 'You can change any of this later in Settings.',
+      interface: 'App language',
+      known: 'Languages you read',
+      knownHint: 'Pick every language you can read — prayers can show side by side.',
+    },
+    profiler: {
+      title: 'Where are you?',
+      subtitle: 'A few gentle questions so we can suggest a good starting point. Nothing is fixed.',
+      prayer: {
+        question: 'How is your prayer life right now?',
+        new: 'New to prayer',
+        some: 'I have some habits',
+        experienced: 'Well established',
+      },
+      formation: {
+        question: 'How familiar are you with the faith?',
+        new: 'Just beginning',
+        some: 'I know the basics',
+        formed: 'Well formed',
+      },
+      time: {
+        question: 'How much time can you give each day?',
+        short: 'A few minutes',
+        medium: '10–30 minutes',
+        long: '30 minutes or more',
+      },
+    },
+    plan: {
+      title: 'A starting plan',
+      subtitle:
+        'Inherit a living tradition as a set of practices. You can add, edit, or remove anything later.',
+      recommended: 'Suggested for you',
+      preview: 'Preview & add this plan',
+    },
+    formation: {
+      title: 'A reading to grow by',
+      subtitle:
+        'A formation reading to learn the faith. We suggest one — choose whichever fits you.',
+      recommended: 'Suggested for you',
+      tag: {
+        program: 'Daily plan',
+        book: 'Read at your pace',
+        reader: 'Catechism reader',
+      },
+      options: {
+        'catechetical-formation': {
+          name: 'My Catholic Faith',
+          desc: 'Bishop Morrow’s illustrated catechism — one short lesson a day.',
+        },
+        compendium: {
+          name: 'Compendium of the Catechism',
+          desc: 'The Catechism in question-and-answer form — a hundred days.',
+        },
+        ccc: {
+          name: 'Catechism of the Catholic Church',
+          desc: 'The full Catechism, to read and search at your own pace.',
+        },
+        'pius-x-catechism': {
+          name: 'Catechism of St. Pius X',
+          desc: 'The classic short Q&A catechism.',
+        },
+        'pius-x-greater-catechism': {
+          name: 'Greater Catechism of St. Pius X',
+          desc: 'A fuller catechetical course in the same tradition.',
+        },
+        'trent-catechism': {
+          name: 'Roman Catechism (Trent)',
+          desc: 'The Catechism of the Council of Trent — deep and systematic.',
+        },
+      },
+    },
+    notifications: {
+      title: 'Gentle reminders',
+      subtitle: 'Let Ember nudge you at the times in your plan. No streaks to chase, no guilt.',
+      enable: 'Enable reminders',
+      timesLabel: 'We’ll remind you around',
+      noTimes: 'Your plan has no set times yet — you can add reminders any time later.',
+    },
+    done: {
+      title: 'You’re ready',
+      body: 'Your plan is set. Come back each day — the Lord meets us in the small, faithful things.',
+      begin: 'Begin',
+    },
   },
 
   reminders: {

--- a/apps/app/src/lib/i18n/locales/pt-BR.ts
+++ b/apps/app/src/lib/i18n/locales/pt-BR.ts
@@ -810,6 +810,9 @@ export default {
     readingProgress: 'Progresso de Leitura',
     bibleTranslation: 'Tradu\u00e7\u00e3o da B\u00edblia',
     change: 'Alterar',
+    view: 'Ver',
+    tour: 'O que \u00e9 o Ember?',
+    tourDescription: 'Um breve tour pelo que o Ember faz',
     markBooks: 'Marcar Livros como J\u00e1 Lidos',
     updatePosition: 'Atualize sua posi\u00e7\u00e3o inicial',
     theme: 'Tema',
@@ -1465,6 +1468,7 @@ export default {
     show: 'Mostrar',
     hide: 'Esconder',
     skip: 'Pular',
+    continue: 'Continuar',
     done: 'Concluir',
     notNow: 'Agora não',
     justNow: 'agora mesmo',
@@ -1476,6 +1480,117 @@ export default {
   error: {
     somethingWrong: 'Algo deu errado.',
     tryAgainLater: 'Por favor, tente novamente.',
+  },
+
+  onboarding: {
+    intro: {
+      getStarted: 'Começar',
+      slides: [
+        {
+          title: 'Bem-vindo ao Ember',
+          body: 'Um companheiro para a vida católica de oração — caminhando com você, um dia de cada vez.',
+        },
+        {
+          title: 'Construa seu plano de vida',
+          body: 'Monte um plano diário de oração e devoção, e veja sua fidelidade crescer com o tempo.',
+        },
+        {
+          title: 'Reze com beleza',
+          body: 'Orações e devoções guiadas — de uma simples Ave-Maria à Santa Missa inteira.',
+        },
+        {
+          title: 'Toda a tradição',
+          body: 'Escritura, Catecismo, os santos e os clássicos espirituais — em português, inglês e latim, totalmente offline.',
+        },
+      ],
+    },
+    language: {
+      title: 'Seus idiomas',
+      subtitle: 'Você pode mudar tudo isso depois nas Configurações.',
+      interface: 'Idioma do app',
+      known: 'Idiomas que você lê',
+      knownHint: 'Escolha todos os idiomas que você lê — as orações podem aparecer lado a lado.',
+    },
+    profiler: {
+      title: 'Onde você está?',
+      subtitle:
+        'Algumas perguntas simples para sugerirmos um bom ponto de partida. Nada é definitivo.',
+      prayer: {
+        question: 'Como está sua vida de oração hoje?',
+        new: 'Começando a rezar',
+        some: 'Tenho alguns hábitos',
+        experienced: 'Bem estabelecida',
+      },
+      formation: {
+        question: 'Quão familiarizado você é com a fé?',
+        new: 'Apenas começando',
+        some: 'Conheço o básico',
+        formed: 'Bem formado',
+      },
+      time: {
+        question: 'Quanto tempo pode dedicar por dia?',
+        short: 'Alguns minutos',
+        medium: '10–30 minutos',
+        long: '30 minutos ou mais',
+      },
+    },
+    plan: {
+      title: 'Um plano inicial',
+      subtitle:
+        'Herde uma tradição viva como um conjunto de práticas. Você pode adicionar, editar ou remover qualquer coisa depois.',
+      recommended: 'Sugerido para você',
+      preview: 'Visualizar e adicionar este plano',
+    },
+    formation: {
+      title: 'Uma leitura para crescer',
+      subtitle:
+        'Uma leitura de formação para aprender a fé. Sugerimos uma — escolha a que combina com você.',
+      recommended: 'Sugerido para você',
+      tag: {
+        program: 'Plano diário',
+        book: 'Leia no seu ritmo',
+        reader: 'Leitor do Catecismo',
+      },
+      options: {
+        'catechetical-formation': {
+          name: 'Minha Fé Católica',
+          desc: 'O catecismo ilustrado de Dom Morrow — uma lição curta por dia.',
+        },
+        compendium: {
+          name: 'Compêndio do Catecismo',
+          desc: 'O Catecismo em forma de perguntas e respostas — cem dias.',
+        },
+        ccc: {
+          name: 'Catecismo da Igreja Católica',
+          desc: 'O Catecismo completo, para ler e pesquisar no seu ritmo.',
+        },
+        'pius-x-catechism': {
+          name: 'Catecismo de São Pio X',
+          desc: 'O clássico catecismo curto de perguntas e respostas.',
+        },
+        'pius-x-greater-catechism': {
+          name: 'Catecismo Maior de São Pio X',
+          desc: 'Um curso catequético mais completo na mesma tradição.',
+        },
+        'trent-catechism': {
+          name: 'Catecismo Romano (Trento)',
+          desc: 'O Catecismo do Concílio de Trento — profundo e sistemático.',
+        },
+      },
+    },
+    notifications: {
+      title: 'Lembretes suaves',
+      subtitle:
+        'Deixe o Ember chamá-lo nos horários do seu plano. Sem sequências para perseguir, sem culpa.',
+      enable: 'Ativar lembretes',
+      timesLabel: 'Vamos lembrá-lo por volta de',
+      noTimes: 'Seu plano ainda não tem horários definidos — você pode adicionar lembretes depois.',
+    },
+    done: {
+      title: 'Tudo pronto',
+      body: 'Seu plano está montado. Volte cada dia — o Senhor nos encontra nas pequenas coisas fiéis.',
+      begin: 'Começar',
+    },
   },
 
   reminders: {

--- a/apps/app/src/stores/preferencesStore.ts
+++ b/apps/app/src/stores/preferencesStore.ts
@@ -263,8 +263,20 @@ export const usePreferencesStore = create<PreferencesState>()(
     setKnownLanguages: (langs) => {
       set((state) => {
         state.knownLanguages = langs
+        // Derive the two-language display from the pool: the interface language
+        // leads when it's a content language, else the first known; the
+        // secondary is the next known language, if any.
+        const primary = contentLanguages.includes(state.language as ContentLanguage)
+          ? (state.language as ContentLanguage)
+          : (langs[0] ?? state.contentLanguage)
+        state.contentLanguage = primary
+        state.secondaryLanguage = langs.find((l) => l !== primary)
       })
+      const { contentLanguage, secondaryLanguage } = usePreferencesStore.getState()
       setPreference('known-languages', JSON.stringify(langs))
+      setPreference('content-language', contentLanguage)
+      if (secondaryLanguage) setPreference('secondary-language', secondaryLanguage)
+      else removePreference('secondary-language')
     },
 
     setFontFamily: (id) => {

--- a/apps/app/src/stores/preferencesStore.ts
+++ b/apps/app/src/stores/preferencesStore.ts
@@ -56,6 +56,13 @@ type PreferencesState = {
   // Reader UX
   bookReaderHintSeen: boolean
 
+  // Onboarding
+  hasOnboarded: boolean
+  // The languages the user reads — the pool that drives cross-language content.
+  // The renderer is capped at two languages today (primary + one secondary), so
+  // this is recorded for that derivation and for future N-language rendering.
+  knownLanguages: ContentLanguage[]
+
   // Reading config
   fontFamily: ReadingFontId
   fontSizeStep: number
@@ -87,6 +94,10 @@ type PreferencesState = {
   setReaderPalette: (palette: ReaderPaletteId) => void
   setBookReaderHintSeen: (seen: boolean) => void
 
+  // Onboarding setters
+  setHasOnboarded: (value: boolean) => void
+  setKnownLanguages: (langs: ContentLanguage[]) => void
+
   // Reading config setters
   setFontFamily: (id: ReadingFontId) => void
   setFontSizeStep: (step: number) => void
@@ -114,6 +125,8 @@ export const usePreferencesStore = create<PreferencesState>()(
     theme: 'system',
     readerPalette: 'auto',
     bookReaderHintSeen: false,
+    hasOnboarded: false,
+    knownLanguages: [],
     fontFamily: 'eb-garamond',
     fontSizeStep: 3,
     lineHeightStep: 5,
@@ -240,6 +253,20 @@ export const usePreferencesStore = create<PreferencesState>()(
       setPreference('book-reader-hint-seen', seen ? '1' : '0')
     },
 
+    setHasOnboarded: (value) => {
+      set((state) => {
+        state.hasOnboarded = value
+      })
+      setPreference('has-onboarded', value ? '1' : '0')
+    },
+
+    setKnownLanguages: (langs) => {
+      set((state) => {
+        state.knownLanguages = langs
+      })
+      setPreference('known-languages', JSON.stringify(langs))
+    },
+
     setFontFamily: (id) => {
       set((state) => {
         state.fontFamily = id
@@ -335,6 +362,21 @@ export const usePreferencesStore = create<PreferencesState>()(
         }
 
         if (prefs['book-reader-hint-seen'] === '1') state.bookReaderHintSeen = true
+
+        if (prefs['has-onboarded'] === '1') state.hasOnboarded = true
+        const known = prefs['known-languages']
+        if (known) {
+          try {
+            const parsed = JSON.parse(known)
+            if (Array.isArray(parsed)) {
+              state.knownLanguages = parsed.filter((l): l is ContentLanguage =>
+                contentLanguages.includes(l as ContentLanguage),
+              )
+            }
+          } catch {
+            // Malformed value — leave the default empty pool.
+          }
+        }
 
         const fontFamily = prefs['reading-font-family']
         if (fontFamily && validFontIds.has(fontFamily as ReadingFontId)) {

--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -109,6 +109,18 @@ Reuses: `ScreenLayout`, `PageHeader`, `Typography`, `Card`, `AnimatedPressable`,
 `useUpdateSlot`; `requestNotificationPermission`; `detectLanguage`. i18n: `onboarding.*` keys in
 `apps/app/src/lib/i18n/locales/{en-US,pt-BR}.ts`.
 
+### Native feel
+
+The flow follows the app-wide tactile convention (`@/lib/haptics`): `selectionTick()` for every
+selection (pills, plan/formation cards, language checkboxes) and for carousel page turns;
+`lightTap()` for primary navigation (Continue, Preview) and the quiet Skip; `successBuzz()` for
+the final **Begin**. Haptics live in the shared `OnboardingButtons` (so every step inherits them)
+and in `PillSelector`. The carousel ticks only on a real swipe — a `buttonDriven` ref suppresses
+the tick when Continue drives the scroll, so it never double-fires with the button's tap. Progress
+and carousel dots (`OnboardingProgress.tsx`) spring their width and tween their fill via Reanimated
+rather than swapping props instantly. `PillSelector` also runs through `AnimatedPressable` for
+press-scale feedback consistent with the cards and CTAs.
+
 ## 7. Phasing
 
 - **MVP:** routing + `hasOnboarded`; steps 1, 2 (language incl. `knownLanguages` pool), 4

--- a/docs/features/onboarding.md
+++ b/docs/features/onboarding.md
@@ -1,0 +1,149 @@
+# Onboarding
+
+> **Status:** Spec-of-record for v1 (MVP). **Track:** Onboarding.
+> A warm, short, fully skippable first-run flow. This is **not** the spiritual-checkup
+> decision tree (`docs/features/spiritual-checkup-profiles/`) — that approach was set aside
+> for onboarding.
+
+## 0. Goal & posture
+
+A new user opens Ember to an empty Plan of Life and ~190 practices with no guidance — the
+classic cold-start problem. Onboarding solves it gently: it introduces what Ember does, sets
+up language, seeds a sensible starter rule of life, offers a formation reading, and asks for
+notification permission. Then it gets out of the way.
+
+**Guiding constraint: onboarding orchestrates and records — it does not build downstream
+features.** Where a deeper capability isn't ready (N-language rendering; per-catechism reading
+programs), onboarding reuses what exists and persists the user's choice/intent for a separate,
+later effort.
+
+### Non-goals
+- Not the spiritual-checkup / archetype decision tree.
+- Not a personality test, not gamified, no badges.
+- Does not build multi-language (3+) rendering.
+- Does not author new formation programs (only the already-built Morrow + Compendium enroll).
+- Fully skippable from any step; shown once.
+
+## 1. Flow
+
+Seven steps, one screen each, under the `onboarding/` route group. Progress dots at top;
+**Skip** available on every step (persists whatever was set so far, then completes).
+
+1. **Intro / features overview** — a few swipeable slides giving an honest, concrete tour of
+   what Ember does today: build & keep a Plan of Life with fidelity tracking; pray beautiful
+   guided practices; a Catholic library + Catechism + saints; bilingual incl. Latin; fully
+   offline. (Not framed as the old "three pillars.") Revisitable later from Settings.
+2. **Language** — confirm interface language (auto-detected via `detectLanguage()`) and choose
+   a multi-select **"languages you know"** so the user can see cross-language content.
+3. **Profiler** — three light questions: prayer-life stage, formation stage, time available
+   per day. Pure in-flow state; feeds the two recommendations below.
+4. **Starter plan** — default everyone toward the built `beginner-minimum` template; recommend
+   others for non-beginners; allow adding practices. Reuses the template + `AdoptSheet` system.
+5. **Formation reading** — nudge to Morrow's *My Catholic Faith* by default; a picker lets the
+   user override (Compendium, CCC, Roman/Trent, Pius X short/larger).
+6. **Notifications** — opt-in; pre-fill reminder times from the seeded plan. Skipped on web.
+7. **Done** — closing screen; marks onboarding complete and routes to `/today`.
+
+## 2. Routing & gating
+
+- New preference `hasOnboarded: boolean` (KV key `has-onboarded`, `'1'`/`'0'`), hydrated like
+  `bookReaderHintSeen`.
+- In `apps/app/src/app/_layout.tsx`, once the app is `ready` (catalog seeded — onboarding needs
+  warm templates/books) and prefs are hydrated, redirect to `/onboarding` when `!hasOnboarded`.
+  Register `<Stack.Screen name="onboarding" />` beside `(tabs)`.
+- **`hasOnboarded` is independent of `firstLaunch`.** `firstLaunch` is derived from
+  `hasCachedCatalog()` and only governs the boot loader; reusing it would re-onboard a
+  returning user who cleared their cache. Keep them separate.
+- `completeOnboarding()` sets `hasOnboarded` and `router.replace('/today')`. Skip calls the same.
+
+## 3. "Languages you know" model (renderer stays at two languages)
+
+- New preference `knownLanguages: ContentLanguage[]` (KV key `known-languages`, JSON array),
+  validated against the content-language set on hydrate; setter `setKnownLanguages`.
+- The bilingual renderer (`localizeBilingual` + `BilingualBlock`) is **hard-capped at two
+  languages** (primary + one secondary). Onboarding does **not** change that. It derives, via
+  the existing setters (so React Query cache keys + persistence stay correct):
+  - `contentLanguage` (primary) = interface `language` if it's a content language, else the
+    first known language;
+  - `secondaryLanguage` = the first known language that differs from primary (when the user
+    has more than one known language).
+- **Deferred (separate track):** true N-language rendering / cycling. The stored
+  `knownLanguages` pool is what makes that possible later without re-touching onboarding.
+
+## 4. Formation picker mechanism (no new content/programs)
+
+- **Default — Morrow** (`practice/catechetical-formation`): pre-selected; enroll =
+  `useEnableSlotsForPractice()` on that practice id (enables its seeded daily slot). Programs
+  tolerate a null cursor and anchor on first completion — no cursor pre-seed needed.
+- **Override — Compendium of the CCC** (`practice/compendium`): same enroll path (ready program).
+- **Book-only catechisms (Pius X short/larger, Trent) + full CCC**: presented as "read at your
+  own pace" — pin the book / deep-link the CCC reader; choice recorded, marked "no day-by-day
+  plan yet" (mirrors `AdoptSheet`'s placeholder idiom).
+- **Deferred (content track):** authoring program + per-day session data for Pius X / Trent so
+  they can become true reading plans.
+
+## 5. New preference keys (no migration — KV store)
+
+| Key | Field | Notes |
+|---|---|---|
+| `has-onboarded` | `hasOnboarded: boolean` | one-time gate, `'1'`/`'0'` |
+| `known-languages` | `knownLanguages: ContentLanguage[]` | JSON array |
+| `today-tour-seen` | `todayTourSeen: boolean` | (follow-up) gates the spotlight tour |
+
+The profiler's time-per-day answer may optionally be persisted for future re-recommendation;
+other profiler answers stay ephemeral (in-flow state).
+
+## 6. Files
+
+New route group **`apps/app/src/app/onboarding/`**: `_layout.tsx` + `intro.tsx`, `language.tsx`,
+`profiler.tsx`, `plan.tsx`, `formation.tsx`, `notifications.tsx`, `done.tsx`.
+
+Shared **`apps/app/src/features/onboarding/`**: `useOnboardingState` (carries profiler answers
+across steps), `recommendations.ts` (profiler → template + formation defaults), `IntroSlides.tsx`
+(shared by step 1 and the Settings revisit entry), `OnboardingProgress.tsx`, `completeOnboarding`,
+barrel `index.ts`.
+
+Reuses: `ScreenLayout`, `PageHeader`, `Typography`, `Card`, `AnimatedPressable`, `FadeInView`,
+`PillSelector`, `AnimatedCheckbox`; the `GalleryBlock` carousel pattern; `LanguageSettings`;
+`useTemplateList`/`useTemplateManifest` + `AdoptSheet`; `useEnableSlotsForPractice`, `useSlots`,
+`useUpdateSlot`; `requestNotificationPermission`; `detectLanguage`. i18n: `onboarding.*` keys in
+`apps/app/src/lib/i18n/locales/{en-US,pt-BR}.ts`.
+
+## 7. Phasing
+
+- **MVP:** routing + `hasOnboarded`; steps 1, 2 (language incl. `knownLanguages` pool), 4
+  (starter plan, default `beginner-minimum`), 5 (formation: Morrow + Compendium enroll, others
+  browse/pin), 6 (notifications, native only), 7 (done). Step 3 profiler ships light (sets
+  expectations + a simple time→template hint).
+- **Follow-ups:** richer profiler-driven recommendations; true multi-language rendering; program
+  data for Pius X / Trent; Settings "revisit tour" entry; the **guided spotlight tour** below.
+
+### Follow-up: guided spotlight tour (post-MVP)
+
+A coach-mark tour of the **Today** screen, shown the first time it's reached *after* onboarding —
+separate from the linear flow so it never entangles with boot/redirect.
+
+- **Guided "Next," not forced-tap.** A root-portal overlay dims the screen, highlights one
+  element at a time (ref + reanimated `measure()`), shows a tooltip, advances via a Next button.
+  Avoids the fragile touch-passthrough + cross-tab re-measurement of a must-tap multi-screen tour.
+- **Build custom** rather than adopting `rn-tourguide`/`react-native-copilot` (Expo SDK 55 /
+  new-architecture / Tamagui friction). **Precedent:** `ReaderTapHint.tsx` (one-time reader
+  overlay) — same "show once + dismiss" shape, gated by `today-tour-seen`.
+- **Targets (initial, ~3):** the time-block checklist, the fidelity wall, the "add practice"
+  entry. Single screen only.
+
+## 8. Verification
+
+1. **Reset**: clear `has-onboarded` (or `ember://dev/reset`, which wipes the DB). Confirm
+   `usePreferencesStore().hasOnboarded === false`.
+2. **Run**: `pnpm ios` (native) / `pnpm start:web` (no-notifications path). Boot → `/onboarding/intro`.
+3. **Walk it**: swipe slides; set interface + known languages (verify `known-languages` written,
+   `secondaryLanguage` derived); answer profiler; confirm `beginner-minimum` pre-selected,
+   adopt → verify slots on Today; pick Morrow → verify `catechetical-formation` slot enabled;
+   grant notifications + confirm times → verify via `getAllScheduledNotificationsAsync()` (native).
+4. **Skip path**: Skip from any step → `/today`, `hasOnboarded` set.
+5. **Persistence + regression**: relaunch → onboarding does NOT reappear; a returning user with
+   a cleared *catalog cache* (boot loader shows) must NOT re-onboard.
+6. **Revisit**: Settings → "Tour / What is Ember" opens `IntroSlides` in revisit mode.
+7. **i18n**: switch to `pt-BR` mid-flow; all copy localizes.
+8. `pnpm test` + `pnpm biome check`.


### PR DESCRIPTION
## Summary

Adds the first-run **Onboarding** flow (per `docs/features/onboarding.md`) — a warm, short, fully skippable seven-step setup that solves Ember's cold-start problem (empty Plan of Life + ~190 practices, no guidance). Built entirely from existing primitives; no new content or downstream features.

### The flow (7 steps, one screen each)
1. **Intro** — swipeable slides tour of what Ember does today (revisitable later from Settings)
2. **Language** — confirm interface language + multi-select "languages you know"
3. **Profiler** — three light questions (prayer stage, formation stage, time/day) feeding the recommendations below
4. **Starter plan** — recommends a built template (default `beginner-minimum`); adopts via the existing `AdoptSheet`
5. **Formation reading** — nudges Morrow's *My Catholic Faith*; picker to override (Compendium, CCC, Pius X, Trent…)
6. **Notifications** — opt-in, pre-filled from the seeded plan; skipped on web
7. **Done** — marks complete and routes to `/today`

### Routing & gating
- New `hasOnboarded` preference (KV `has-onboarded`), independent of `firstLaunch` so a returning user who cleared their catalog cache is never re-onboarded.
- `_layout.tsx` gates with `Stack.Protected` — the guard flips the moment onboarding completes, revealing the tabs with no manual navigation or flash.
- Skip from any step persists whatever was set, then completes.

### Native feel
Follows the app-wide tactile convention (`@/lib/haptics`):
- `selectionTick()` on pill / card / checkbox selections and carousel page turns; `lightTap()` on Continue / Preview / Skip; `successBuzz()` on the final **Begin** — baked into the shared `OnboardingButtons` + `PillSelector` so every step inherits it.
- Carousel ticks only on a real swipe (a `buttonDriven` ref suppresses the tick when Continue drives the scroll, so it never double-fires with the button's tap).
- Progress / carousel dots spring their width and tween their fill via Reanimated instead of instant prop swaps.
- `PillSelector` runs through `AnimatedPressable` for press-scale feedback consistent with the cards and CTAs (also improves Settings).

## Test plan
- `pnpm biome check` — clean
- `pnpm exec tsc --noEmit` — clean for all touched files (two unrelated pre-existing errors in `resolver.test.ts` / `divine-office/hooks.ts` remain, untouched by this branch)
- `pnpm test` — 607 passing; the 10 failures are pre-existing Hearth-catalog 404s (no network to the corpus in the test sandbox), unchanged by this branch
- Manual walkthrough steps documented in `docs/features/onboarding.md` §8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUNpFCQpqxqXnVMP3NLnu7)_