### PR TITLE
Mass Times: map UX overhaul — viewport churches, native pins/controls, sheet polish

### DIFF
--- a/apps/app/src/app/(tabs)/(today,explore,library,you,search)/mass-times/index.tsx
+++ b/apps/app/src/app/(tabs)/(today,explore,library,you,search)/mass-times/index.tsx
@@ -9,6 +9,7 @@ import {
   ChurchSheet,
   countActiveFilters,
   emptyFilter,
+  type MapRegion,
   type MassFilter,
   MassFilterSheet,
   useMassTimesNearby,
@@ -25,7 +26,9 @@ export default function MassTimesScreen() {
   const insets = useSafeAreaInsets()
   const [filter, setFilter] = useState<MassFilter>(emptyFilter)
   const [filtersOpen, setFiltersOpen] = useState(false)
-  const nearby = useMassTimesNearby(filter)
+  // The viewed map region (undefined until the user pans) — lets the nearby results follow the map.
+  const [region, setRegion] = useState<MapRegion>()
+  const nearby = useMassTimesNearby(filter, region)
 
   // Ask for location up front: lights the blue dot + pulls real nearby results. iOS shows the dialog
   // only once; later calls just read status, so a guarded single fire.
@@ -43,6 +46,7 @@ export default function MassTimesScreen() {
         locale={i18n.language}
         filterCount={countActiveFilters(filter)}
         onOpenFilters={() => setFiltersOpen(true)}
+        onRegionChange={setRegion}
       />
 
       {/* Floating back button — the only top chrome, over the map. */}

--- a/apps/app/src/features/mass-times/components/ChurchDetail.tsx
+++ b/apps/app/src/features/mass-times/components/ChurchDetail.tsx
@@ -33,7 +33,7 @@ export function ChurchDetail({ churchId }: { churchId: string }) {
       <YStack gap="$xs">
         <XStack justifyContent="space-between" alignItems="flex-start" gap="$md">
           <Typography variant="sacred-title" fontSize={26} textAlign="left" flexShrink={1}>
-            {data.name}
+            {data.longName ?? data.name}
           </Typography>
           <FavoriteButton
             church={{

--- a/apps/app/src/features/mass-times/components/ChurchSheet.tsx
+++ b/apps/app/src/features/mass-times/components/ChurchSheet.tsx
@@ -1,5 +1,6 @@
 import { BottomSheet, Group, Host, RNHostView } from '@expo/ui/swift-ui'
 import {
+  ignoreSafeArea,
   interactiveDismissDisabled,
   type PresentationDetent,
   presentationBackgroundInteraction,
@@ -22,7 +23,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { Input, useTheme, XStack, YStack } from 'tamagui'
 import { AnimatedPressable, Skeleton, Typography } from '@/components'
 import type { NearbyChurch } from '@/lib/mass-times'
-import { nextService, useChurchSearch, wallClockNow } from '@/lib/mass-times'
+import { nextService, useChurch, useChurchSearch, wallClockNow } from '@/lib/mass-times'
 import { useDebounced } from '@/lib/useDebounced'
 import { useCheckInCount } from '../checkins'
 import { dayLabel, formatDistanceKm, formatTimeOfDay } from '../format'
@@ -34,13 +35,16 @@ import { type ChurchRowData, ChurchSearchRow } from './ChurchSearchRow'
 import { useGlassTile } from './glass'
 import { LocationBar } from './LocationBar'
 import { MassLog } from './MassLog'
+import type { CameraIdle } from './NativeChurchesMap'
 import { SavedChurches } from './SavedChurches'
 
 type Selected = { id: string; name: string; lat?: number; lng?: number }
 type SheetView = { kind: 'browse' } | { kind: 'detail'; church: Selected } | { kind: 'log' }
 
-// Stable detent identities (the native selection compares by value — keep them steady).
-const PEEK: PresentationDetent = { fraction: 0.16 }
+// Stable detent identities (the native selection compares by value — keep them steady). PEEK is a fixed
+// height sized to the search bar (grabber + search row + home-indicator inset), so minimized the sheet
+// shrinks to just the search field, Apple-Maps style — not a fraction that leaves content peeking.
+const PEEK: PresentationDetent = { height: 96 }
 const HALF: PresentationDetent = { fraction: 0.55 }
 const FULL: PresentationDetent = 'large'
 const DETENTS = [PEEK, HALF, FULL]
@@ -54,11 +58,13 @@ export function ChurchSheet({
   locale,
   filterCount,
   onOpenFilters,
+  onRegionChange,
 }: {
   nearby: MassTimesNearby
   locale: string
   filterCount: number
   onOpenFilters: () => void
+  onRegionChange?: (region: CameraIdle) => void
 }) {
   // One mode at a time: browse/search, a selected church's detail, or the check-in log. A discriminated
   // union (not two booleans) keeps the three exclusive and carries the selected church with the detail.
@@ -72,6 +78,20 @@ export function ChurchSheet({
   }
   const browse = () => setView({ kind: 'browse' })
 
+  // Authoritative coordinates for the map to focus, resolved from the detail query (shares the cache
+  // with the detail pane — no extra round-trip). This makes every selection source recenter the map,
+  // even saved/search rows whose tap payload carries no lat/lng.
+  const detailId = view.kind === 'detail' ? view.church.id : undefined
+  const { data: detailChurch } = useChurch(detailId)
+  const focused =
+    view.kind === 'detail'
+      ? {
+          id: view.church.id,
+          lat: detailChurch?.lat ?? view.church.lat,
+          lng: detailChurch?.lng ?? view.church.lng,
+        }
+      : undefined
+
   return (
     // ignoreSafeArea="all" so the hosted map bleeds edge to edge (through the notch + home indicator)
     // instead of the SwiftUI host insetting it and leaving black bars.
@@ -80,9 +100,10 @@ export function ChurchSheet({
         <View style={styles.fill}>
           <ChurchesMap
             nearby={nearby}
-            focused={view.kind === 'detail' ? view.church : undefined}
-            bottomInset={150}
+            focused={focused}
             onSelectChurch={(c) => openDetail({ id: c.id, name: c.name, lat: c.lat, lng: c.lng })}
+            onDismiss={browse}
+            onRegionChange={onRegionChange}
           />
         </View>
       </RNHostView>
@@ -94,6 +115,9 @@ export function ChurchSheet({
             presentationBackgroundInteraction('enabled'),
             interactiveDismissDisabled(true),
             presentationDragIndicator('visible'),
+            // Let the content fill through the home-indicator safe area instead of stopping above it
+            // and leaving a bare strip of sheet material (the "footer" seam).
+            ignoreSafeArea({ edges: 'bottom' }),
           ]}
         >
           <RNHostView>
@@ -252,89 +276,93 @@ function BrowseSearch({
   const results = search.data ?? []
 
   return (
-    <FlatList
-      style={styles.fill}
-      nestedScrollEnabled
-      keyboardShouldPersistTaps="handled"
-      keyboardDismissMode="on-drag"
-      data={searching ? results : churches}
-      keyExtractor={(c) => c.id}
-      renderItem={({ item }) =>
-        searching ? (
-          <ChurchSearchRow church={item as ChurchRowData} onSelect={onSelectRow} />
-        ) : (
-          <ChurchListItem
-            church={item as NearbyChurch}
-            locale={locale}
-            kind={nearby.kind}
-            onSelect={onSelectNearby}
+    <View style={styles.fill}>
+      {/* Pinned search bar (Apple Maps style): stays put while the list scrolls beneath it, and is all
+          that shows at the peek detent. */}
+      <XStack
+        gap="$sm"
+        alignItems="center"
+        paddingHorizontal={16}
+        paddingTop={16}
+        paddingBottom={12}
+      >
+        <XStack
+          flex={1}
+          backgroundColor={tile}
+          borderRadius="$lg"
+          paddingHorizontal="$md"
+          alignItems="center"
+          gap="$sm"
+        >
+          <Search size={18} color={theme.colorSecondary?.val} />
+          <Input
+            flex={1}
+            value={query}
+            onChangeText={onQuery}
+            onFocus={onFocusSearch}
+            placeholder={t('massTimes.searchPlaceholder')}
+            placeholderTextColor="$colorSecondary"
+            backgroundColor="transparent"
+            borderWidth={0}
+            paddingHorizontal={0}
+            height={44}
+            color="$color"
+            fontFamily="$body"
+            returnKeyType="search"
+            accessibilityLabel={t('massTimes.searchPlaceholder')}
           />
-        )
-      }
-      ItemSeparatorComponent={() => <YStack height="$sm" />}
-      contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: insets.bottom + 32 }}
-      showsVerticalScrollIndicator={false}
-      ListHeaderComponent={
-        <YStack gap="$md" paddingTop="$xs" paddingBottom="$md">
-          <XStack gap="$sm" alignItems="center">
-            <XStack
-              flex={1}
-              backgroundColor={tile}
-              borderRadius="$lg"
-              paddingHorizontal="$md"
-              alignItems="center"
-              gap="$sm"
-            >
-              <Search size={18} color={theme.colorSecondary?.val} />
-              <Input
-                flex={1}
-                value={query}
-                onChangeText={onQuery}
-                onFocus={onFocusSearch}
-                placeholder={t('massTimes.searchPlaceholder')}
-                placeholderTextColor="$colorSecondary"
-                backgroundColor="transparent"
-                borderWidth={0}
-                paddingHorizontal={0}
-                height={44}
-                color="$color"
-                fontFamily="$body"
-                returnKeyType="search"
-                accessibilityLabel={t('massTimes.searchPlaceholder')}
-              />
-              {query.length > 0 ? (
-                <AnimatedPressable
-                  onPress={() => onQuery('')}
-                  hitSlop={8}
-                  accessibilityRole="button"
-                >
-                  <X size={16} color={theme.colorSecondary?.val} />
-                </AnimatedPressable>
-              ) : null}
-            </XStack>
-            <AnimatedPressable
-              onPress={onOpenFilters}
-              accessibilityRole="button"
-              accessibilityLabel={t('massTimes.filters')}
-            >
-              <YStack
-                backgroundColor={tile}
-                borderRadius="$lg"
-                alignItems="center"
-                justifyContent="center"
-                width={42}
-                height={42}
-              >
-                <SlidersHorizontal
-                  size={18}
-                  color={filterCount > 0 ? theme.accent?.val : theme.colorSecondary?.val}
-                />
-              </YStack>
+          {query.length > 0 ? (
+            <AnimatedPressable onPress={() => onQuery('')} hitSlop={8} accessibilityRole="button">
+              <X size={16} color={theme.colorSecondary?.val} />
             </AnimatedPressable>
-          </XStack>
+          ) : null}
+        </XStack>
+        <AnimatedPressable
+          onPress={onOpenFilters}
+          accessibilityRole="button"
+          accessibilityLabel={t('massTimes.filters')}
+        >
+          <YStack
+            backgroundColor={tile}
+            borderRadius="$lg"
+            alignItems="center"
+            justifyContent="center"
+            width={42}
+            height={42}
+          >
+            <SlidersHorizontal
+              size={18}
+              color={filterCount > 0 ? theme.accent?.val : theme.colorSecondary?.val}
+            />
+          </YStack>
+        </AnimatedPressable>
+      </XStack>
 
-          {searching ? null : (
-            <>
+      <FlatList
+        style={styles.fill}
+        nestedScrollEnabled
+        keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
+        data={searching ? results : churches}
+        keyExtractor={(c) => c.id}
+        renderItem={({ item }) =>
+          searching ? (
+            <ChurchSearchRow church={item as ChurchRowData} onSelect={onSelectRow} />
+          ) : (
+            <ChurchListItem
+              church={item as NearbyChurch}
+              locale={locale}
+              kind={nearby.kind}
+              onSelect={onSelectNearby}
+            />
+          )
+        }
+        ItemSeparatorComponent={() => <YStack height="$sm" />}
+        contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: insets.bottom + 24 }}
+        showsVerticalScrollIndicator={false}
+        ListHeaderComponent={
+          searching ? null : (
+            <YStack gap="$sm" paddingBottom="$sm">
               <LocationBar location={nearby.location} />
               <NextMassNearby churches={churches} locale={locale} />
               <SavedChurches onSelect={onSelectRow} />
@@ -364,37 +392,37 @@ function BrowseSearch({
               {churches.length > 0 ? (
                 <Typography variant="label">{t('massTimes.nearbyHeading')}</Typography>
               ) : null}
-            </>
-          )}
-        </YStack>
-      }
-      ListEmptyComponent={
-        searching ? (
-          search.isLoading ? (
+            </YStack>
+          )
+        }
+        ListEmptyComponent={
+          searching ? (
+            search.isLoading ? (
+              <YStack gap="$sm">
+                {[0, 1, 2].map((i) => (
+                  <Skeleton key={i} height={72} borderRadius={12} />
+                ))}
+              </YStack>
+            ) : (
+              <YStack paddingTop="$md" alignItems="center">
+                <Typography variant="annotation">{t('massTimes.noResults')}</Typography>
+              </YStack>
+            )
+          ) : nearby.isLoading ? (
             <YStack gap="$sm">
               {[0, 1, 2].map((i) => (
-                <Skeleton key={i} height={72} borderRadius={12} />
+                <Skeleton key={i} height={88} borderRadius={12} />
               ))}
             </YStack>
           ) : (
-            <YStack paddingTop="$md" alignItems="center">
-              <Typography variant="annotation">{t('massTimes.noResults')}</Typography>
+            <YStack gap="$xs" paddingTop="$md" alignItems="center">
+              <Typography variant="interface">{t('massTimes.empty')}</Typography>
+              <Typography variant="annotation">{t('massTimes.emptyHint')}</Typography>
             </YStack>
           )
-        ) : nearby.isLoading ? (
-          <YStack gap="$sm">
-            {[0, 1, 2].map((i) => (
-              <Skeleton key={i} height={88} borderRadius={12} />
-            ))}
-          </YStack>
-        ) : (
-          <YStack gap="$xs" paddingTop="$md" alignItems="center">
-            <Typography variant="interface">{t('massTimes.empty')}</Typography>
-            <Typography variant="annotation">{t('massTimes.emptyHint')}</Typography>
-          </YStack>
-        )
-      }
-    />
+        }
+      />
+    </View>
   )
 }
 

--- a/apps/app/src/features/mass-times/components/ChurchesMap.tsx
+++ b/apps/app/src/features/mass-times/components/ChurchesMap.tsx
@@ -1,14 +1,12 @@
-import { LocateFixed } from 'lucide-react-native'
 import { lazy, Suspense, useCallback, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Platform } from 'react-native'
-import { useTheme, useThemeName, YStack } from 'tamagui'
-import { AnimatedPressable, GlassSurface, Typography } from '@/components'
-import { lightTap } from '@/lib/haptics'
+import { YStack } from 'tamagui'
+import { Typography } from '@/components'
 import type { NearbyChurch } from '@/lib/mass-times'
 import type { MassTimesNearby } from '../useMassTimesNearby'
 import { MapErrorBoundary } from './MapErrorBoundary'
-import type { MapHandle } from './NativeChurchesMap'
+import type { CameraIdle, MapHandle } from './NativeChurchesMap'
 
 // Loaded only when the map view is shown, so the list path never executes expo-maps' native binding.
 const NativeChurchesMap = lazy(() => import('./NativeChurchesMap'))
@@ -16,24 +14,40 @@ const NativeChurchesMap = lazy(() => import('./NativeChurchesMap'))
 const overviewZoom = 12
 const userZoom = 14
 
-// The full-bleed map canvas behind the sheet: it drives the camera through the native ref (recenter +
-// auto-center-on-GPS) and bubbles marker taps up via `onSelectChurch`. The browse/detail surface is
-// the sheet on top; the recenter button floats above the sheet's peek (`bottomInset`).
+// How long to wait after the camera settles before refetching the viewed area, how far it must pan (as a
+// fraction of the visible latitude span), and how much it must zoom (span grow/shrink ratio) to count —
+// so tiny nudges don't churn, but both panning AND zooming refetch.
+const regionSettleMs = 500
+const regionMoveFraction = 0.25
+const regionZoomRatio = 1.3
+
+// Fraction of the visible latitude span to shift the focus camera south by, so the pin lands in the
+// upper area clear of the half-height sheet (pin ends up ~22% from the top, not dead center under it).
+const focusOffsetFraction = 0.28
+// Fallback visible span at `userZoom` on a phone, until the first real camera move reports one.
+const fallbackLatitudeDelta = 0.07
+
+// The full-bleed map canvas behind the sheet: it drives the camera through the native ref (auto-center
+// on GPS, focus-a-pin), keeps the native pin selection in sync with the sheet, and reports the viewed
+// region up so the nearby query can follow the map. Recenter + re-north are the map's own native
+// controls (see NativeChurchesMap uiSettings), which the system keeps clear of the sheet.
 export function ChurchesMap({
   nearby,
   onSelectChurch,
+  onDismiss,
+  onRegionChange,
   focused,
-  bottomInset = 140,
 }: {
   nearby: MassTimesNearby
   onSelectChurch?: (church: NearbyChurch) => void
-  // When a church is selected (place mode), swing the camera to it — like Apple Maps centering a pin.
-  focused?: { lat?: number; lng?: number }
-  bottomInset?: number
+  // Tapping the empty map deselects — used to dismiss the open detail (and the pin) together.
+  onDismiss?: () => void
+  // The viewed area settled somewhere meaningfully new — refetch churches around it.
+  onRegionChange?: (region: CameraIdle) => void
+  // The selected church (place mode): swing the camera to it (offset above the sheet) and select its pin.
+  focused?: { id: string; lat?: number; lng?: number }
 }) {
   const { t } = useTranslation()
-  const theme = useTheme()
-  const isDark = useThemeName().startsWith('dark')
   const { location } = nearby
 
   const mapRef = useRef<MapHandle>(null)
@@ -43,6 +57,47 @@ export function ChurchesMap({
     coordinates: { latitude: location.coords.lat, longitude: location.coords.lng },
     zoom: overviewZoom,
   }).current
+
+  // Latest settled camera (updated synchronously on every move) — read for the focus offset.
+  const lastCamera = useRef<CameraIdle>({
+    latitude: location.coords.lat,
+    longitude: location.coords.lng,
+    latitudeDelta: fallbackLatitudeDelta,
+    longitudeDelta: fallbackLatitudeDelta,
+    zoom: overviewZoom,
+  })
+  // The last region we reported up + a settle timer, so refetches debounce and only fire on real moves.
+  const lastReported = useRef({
+    latitude: location.coords.lat,
+    longitude: location.coords.lng,
+    latitudeDelta: fallbackLatitudeDelta,
+  })
+  const settleTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  const onCameraIdle = useCallback(
+    (camera: CameraIdle) => {
+      lastCamera.current = camera
+      if (settleTimer.current) clearTimeout(settleTimer.current)
+      settleTimer.current = setTimeout(() => {
+        const moved = Math.hypot(
+          camera.latitude - lastReported.current.latitude,
+          camera.longitude - lastReported.current.longitude,
+        )
+        const pannedEnough = moved >= camera.latitudeDelta * regionMoveFraction
+        const spanRatio = camera.latitudeDelta / lastReported.current.latitudeDelta
+        const zoomedEnough = spanRatio >= regionZoomRatio || spanRatio <= 1 / regionZoomRatio
+        if (!pannedEnough && !zoomedEnough) return
+        lastReported.current = {
+          latitude: camera.latitude,
+          longitude: camera.longitude,
+          latitudeDelta: camera.latitudeDelta,
+        }
+        onRegionChange?.(camera)
+      }, regionSettleMs)
+    },
+    [onRegionChange],
+  )
+  useEffect(() => () => clearTimeout(settleTimer.current), [])
 
   const centerOnUser = useCallback(
     () =>
@@ -61,24 +116,28 @@ export function ChurchesMap({
     if (becameGranted) centerOnUser()
   }, [location.status, centerOnUser])
 
-  // Swing to the focused church when place mode opens.
+  // Place mode: swing to the focused church (offset above the sheet) and select its pin. Clearing the
+  // focus (back to browse) deselects the pin — keeping map and sheet in lockstep both ways.
+  const fId = focused?.id
   const fLat = focused?.lat
   const fLng = focused?.lng
   useEffect(() => {
+    if (!fId) {
+      mapRef.current?.deselect()
+      return
+    }
     if (fLat == null || fLng == null) return
+    // Scale the last-seen visible span to the target zoom (each zoom level halves the span).
+    const span = lastCamera.current.latitudeDelta * 2 ** (lastCamera.current.zoom - userZoom)
+    const offset = (Number.isFinite(span) ? span : fallbackLatitudeDelta) * focusOffsetFraction
     mapRef.current?.setCameraPosition({
-      coordinates: { latitude: fLat, longitude: fLng },
+      coordinates: { latitude: fLat - offset, longitude: fLng },
       zoom: userZoom,
     })
-  }, [fLat, fLng])
+    mapRef.current?.select(fId)
+  }, [fId, fLat, fLng])
 
   if (Platform.OS === 'web') return <MapUnavailable message={t('massTimes.mapWeb')} />
-
-  const recenter = () => {
-    void lightTap()
-    if (location.status === 'granted') centerOnUser()
-    else void location.request()
-  }
 
   return (
     <YStack flex={1}>
@@ -89,34 +148,11 @@ export function ChurchesMap({
             nearby={nearby}
             initialCamera={initialCamera}
             onSelect={(church) => onSelectChurch?.(church)}
+            onDeselect={onDismiss}
+            onCameraIdle={onCameraIdle}
           />
         </Suspense>
       </MapErrorBoundary>
-
-      {/* My-location button, floated above the sheet's peek edge. */}
-      <YStack position="absolute" right="$lg" bottom={bottomInset}>
-        <AnimatedPressable
-          onPress={recenter}
-          accessibilityRole="button"
-          accessibilityLabel={t('massTimes.recenter')}
-        >
-          <GlassSurface
-            isDark={isDark}
-            style={{
-              width: 46,
-              height: 46,
-              borderRadius: 23,
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}
-          >
-            <LocateFixed
-              size={20}
-              color={location.status === 'granted' ? theme.accent?.val : theme.colorSecondary?.val}
-            />
-          </GlassSurface>
-        </AnimatedPressable>
-      </YStack>
     </YStack>
   )
 }

--- a/apps/app/src/features/mass-times/components/NativeChurchesMap.tsx
+++ b/apps/app/src/features/mass-times/components/NativeChurchesMap.tsx
@@ -1,4 +1,4 @@
-import { AppleMaps, GoogleMaps } from 'expo-maps'
+import { AppleMaps, type CameraMoveEvent, GoogleMaps } from 'expo-maps'
 import { forwardRef, useImperativeHandle, useMemo, useRef } from 'react'
 import { Platform } from 'react-native'
 import { useTheme } from 'tamagui'
@@ -6,18 +6,53 @@ import type { NearbyChurch } from '@/lib/mass-times'
 import { useFavoritesStore } from '../favorites'
 import type { MassTimesNearby } from '../useMassTimesNearby'
 
+// Stained-glass jewel tones so the directory pins aren't a monotone wall of gold — each church gets a
+// stable color hashed from its name (favorites stay the burgundy heart, see below).
+const pinPalette = [
+  '#C9A84C', // gold
+  '#B23A48', // crimson
+  '#2F5C9E', // royal blue
+  '#2E8B57', // emerald
+  '#6A4C93', // violet
+  '#D08C34', // amber
+  '#2A9D8F', // teal
+  '#C45B7C', // rose
+  '#3D4EA8', // indigo
+  '#4F7942', // forest
+]
+
+function pinColor(seed: string): string {
+  let hash = 0
+  for (let i = 0; i < seed.length; i++) hash = (hash * 31 + seed.charCodeAt(i)) | 0
+  return pinPalette[Math.abs(hash) % pinPalette.length]
+}
+
 export type CameraPosition = {
   coordinates: { latitude: number; longitude: number }
   zoom: number
 }
 
-// What the wrapper drives the camera with. expo-maps' `cameraPosition` prop is initial-only, so moves
-// go through the native view's imperative `setCameraPosition` (exposed here via the forwarded ref).
-export type MapHandle = { setCameraPosition: (camera: CameraPosition) => void }
+// Where the camera settled after a move: center + zoom + visible span (used to refetch the viewed area
+// as a bounding box and to offset the focus camera so a pin clears the sheet).
+export type CameraIdle = {
+  latitude: number
+  longitude: number
+  latitudeDelta: number
+  longitudeDelta: number
+  zoom: number
+}
+
+// What the wrapper drives the map with. expo-maps' `cameraPosition` prop is initial-only, so moves go
+// through the native view's imperative methods (exposed here via the forwarded ref). `select`/`deselect`
+// keep the native pin selection in lockstep with the sheet (iOS 18+ / current Google Maps).
+export type MapHandle = {
+  setCameraPosition: (camera: CameraPosition) => void
+  select: (id: string) => void
+  deselect: () => void
+}
 
 // The actual native map. Kept in its own module and loaded lazily (see ChurchesMap) so importing the
 // Mass Times screen never pulls expo-maps' native view into the list path — only opening the map does.
-// Marker taps bubble up via `onSelect`; the recenter button moves the camera through the ref handle.
 const NativeChurchesMap = forwardRef<
   MapHandle,
   {
@@ -25,13 +60,14 @@ const NativeChurchesMap = forwardRef<
     initialCamera: CameraPosition
     onSelect: (church: NearbyChurch) => void
     onDeselect?: () => void
+    onCameraIdle?: (camera: CameraIdle) => void
   }
->(function NativeChurchesMap({ nearby, initialCamera, onSelect, onDeselect }, ref) {
+>(function NativeChurchesMap({ nearby, initialCamera, onSelect, onDeselect, onCameraIdle }, ref) {
   const theme = useTheme()
   const accent = theme.accent?.val
   const favoriteTint = theme.colorBurgundy?.val ?? accent
   const { churches } = nearby
-  // Raw record is referentially stable; we derive the per-marker icon from it in the memo below.
+  // Raw record is referentially stable; we derive the per-marker icon from it in the memos below.
   const favorites = useFavoritesStore((s) => s.favorites)
 
   const appleRef = useRef<React.ElementRef<typeof AppleMaps.View>>(null)
@@ -42,6 +78,15 @@ const NativeChurchesMap = forwardRef<
       setCameraPosition: (camera) => {
         appleRef.current?.setCameraPosition(camera)
         googleRef.current?.setCameraPosition(camera)
+      },
+      // moveCamera:false — the wrapper owns the camera (so it can offset the pin above the sheet).
+      select: (id) => {
+        appleRef.current?.selectMarker(id, { moveCamera: false })
+        void googleRef.current?.selectMarker(id, { moveCamera: false })
+      },
+      deselect: () => {
+        appleRef.current?.selectMarker(undefined)
+        void googleRef.current?.selectMarker(undefined)
       },
     }),
     [],
@@ -57,24 +102,38 @@ const NativeChurchesMap = forwardRef<
       })),
     [churches],
   )
-  // A church glyph for the directory, a heart for saved ones — mirroring the cards (the SF Symbol
-  // `church` matches our lucide Church icon; `heart.fill` the FavoriteButton).
+  // A cross for the directory, a heart for saved ones. NOTE: there is no `church` SF Symbol (it renders
+  // a blank fallback pin), so we use `cross.fill` — the clearest native glyph for a Catholic church.
+  // Non-favorites are tinted by a name-hashed jewel tone for variety; favorites keep the burgundy heart.
   const appleMarkers = useMemo(
     () =>
       markers.map((m) => {
         const isFavorite = Boolean(favorites[m.id])
         return {
           ...m,
-          systemImage: isFavorite ? 'heart.fill' : 'church',
-          tintColor: isFavorite ? favoriteTint : accent,
+          systemImage: isFavorite ? 'heart.fill' : 'cross.fill',
+          tintColor: isFavorite ? favoriteTint : pinColor(m.title),
         }
       }),
-    [markers, favorites, accent, favoriteTint],
+    [markers, favorites, favoriteTint],
   )
 
   const select = (id?: string) => {
     const church = id ? byId.get(id) : undefined
     if (church) onSelect(church)
+  }
+
+  const handleCameraMove = (e: CameraMoveEvent) => {
+    const lat = e.coordinates?.latitude
+    const lng = e.coordinates?.longitude
+    if (lat == null || lng == null) return
+    onCameraIdle?.({
+      latitude: lat,
+      longitude: lng,
+      latitudeDelta: e.latitudeDelta,
+      longitudeDelta: e.longitudeDelta,
+      zoom: e.zoom,
+    })
   }
 
   if (Platform.OS === 'android') {
@@ -86,13 +145,16 @@ const NativeChurchesMap = forwardRef<
         markers={markers}
         properties={{ isMyLocationEnabled: true }}
         uiSettings={{
-          myLocationButtonEnabled: false,
-          compassEnabled: false,
+          // Native map controls (the Apple/Google Maps way): the compass re-norths when rotated and the
+          // my-location button recenters — the system keeps them clear of the sheet, no custom chrome.
+          compassEnabled: true,
+          myLocationButtonEnabled: true,
           mapToolbarEnabled: false,
           zoomControlsEnabled: false,
         }}
         onMarkerClick={(m) => select(m.id)}
         onMapClick={onDeselect}
+        onCameraMove={handleCameraMove}
       />
     )
   }
@@ -104,16 +166,17 @@ const NativeChurchesMap = forwardRef<
       cameraPosition={initialCamera}
       markers={appleMarkers}
       properties={{ isMyLocationEnabled: true }}
-      // We supply our own glass search + recenter, so suppress all native MapKit chrome (the stray
-      // compass / pitch / scale controls that otherwise float on the right edge).
+      // Native map controls (the Apple Maps way): the compass re-norths when rotated and the my-location
+      // button recenters. SwiftUI keeps `.mapControls` clear of the sheet, so we drop our custom chrome.
       uiSettings={{
-        compassEnabled: false,
-        myLocationButtonEnabled: false,
+        compassEnabled: true,
+        myLocationButtonEnabled: true,
         scaleBarEnabled: false,
         togglePitchEnabled: false,
       }}
       onMarkerClick={(m) => select(m.id)}
       onMapClick={onDeselect}
+      onCameraMove={handleCameraMove}
     />
   )
 })

--- a/apps/app/src/features/mass-times/index.ts
+++ b/apps/app/src/features/mass-times/index.ts
@@ -17,6 +17,7 @@ export { type DeviceLocation, useDeviceLocation } from './useDeviceLocation'
 export {
   countActiveFilters,
   emptyFilter,
+  type MapRegion,
   type MassFilter,
   type MassTimesNearby,
   useMassTimesNearby,

--- a/apps/app/src/features/mass-times/useMassTimesNearby.ts
+++ b/apps/app/src/features/mass-times/useMassTimesNearby.ts
@@ -1,13 +1,45 @@
 import type { ServiceKind } from '@ember/api'
 import { useMemo } from 'react'
-import type { NearbyChurch } from '@/lib/mass-times'
-import { hasServiceToday, useNearbyChurches } from '@/lib/mass-times'
+import type { Bbox, NearbyChurch } from '@/lib/mass-times'
+import { hasServiceToday, useChurchesInBbox } from '@/lib/mass-times'
 import { useFavoritesStore } from './favorites'
 import type { DeviceLocation } from './useDeviceLocation'
 import { useDeviceLocation } from './useDeviceLocation'
 
-const radiusKm = 15
-const fetchLimit = 60
+// Backend browse is capped at 100 churches per request.
+const fetchLimit = 100
+// Initial viewport span (degrees) before the map reports its real region — ~28 km around the user.
+const defaultSpanDeg = 0.25
+const earthRadiusKm = 6371
+
+// The viewed map region. Structurally satisfied by the map's `CameraIdle` payload.
+export type MapRegion = {
+  latitude: number
+  longitude: number
+  latitudeDelta: number
+  longitudeDelta: number
+}
+
+function bboxFromRegion(r: MapRegion): Bbox {
+  const halfLat = r.latitudeDelta / 2
+  const halfLng = r.longitudeDelta / 2
+  return {
+    minLat: Math.max(-90, r.latitude - halfLat),
+    maxLat: Math.min(90, r.latitude + halfLat),
+    minLng: Math.max(-180, r.longitude - halfLng),
+    maxLng: Math.min(180, r.longitude + halfLng),
+  }
+}
+
+function haversineKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const toRad = (d: number) => (d * Math.PI) / 180
+  const dLat = toRad(lat2 - lat1)
+  const dLng = toRad(lng2 - lng1)
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2
+  return earthRadiusKm * 2 * Math.asin(Math.min(1, Math.sqrt(a)))
+}
 
 // The nearby filters. `kind` narrows server-side; `today` and `favoritesOnly` refine on-device (the
 // list already carries each church's service rules + a saved-id lookup, so no extra round-trip).
@@ -33,28 +65,54 @@ export type MassTimesNearby = {
   refetch: () => void
 }
 
-// Location + nearby query as one unit, so the list and map views share a single location instance and
-// a single cached request. The server narrows by `kind`; `today`/`favoritesOnly` filter the result.
-export function useMassTimesNearby(filter: MassFilter): MassTimesNearby {
+// Churches for the current map viewport, shared by the list and the map. We query the viewport as a
+// bounding box (`/churches?bbox`) rather than a fixed radius, so any zoom works — from a city block to
+// the whole globe (capped at `fetchLimit`). `today`/`favoritesOnly` refine on-device; distance is
+// computed from the view center so the list reads nearest-first.
+export function useMassTimesNearby(filter: MassFilter, region?: MapRegion): MassTimesNearby {
   const location = useDeviceLocation()
   const favorites = useFavoritesStore((s) => s.favorites)
-  const { data, isLoading, isFetching, isError, refetch } = useNearbyChurches({
-    lat: location.coords.lat,
-    lng: location.coords.lng,
-    radiusKm,
-    limit: fetchLimit,
-    kind: filter.kind,
-  })
 
-  const churches = useMemo(() => {
-    if (!data) return data
-    return data.filter((c) => {
-      if (filter.favoritesOnly && !favorites[c.id]) return false
-      if (filter.today && !hasServiceToday(c.services, { timezone: c.timezone, kind: filter.kind }))
-        return false
-      return true
-    })
-  }, [data, filter.today, filter.favoritesOnly, filter.kind, favorites])
+  const view: MapRegion = region ?? {
+    latitude: location.coords.lat,
+    longitude: location.coords.lng,
+    latitudeDelta: defaultSpanDeg,
+    longitudeDelta: defaultSpanDeg,
+  }
+  const bbox = bboxFromRegion(view)
+  const { data, isLoading, isFetching, isError, refetch } = useChurchesInBbox(
+    bbox,
+    filter.kind,
+    fetchLimit,
+  )
+
+  const churches = useMemo<NearbyChurch[] | undefined>(() => {
+    if (!data) return undefined
+    return data
+      .map((c) => ({
+        ...c,
+        services: c.services ?? [],
+        distanceKm: haversineKm(view.latitude, view.longitude, c.lat, c.lng),
+      }))
+      .sort((a, b) => a.distanceKm - b.distanceKm)
+      .filter((c) => {
+        if (filter.favoritesOnly && !favorites[c.id]) return false
+        if (
+          filter.today &&
+          !hasServiceToday(c.services, { timezone: c.timezone, kind: filter.kind })
+        )
+          return false
+        return true
+      })
+  }, [
+    data,
+    filter.today,
+    filter.favoritesOnly,
+    filter.kind,
+    favorites,
+    view.latitude,
+    view.longitude,
+  ])
 
   return { location, churches, kind: filter.kind, isLoading, isFetching, isError, refetch }
 }

--- a/apps/app/src/lib/mass-times/client.ts
+++ b/apps/app/src/lib/mass-times/client.ts
@@ -29,6 +29,8 @@ export type NearbyParams = {
   limit?: number
 }
 
+export type Bbox = { minLng: number; minLat: number; maxLng: number; maxLat: number }
+
 async function getJson<T>(path: string, query?: Record<string, string | number | undefined>) {
   const url = new URL(path, baseUrl)
   for (const [key, value] of Object.entries(query ?? {})) {
@@ -56,6 +58,20 @@ export async function fetchNearbyChurches(params: NearbyParams): Promise<NearbyC
     radius_km: params.radiusKm,
     kind: params.kind,
     limit: params.limit,
+  })
+  return churches
+}
+
+// Churches within a map viewport (any zoom — no radius cap, unlike `/near`). Returns up to `limit`
+// churches in the box (the backend browse is capped at 100), with their embedded services.
+export async function fetchChurchesInBbox(
+  bbox: Bbox,
+  opts: { kind?: ServiceKind; limit?: number } = {},
+): Promise<Church[]> {
+  const { churches } = await getJson<{ churches: Church[] }>('/churches', {
+    bbox: `${bbox.minLng},${bbox.minLat},${bbox.maxLng},${bbox.maxLat}`,
+    kind: opts.kind,
+    limit: opts.limit,
   })
   return churches
 }

--- a/apps/app/src/lib/mass-times/hooks.ts
+++ b/apps/app/src/lib/mass-times/hooks.ts
@@ -1,7 +1,9 @@
-import type { CorrectionBody } from '@ember/api'
-import { useMutation, useQuery } from '@tanstack/react-query'
+import type { CorrectionBody, ServiceKind } from '@ember/api'
+import { keepPreviousData, useMutation, useQuery } from '@tanstack/react-query'
 import {
+  type Bbox,
   fetchChurch,
+  fetchChurchesInBbox,
   fetchNearbyChurches,
   type NearbyParams,
   searchChurches,
@@ -20,6 +22,20 @@ export function useNearbyChurches(params: NearbyParams | undefined) {
     queryFn: () => fetchNearbyChurches(params as NearbyParams),
     enabled: !!params,
     staleTime,
+    // Keep the current churches on screen while panning to a new area refetches — no flicker of the
+    // pins vanishing and re-appearing as the region changes.
+    placeholderData: keepPreviousData,
+  })
+}
+
+export function useChurchesInBbox(bbox: Bbox | undefined, kind?: ServiceKind, limit?: number) {
+  return useQuery({
+    queryKey: ['mass-times', 'bbox', bbox, kind, limit],
+    queryFn: () => fetchChurchesInBbox(bbox as Bbox, { kind, limit }),
+    enabled: !!bbox,
+    staleTime,
+    // Keep the current churches while panning/zooming to a new viewport refetches — no pin flicker.
+    placeholderData: keepPreviousData,
   })
 }
 

--- a/apps/app/src/lib/mass-times/index.ts
+++ b/apps/app/src/lib/mass-times/index.ts
@@ -1,6 +1,8 @@
 export {
+  type Bbox,
   type ChurchDetail,
   fetchChurch,
+  fetchChurchesInBbox,
   fetchNearbyChurches,
   type NearbyChurch,
   type NearbyParams,
@@ -10,6 +12,7 @@ export {
 } from './client'
 export {
   useChurch,
+  useChurchesInBbox,
   useChurchSearch,
   useNearbyChurches,
   useSubmitCorrection,


### PR DESCRIPTION
Reworks the Mass Times map surface to feel native and stay in sync with the bottom sheet.

## Map data
- **Churches follow the viewport.** The map + list now query the visible bounding box (`/churches?bbox`) instead of a fixed-radius `/near` — works at any zoom (city block → globe), capped at 100, debounced on pan/zoom with previous pins kept so they don't flicker out and back in. Distance is computed from the view center so the list still reads nearest-first. No new backend endpoint.

## Pins & controls
- **Native pin glyph.** Uses the `cross.fill` SF Symbol — confirmed against the SFSafeSymbols catalog that there is **no** `church` symbol (it silently fell back to a blank pin). Each church is tinted from a stained-glass palette hashed off its name; favorites keep the burgundy heart.
- **Native map controls.** Enables the compass (re-north when rotated) and the my-location button, replacing the custom glass recenter button.

## Selection ↔ sheet sync
- Tapping a pin opens its detail and selects it; tapping the empty map or going back deselects both.
- List / saved / search selections recenter the map (coords resolved from the cached detail query), with the camera offset so the pin clears the half-height sheet.

## Detail & sheet polish
- Detail header uses the church **long name**.
- **Pinned search bar** so the minimized peek collapses to just the search field (Apple-Maps style).
- Fixed the bottom safe-area **"footer" seam** with `ignoreSafeArea`; tightened spacing.

## Notes
- iOS-first (verified on device); Android paths kept correct.
- Even global sampling (one pin per region when zoomed way out) is **not** included — a single bbox query returns up to 100 by import order. Follow-up if worldwide data lands: `ORDER BY RANDOM()` on the backend browse or client-side grid sampling.