### PR TITLE
Mass Times: embed services/texts/links on church + sourceId mapping + idempotent re-imports

### DIFF
--- a/apps/backend/migrations/0003_embed_services.sql
+++ b/apps/backend/migrations/0003_embed_services.sql
@@ -1,0 +1,6 @@
+DROP TABLE `church_link`;--> statement-breakpoint
+DROP TABLE `church_text`;--> statement-breakpoint
+DROP TABLE `service`;--> statement-breakpoint
+ALTER TABLE `church` ADD `services` text;--> statement-breakpoint
+ALTER TABLE `church` ADD `texts` text;--> statement-breakpoint
+ALTER TABLE `church` ADD `links` text;

--- a/apps/backend/migrations/0003_embed_services.sql
+++ b/apps/backend/migrations/0003_embed_services.sql
@@ -1,3 +1,4 @@
+DROP INDEX IF EXISTS `church_country_city_idx`;--> statement-breakpoint
 DROP TABLE `church_link`;--> statement-breakpoint
 DROP TABLE `church_text`;--> statement-breakpoint
 DROP TABLE `service`;--> statement-breakpoint

--- a/apps/backend/migrations/meta/0002_snapshot.json
+++ b/apps/backend/migrations/meta/0002_snapshot.json
@@ -265,14 +265,6 @@
             "geohash"
           ],
           "isUnique": false
-        },
-        "church_country_city_idx": {
-          "name": "church_country_city_idx",
-          "columns": [
-            "country_code",
-            "city"
-          ],
-          "isUnique": false
         }
       },
       "foreignKeys": {},

