### PR TITLE
Mass Times: route map viewport query through the geohash index

### DIFF
--- a/apps/backend/src/features/churches/queries.ts
+++ b/apps/backend/src/features/churches/queries.ts
@@ -2,7 +2,6 @@ import type { Church } from '@ember/api'
 import { church, verificationEvent } from '@ember/api'
 import { and, desc, eq, inArray, sql } from 'drizzle-orm'
 import type { Db } from '../../db'
-import type { Bbox } from '../../lib/geo'
 
 // Geo prefilter: OR of half-open geohash prefix ranges. Built with the query builder (so rows map
 // to camelCase typed Church) plus a raw `sql` fragment for the ranges — which stays sargable on the
@@ -70,37 +69,6 @@ export async function churchIdsMatchingText(
     LIMIT ${page.limit} OFFSET ${page.offset}
   `)
   return rows.map((r) => r.id)
-}
-
-// Browse / filter (non-FTS path): country/city/bbox + church-level filters.
-export function browseChurches(
-  db: Db,
-  opts: {
-    country?: string
-    city?: string
-    bbox?: Bbox
-    institute?: string
-    status?: string
-    limit: number
-    offset: number
-  },
-): Promise<Church[]> {
-  const conds = []
-  if (opts.country) conds.push(eq(church.country, opts.country))
-  if (opts.city) conds.push(eq(church.city, opts.city))
-  if (opts.institute) conds.push(eq(church.institute, opts.institute))
-  if (opts.status) conds.push(eq(church.status, opts.status))
-  if (opts.bbox) {
-    conds.push(
-      sql`${church.lat} >= ${opts.bbox.minLat} AND ${church.lat} <= ${opts.bbox.maxLat} AND ${church.lng} >= ${opts.bbox.minLng} AND ${church.lng} <= ${opts.bbox.maxLng}`,
-    )
-  }
-  return db
-    .select()
-    .from(church)
-    .where(conds.length ? and(...conds) : undefined)
-    .limit(opts.limit)
-    .offset(opts.offset)
 }
 
 export function churchesByIds(db: Db, ids: string[]): Promise<Church[]> {

--- a/apps/backend/src/features/churches/service.ts
+++ b/apps/backend/src/features/churches/service.ts
@@ -1,14 +1,15 @@
 import type { Church, ChurchesQuery, NearQuery, Service } from '@ember/api'
 import type { Db } from '../../db'
+import type { Bbox } from '../../lib/geo'
 import {
   boundingBox,
   coveringPrefixes,
+  geohashPrecisionForBbox,
   geohashPrecisionForRadiusKm,
   haversineKm,
   prefixRanges,
 } from '../../lib/geo'
 import {
-  browseChurches,
   churchById,
   churchesByIds,
   churchesInGeohashRanges,
@@ -56,8 +57,27 @@ export async function churchDetail(db: Db, id: string): Promise<ChurchDetail | u
   return { ...c, services: c.services ?? [], texts: c.texts ?? [], links: c.links ?? [] }
 }
 
-// Browse / search. `q` → FTS5 (rank-ordered ids → hydrate); otherwise country/city/bbox + filters.
-// Service-level filters (kind/rite) are applied uniformly afterwards — same mechanism as `near`.
+const inBbox = (c: { lat: number; lng: number }, b: Bbox) =>
+  c.lat >= b.minLat && c.lat <= b.maxLat && c.lng >= b.minLng && c.lng <= b.maxLng
+
+// Viewport browse: the same geohash covering-set → indexed prefix scan as `near`, bounded by a box
+// instead of a radius. Covering cells overshoot the box, so refine to true containment, then cap.
+export async function churchesInViewport(
+  db: Db,
+  q: { bbox: Bbox; status?: string; institute?: string; limit: number },
+): Promise<Church[]> {
+  const ranges = prefixRanges(coveringPrefixes(q.bbox, geohashPrecisionForBbox(q.bbox)))
+  const candidates = await churchesInGeohashRanges(db, ranges, {
+    status: q.status,
+    institute: q.institute,
+  })
+  return candidates.filter((c) => inBbox(c, q.bbox)).slice(0, q.limit)
+}
+
+// Search. `q` → FTS5 (rank-ordered ids → hydrate); else a viewport `bbox` → geohash-indexed scan.
+// Both paths are index-backed; an unbounded list (neither given) has no indexed answer and is
+// rejected by the validator (this returns []). Service-level filters (kind/rite) apply uniformly
+// afterwards — same mechanism as `near`.
 export async function searchChurches(db: Db, query: ChurchesQuery): Promise<Church[]> {
   let base: Church[]
   if (query.q) {
@@ -68,16 +88,15 @@ export async function searchChurches(db: Db, query: ChurchesQuery): Promise<Chur
     const rows = await churchesByIds(db, ids)
     const order = new Map(ids.map((id, i) => [id, i]))
     base = rows.sort((a, b) => (order.get(a.id) ?? 0) - (order.get(b.id) ?? 0))
-  } else {
-    base = await browseChurches(db, {
-      country: query.country,
-      city: query.city,
+  } else if (query.bbox) {
+    base = await churchesInViewport(db, {
       bbox: query.bbox,
-      institute: query.institute,
       status: query.status,
+      institute: query.institute,
       limit: query.limit,
-      offset: query.offset,
     })
+  } else {
+    return []
   }
   if (!query.kind && !query.rite) return base
   return base.filter((c) => (c.services ?? []).some((s) => matchesFilter(s, query)))

--- a/apps/backend/src/lib/geo.ts
+++ b/apps/backend/src/lib/geo.ts
@@ -41,6 +41,16 @@ export function geohashPrecisionForRadiusKm(radiusKm: number): number {
   return 3
 }
 
+// A viewport box's precision: take its larger span as the working diameter and reuse the radius
+// mapping (half the diameter). Keeps the covering set small for wide boxes, fine-grained for tight
+// ones — same indexed prefix-range path as "near", just bounded by a box instead of a circle.
+export function geohashPrecisionForBbox(bbox: Bbox): number {
+  const midLat = (bbox.minLat + bbox.maxLat) / 2
+  const latSpanKm = (bbox.maxLat - bbox.minLat) * 111
+  const lngSpanKm = Math.abs(bbox.maxLng - bbox.minLng) * 111 * Math.cos(toRad(midLat))
+  return geohashPrecisionForRadiusKm(Math.max(latSpanKm, lngSpanKm) / 2)
+}
+
 // Every geohash cell of the given length that intersects the box (more than "center + 8 neighbors"
 // whenever the box spans multiple cells). ngeohash.bboxes returns exactly this set.
 export function coveringPrefixes(bbox: Bbox, precision: number): string[] {

--- a/apps/backend/test/churches.test.ts
+++ b/apps/backend/test/churches.test.ts
@@ -86,7 +86,10 @@ describe('GET /churches/near', () => {
   })
 })
 
-describe('GET /churches (browse + FTS)', () => {
+describe('GET /churches (viewport + FTS)', () => {
+  // Box around the center: contains the 3 near churches, excludes the ~111 km one.
+  const nearBox = '-74.1,39.9,-73.9,40.1' // minLng,minLat,maxLng,maxLat
+
   it('finds a church by FTS5 name search', async () => {
     const res = await app.request('/churches?q=Joseph', {}, env)
     const ids = (await json(res)).churches.map((c) => c.id)
@@ -99,10 +102,23 @@ describe('GET /churches (browse + FTS)', () => {
     expect(ids).toEqual(['st-joseph-b'])
   })
 
-  it('applies kind/rite service-filter on the browse path too', async () => {
-    const res = await app.request('/churches?rite=latin_tridentine', {}, env)
+  it('returns churches inside the viewport box and excludes far ones', async () => {
+    const res = await app.request(`/churches?bbox=${nearBox}`, {}, env)
+    expect(res.status).toBe(200)
+    const ids = (await json(res)).churches.map((c) => c.id)
+    expect(ids).toEqual(expect.arrayContaining(['st-mary-a', 'st-joseph-b', 'st-peter-c']))
+    expect(ids).not.toContain('st-far-d')
+  })
+
+  it('applies kind/rite service-filter on the viewport path too', async () => {
+    const res = await app.request(`/churches?bbox=${nearBox}&rite=latin_tridentine`, {}, env)
     const ids = (await json(res)).churches.map((c) => c.id)
     expect(ids).toEqual(['st-mary-a'])
+  })
+
+  it('rejects an unbounded list with neither q nor bbox (Zod 400)', async () => {
+    const res = await app.request('/churches?rite=latin_tridentine', {}, env)
+    expect(res.status).toBe(400)
   })
 })
 

--- a/packages/api/src/validators.ts
+++ b/packages/api/src/validators.ts
@@ -29,18 +29,23 @@ const bbox = z.string().transform((s, ctx) => {
   return { minLng, minLat, maxLng, maxLat }
 })
 
-export const churchesQuerySchema = z.object({
-  country: z.string().optional(),
-  city: z.string().optional(),
-  q: z.string().optional(), // FTS5 name search
-  bbox: bbox.optional(), // map pins (zoomed in)
-  kind: z.string().optional(),
-  rite: z.string().optional(),
-  institute: z.string().optional(),
-  status: z.string().optional(),
-  limit,
-  offset,
-})
+// Every branch must be index-backed: `q` → FTS5, `bbox` → geohash. An unbounded list has no indexed
+// answer (the only church indexes are FTS, the PK, and geohash), so require one of the two — the
+// contract can't express a full table scan.
+export const churchesQuerySchema = z
+  .object({
+    q: z.string().optional(), // FTS5 name search
+    bbox: bbox.optional(), // map viewport → geohash covering-set
+    kind: z.string().optional(),
+    rite: z.string().optional(),
+    institute: z.string().optional(),
+    status: z.string().optional(),
+    limit,
+    offset,
+  })
+  .refine((v) => v.q !== undefined || v.bbox !== undefined, {
+    message: 'provide q (name search) or bbox (map viewport)',
+  })
 
 export const verificationsQuerySchema = z.object({ limit, offset })
 


### PR DESCRIPTION
## Problem

The map viewport is the only geo query the app actually fires (`useMassTimesNearby` → `useChurchesInBbox` → `GET /churches?bbox=…`), and it was the one query that **couldn't** use the geohash index.

`browseChurches` filtered the bbox on raw `lat`/`lng`. SQLite can't use `church_geohash_idx` there — the predicate never references `geohash`, and a lat/lng rectangle doesn't map to one contiguous geohash range. So the planner did `SCAN church`, reading **all ~138k rows on every pan/zoom** (D1 bills per row read).

The indexed covering-set path already existed for `/churches/near` (`coveringPrefixes` → `prefixRanges` → `churchesInGeohashRanges`), but nothing in the app called it. Migration `0003` had also dropped `church_country_city_idx`, leaving `church_geohash_idx` as the only secondary index — so the browse path's country/city/institute/status branch was a latent full-scan too.

## Change

Make **every church read index-backed** — geohash for geo, PK for detail, FTS5 for text — so no request can full-scan.

- **`geo.ts`** — add `geohashPrecisionForBbox` (box's larger span as working diameter → reuse the radius→precision mapping; small covering set for wide boxes).
- **`service.ts`** — add `churchesInViewport` (covering cells → indexed `churchesInGeohashRanges` → refine to true box containment → limit); rewrite `searchChurches` to only index-backed branches (`q` → FTS5, `bbox` → viewport, neither → `[]`).
- **`queries.ts`** — delete `browseChurches` (the lat/lng scan).
- **`validators.ts`** — drop `country`/`city`; require `q` OR `bbox`, so an unbounded `GET /churches` is a 400. The contract can no longer express a full scan.

No change to the request/response shape the app uses — `GET /churches?bbox=…` and `?q=…` behave as before, so the frontend is untouched.

## Effect

Per-pan/zoom cost drops from ~138k rows read to roughly the covering-cell row count.

## Tests

`apps/backend` — 30/30 pass. Added viewport correctness (inside-box vs far), kind/rite-on-viewport, and 400-on-unbounded; existing `EXPLAIN QUERY PLAN` test asserts `church_geohash_idx` is used.

## Follow-up (out of scope)

Low-zoom cell fan-out guard (min-zoom / cluster counts) and an on-device geohash tile cache to make revisited areas cost zero server reads.