### PR TITLE
Books: close the TOC tray when a chapter node is tapped

### DIFF
--- a/apps/app/src/features/books/reader/ReaderTocSheet.tsx
+++ b/apps/app/src/features/books/reader/ReaderTocSheet.tsx
@@ -213,7 +213,10 @@ export function ReaderTocSheet({
               const timing = chapterTimings?.get(node.id)
               return (
                 <Pressable
-                  onPress={() => onSelect(node.id)}
+                  onPress={() => {
+                    onSelect(node.id)
+                    onClose()
+                  }}
                   accessibilityRole="link"
                   accessibilityLabel={title}
                   accessibilityState={{ selected: isCurrent, checked: isCompleted }}
@@ -287,7 +290,16 @@ export function ReaderTocSheet({
                 </Pressable>
                 <Pressable
                   style={{ flex: 1 }}
-                  onPress={() => (isReadableGroup ? onSelect(node.id) : toggleExpand(node.id))}
+                  onPress={() => {
+                    // Readable group → navigate + close the tray (like leaves);
+                    // a body-less group just expands and the tray stays open.
+                    if (isReadableGroup) {
+                      onSelect(node.id)
+                      onClose()
+                    } else {
+                      toggleExpand(node.id)
+                    }
+                  }}
                   accessibilityRole={isReadableGroup ? 'link' : 'button'}
                   accessibilityLabel={title}
                   accessibilityState={


### PR DESCRIPTION
## Problem

In the book reader, tapping a chapter (or a readable Part/Section node) in the table-of-contents sheet navigated correctly but left the **TOC tray open**.

## Root cause

`ReaderTocSheet` only fired `onSelect` on tap and relied on each parent screen to dismiss it by flipping the sheet's open flag via the native `index` prop. That parent-driven close is unreliable mid-touch. Its three sibling sheets — **Search**, **Bookmarks**, and **Highlights** — all instead call `onClose()` from within the row press, right after `onSelect()`. `ReaderTocSheet` was the lone exception.

## Fix

`apps/app/src/features/books/reader/ReaderTocSheet.tsx` now closes itself on select, matching the sibling convention:

- **Leaf chapters** — `onSelect(node.id)` then `onClose()`.
- **Readable group nodes** (the first-class Part/Section nodes from #309) — navigate and close.
- **Body-less group nodes** — unchanged; they just expand and keep the tray open.

## Testing

Lint/tests weren't runnable in the remote session (no `node_modules`); the change is a small, self-contained edit to two press handlers and should be covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016DgMQtSN32sWk6EuGGnHnY)_