--- a/apps/backend/migrations/meta/0002_snapshot.json
+++ b/apps/backend/migrations/meta/0002_snapshot.json
@@ -1,0 +1,446 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8242a79b-be3d-4327-b37f-9f785cfc6d9a",
+  "prevId": "a6586a82-8502-419e-b37e-45607fdbfc90",
+  "tables": {
+    "attachment": {
+      "name": "attachment",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "church_id": {
+          "name": "church_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "attachment_church_idx": {
+          "name": "attachment_church_idx",
+          "columns": [
+            "church_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "church": {
+      "name": "church",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "long_name": {
+          "name": "long_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lat": {
+          "name": "lat",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lng": {
+          "name": "lng",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "geohash": {
+          "name": "geohash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phone_e164": {
+          "name": "phone_e164",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "featured": {
+          "name": "featured",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "administration": {
+          "name": "administration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "institute": {
+          "name": "institute",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_status": {
+          "name": "canonical_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_structured_schedule": {
+          "name": "has_structured_schedule",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_verified_at": {
+          "name": "last_verified_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified_source": {
+          "name": "verified_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "services": {
+          "name": "services",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "texts": {
+          "name": "texts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "links": {
+          "name": "links",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "church_geohash_idx": {
+          "name": "church_geohash_idx",
+          "columns": [
+            "geohash"
+          ],
+          "isUnique": false
+        },
+        "church_country_city_idx": {
+          "name": "church_country_city_idx",
+          "columns": [
+            "country_code",
+            "city"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "correction": {
+      "name": "correction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "church_id": {
+          "name": "church_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "correction_church_idx": {
+          "name": "correction_church_idx",
+          "columns": [
+            "church_id"
+          ],
+          "isUnique": false
+        },
+        "correction_status_idx": {
+          "name": "correction_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification_event": {
+      "name": "verification_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "church_id": {
+          "name": "church_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"
+        }
+      },
+      "indexes": {
+        "verification_church_fp_idx": {
+          "name": "verification_church_fp_idx",
+          "columns": [
+            "church_id",
+            "fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/backend/migrations/meta/_journal.json
+++ b/apps/backend/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1781664640698,
       "tag": "0002_attachment",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1781746267081,
+      "tag": "0003_embed_services",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/scripts/import.ts
+++ b/apps/backend/scripts/import.ts
@@ -40,8 +40,8 @@ const prior = priorPath ? readJsonl<IdMapping>(priorPath) : []
 const rows = buildRows(dump, prior)
 writeFileSync(outputPath, rowsToSql(rows, { upsert }))
 
-const total = rows.churches.length + rows.services.length + rows.texts.length + rows.links.length
-process.stdout.write(`Wrote ${total} rows (${rows.churches.length} churches) → ${outputPath}\n`)
+// One row per church now — services/texts/links are embedded JSON columns on it.
+process.stdout.write(`Wrote ${rows.churches.length} church rows → ${outputPath}\n`)
 
 if (rows.mapping.length) {
   writeFileSync(mappingPath, mappingToJsonl(rows.mapping))

--- a/apps/backend/src/db.ts
+++ b/apps/backend/src/db.ts
@@ -1,23 +1,7 @@
-import {
-  attachment,
-  church,
-  churchLink,
-  churchText,
-  correction,
-  service,
-  verificationEvent,
-} from '@ember/api'
+import { attachment, church, correction, verificationEvent } from '@ember/api'
 import { drizzle } from 'drizzle-orm/d1'
 
-const schema = {
-  church,
-  service,
-  churchText,
-  churchLink,
-  correction,
-  verificationEvent,
-  attachment,
-}
+const schema = { church, correction, verificationEvent, attachment }
 
 // Drizzle client over the D1 binding. Simple CRUD uses the query builder; the hot geo queries drop
 // to raw `sql` templates (see features/churches/queries.ts).

--- a/apps/backend/src/features/churches/queries.ts
+++ b/apps/backend/src/features/churches/queries.ts
@@ -1,5 +1,5 @@
-import type { Church, Service } from '@ember/api'
-import { church, churchLink, churchText, service, verificationEvent } from '@ember/api'
+import type { Church } from '@ember/api'
+import { church, verificationEvent } from '@ember/api'
 import { and, desc, eq, inArray, sql } from 'drizzle-orm'
 import type { Db } from '../../db'
 import type { Bbox } from '../../lib/geo'
@@ -25,36 +25,9 @@ export function churchesInGeohashRanges(
     .where(and(...conds))
 }
 
-export function servicesForChurches(
-  db: Db,
-  churchIds: string[],
-  filters: { kind?: string; rite?: string },
-): Promise<Service[]> {
-  if (churchIds.length === 0) return Promise.resolve([])
-  const conds = [inArray(service.churchId, churchIds)]
-  if (filters.kind) conds.push(eq(service.kind, filters.kind))
-  if (filters.rite) conds.push(eq(service.rite, filters.rite))
-  return db
-    .select()
-    .from(service)
-    .where(and(...conds))
-}
-
 export async function churchById(db: Db, id: string): Promise<Church | undefined> {
   const rows = await db.select().from(church).where(eq(church.id, id)).limit(1)
   return rows[0]
-}
-
-export function servicesForChurch(db: Db, churchId: string): Promise<Service[]> {
-  return db.select().from(service).where(eq(service.churchId, churchId))
-}
-
-export function textsForChurch(db: Db, churchId: string) {
-  return db.select().from(churchText).where(eq(churchText.churchId, churchId))
-}
-
-export function linksForChurch(db: Db, churchId: string) {
-  return db.select().from(churchLink).where(eq(churchLink.churchId, churchId))
 }
 
 export function verificationsForChurch(

--- a/apps/backend/src/features/churches/service.ts
+++ b/apps/backend/src/features/churches/service.ts
@@ -13,16 +13,17 @@ import {
   churchesByIds,
   churchesInGeohashRanges,
   churchIdsMatchingText,
-  linksForChurch,
-  servicesForChurch,
-  servicesForChurches,
-  textsForChurch,
 } from './queries'
 
 export type NearbyChurch = Church & { distanceKm: number; services: Service[] }
 
+const matchesFilter = (s: Service, f: { kind?: string; rite?: string }) =>
+  (!f.kind || s.kind === f.kind) && (!f.rite || s.rite === f.rite)
+
 // "Near me": geohash covering-set prunes to a small candidate set → haversine trims to the true
-// circle → attach service rules. The DB does pure geo; the device expands rules + sorts by soonest.
+// circle → the church carries its (embedded) service rules. The DB does pure geo; the device expands
+// rules + sorts by soonest. A kind/rite filter trims each church's services and drops churches left
+// with none — the same predicate `searchChurches` applies.
 export async function nearbyChurches(db: Db, q: NearQuery): Promise<NearbyChurch[]> {
   const bbox = boundingBox(q.lat, q.lng, q.radiusKm)
   const precision = geohashPrecisionForRadiusKm(q.radiusKm)
@@ -38,34 +39,21 @@ export async function nearbyChurches(db: Db, q: NearQuery): Promise<NearbyChurch
     .filter((c) => c.distanceKm <= q.radiusKm)
     .sort((a, b) => a.distanceKm - b.distanceKm)
     .slice(0, q.limit)
+    .map((c) => ({ ...c, services: (c.services ?? []).filter((s) => matchesFilter(s, q)) }))
 
-  const services = await servicesForChurches(
-    db,
-    within.map((c) => c.id),
-    { kind: q.kind, rite: q.rite },
-  )
-  const byChurch = groupBy(services, (s) => s.churchId)
-
-  const result = within.map((c) => ({ ...c, services: byChurch.get(c.id) ?? [] }))
-  // When kind/rite is filtered, only keep churches that actually have a matching service.
-  return q.kind || q.rite ? result.filter((c) => c.services.length > 0) : result
+  return q.kind || q.rite ? within.filter((c) => c.services.length > 0) : within
 }
 
 export type ChurchDetail = Church & {
   services: Service[]
-  texts: Awaited<ReturnType<typeof textsForChurch>>
-  links: Awaited<ReturnType<typeof linksForChurch>>
+  texts: NonNullable<Church['texts']>
+  links: NonNullable<Church['links']>
 }
 
 export async function churchDetail(db: Db, id: string): Promise<ChurchDetail | undefined> {
   const c = await churchById(db, id)
   if (!c) return undefined
-  const [services, texts, links] = await Promise.all([
-    servicesForChurch(db, id),
-    textsForChurch(db, id),
-    linksForChurch(db, id),
-  ])
-  return { ...c, services, texts, links }
+  return { ...c, services: c.services ?? [], texts: c.texts ?? [], links: c.links ?? [] }
 }
 
 // Browse / search. `q` → FTS5 (rank-ordered ids → hydrate); otherwise country/city/bbox + filters.
@@ -91,33 +79,6 @@ export async function searchChurches(db: Db, query: ChurchesQuery): Promise<Chur
       offset: query.offset,
     })
   }
-  return restrictByServiceFilters(db, base, { kind: query.kind, rite: query.rite })
-}
-
-// Restrict a church set to those with ≥1 service matching kind/rite. `near` applies the same
-// predicate inline (it already fetches the services to attach them).
-async function restrictByServiceFilters(
-  db: Db,
-  churches: Church[],
-  filters: { kind?: string; rite?: string },
-): Promise<Church[]> {
-  if (!filters.kind && !filters.rite) return churches
-  const matching = await servicesForChurches(
-    db,
-    churches.map((c) => c.id),
-    filters,
-  )
-  const matchedIds = new Set(matching.map((s) => s.churchId))
-  return churches.filter((c) => matchedIds.has(c.id))
-}
-
-function groupBy<T, K>(items: T[], key: (item: T) => K): Map<K, T[]> {
-  const map = new Map<K, T[]>()
-  for (const item of items) {
-    const k = key(item)
-    const bucket = map.get(k)
-    if (bucket) bucket.push(item)
-    else map.set(k, [item])
-  }
-  return map
+  if (!query.kind && !query.rite) return base
+  return base.filter((c) => (c.services ?? []).some((s) => matchesFilter(s, query)))
 }

--- a/apps/backend/src/lib/import.ts
+++ b/apps/backend/src/lib/import.ts
@@ -1,15 +1,16 @@
 // Deep imports (not the barrel) so the CLI run under tsx doesn't transitively load `expand.ts` →
 // `rrule` (CJS), which the import path never needs.
-import type { ChurchDump } from '@ember/api/src/dump'
-import { church, churchLink, churchText, service } from '@ember/api/src/schema'
-import { getTableColumns, inArray, sql } from 'drizzle-orm'
+import type { ChurchDump, ServiceDump } from '@ember/api/src/dump'
+import { church } from '@ember/api/src/schema'
+import { getTableColumns, sql } from 'drizzle-orm'
 import { drizzle } from 'drizzle-orm/d1'
 import type { Db } from '../db'
 import { encodeGeohash } from './geo'
 
 // Pure import logic (worker-safe — no node:fs). The CLI shell lives in scripts/import.ts.
-// Reads `@ember/api` `ChurchDump` records, derives each church's slug id + geohash, then either
-// inserts via Drizzle (`importRows`) or emits a `.sql` dump (`rowsToSql`) for `wrangler d1 import`.
+// Reads `@ember/api` `ChurchDump` records, derives each church's slug id + geohash, and embeds the
+// schedule/text/link content as JSON on the church row (no child tables). Then either inserts via
+// Drizzle (`importRows`) or emits a `.sql` dump (`rowsToSql`).
 
 // `sourceId -> generated id` for every dump church that carried a `sourceId`. Lets the (origin-blind)
 // producer line its own records up with the ids we slugged — the only thing flowing back out.
@@ -17,9 +18,6 @@ export type IdMapping = { sourceId: string; id: string }
 
 export type BuiltRows = {
   churches: (typeof church.$inferInsert)[]
-  services: (typeof service.$inferInsert)[]
-  texts: (typeof churchText.$inferInsert)[]
-  links: (typeof churchLink.$inferInsert)[]
   mapping: IdMapping[]
 }
 
@@ -29,7 +27,7 @@ export type BuiltRows = {
 // `sourceId`s get a fresh slug that avoids every prior id. The returned `mapping` is the full updated
 // ledger (reuse it as `prior` next time).
 export function buildRows(dump: ChurchDump[], prior: IdMapping[] = []): BuiltRows {
-  const rows: BuiltRows = { churches: [], services: [], texts: [], links: [], mapping: [] }
+  const rows: BuiltRows = { churches: [], mapping: [] }
   const priorId = new Map(prior.map((m) => [m.sourceId, m.id]))
   // Reserve every prior id so a new church never slugs onto an id already owned by another source.
   const usedIds = new Set<string>(prior.map((m) => m.id))
@@ -38,6 +36,8 @@ export function buildRows(dump: ChurchDump[], prior: IdMapping[] = []): BuiltRow
     const known = d.sourceId !== undefined ? priorId.get(d.sourceId) : undefined
     const id = known ?? uniqueSlug([d.name, d.city, d.region], usedIds)
     if (d.sourceId !== undefined) rows.mapping.push({ sourceId: d.sourceId, id })
+
+    const services = (d.services ?? []).map((s) => ({ id: serviceId(id, s), ...s }))
     rows.churches.push({
       id,
       name: d.name,
@@ -60,55 +60,47 @@ export function buildRows(dump: ChurchDump[], prior: IdMapping[] = []): BuiltRow
       institute: d.institute,
       canonicalStatus: d.canonicalStatus,
       note: d.note,
-      hasStructuredSchedule: d.hasStructuredSchedule ?? (d.services?.length ?? 0) > 0,
+      hasStructuredSchedule: d.hasStructuredSchedule ?? services.length > 0,
       lastVerifiedAt: d.lastVerifiedAt,
       verifiedSource: d.verifiedSource,
+      // embedded owned content — null (not []) when empty, so an absent column reads cleanly
+      services: services.length ? services : undefined,
+      texts: d.texts?.length ? d.texts : undefined,
+      links: d.links?.length ? d.links : undefined,
     })
-    for (const s of d.services ?? [])
-      rows.services.push({ id: crypto.randomUUID(), churchId: id, ...s })
-    for (const t of d.texts ?? []) rows.texts.push({ churchId: id, ...t })
-    for (const l of d.links ?? []) rows.links.push({ churchId: id, ...l })
   }
   return rows
 }
 
-// Child tables — no stable id of their own, so a re-import replaces a church's set wholesale.
-const childTables = [service, churchText, churchLink] as const
+// Deterministic per-church service id (`churchId:hash(slot)`) so a `correction` can target one Mass
+// and a re-import keeps the same id for an unchanged slot — strictly more stable than a random UUID.
+function serviceId(churchId: string, s: ServiceDump): string {
+  const sig = [s.kind, s.rrule, s.startTime, s.endTime ?? '', s.language ?? '', s.rite ?? ''].join(
+    '|',
+  )
+  return `${churchId}:${fnv1a(sig)}`
+}
 
-// Apply via Drizzle, idempotently. Churches upsert on their id (last import wins for canonical
-// fields); each imported church's children are deleted then reinserted, so re-running the same dump
-// converges instead of duplicating. `correction` / `verification_event` reference churches but are
-// never touched (no FK cascade), so crowd input survives a re-import. For the initial ~138k-church
-// load use `rowsToSql` → `wrangler d1 import` instead (one bulk INSERT pass into an empty DB).
+function fnv1a(str: string): string {
+  let h = 0x811c9dc5
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return (h >>> 0).toString(36)
+}
+
+// Apply via Drizzle, idempotently: churches upsert on their id (last import wins; the embedded
+// services/texts/links are replaced wholesale, since they live on the row). `correction` /
+// `verification_event` reference churches but are never touched, so crowd input survives a re-import.
+// For the initial ~138k-church load use `rowsToSql` → `wrangler d1 import` instead.
 export async function importRows(db: Db, rows: BuiltRows): Promise<void> {
   for (const group of chunk(rows.churches, 25))
     if (group.length)
       await db
         .insert(church)
         .values(group)
-        .onConflictDoUpdate({
-          target: church.id,
-          set: excludedSet(church),
-        })
-
-  const churchIds = rows.churches.map((c) => c.id)
-  for (const table of childTables)
-    for (const group of chunk(churchIds, 100))
-      if (group.length) await db.delete(table).where(inArray(table.churchId, group))
-
-  await insertChunked(db, service, rows.services)
-  await insertChunked(db, churchText, rows.texts)
-  await insertChunked(db, churchLink, rows.links)
-}
-
-async function insertChunked<T extends (typeof childTables)[number]>(
-  db: Db,
-  table: T,
-  values: T['$inferInsert'][],
-): Promise<void> {
-  for (const group of chunk(values, 25)) {
-    if (group.length) await db.insert(table).values(group)
-  }
+        .onConflictDoUpdate({ target: church.id, set: excludedSet(church) })
 }
 
 // ON CONFLICT DO UPDATE set that overwrites every non-PK column from the incoming row (`excluded.*`).
@@ -121,37 +113,24 @@ function excludedSet(table: typeof church): Record<string, ReturnType<typeof sql
   return set
 }
 
-// Serialize the rows to a `.sql` dump. The schema is the single source of truth: Drizzle generates
-// each statement's column list + placeholders; we inline the params as SQL literals. One
-// self-contained statement per row keeps column lists aligned and the file streamable.
+// Serialize the church rows to a `.sql` dump. The schema is the single source of truth: Drizzle
+// generates each statement's column list + placeholders (embedded JSON columns serialize to a JSON
+// string param); we inline the params as SQL literals. One self-contained statement per row.
 //
 // `upsert: false` (default) → plain INSERTs for the initial bulk `wrangler d1 import` into an empty
-// DB. `upsert: true` → idempotent re-import: churches `ON CONFLICT DO UPDATE`, each imported church's
-// children deleted then reinserted. Apply the re-import SQL with `wrangler d1 execute --file`.
+// DB. `upsert: true` → re-import: `ON CONFLICT DO UPDATE` (replaces the whole row incl. its embedded
+// content). Apply the re-import SQL with `wrangler d1 execute --file`.
 export function rowsToSql(rows: BuiltRows, { upsert = false }: { upsert?: boolean } = {}): string {
   const qb = drizzle({} as D1Database)
   const out: string[] = []
-  const push = (q: { toSQL(): { sql: string; params: unknown[] } }) => {
+  for (const row of rows.churches) {
+    const insert = qb.insert(church).values(row)
+    const q = upsert
+      ? insert.onConflictDoUpdate({ target: church.id, set: excludedSet(church) })
+      : insert
     const { sql, params } = q.toSQL()
     out.push(`${inlineParams(sql, params)};`)
   }
-
-  for (const row of rows.churches) {
-    const insert = qb.insert(church).values(row)
-    push(
-      upsert ? insert.onConflictDoUpdate({ target: church.id, set: excludedSet(church) }) : insert,
-    )
-  }
-  if (upsert) {
-    const churchIds = rows.churches.map((c) => c.id)
-    for (const table of childTables)
-      for (const group of chunk(churchIds, 200))
-        if (group.length) push(qb.delete(table).where(inArray(table.churchId, group)))
-  }
-  for (const row of rows.services) push(qb.insert(service).values(row))
-  for (const row of rows.texts) push(qb.insert(churchText).values(row))
-  for (const row of rows.links) push(qb.insert(churchLink).values(row))
-
   return out.join('\n')
 }
 

--- a/apps/backend/test/churches.test.ts
+++ b/apps/backend/test/churches.test.ts
@@ -15,27 +15,27 @@ const churches = [
 ]
 
 async function seed() {
-  await resetTables(
-    'service',
-    'church_text',
-    'church_link',
-    'verification_event',
-    'correction',
-    'church',
-  )
+  await resetTables('verification_event', 'correction', 'church')
   for (const c of churches) {
+    // Only Saint Mary has a TLM, embedded as JSON; used to prove kind/rite service-filtering.
+    const services =
+      c.id === 'st-mary-a'
+        ? JSON.stringify([
+            {
+              id: 'svc-mary',
+              kind: 'mass',
+              rite: 'latin_tridentine',
+              rrule: 'FREQ=WEEKLY;BYDAY=SU',
+              startTime: '09:00',
+            },
+          ])
+        : null
     await env.DB.prepare(
-      'INSERT INTO church (id, name, lat, lng, geohash, timezone) VALUES (?, ?, ?, ?, ?, ?)',
+      'INSERT INTO church (id, name, lat, lng, geohash, timezone, services) VALUES (?, ?, ?, ?, ?, ?, ?)',
     )
-      .bind(c.id, c.name, c.lat, c.lng, encodeGeohash(c.lat, c.lng), 'America/New_York')
+      .bind(c.id, c.name, c.lat, c.lng, encodeGeohash(c.lat, c.lng), 'America/New_York', services)
       .run()
   }
-  // Only Saint Mary has a TLM; used to prove kind/rite service-filtering.
-  await env.DB.prepare(
-    'INSERT INTO service (id, church_id, kind, rite, rrule, start_time) VALUES (?, ?, ?, ?, ?, ?)',
-  )
-    .bind('svc-mary', 'st-mary-a', 'mass', 'latin_tridentine', 'FREQ=WEEKLY;BYDAY=SU', '09:00')
-    .run()
 }
 
 const json = async (res: Response) => res.json() as Promise<{ churches: { id: string }[] }>

--- a/apps/backend/test/corrections.test.ts
+++ b/apps/backend/test/corrections.test.ts
@@ -6,7 +6,7 @@ import { resetTables } from './helpers'
 const churchId = 'st-mary-a'
 
 async function reset() {
-  await resetTables('service', 'verification_event', 'correction', 'attachment', 'church')
+  await resetTables('verification_event', 'correction', 'attachment', 'church')
   await env.DB.prepare(
     'INSERT INTO church (id, name, lat, lng, geohash, timezone) VALUES (?, ?, ?, ?, ?, ?)',
   )

--- a/apps/backend/test/import.test.ts
+++ b/apps/backend/test/import.test.ts
@@ -1,5 +1,5 @@
 import { env } from 'cloudflare:test'
-import type { ChurchDump } from '@ember/api'
+import type { ChurchDump, Service } from '@ember/api'
 import { beforeEach, describe, expect, it } from 'vitest'
 import { createDb } from '../src/db'
 import { encodeGeohash } from '../src/lib/geo'
@@ -29,7 +29,7 @@ const dump: ChurchDump[] = [
   },
 ]
 
-beforeEach(() => resetTables('service', 'church_text', 'church_link', 'church'))
+beforeEach(() => resetTables('church'))
 
 describe('buildRows', () => {
   it('derives a human-friendly slug id and disambiguates collisions', () => {
@@ -40,11 +40,18 @@ describe('buildRows', () => {
     ])
   })
 
-  it('computes the geohash from lat/lng and links children to the church id', () => {
-    const rows = buildRows(dump)
-    expect(rows.churches[0].geohash).toBe(encodeGeohash(39.8, -89.65))
-    expect(rows.services[0].churchId).toBe('st-marys-springfield-il')
-    expect(rows.links[0].churchId).toBe('st-marys-springfield-il')
+  it('embeds services/links on the church row with a churchId-scoped deterministic service id', () => {
+    const c = buildRows(dump).churches[0]
+    expect(c.geohash).toBe(encodeGeohash(39.8, -89.65))
+    expect(c.services).toHaveLength(1)
+    expect(c.services?.[0]?.id).toMatch(/^st-marys-springfield-il:/)
+    expect(c.links).toEqual([{ kind: 'website', url: 'https://stmarys.example' }])
+    expect(buildRows(dump).churches[1].services).toBeUndefined() // no services → column omitted
+  })
+
+  it('gives a service a stable id across rebuilds (so corrections can target it)', () => {
+    const id = (rows: ReturnType<typeof buildRows>) => rows.churches[0].services?.[0]?.id
+    expect(id(buildRows(dump))).toBe(id(buildRows(dump)))
   })
 
   it('maps sourceId → generated id, omitting records with no sourceId', () => {
@@ -57,24 +64,27 @@ describe('buildRows', () => {
     const prior = buildRows(dump).mapping
     const renamed: ChurchDump[] = [{ ...dump[0], name: 'Our Lady of the Snows', city: 'Chatham' }]
     const rows = buildRows(renamed, prior)
-    // id is held stable by sourceId, not re-slugged from the new name/city
     expect(rows.churches[0].id).toBe('st-marys-springfield-il')
     expect(rows.mapping).toEqual([{ sourceId: 'SRC-1', id: 'st-marys-springfield-il' }])
   })
 
   it('slugs a new sourceId clear of every reserved prior id', () => {
     const prior = [{ sourceId: 'SRC-1', id: 'st-marys-springfield-il' }]
-    // a different church that happens to slug to the same base → must disambiguate, not collide
     const fresh: ChurchDump[] = [{ ...dump[0], sourceId: 'SRC-NEW' }]
-    const rows = buildRows(fresh, prior)
-    expect(rows.churches[0].id).toBe('st-marys-springfield-il-2')
+    expect(buildRows(fresh, prior).churches[0].id).toBe('st-marys-springfield-il-2')
   })
 })
 
+const churchServices = async (id: string): Promise<Service[]> => {
+  const row = await env.DB.prepare('SELECT services FROM church WHERE id = ?')
+    .bind(id)
+    .first<{ services: string | null }>()
+  return row?.services ? (JSON.parse(row.services) as Service[]) : []
+}
+
 describe('importRows', () => {
-  it('inserts churches + children into D1 with geohash populated', async () => {
-    const db = createDb(env.DB)
-    await importRows(db, buildRows(dump))
+  it('inserts churches with embedded services + geohash into D1', async () => {
+    await importRows(createDb(env.DB), buildRows(dump))
 
     const churches = await env.DB.prepare('SELECT id, geohash FROM church ORDER BY id').all<{
       id: string
@@ -86,16 +96,10 @@ describe('importRows', () => {
     ])
     expect(churches.results[0].geohash).toBe(encodeGeohash(39.8, -89.65))
 
-    const { count: svc } = await env.DB.prepare('SELECT COUNT(*) AS count FROM service').first<{
-      count: number
-    }>()
-    const { count: links } = await env.DB.prepare(
-      'SELECT COUNT(*) AS count FROM church_link',
-    ).first<{
-      count: number
-    }>()
-    expect(svc).toBe(1)
-    expect(links).toBe(1)
+    const services = await churchServices('st-marys-springfield-il')
+    expect(services).toHaveLength(1)
+    expect(services[0]).toMatchObject({ kind: 'mass', startTime: '09:00' })
+    expect(await churchServices('st-marys-springfield-il-2')).toEqual([])
   })
 
   it('imported churches are findable via FTS (triggers fired on insert)', async () => {
@@ -112,14 +116,11 @@ describe('importRows', () => {
     const db = createDb(env.DB)
     await importRows(db, buildRows(dump))
     await importRows(db, buildRows(dump))
-
-    const counts = async (sql: string) => (await env.DB.prepare(sql).first<{ n: number }>()).n
-    expect(await counts('SELECT COUNT(*) AS n FROM church')).toBe(2)
-    expect(await counts('SELECT COUNT(*) AS n FROM service')).toBe(1)
-    expect(await counts('SELECT COUNT(*) AS n FROM church_link')).toBe(1)
+    const { n } = await env.DB.prepare('SELECT COUNT(*) AS n FROM church').first<{ n: number }>()
+    expect(n).toBe(2)
   })
 
-  it('re-import updates a church in place and replaces its children, keyed by sourceId', async () => {
+  it('re-import updates a church in place and replaces its services, keyed by sourceId', async () => {
     const db = createDb(env.DB)
     const prior = buildRows(dump).mapping
     await importRows(db, buildRows(dump))
@@ -141,10 +142,7 @@ describe('importRows', () => {
       .bind('st-marys-springfield-il')
       .first<{ name: string }>()
     expect(row.name).toBe('Our Lady of the Snows') // updated in place, id preserved
-    const { n } = await env.DB.prepare('SELECT COUNT(*) AS n FROM service WHERE church_id = ?')
-      .bind('st-marys-springfield-il')
-      .first<{ n: number }>()
-    expect(n).toBe(2) // old single Mass replaced by the two new ones
+    expect(await churchServices('st-marys-springfield-il')).toHaveLength(2) // replaced wholesale
   })
 })
 
@@ -155,9 +153,9 @@ describe('rowsToSql', () => {
     expect(sql).toContain("St. Mary''s") // single quote doubled
   })
 
-  it('emits idempotent upsert + child-replace SQL when upsert is set', () => {
+  it('emits ON CONFLICT DO UPDATE when upsert is set (no child tables to delete)', () => {
     const sql = rowsToSql(buildRows(dump), { upsert: true })
     expect(sql).toMatch(/on conflict.+do update/i)
-    expect(sql).toMatch(/delete from .?service.? where/i)
+    expect(sql).not.toMatch(/delete from/i)
   })
 })

--- a/docs/future-plans/mass-times-backend.md
+++ b/docs/future-plans/mass-times-backend.md
@@ -257,13 +257,21 @@ up, so the API doesn't allow one.
 > requirement. **H3** is the worst fit here (best library, but multi-resolution-column DB awkwardness
 > + approximate containment).
 
-### Schedule grain — one row per slot
-**One `service` row = one (time, pattern) slot.** An `RRULE` is a single pattern at a single
+### Schedule grain — one slot per entry, **embedded** on the church
+**One service entry = one (time, pattern) slot.** An `RRULE` is a single pattern at a single
 time-of-day (per RFC 5545 all recurrence shares one `DTSTART`), so "9:00 on the 13th **and** 11:00
-on Mondays" is **two rows**, not one rule — and a church's schedule is the **union of its rows**
-(`expand.ts` expands each row and concatenates). Don't pack multiple positive patterns into one
-rule; combining `BYMONTHDAY`+`BYDAY` yields the *intersection*, not the union. Per-row **exceptions**
-(a cancelled Sunday, a one-off) use `exdate`/`rdate` via `RRuleSet` — the only place a set is needed.
+on Mondays" is **two entries**, not one rule — and a church's schedule is the **union of its
+entries** (`expand.ts` expands each and concatenates). Don't pack multiple positive patterns into one
+rule; combining `BYMONTHDAY`+`BYDAY` yields the *intersection*, not the union. Per-entry
+**exceptions** (a cancelled Sunday, a one-off) use `exdate`/`rdate` via `RRuleSet`.
+
+> **Embedded, not a child table.** `service` / `church_text` / `church_link` are **JSON columns on
+> `church`** (`services` / `texts` / `links`), not separate tables. The server never queries inside a
+> schedule (expansion is on-device), so a church is always read whole — embedding makes `/near` a
+> single geohash scan (no JOIN) and cuts rows written/read ~4× (no per-child rows + indexes). Each
+> embedded service carries a **deterministic id** (`churchId:hash(slot)`) so a `correction` can still
+> target one Mass and a re-import keeps a stable id for an unchanged slot. `correction` /
+> `verification_event` / `attachment` stay their own (append-only) tables; `church_fts` stays.
 
 ### Time = wall-clock, expanded on-device (no tz math on the core path)
 `service` stores an rrule + wall-clock `start_time`; there is **no materialized instance table**.

--- a/packages/api/src/expand.ts
+++ b/packages/api/src/expand.ts
@@ -18,7 +18,11 @@ export type ExpandOptions = {
   count?: number // max occurrences to return; defaults to 10. Always bounded — never expand infinitely
 }
 
-type RRuleSource = Pick<Service, 'rrule' | 'startTime' | 'exdate' | 'rdate'>
+// exdate/rdate accept null too, so a row read straight from D1 (or a test) drops in unchanged.
+type RRuleSource = Pick<Service, 'rrule' | 'startTime'> & {
+  exdate?: string | null
+  rdate?: string | null
+}
 
 export function expandService(service: RRuleSource, options: ExpandOptions = {}): Occurrence[] {
   const { from = new Date(), count = 10 } = options
@@ -47,7 +51,7 @@ function buildRuleSet(service: RRuleSource, from: Date): RRuleSet {
 }
 
 // exdate/rdate are stored as a comma-separated list of 'YYYY-MM-DD' (or full ISO) dates.
-function parseDateList(value: string | null): Date[] {
+function parseDateList(value: string | null | undefined): Date[] {
   if (!value) return []
   return value
     .split(',')

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -20,11 +20,8 @@ export {
   type ChurchText,
   type Correction,
   church,
-  churchLink,
-  churchText,
   correction,
   type Service,
-  service,
   type VerificationEvent,
   verificationEvent,
 } from './schema'

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -1,5 +1,5 @@
 import { type InferSelectModel, sql } from 'drizzle-orm'
-import { index, integer, primaryKey, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
+import { index, integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
 // Source of truth for the Mass-Times directory. Domain types are inferred from these tables
 // (no hand-written `type`s) and migrations are generated from them via drizzle-kit.
@@ -8,6 +8,36 @@ import { index, integer, primaryKey, real, sqliteTable, text } from 'drizzle-orm
 // index below is binary-collated for free — the prefix-range geo filters are sargable as-is.
 // The FTS5 `church_fts` virtual table is intentionally NOT modelled here (drizzle-kit can't emit
 // virtual tables); it lives in a hand-written migration and is queried via raw `sql`.
+
+// A church owns its schedule + text + links. They are EMBEDDED as JSON columns on `church` (below),
+// not separate tables: the server never queries inside a schedule (rrule expansion is on-device), so
+// a church is always read whole. Embedding makes `/near` a single geohash scan and cuts row writes
+// ~4× (no per-child rows/indexes). `service.id` is deterministic (`churchId:hash(slot)`) so a
+// `correction` can still target one Mass.
+export type Service = {
+  id: string
+  kind: string // mass | confession | adoration
+  rite?: string // Mass only; latin_novus_ordo | latin_tridentine | byzantine | ...
+  language?: string // ISO 639
+  rrule: string // iCal RRULE: ONE pattern at ONE time
+  startTime: string // 'HH:MM' wall-clock; displayed as-is, expanded on-device
+  endTime?: string
+  exdate?: string // RRuleSet EXDATE (cancelled dates)
+  rdate?: string // RRuleSet RDATE (one-off added dates)
+  locationNote?: string
+  note?: string
+  source?: string // import | manual | user
+  confidence?: number
+}
+export type ChurchText = {
+  kind: string // mass_times | seasonal_mass_times | confession | adoration | info
+  rawText: string
+  sourceUpdatedAt?: string
+}
+export type ChurchLink = {
+  kind: string // website | instagram | facebook | whatsapp | youtube | livestream | donation
+  url: string
+}
 
 export const church = sqliteTable(
   'church',
@@ -38,59 +68,15 @@ export const church = sqliteTable(
     lastVerifiedAt: text('last_verified_at'), // ISO
     verifiedSource: text('verified_source'), // import | user | moderator
     updatedAt: text('updated_at'),
+    // embedded owned content (see the note above); shipped to the device, expanded there
+    services: text('services', { mode: 'json' }).$type<Service[]>(),
+    texts: text('texts', { mode: 'json' }).$type<ChurchText[]>(),
+    links: text('links', { mode: 'json' }).$type<ChurchLink[]>(),
   },
   (t) => [
     index('church_geohash_idx').on(t.geohash),
     index('church_country_city_idx').on(t.countryCode, t.city),
   ],
-)
-
-export const service = sqliteTable(
-  'service',
-  {
-    id: text('id').primaryKey(), // generated crypto.randomUUID()
-    churchId: text('church_id')
-      .notNull()
-      .references(() => church.id),
-    kind: text('kind').notNull(), // mass | confession | adoration
-    rite: text('rite'), // Mass only; extensible enum (latin_novus_ordo | latin_tridentine | byzantine | ...)
-    language: text('language'), // ISO 639, per-service
-    rrule: text('rrule').notNull(), // iCal RRULE: ONE pattern at ONE time; union = multiple rows
-    startTime: text('start_time').notNull(), // 'HH:MM' wall-clock; displayed as-is, expanded on-device
-    endTime: text('end_time'),
-    exdate: text('exdate'), // optional RRuleSet EXDATE (cancelled dates)
-    rdate: text('rdate'), // optional RRuleSet RDATE (one-off added dates)
-    locationNote: text('location_note'),
-    note: text('note'),
-    source: text('source'), // import | manual | user
-    confidence: real('confidence'),
-  },
-  (t) => [index('service_church_idx').on(t.churchId)],
-)
-
-export const churchText = sqliteTable(
-  'church_text',
-  {
-    churchId: text('church_id')
-      .notNull()
-      .references(() => church.id),
-    kind: text('kind').notNull(), // mass_times | seasonal_mass_times | confession | adoration | info
-    rawText: text('raw_text'),
-    sourceUpdatedAt: text('source_updated_at'),
-  },
-  (t) => [primaryKey({ columns: [t.churchId, t.kind] })],
-)
-
-export const churchLink = sqliteTable(
-  'church_link',
-  {
-    churchId: text('church_id')
-      .notNull()
-      .references(() => church.id),
-    kind: text('kind').notNull(), // website | instagram | facebook | whatsapp | youtube | livestream | donation
-    url: text('url').notNull(),
-  },
-  (t) => [primaryKey({ columns: [t.churchId, t.kind] })],
 )
 
 export const correction = sqliteTable(
@@ -141,9 +127,6 @@ export const attachment = sqliteTable(
 )
 
 export type Church = InferSelectModel<typeof church>
-export type Service = InferSelectModel<typeof service>
-export type ChurchText = InferSelectModel<typeof churchText>
-export type ChurchLink = InferSelectModel<typeof churchLink>
 export type Correction = InferSelectModel<typeof correction>
 export type VerificationEvent = InferSelectModel<typeof verificationEvent>
 export type Attachment = InferSelectModel<typeof attachment>

--- a/packages/api/src/schema.ts
+++ b/packages/api/src/schema.ts
@@ -73,10 +73,7 @@ export const church = sqliteTable(
     texts: text('texts', { mode: 'json' }).$type<ChurchText[]>(),
     links: text('links', { mode: 'json' }).$type<ChurchLink[]>(),
   },
-  (t) => [
-    index('church_geohash_idx').on(t.geohash),
-    index('church_country_city_idx').on(t.countryCode, t.city),
-  ],
+  (t) => [index('church_geohash_idx').on(t.geohash)],
 )
 
 export const correction = sqliteTable(


### PR DESCRIPTION
Backend storage + import model for the Mass-Times corpus. **Supersedes #299** (includes its two commits: the `sourceId→id` mapping and idempotent re-imports).

## Import contract (from #299)
- `ChurchDump.sourceId` — opaque stable id; importer keeps slug ids, emits a `sourceId→id` mapping sidecar.
- Idempotent re-imports: `--prior` reuses a known sourceId's id (stable across renames/moves); `--upsert` emits convergent SQL. `correction`/`verification_event` never touched.

## Embed model (new)
- `service`/`church_text`/`church_link` tables → **JSON columns on `church`** (`services`/`texts`/`links`). The server never queries inside a schedule (rrule expansion is on-device), so a church is read whole — `/near` becomes a single geohash scan (no JOIN).
- Each embedded service gets a **deterministic id** (`churchId:hash(slot)`) so a correction can target one Mass and a re-import keeps stable ids.
- Dropped the dead `(country_code, city)` index (mismatched with its query + unused).
- Migration `0003` drops the child tables + index, adds the JSON columns.

## Measured (real São Paulo run on a throwaway D1)
- **5.0 → 4.0 rows-written/church** (embed; minus the dropped index) vs **25.3** normalized — ~6× less.
- Full 138k load ≈ **~555k writes** (~416k if FTS-deferred), ~$0 on Workers Paid.
- FTS5 bulk `rebuild` bills ~1 write (vs ~1/church incremental); B-tree `CREATE INDEX` bills ~1/row (deferral saves nothing there).

28 backend tests + api/backend typecheck green; app typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)