### PR TITLE
Mass Times: sourceId mapping + idempotent re-imports

### DIFF
--- a/apps/backend/scripts/import.ts
+++ b/apps/backend/scripts/import.ts
@@ -1,13 +1,15 @@
 import { readFileSync, writeFileSync } from 'node:fs'
 import type { ChurchDump } from '@ember/api'
-import { buildRows, rowsToSql } from '../src/lib/import'
+import { buildRows, mappingToJsonl, rowsToSql } from '../src/lib/import'
 
-// CLI shell: JSONL dump → `dump.sql` for `wrangler d1 import`. The pure logic lives in
+// CLI shell: JSONL dump → `dump.sql` for `wrangler d1 import`, plus a `sourceId -> generated id`
+// mapping sidecar for any records that carried a `sourceId`. The pure logic lives in
 // src/lib/import.ts (worker-safe + unit-tested). The dump's provenance is out of scope.
-//   tsx scripts/import.ts <dump.jsonl> [dump.sql]
-const [inputPath, outputPath = 'dump.sql'] = process.argv.slice(2)
+//   tsx scripts/import.ts <dump.jsonl> [dump.sql] [mapping.jsonl]
+const [inputPath, outputPath = 'dump.sql', mappingPath = deriveMappingPath(outputPath)] =
+  process.argv.slice(2)
 if (!inputPath) {
-  throw new Error('usage: tsx scripts/import.ts <dump.jsonl> [dump.sql]')
+  throw new Error('usage: tsx scripts/import.ts <dump.jsonl> [dump.sql] [mapping.jsonl]')
 }
 
 const dump = readFileSync(inputPath, 'utf8')
@@ -21,3 +23,13 @@ writeFileSync(outputPath, rowsToSql(rows))
 
 const total = rows.churches.length + rows.services.length + rows.texts.length + rows.links.length
 process.stdout.write(`Wrote ${total} rows (${rows.churches.length} churches) → ${outputPath}\n`)
+
+if (rows.mapping.length) {
+  writeFileSync(mappingPath, mappingToJsonl(rows.mapping))
+  process.stdout.write(`Wrote ${rows.mapping.length} id mappings → ${mappingPath}\n`)
+}
+
+// `dump.sql` → `dump.mapping.jsonl` (sits next to the SQL, distinct extension).
+function deriveMappingPath(sqlPath: string): string {
+  return `${sqlPath.replace(/\.sql$/, '')}.mapping.jsonl`
+}

--- a/apps/backend/scripts/import.ts
+++ b/apps/backend/scripts/import.ts
@@ -1,25 +1,44 @@
 import { readFileSync, writeFileSync } from 'node:fs'
 import type { ChurchDump } from '@ember/api'
-import { buildRows, mappingToJsonl, rowsToSql } from '../src/lib/import'
+import { buildRows, type IdMapping, mappingToJsonl, rowsToSql } from '../src/lib/import'
 
-// CLI shell: JSONL dump → `dump.sql` for `wrangler d1 import`, plus a `sourceId -> generated id`
-// mapping sidecar for any records that carried a `sourceId`. The pure logic lives in
-// src/lib/import.ts (worker-safe + unit-tested). The dump's provenance is out of scope.
-//   tsx scripts/import.ts <dump.jsonl> [dump.sql] [mapping.jsonl]
-const [inputPath, outputPath = 'dump.sql', mappingPath = deriveMappingPath(outputPath)] =
-  process.argv.slice(2)
-if (!inputPath) {
-  throw new Error('usage: tsx scripts/import.ts <dump.jsonl> [dump.sql] [mapping.jsonl]')
+// CLI shell: JSONL dump → `.sql` for wrangler, plus a `sourceId -> generated id` mapping sidecar for
+// any records that carried a `sourceId`. Pure logic lives in src/lib/import.ts (worker-safe +
+// unit-tested). The dump's provenance is out of scope.
+//
+//   tsx scripts/import.ts <dump.jsonl> [--sql out] [--map out] [--prior in] [--upsert]
+//
+// Initial bulk load: no flags → plain INSERTs for `wrangler d1 import` into an empty DB.
+// Re-import:         --prior <last mapping> --upsert → reuse prior ids (stable identity) + emit
+//                    idempotent upsert/replace SQL, applied with `wrangler d1 execute --file`.
+const args = process.argv.slice(2)
+const inputPath = args[0]
+if (!inputPath || inputPath.startsWith('-')) {
+  throw new Error(
+    'usage: tsx scripts/import.ts <dump.jsonl> [--sql out] [--map out] [--prior in] [--upsert]',
+  )
 }
+const flag = (name: string): string | undefined => {
+  const i = args.indexOf(name)
+  return i >= 0 ? args[i + 1] : undefined
+}
+const outputPath = flag('--sql') ?? 'dump.sql'
+const mappingPath = flag('--map') ?? `${outputPath.replace(/\.sql$/, '')}.mapping.jsonl`
+const priorPath = flag('--prior')
+const upsert = args.includes('--upsert')
 
-const dump = readFileSync(inputPath, 'utf8')
-  .split('\n')
-  .map((line) => line.trim())
-  .filter(Boolean)
-  .map((line) => JSON.parse(line) as ChurchDump)
+const readJsonl = <T>(path: string): T[] =>
+  readFileSync(path, 'utf8')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as T)
 
-const rows = buildRows(dump)
-writeFileSync(outputPath, rowsToSql(rows))
+const dump = readJsonl<ChurchDump>(inputPath)
+const prior = priorPath ? readJsonl<IdMapping>(priorPath) : []
+
+const rows = buildRows(dump, prior)
+writeFileSync(outputPath, rowsToSql(rows, { upsert }))
 
 const total = rows.churches.length + rows.services.length + rows.texts.length + rows.links.length
 process.stdout.write(`Wrote ${total} rows (${rows.churches.length} churches) → ${outputPath}\n`)
@@ -27,9 +46,4 @@ process.stdout.write(`Wrote ${total} rows (${rows.churches.length} churches) →
 if (rows.mapping.length) {
   writeFileSync(mappingPath, mappingToJsonl(rows.mapping))
   process.stdout.write(`Wrote ${rows.mapping.length} id mappings → ${mappingPath}\n`)
-}
-
-// `dump.sql` → `dump.mapping.jsonl` (sits next to the SQL, distinct extension).
-function deriveMappingPath(sqlPath: string): string {
-  return `${sqlPath.replace(/\.sql$/, '')}.mapping.jsonl`
 }

--- a/apps/backend/src/lib/import.ts
+++ b/apps/backend/src/lib/import.ts
@@ -10,19 +10,25 @@ import { encodeGeohash } from './geo'
 // Reads `@ember/api` `ChurchDump` records, derives each church's slug id + geohash, then either
 // inserts via Drizzle (`importRows`) or emits a `.sql` dump (`rowsToSql`) for `wrangler d1 import`.
 
+// `sourceId -> generated id` for every dump church that carried a `sourceId`. Lets the (origin-blind)
+// producer line its own records up with the ids we slugged — the only thing flowing back out.
+export type IdMapping = { sourceId: string; id: string }
+
 export type BuiltRows = {
   churches: (typeof church.$inferInsert)[]
   services: (typeof service.$inferInsert)[]
   texts: (typeof churchText.$inferInsert)[]
   links: (typeof churchLink.$inferInsert)[]
+  mapping: IdMapping[]
 }
 
 export function buildRows(dump: ChurchDump[]): BuiltRows {
-  const rows: BuiltRows = { churches: [], services: [], texts: [], links: [] }
+  const rows: BuiltRows = { churches: [], services: [], texts: [], links: [], mapping: [] }
   const usedIds = new Set<string>()
 
   for (const d of dump) {
     const id = uniqueSlug([d.name, d.city, d.region], usedIds)
+    if (d.sourceId !== undefined) rows.mapping.push({ sourceId: d.sourceId, id })
     rows.churches.push({
       id,
       name: d.name,
@@ -94,6 +100,12 @@ export function rowsToSql(rows: BuiltRows): string {
   emit(churchText, rows.texts)
   emit(churchLink, rows.links)
   return out.join('\n')
+}
+
+// The `sourceId -> generated id` sidecar, one JSON object per line. The producer reads it back to
+// align its records with the slugged ids; the public side keeps no copy.
+export function mappingToJsonl(mapping: IdMapping[]): string {
+  return mapping.map((m) => JSON.stringify(m)).join('\n')
 }
 
 function inlineParams(sql: string, params: unknown[]): string {

--- a/apps/backend/src/lib/import.ts
+++ b/apps/backend/src/lib/import.ts
@@ -2,6 +2,7 @@
 // `rrule` (CJS), which the import path never needs.
 import type { ChurchDump } from '@ember/api/src/dump'
 import { church, churchLink, churchText, service } from '@ember/api/src/schema'
+import { getTableColumns, inArray, sql } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/d1'
 import type { Db } from '../db'
 import { encodeGeohash } from './geo'
@@ -22,12 +23,20 @@ export type BuiltRows = {
   mapping: IdMapping[]
 }
 
-export function buildRows(dump: ChurchDump[]): BuiltRows {
+// `prior` is the `sourceId -> id` mapping from an earlier import. Passing it makes re-imports
+// idempotent on identity: a church with a known `sourceId` keeps its existing id even if its name or
+// city changed (so app favorites / check-ins / reminders, all keyed on church id, never break). New
+// `sourceId`s get a fresh slug that avoids every prior id. The returned `mapping` is the full updated
+// ledger (reuse it as `prior` next time).
+export function buildRows(dump: ChurchDump[], prior: IdMapping[] = []): BuiltRows {
   const rows: BuiltRows = { churches: [], services: [], texts: [], links: [], mapping: [] }
-  const usedIds = new Set<string>()
+  const priorId = new Map(prior.map((m) => [m.sourceId, m.id]))
+  // Reserve every prior id so a new church never slugs onto an id already owned by another source.
+  const usedIds = new Set<string>(prior.map((m) => m.id))
 
   for (const d of dump) {
-    const id = uniqueSlug([d.name, d.city, d.region], usedIds)
+    const known = d.sourceId !== undefined ? priorId.get(d.sourceId) : undefined
+    const id = known ?? uniqueSlug([d.name, d.city, d.region], usedIds)
     if (d.sourceId !== undefined) rows.mapping.push({ sourceId: d.sourceId, id })
     rows.churches.push({
       id,
@@ -63,42 +72,86 @@ export function buildRows(dump: ChurchDump[]): BuiltRows {
   return rows
 }
 
-// Insert via Drizzle, chunked to stay within D1's bound-variable limit. Parents before children
-// (FK). For the initial ~138k-church load use `rowsToSql` → `wrangler d1 import` instead.
+// Child tables — no stable id of their own, so a re-import replaces a church's set wholesale.
+const childTables = [service, churchText, churchLink] as const
+
+// Apply via Drizzle, idempotently. Churches upsert on their id (last import wins for canonical
+// fields); each imported church's children are deleted then reinserted, so re-running the same dump
+// converges instead of duplicating. `correction` / `verification_event` reference churches but are
+// never touched (no FK cascade), so crowd input survives a re-import. For the initial ~138k-church
+// load use `rowsToSql` → `wrangler d1 import` instead (one bulk INSERT pass into an empty DB).
 export async function importRows(db: Db, rows: BuiltRows): Promise<void> {
-  await insertChunked(db, church, rows.churches)
+  for (const group of chunk(rows.churches, 25))
+    if (group.length)
+      await db
+        .insert(church)
+        .values(group)
+        .onConflictDoUpdate({
+          target: church.id,
+          set: excludedSet(church),
+        })
+
+  const churchIds = rows.churches.map((c) => c.id)
+  for (const table of childTables)
+    for (const group of chunk(churchIds, 100))
+      if (group.length) await db.delete(table).where(inArray(table.churchId, group))
+
   await insertChunked(db, service, rows.services)
   await insertChunked(db, churchText, rows.texts)
   await insertChunked(db, churchLink, rows.links)
 }
 
-async function insertChunked<
-  T extends typeof church | typeof service | typeof churchText | typeof churchLink,
->(db: Db, table: T, values: T['$inferInsert'][]): Promise<void> {
+async function insertChunked<T extends (typeof childTables)[number]>(
+  db: Db,
+  table: T,
+  values: T['$inferInsert'][],
+): Promise<void> {
   for (const group of chunk(values, 25)) {
     if (group.length) await db.insert(table).values(group)
   }
 }
 
-// Serialize the rows to a `.sql` dump for `wrangler d1 import`. The schema is the single source of
-// truth: Drizzle generates each INSERT's column list + placeholders; we inline the params as SQL
-// literals. One self-contained statement per row keeps column lists aligned and the file streamable.
-export function rowsToSql(rows: BuiltRows): string {
+// ON CONFLICT DO UPDATE set that overwrites every non-PK column from the incoming row (`excluded.*`).
+function excludedSet(table: typeof church): Record<string, ReturnType<typeof sql.raw>> {
+  const set: Record<string, ReturnType<typeof sql.raw>> = {}
+  for (const [key, col] of Object.entries(getTableColumns(table))) {
+    if (col.primary) continue
+    set[key] = sql.raw(`excluded."${col.name}"`)
+  }
+  return set
+}
+
+// Serialize the rows to a `.sql` dump. The schema is the single source of truth: Drizzle generates
+// each statement's column list + placeholders; we inline the params as SQL literals. One
+// self-contained statement per row keeps column lists aligned and the file streamable.
+//
+// `upsert: false` (default) → plain INSERTs for the initial bulk `wrangler d1 import` into an empty
+// DB. `upsert: true` → idempotent re-import: churches `ON CONFLICT DO UPDATE`, each imported church's
+// children deleted then reinserted. Apply the re-import SQL with `wrangler d1 execute --file`.
+export function rowsToSql(rows: BuiltRows, { upsert = false }: { upsert?: boolean } = {}): string {
   const qb = drizzle({} as D1Database)
   const out: string[] = []
-  const emit = <T extends typeof church | typeof service | typeof churchText | typeof churchLink>(
-    table: T,
-    values: T['$inferInsert'][],
-  ) => {
-    for (const row of values) {
-      const { sql, params } = qb.insert(table).values(row).toSQL()
-      out.push(`${inlineParams(sql, params)};`)
-    }
+  const push = (q: { toSQL(): { sql: string; params: unknown[] } }) => {
+    const { sql, params } = q.toSQL()
+    out.push(`${inlineParams(sql, params)};`)
   }
-  emit(church, rows.churches)
-  emit(service, rows.services)
-  emit(churchText, rows.texts)
-  emit(churchLink, rows.links)
+
+  for (const row of rows.churches) {
+    const insert = qb.insert(church).values(row)
+    push(
+      upsert ? insert.onConflictDoUpdate({ target: church.id, set: excludedSet(church) }) : insert,
+    )
+  }
+  if (upsert) {
+    const churchIds = rows.churches.map((c) => c.id)
+    for (const table of childTables)
+      for (const group of chunk(churchIds, 200))
+        if (group.length) push(qb.delete(table).where(inArray(table.churchId, group)))
+  }
+  for (const row of rows.services) push(qb.insert(service).values(row))
+  for (const row of rows.texts) push(qb.insert(churchText).values(row))
+  for (const row of rows.links) push(qb.insert(churchLink).values(row))
+
   return out.join('\n')
 }
 

--- a/apps/backend/test/import.test.ts
+++ b/apps/backend/test/import.test.ts
@@ -3,11 +3,12 @@ import type { ChurchDump } from '@ember/api'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { createDb } from '../src/db'
 import { encodeGeohash } from '../src/lib/geo'
-import { buildRows, importRows, rowsToSql } from '../src/lib/import'
+import { buildRows, importRows, mappingToJsonl, rowsToSql } from '../src/lib/import'
 import { resetTables } from './helpers'
 
 const dump: ChurchDump[] = [
   {
+    sourceId: 'SRC-1',
     name: "St. Mary's",
     city: 'Springfield',
     region: 'IL',
@@ -17,7 +18,7 @@ const dump: ChurchDump[] = [
     services: [{ kind: 'mass', rrule: 'FREQ=WEEKLY;BYDAY=SU', startTime: '09:00' }],
     links: [{ kind: 'website', url: 'https://stmarys.example' }],
   },
-  // same name + city + region → slug collision, must disambiguate
+  // same name + city + region → slug collision, must disambiguate. No sourceId → omitted from the map.
   {
     name: "St. Mary's",
     city: 'Springfield',
@@ -44,6 +45,12 @@ describe('buildRows', () => {
     expect(rows.churches[0].geohash).toBe(encodeGeohash(39.8, -89.65))
     expect(rows.services[0].churchId).toBe('st-marys-springfield-il')
     expect(rows.links[0].churchId).toBe('st-marys-springfield-il')
+  })
+
+  it('maps sourceId → generated id, omitting records with no sourceId', () => {
+    const rows = buildRows(dump)
+    expect(rows.mapping).toEqual([{ sourceId: 'SRC-1', id: 'st-marys-springfield-il' }])
+    expect(mappingToJsonl(rows.mapping)).toBe('{"sourceId":"SRC-1","id":"st-marys-springfield-il"}')
   })
 })
 

--- a/apps/backend/test/import.test.ts
+++ b/apps/backend/test/import.test.ts
@@ -52,6 +52,23 @@ describe('buildRows', () => {
     expect(rows.mapping).toEqual([{ sourceId: 'SRC-1', id: 'st-marys-springfield-il' }])
     expect(mappingToJsonl(rows.mapping)).toBe('{"sourceId":"SRC-1","id":"st-marys-springfield-il"}')
   })
+
+  it('reuses the prior id for a known sourceId even when name/city changed', () => {
+    const prior = buildRows(dump).mapping
+    const renamed: ChurchDump[] = [{ ...dump[0], name: 'Our Lady of the Snows', city: 'Chatham' }]
+    const rows = buildRows(renamed, prior)
+    // id is held stable by sourceId, not re-slugged from the new name/city
+    expect(rows.churches[0].id).toBe('st-marys-springfield-il')
+    expect(rows.mapping).toEqual([{ sourceId: 'SRC-1', id: 'st-marys-springfield-il' }])
+  })
+
+  it('slugs a new sourceId clear of every reserved prior id', () => {
+    const prior = [{ sourceId: 'SRC-1', id: 'st-marys-springfield-il' }]
+    // a different church that happens to slug to the same base → must disambiguate, not collide
+    const fresh: ChurchDump[] = [{ ...dump[0], sourceId: 'SRC-NEW' }]
+    const rows = buildRows(fresh, prior)
+    expect(rows.churches[0].id).toBe('st-marys-springfield-il-2')
+  })
 })
 
 describe('importRows', () => {
@@ -90,6 +107,45 @@ describe('importRows', () => {
       .all<{ id: string }>()
     expect(hit.results.length).toBe(2)
   })
+
+  it('is idempotent — re-applying the same dump converges (no duplicate rows)', async () => {
+    const db = createDb(env.DB)
+    await importRows(db, buildRows(dump))
+    await importRows(db, buildRows(dump))
+
+    const counts = async (sql: string) => (await env.DB.prepare(sql).first<{ n: number }>()).n
+    expect(await counts('SELECT COUNT(*) AS n FROM church')).toBe(2)
+    expect(await counts('SELECT COUNT(*) AS n FROM service')).toBe(1)
+    expect(await counts('SELECT COUNT(*) AS n FROM church_link')).toBe(1)
+  })
+
+  it('re-import updates a church in place and replaces its children, keyed by sourceId', async () => {
+    const db = createDb(env.DB)
+    const prior = buildRows(dump).mapping
+    await importRows(db, buildRows(dump))
+
+    // re-scrape: SRC-1 renamed, now two Masses instead of one
+    const rescrape: ChurchDump[] = [
+      {
+        ...dump[0],
+        name: 'Our Lady of the Snows',
+        services: [
+          { kind: 'mass', rrule: 'FREQ=WEEKLY;BYDAY=SA', startTime: '17:00' },
+          { kind: 'mass', rrule: 'FREQ=WEEKLY;BYDAY=SU', startTime: '09:00' },
+        ],
+      },
+    ]
+    await importRows(db, buildRows(rescrape, prior))
+
+    const row = await env.DB.prepare('SELECT name FROM church WHERE id = ?')
+      .bind('st-marys-springfield-il')
+      .first<{ name: string }>()
+    expect(row.name).toBe('Our Lady of the Snows') // updated in place, id preserved
+    const { n } = await env.DB.prepare('SELECT COUNT(*) AS n FROM service WHERE church_id = ?')
+      .bind('st-marys-springfield-il')
+      .first<{ n: number }>()
+    expect(n).toBe(2) // old single Mass replaced by the two new ones
+  })
 })
 
 describe('rowsToSql', () => {
@@ -97,5 +153,11 @@ describe('rowsToSql', () => {
     const sql = rowsToSql(buildRows(dump))
     expect(sql).toMatch(/insert into .?church.?/i)
     expect(sql).toContain("St. Mary''s") // single quote doubled
+  })
+
+  it('emits idempotent upsert + child-replace SQL when upsert is set', () => {
+    const sql = rowsToSql(buildRows(dump), { upsert: true })
+    expect(sql).toMatch(/on conflict.+do update/i)
+    expect(sql).toMatch(/delete from .?service.? where/i)
   })
 })

--- a/docs/future-plans/mass-times-backend.md
+++ b/docs/future-plans/mass-times-backend.md
@@ -330,12 +330,22 @@ On-device expansion removes the entire "keep a materialized window current" job:
 occurrence expansion (rules are stored as-is). Run with your Cloudflare creds; the dump's
 provenance is out of scope here.
 
+**Stable identity + idempotent re-imports.** The importer slugs each church a human-friendly id
+(`name + city + disambiguator`). A dump record may also carry an opaque `sourceId`; the importer
+never stores it but echoes a **`sourceId → generated id` mapping sidecar** (`*.mapping.jsonl`).
+Feeding that mapping back on the next run (`--prior`) makes a church **keep its id even if its name
+or city changed** — so app favorites / check-ins / reminders (all keyed on church id) never break,
+and a re-scrape diffs cleanly. With `--upsert`, the emitted SQL is idempotent: churches
+`ON CONFLICT(id) DO UPDATE` (last import wins), and each imported church's children
+(`service`/`church_text`/`church_link`) are deleted then reinserted. `correction` /
+`verification_event` are never touched, so crowd input survives a re-import.
+
 > **Initial bulk load — throughput, not cost.** The one-time load (~138k churches + ~650k services
 > + texts/links ≈ <1M rows) is well inside D1's free write allowance, so it costs nothing — but do
 > **not** push it as per-row INSERTs through a Worker (subrequest/CPU limits). Use
-> `wrangler d1 import --file=dump.sql` (server-side bulk path) for the initial load; use
-> `import.ts` (Drizzle `batch()`) for any later operator-run loads — idempotency across runs is the
-> operator's concern, not the backend's.
+> `wrangler d1 import --file=dump.sql` (server-side bulk path, plain INSERTs into an empty DB) for
+> the initial load; for later re-imports emit upsert SQL (`--upsert`) and apply it with
+> `wrangler d1 execute --file=dump.sql`.
 
 **Writes after launch are trivial** — occasional re-imports plus the tiny append-only
 `correction`/`verify` queues. There is no recurring per-day write cost, because nothing is

--- a/packages/api/src/dump.ts
+++ b/packages/api/src/dump.ts
@@ -6,6 +6,10 @@
 // name+city+region) and the `geohash` (from lat/lng), and assigns `service` ids. Provide identity
 // + content; the importer derives the rest.
 //
+// `sourceId` is an opaque stable id the dump producer may carry per church. The importer never
+// stores it and treats it as having no meaning — it only echoes `sourceId -> generated id` back as
+// a mapping sidecar, so the producer can line its own records up with the ids the importer slugged.
+//
 // Example line:
 //   {"name":"St. Patrick's Cathedral","city":"New York","region":"NY","lat":40.7585,"lng":-73.9759,
 //    "timezone":"America/New_York","canonicalStatus":"full_communion",
@@ -47,6 +51,7 @@ export type ChurchLinkKind = Open<
 >
 
 export type ChurchDump = {
+  sourceId?: string // opaque stable id from the producer; echoed back in the id mapping, never stored
   name: string
   longName?: string
   address?: string


### PR DESCRIPTION
Public-side import changes that make the Mass-Times corpus re-importable without churn. The dump's provenance stays out of scope here — the importer only sees an opaque, stable `sourceId`.

## What changed
- **`sourceId` on the dump contract** (`@ember/api`). Optional, opaque, **never stored**. The importer keeps slugging its own human-readable church ids and now echoes a **`sourceId → generated id` mapping sidecar** (`*.mapping.jsonl`) so the dump producer can line its records up with the slugged ids.
- **Idempotent re-imports with stable ids.** `buildRows(dump, prior)` reuses the existing id for a known `sourceId`, so a church **keeps its id even when its name/city change** — app favorites / check-ins / reminders (all keyed on church id) never break, and re-scrapes diff cleanly.
- **Convergent apply.** `importRows` upserts churches (`ON CONFLICT(id) DO UPDATE`) and delete-then-reinserts each imported church's children (`service`/`church_text`/`church_link`); `rowsToSql({ upsert: true })` emits the same SQL for `wrangler d1 execute`. `correction` / `verification_event` are never touched, so crowd input survives.
- **CLI:** `--prior <mapping>` and `--upsert` flags; mapping sidecar written automatically.

## Tests
27 passing (backend), including: prior-id reuse across rename, new-sourceId slug disambiguation, re-apply convergence (no duplicate rows), in-place update + child replace, and upsert-SQL shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)