### PR TITLE
Fix formatting across imported little offices

### DIFF
--- a/content/practices/little-office-all-saints/flow.json
+++ b/content/practices/little-office-all-saints/flow.json
@@ -29,7 +29,39 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudate Dominum in Sanctis ejus: laudate eum in firmamento virtutis ejus.\n℣. Domine, labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri. Alleluia."
+                "la": "Laudate Dominum in Sanctis ejus: laudate eum in firmamento virtutis ejus."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
               }
             },
             {
@@ -39,25 +71,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus ad B. Virginem Reginam Sanctorum omnium."
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O Mater! O senatus\nRegina coelicolae,\nThronusque praeparatus\nIn orbe Numini!\nTe nominat parentem\nCreator omnium;\nTe praedicat potentem\nCaterva supplicum."
+                "la": "O Mater! O senatus\nRegina coelicolae,\nThronusque praeparatus\nIn orbe Numini!\nTe nominat parentem\nCreator omnium;\nTe praedicat potentem\nCaterva supplicum.\n\nTe, Mater, opto mille\nLaudare vocibus,\nEt mille, mille, mille\nAmore cordibus.\nCor millies renatum\nSi, Mater, imples,\nCor millies dicatum,\nO Mater, auferes."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Te, Mater, opto mille\nLaudare vocibus,\nEt mille, mille, mille\nAmore cordibus.\nCor millies renatum\nSi, Mater, imples,\nCor millies dicatum,\nO Mater, auferes."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Luc. 1, 48, 49."
               }
@@ -65,20 +91,78 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Beatum te dicent omnes generationes: quia fecit tibi magna, qui potens est, et sanctum nomen ejus.\n℣. Benedicta tu in mulieribus.\n℟. Et benedictus fructus ventris tui."
+                "la": "Beatum te dicent omnes generationes: quia fecit tibi magna, qui potens est, et sanctum nomen ejus."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicta tu in mulieribus."
+                  },
+                  "r": {
+                    "la": "Et benedictus fructus ventris tui."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nOmnipotens aeterne Deus, qui beatissimam Virginem Mariam innumeris donis et gratiis exornatam, in Matrem unigeniti Filii tui elegisti, et super omnes Angelos et electos in regno tuo exaltasti: concede propitius ut qui eam interitus colimus, ejusdem patrocinio aeternam gloriam consequamur. Per eundem Christum Dominum nostrum."
+                "la": "Omnipotens aeterne Deus, qui beatissimam Virginem Mariam innumeris donis et gratiis exornatam, in Matrem unigeniti Filii tui elegisti, et super omnes Angelos et electos in regno tuo exaltasti: concede propitius ut qui eam interitus colimus, ejusdem patrocinio aeternam gloriam consequamur. Per eundem Christum Dominum nostrum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Amen.\n℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -93,29 +177,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudate Dominum in Sanctis ejus: laudate eum in firmamento virtutis ejus.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
+                "la": "Laudate Dominum in Sanctis ejus: laudate eum in firmamento virtutis ejus."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus ad SS. Angelos."
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O candidae cohortes\nStellantum aetheris!\nPrompte fertis sortes\nEt lata Numini:\nVos ore triplicato,\nTernoque carmine,\nTer Sanctum ordinato\nCantatis agmine."
+                "la": "O candidae cohortes\nStellantum aetheris!\nPrompte fertis sortes\nEt lata Numini:\nVos ore triplicato,\nTernoque carmine,\nTer Sanctum ordinato\nCantatis agmine.\n\nAh! possit esse mima\nVox nostra coelitum,\nUt summa vox optima\nDet suave canticum!\nFovete mille corda,\nUt inde concinat\nFiat vel una chorda\nAptanda musica."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Ah! possit esse mima\nVox nostra coelitum,\nUt summa vox optima\nDet suave canticum!\nFovete mille corda,\nUt inde concinat\nFiat vel una chorda\nAptanda musica."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Ps. 137. 2."
               }
@@ -123,19 +213,38 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "In conspectu Angelorum psallam tibi, Deus meus: adorabo ad templum sanctum tuum, et confitebor Nomini tuo.\n℣. Angelis suis Deus mandavit de te.\n℟. Ut custodiant te in omnibus viis tuis."
+                "la": "In conspectu Angelorum psallam tibi, Deus meus: adorabo ad templum sanctum tuum, et confitebor Nomini tuo."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Angelis suis Deus mandavit de te."
+                  },
+                  "r": {
+                    "la": "Ut custodiant te in omnibus viis tuis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nOmnipotens aeterne Deus, qui et majestatem tuam in numero et sanctitate Angelorum ostendis; et nobis eosdem Custodes, et Magistros tribuisti: concede propitius, ut eorum exemplo tibi ita serviamus in terris, ut aeternum cum iisdem te laudare mereamur in coelis. Per Dominum nostrum."
+                "la": "Omnipotens aeterne Deus, qui et majestatem tuam in numero et sanctitate Angelorum ostendis; et nobis eosdem Custodes, et Magistros tribuisti: concede propitius, ut eorum exemplo tibi ita serviamus in terris, ut aeternum cum iisdem te laudare mereamur in coelis. Per Dominum nostrum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi, supra."
+                "la": "Domine, exaudi, supra."
               }
             }
           ]
@@ -151,29 +260,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudate Dominum in Sanctis ejus: laudate eum in firmamento virtutis ejus.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
+                "la": "Laudate Dominum in Sanctis ejus: laudate eum in firmamento virtutis ejus."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus ad SS. Patriarchas."
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Spectabilis senecta,\nSalvete, principes,\nQuos vita mensque recta\nFecere coelites.\nVos terra Patriarchas\nDuceque nuncupat;\nSed rectius monarchas\nVos aether praedicat."
+                "la": "Spectabilis senecta,\nSalvete, principes,\nQuos vita mensque recta\nFecere coelites.\nVos terra Patriarchas\nDuceque nuncupat;\nSed rectius monarchas\nVos aether praedicat.\n\nSpes vera nascitur\nParente Virgine,\nCui firmiore muro\nEst visa surgere.\nEt nostra spes in isto\nSuspensa cardine,\nUniquae nixa Christo\nStat firma numine."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Spes vera nascitur\nParente Virgine,\nCui firmiore muro\nEst visa surgere.\nEt nostra spes in isto\nSuspensa cardine,\nUniquae nixa Christo\nStat firma numine."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Ps. 21, 4, 5."
               }
@@ -181,19 +296,38 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "In te speraverunt Patres nostri: speraverunt et liberasti eos; ad te clamaverunt et salvi facti sunt.\n℣. Notas mihi fecisti vias vitae.\n℟. Adimplebis me laetitia cum vultu tuo."
+                "la": "In te speraverunt Patres nostri: speraverunt et liberasti eos; ad te clamaverunt et salvi facti sunt."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Notas mihi fecisti vias vitae."
+                  },
+                  "r": {
+                    "la": "Adimplebis me laetitia cum vultu tuo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nOmnipotens aeterne Deus, qui sanctos Veteris Testamenti Patriarchas propter constantem mandatorum tuorum observationem, et fidem in promissum Unigeniti tui mundi Redemptoris venturi praemia beatitudinis aeternae tribuisti: praesta, quaesumus, ut illorum exemplo in tui participationem consortii mereamur concedi. Per eundem Christum Dominum nostrum."
+                "la": "Omnipotens aeterne Deus, qui sanctos Veteris Testamenti Patriarchas propter constantem mandatorum tuorum observationem, et fidem in promissum Unigeniti tui mundi Redemptoris venturi praemia beatitudinis aeternae tribuisti: praesta, quaesumus, ut illorum exemplo in tui participationem consortii mereamur concedi. Per eundem Christum Dominum nostrum."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Domine, exaudi. ut supra."
               }
             }
           ]
@@ -209,29 +343,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudate Dominum in Sanctis ejus: laudate eum in firmamento virtutis ejus.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
+                "la": "Laudate Dominum in Sanctis ejus: laudate eum in firmamento virtutis ejus."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus ad SS. Prophetas."
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O sancta turba Patrum,\nQuae mente provida\nProducis in theatrum\nVentura tempora,\nArcana multa pandens\nDe prole Numins,\nPer dura multa scandens\nAd limen aetheris!"
+                "la": "O sancta turba Patrum,\nQuae mente provida\nProducis in theatrum\nVentura tempora,\nArcana multa pandens\nDe prole Numins,\nPer dura multa scandens\nAd limen aetheris!\n\nIn orbe vos labores\nPressere feri:\nIn aevum nunc honores\nRedundant aurei.\nJuvate, sic fideli\nSequermur orbita,\nDomne superna caeli\nIntermus atria."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "In orbe vos labores\nPressere feri:\nIn aevum nunc honores\nRedundant aurei.\nJuvate, sic fideli\nSequermur orbita,\nDomne superna caeli\nIntermus atria."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Matth. 23, 37."
               }
@@ -243,21 +383,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Da mercedem sustinentibus te.\n℟. Ut prophetae tui fideles inveniantur."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Da mercedem sustinentibus te."
+                  },
+                  "r": {
+                    "la": "Ut prophetae tui fideles inveniantur."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nOmnipotens sempiterne Deus, qui Prophetas tuos sancti Spiritus gratia illuminatos et confortatos, per plurimas hujus vitae adversitates ad aeternam gloriam luce lumen perduxisti: concede propitius; ut nos eodem sancti Spiritus lumine illustrati, te Deum verum, et quem misisti, Dominum Jesum Christum, ita in terris agnoscamus et colamus, ut in coelis clare intueri, et perfecte possidere mereamur. Per eundem Christum Dominum nostrum."
+                "la": "Omnipotens sempiterne Deus, qui Prophetas tuos sancti Spiritus gratia illuminatos et confortatos, per plurimas hujus vitae adversitates ad aeternam gloriam luce lumen perduxisti: concede propitius; ut nos eodem sancti Spiritus lumine illustrati, te Deum verum, et quem misisti, Dominum Jesum Christum, ita in terris agnoscamus et colamus, ut in coelis clare intueri, et perfecte possidere mereamur. Per eundem Christum Dominum nostrum."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Domine, exaudi. ut supra."
               }
             }
           ]
@@ -273,29 +426,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudate Dominum in Sanctis ejus: laudate eum in firmamento virtutis ejus.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
+                "la": "Laudate Dominum in Sanctis ejus: laudate eum in firmamento virtutis ejus."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus Ad SS. Apostolos."
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O ordo nuntiorum,\nO clara luminaria,\nEt orbis est polorum\nBis sena sidera!\nVobis ad astra clavis\nEst certa tradita,\nEcclesiaeque navis\nIn orbe credita."
+                "la": "O ordo nuntiorum,\nO clara luminaria,\nEt orbis est polorum\nBis sena sidera!\nVobis ad astra clavis\nEst certa tradita,\nEcclesiaeque navis\nIn orbe credita.\n\nQuae sacra seminastis\nUbique semina,\nEt voces praedicastis\nFactisque dogmata.\nAh! imperate lumen,\nUt corde impleam;\nAh! invocate Numen,\nFactis ut exprimam."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Quae sacra seminastis\nUbique semina,\nEt voces praedicastis\nFactisque dogmata.\nAh! imperate lumen,\nUt corde impleam;\nAh! invocate Numen,\nFactis ut exprimam."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Matth. 19. 28."
               }
@@ -307,21 +466,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Nimis honorificati sunt amici tui, Deus.\n℟. Nimis confortatus est principatus eorum."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Nimis honorificati sunt amici tui, Deus."
+                  },
+                  "r": {
+                    "la": "Nimis confortatus est principatus eorum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe, qui novam charitatis legem pectoribus nostris per beatos Apostolos tuos infudisti: horum nobis, quaesumus, intercessione concede; ut jugum Novae Legis ista jugum prompta voluntate amplectamur, et opere perfecto expleamus. Qui vivis et regnas in saecula saeculorum.\nAmen."
+                "la": "Domine Jesu Christe, qui novam charitatis legem pectoribus nostris per beatos Apostolos tuos infudisti: horum nobis, quaesumus, intercessione concede; ut jugum Novae Legis ista jugum prompta voluntate amplectamur, et opere perfecto expleamus. Qui vivis et regnas in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Domine, exaudi. ut supra."
               }
             }
           ]
@@ -337,29 +509,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudate Dominum in Sanctis ejus: laudate eum in firmamento virtutis ejus.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
+                "la": "Laudate Dominum in Sanctis ejus: laudate eum in firmamento virtutis ejus."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus Ad SS. Martyres."
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O turba laureata,\nO agmen inclytum,\nChristique purpurata\nCaterva Martyrum!\nAthletico duella\nAgressa robore,\nEt gloriosa bella\nEdocta vincere."
+                "la": "O turba laureata,\nO agmen inclytum,\nChristique purpurata\nCaterva Martyrum!\nAthletico duella\nAgressa robore,\nEt gloriosa bella\nEdocta vincere.\n\nDa bella sic capessam,\nQuae semper ingruunt,\nHostesque sic lacessam,\nQui semper impetunt,\nUt victor in superna\nTheatra transferar,\nLauroque sempiterna\nTecum revincier!"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Da bella sic capessam,\nQuae semper ingruunt,\nHostesque sic lacessam,\nQui semper impetunt,\nUt victor in superna\nTheatra transferar,\nLauroque sempiterna\nTecum revincier!"
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Apoc. 7. 14. 15."
               }
@@ -371,21 +549,40 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Exsultabunt Sancti in gloria.\n℟. Laetabuntur in cubilibus suis."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Exsultabunt Sancti in gloria."
+                  },
+                  "r": {
+                    "la": "Laetabuntur in cubilibus suis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe, cujus acerbissima passio et justorum Martyrum constantia, martyres abundantem gratiam concessit sunt, ut pro confessione nominis tui sanguinem suum fuderiut: concede propitius; ut et nos eorum meritorum abundantia, et Martyrum tuorum intercessione, constantem fidem tuam profiteamur, et semper mortificationem tuam, Jesu, in corpore nostro circumferre valeamus. Qui vivis et regnas in saecula saeculorum.\n℟. Amen."
+                "la": "Domine Jesu Christe, cujus acerbissima passio et justorum Martyrum constantia, martyres abundantem gratiam concessit sunt, ut pro confessione nominis tui sanguinem suum fuderiut: concede propitius; ut et nos eorum meritorum abundantia, et Martyrum tuorum intercessione, constantem fidem tuam profiteamur, et semper mortificationem tuam, Jesu, in corpore nostro circumferre valeamus. Qui vivis et regnas in saecula saeculorum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi. ut supra."
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Domine, exaudi. ut supra."
               }
             }
           ]
@@ -401,29 +598,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudate Dominum in Sanctis ejus: laudate eum in firmamento virtutis ejus.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
+                "la": "Laudate Dominum in Sanctis ejus: laudate eum in firmamento virtutis ejus."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus ad SS. Confessores."
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O casibus probati\nHeroes arduis,\nAd multa dura nati\nIn rebus asperis!\nVos mille activitati\nSors dura fluctibus,\nOrbibus crebro probavit\nTentator ictibus."
+                "la": "O casibus probati\nHeroes arduis,\nAd multa dura nati\nIn rebus asperis!\nVos mille activitati\nSors dura fluctibus,\nOrbibus crebro probavit\nTentator ictibus.\n\nTullistis illa laeto\nFirmoque pectore,\nDum staret inquieto\nCarina litore.\nCor imperate forte,\nUt dura perferam,\nContentus esse sorte\nQuacumque queadam."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Tullistis illa laeto\nFirmoque pectore,\nDum staret inquieto\nCarina litore.\nCor imperate forte,\nUt dura perferam,\nContentus esse sorte\nQuacumque queadam."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Sap. 5. 1."
               }
@@ -435,21 +638,40 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ecce quomodo computati sunt inter filios Dei.\n℟. Et inter Sanctos sors illorum est."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ecce quomodo computati sunt inter filios Dei."
+                  },
+                  "r": {
+                    "la": "Et inter Sanctos sors illorum est."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe, cujus doctrina et exemplo Confessores tui mites et humiles facit, et requiem animabus suis in hac et in altera vita consecuti sunt: da nobis gratiam eorumdem vestigiis devote ita hic investire; ut demum ad aeternae quietis locum pervenire feliciter mereamur. Qui vivis et regnas in saecula saeculorum.\n℟. Amen."
+                "la": "Domine Jesu Christe, cujus doctrina et exemplo Confessores tui mites et humiles facit, et requiem animabus suis in hac et in altera vita consecuti sunt: da nobis gratiam eorumdem vestigiis devote ita hic investire; ut demum ad aeternae quietis locum pervenire feliciter mereamur. Qui vivis et regnas in saecula saeculorum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi. ut supra."
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Domine, exaudi. ut supra."
               }
             }
           ]
@@ -465,29 +687,48 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudate Dominum in Sanctis ejus: laudate eum in firmamento virtutis ejus.\n℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
+                "la": "Laudate Dominum in Sanctis ejus: laudate eum in firmamento virtutis ejus."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos, Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus ad SS. Virgines."
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O digna lilietis\nCaterva coelicis!\nQuae vivis in viretis,\nSponsisque pascuis!\nNix cana liliorum\nAlberte vellere,\nEt lac eburneum florum\nTe vestit undique."
+                "la": "O digna lilietis\nCaterva coelicis!\nQuae vivis in viretis,\nSponsisque pascuis!\nNix cana liliorum\nAlberte vellere,\nEt lac eburneum florum\nTe vestit undique.\n\nTu carmen innocentii\nScis ore fundere,\nQuod colites silentii\nMirantur aethere.\nValete, vah! valete,\nImpura basia,\nMihi nec invidete\nHaec casta gaudia."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Tu carmen innocentii\nScis ore fundere,\nQuod colites silentii\nMirantur aethere.\nValete, vah! valete,\nImpura basia,\nMihi nec invidete\nHaec casta gaudia."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Apoc. 14. 3. 4."
               }
@@ -499,21 +740,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Hi empti sunt ex hominibus primitiae Deo et Agno.\n℟. Et in ore eorum non est inventum mendacium."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Hi empti sunt ex hominibus primitiae Deo et Agno."
+                  },
+                  "r": {
+                    "la": "Et in ore eorum non est inventum mendacium."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe, sponse et singularis amator animarum, quas prae ceteris Sanctis in regno tuo peculiari laureola coronas, largire nobis gratiam ut eandem vestigiis insistentes, eadem quoque praemia consequamur. Qui vivis."
+                "la": "Domine Jesu Christe, sponse et singularis amator animarum, quas prae ceteris Sanctis in regno tuo peculiari laureola coronas, largire nobis gratiam ut eandem vestigiis insistentes, eadem quoque praemia consequamur. Qui vivis."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Domine, exaudi. ut supra."
               }
             }
           ]
@@ -539,7 +793,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Oratio S. Augustini ad Omnes Sanctos."
       }
@@ -551,7 +805,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Oratio ad S. Patronum, cujus quis nomen habet."
       }

--- a/content/practices/little-office-b-niccolo-albergati/flow.json
+++ b/content/practices/little-office-b-niccolo-albergati/flow.json
@@ -26,25 +26,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper,\net in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper,\net in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Magni Patris magnae Proli,\nE Brunonis caelo Soli\nLingua laudes resonat,\nDulce melos intonat.\n\nNicolai Albergati,\nCaeli Civis ter Beati,\nCelebra memoriam,\nMeditare gloriam.\n\nCandicantem puritatem,\nPurpuratam sanctitatem,\nSacras decet Violas\nMagni Myrae recolat.\n\nPia tibi mens probetur\nDive, esto superetur\nLabii inopia\nLaudandorum copia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Ps. 21)"
               }
@@ -56,15 +82,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedicam Dominum in omni tempore.\n℟. Semper laus ejus in ore meo. (Ps. 33)"
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicam Dominum in omni tempore."
+                  },
+                  "r": {
+                    "la": "Semper laus ejus in ore meo. (Ps. 33)"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nExaudi quaesumus Domine preces nostras, quas in Beati Nicolai Confessoris tui atque Pontificis solemnitate deferimus:\net qui Tibi digne meruit famulari, ejus intercedentibus meritis, ab omnibus nos absolve peccatis.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum.\nAmen."
+                "la": "Exaudi quaesumus Domine preces nostras, quas in Beati Nicolai Confessoris tui atque Pontificis solemnitate deferimus:\net qui Tibi digne meruit famulari, ejus intercedentibus meritis, ab omnibus nos absolve peccatis.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum.\nAmen."
               }
             }
           ]
@@ -78,25 +117,32 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Vix illustri stirpe fatum,\nJam ad magna videt natum\nTanto cive patria\nCelebris Bononia.\n\nPrimum florem juventutis\n(ut, quam ferax est virtutis,\nesset et scientiae)\nDat juris prudentiae.\n\nSed ad summa destinatus,\nRes, spes mundi aversatus\nFugit fasces Curiae,\nSacrat se Carthusiae.\n\nO beata solitudo,\nSola es beatitudo!\nIstud Dive capiam,\nUt vel sero sapiam."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Eccles. 2, 6)"
               }
@@ -108,10 +154,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Beatus est vir, cujus est nomen Domini spes ejus.\n℟. Et non respexit in vanitates et insanias falsas. (Ps. 39)"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Beatus est vir, cujus est nomen Domini spes ejus."
+                  },
+                  "r": {
+                    "la": "Et non respexit in vanitates et insanias falsas. (Ps. 39)"
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -130,25 +183,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Quanto quaerit plus latere,\nUrbi tanto resplendere\nCoeperit virtus rarior,\nLux ab umbra clarior.\n\nQuam ut Roma coronaret,\nQuo sic latius micaret,\nLinqui jubet cellulam,\nPatriae dat Insulam.\n\nTantum nacta Urbs Pastorem,\nNovum induit decorem,\nExul redit Sanctitas,\nExultat improbitas.\n\nMihi, Dive, fac viliscam,\nEt ignotus delitescam,\nSanctitate inclytus,\nSoli Deo cognitus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Agg. 2)"
               }
@@ -160,10 +226,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Caput in tribubus Israel factus es.\n℟. Cum parvulus esses in oculis tuis. (1 Reg. 15)"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Caput in tribubus Israel factus es."
+                  },
+                  "r": {
+                    "la": "Cum parvulus esses in oculis tuis. (1 Reg. 15)"
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -182,25 +255,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Vix haec Viola florescit,\nJam in purpuram rubescit;\nUnius Bononiae\nCardo fit Ecclesiae.\n\nPurpuratus nil rigoris\nVitae minuit prioris,\nIn se inclementior,\nQuanto eminentior.\n\nSic spinosa Christi Ducis\nCardinalis Sanctae Crucis\nScandit per vestigia\nNominis fastigia.\n\nNicolae, non honores\nIncorruptos mutent mores,\nChristianus nomine,\nSim, et ipso omine."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Gal. 6)"
               }
@@ -212,10 +298,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Dilectus meus candidus et rubicundus. (Cant. 5)\n℟. Qui pascitur inter Lilia. (Cant. 2)"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dilectus meus candidus et rubicundus. (Cant. 5)"
+                  },
+                  "r": {
+                    "la": "Qui pascitur inter Lilia. (Cant. 2)"
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -234,25 +327,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Sic in se pie crudelis\nCurat populi fidelis\nLeni manu vulnera,\nMatris gestans viscera.\n\nAdgemiscit ingementi,\nPronus solvit poenitenti\nPeccatorum vincula,\nAbolet piacula.\n\nHinc ut orbi mederetur\nAegrienti, Magnus detur\nPoenitentiarius,\nChristi vult Vicarius.\n\nPro me Deum deprecare,\nUt peccanti salutare\nDonum poenitentiae\nDet, et indulgentiae."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Jerem. 1)"
               }
@@ -264,10 +370,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Inveni Filium Jesse virum secundum cor meum.\n℟. Qui fecit omnes voluntates meas. (Act. 13)"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Inveni Filium Jesse virum secundum cor meum."
+                  },
+                  "r": {
+                    "la": "Qui fecit omnes voluntates meas. (Act. 13)"
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -286,25 +399,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Apostolicus Legatus\nTurbidos regnorum status\nIntegrat oraculis,\nRoborat miraculis.\n\nPacis studio Togatus,\nAulis Principum sagatus\nFert de Marte Lauream,\nPlantat Pacis Oleam.\n\nObstupescunt Orbis partes\nRem gerendi sacras artes,\nApprobant Concilia\nAngeli Consilia.\n\nNostros Dive, terge luctus,\nDulces Pacis posse fructus!\nCordaque discordia\nUniat Concordia!"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Jerem. 28)"
               }
@@ -316,10 +442,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. In doctrina glorificate Dominum. (Jerem. 24)\n℟. Et docete eos servare omnia, quae praecepi vobis. (Matth. 28)"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In doctrina glorificate Dominum. (Jerem. 24)"
+                  },
+                  "r": {
+                    "la": "Et docete eos servare omnia, quae praecepi vobis. (Matth. 28)"
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -338,25 +471,32 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Sic dum Deo militat,\nAd promissum evolavit\nPraemium militiae:\nLauream justitiae.\n\nIn amoris argumentum\nPietatis monumentum\nSacrae, vult, Exuviae\nCederent Carthusiae.\n\nSic cui cella est viventi,\nCaelum, decet, quiescenti.\nMollem sternat lectulum\nGloriae in cumulum.\n\nO si detur morte pari\nFungi, tibi sociari\nIn supernis aedibus,\nBeatorum sedibus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (2 Cor. 5)"
               }
@@ -368,10 +508,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Pretiosa in conspectu Domini. (Ps. 115)\n℟. Mors Sanctorum ejus."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Pretiosa in conspectu Domini. (Ps. 115)"
+                  },
+                  "r": {
+                    "la": "Mors Sanctorum ejus."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",

--- a/content/practices/little-office-benedictine-oblates-alternative-version/flow.json
+++ b/content/practices/little-office-benedictine-oblates-alternative-version/flow.json
@@ -8,11 +8,19 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Deus in adjutorium meum intende.\n℟. Domine, ad adjuvandam me festina",
-        "en-US": "℣. O God, come to my assistance.\n℟. O Lord, make haste to help me."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Deus in adjutorium meum intende.",
+            "en-US": "O God, come to my assistance."
+          },
+          "r": {
+            "la": "Domine, ad adjuvandam me festina",
+            "en-US": "O Lord, make haste to help me."
+          }
+        }
+      ]
     },
     {
       "type": "prayer",
@@ -29,7 +37,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Psalmus 116",
         "en-US": "Psalm 116"
@@ -43,11 +51,34 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.",
-        "en-US": "℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful, through the mercy of God, rest in peace.\n℟. Amen."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Benedicamus Domino.",
+            "en-US": "Let us bless the Lord."
+          },
+          "r": {
+            "la": "Deo gratias.",
+            "en-US": "Thanks be to God."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+            "en-US": "May the souls of the faithful, through the mercy of God, rest in peace."
+          },
+          "r": {
+            "la": "Amen.",
+            "en-US": "Amen."
+          }
+        }
+      ]
     }
   ]
 }

--- a/content/practices/little-office-benedictine-oblates/flow.json
+++ b/content/practices/little-office-benedictine-oblates/flow.json
@@ -27,14 +27,44 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende.",
+                    "en-US": "Incline unto mine aid, O God."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nAlleluia.\n(Vel: Laus tibi Domine, Rex aeternae gloriae.)\n\n℣. Domine, labia mea aperies:\n℟. Et os meum annuntiabit laudem tuam.",
-                "en-US": "℣. Incline unto mine aid, O God.\n℟. O Lord, make haste to help me.\n\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end.\n(Or: Praise be to thee, O Lord, King of eternal glory.)\n\n℣. O Lord, open thou my lips:\n℟. And my mouth shall declare thy praise."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nAlleluia.\n(Vel: Laus tibi Domine, Rex aeternae gloriae.)",
+                "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end.\n(Or: Praise be to thee, O Lord, King of eternal glory.)"
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies:",
+                    "en-US": "O Lord, open thou my lips:"
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam.",
+                    "en-US": "And my mouth shall declare thy praise."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Psalmus III",
                 "en-US": "Psalm 3"
@@ -48,21 +78,21 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Nocte surgentes vigilemus omnes,\nSemper in psalmis meditemur, atque\nViribus totis Domino canamus\nDulciter hymnos.\n\nUt pio Regi pariter canentes,\nCum suis Sanctis mereamur aulam\nIngredi coeli, simul et beatam\nDucere vitam.\n\nPraestet hoc nobis Deitas beata\nPatris, ac Nati, pariterque Sancti\nSpiritus, cujus reboat in omni\nGloria mundo. Amen. Amen.",
                 "en-US": "Now, from the slumbers of the night arising,\nChant we the holy psalmody of David,\nHymns to our Master, with a voice concordant,\nSweetly intoning.\n\nSo may our Monarch mercifully hear us,\nThat we may merit with His Saints to enter\nMansions eternal, therewithal possessing\nJoy beatific.\n\nThis be our portion, God forever blessed,\nFather eternal, Son, and Holy Spirit,\nWhose is the glory, which through all creation\nEver resoundeth. Amen. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -76,7 +106,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus VIII",
                 "en-US": "Psalm 8"
@@ -90,7 +120,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -104,7 +134,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Lectio (1 Cor. 16, 13–14)",
                 "en-US": "Lesson (1 Cor. 16, 13–14)"
@@ -113,22 +143,66 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Vigilate, state in fide; viriliter agite et confortamini.\nOmnia vestra in caritate fiant.\n℣. Tu autem Domine, miserere nobis.\n℟. Deo gratias.",
-                "en-US": "Watch ye, stand fast in the faith, do manfully, and be strengthened.\nLet all your things be done in charity.\nBut thou, O Lord, have mercy on us.\n℟. Thanks be to God."
+                "la": "Vigilate, state in fide; viriliter agite et confortamini.\nOmnia vestra in caritate fiant.",
+                "en-US": "Watch ye, stand fast in the faith, do manfully, and be strengthened.\nLet all your things be done in charity."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Tu autem Domine, miserere nobis.",
+                    "en-US": "But thou, O Lord, have mercy on us."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Kyrie eleison. Christe eleison. Kyrie eleison.\nPater noster (secreto).",
+                "en-US": "Lord, have mercy on us. Christ, have mercy on us. Lord, have mercy on us.\nOur Father (silently)."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem.",
+                    "en-US": "And lead us not into temptation."
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo.",
+                    "en-US": "But deliver us from evil."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Kyrie eleison. Christe eleison. Kyrie eleison.\nPater noster (secreto).\n\n℣. Et ne nos inducas in tentationem.\n℟. Sed libera nos a malo.",
-                "en-US": "Lord, have mercy on us. Christ, have mercy on us. Lord, have mercy on us.\nOur Father (silently).\n\n℣. And lead us not into temptation.\n℟. But deliver us from evil."
+                "la": "Sancti nominis tui, Domine, timorem pariter et amorem fac nos habere perpetuum:\nquia nunquam tua gubernatione destituis, quos in soliditate tuae dilectionis instituis.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum.",
+                "en-US": "Make us, O Lord, to have a perpetual fear and love of thy holy Name,\nfor thou never failest to govern those whom thou dost solidly establish in thy love.\nThrough our Lord Jesus Christ, thy Son, who liveth and reigneth with thee,\nin the unity of the Holy Ghost, one God, world without end."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nSancti nominis tui, Domine, timorem pariter et amorem fac nos habere perpetuum:\nquia nunquam tua gubernatione destituis, quos in soliditate tuae dilectionis instituis.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\n℟. Amen.",
-                "en-US": "Let us pray,\nMake us, O Lord, to have a perpetual fear and love of thy holy Name,\nfor thou never failest to govern those whom thou dost solidly establish in thy love.\nThrough our Lord Jesus Christ, thy Son, who liveth and reigneth with thee,\nin the unity of the Holy Ghost, one God, world without end.\n℟. Amen."
+                "la": "Amen.",
+                "en-US": "Amen."
               }
             },
             {
@@ -149,14 +223,29 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende.",
+                    "en-US": "Incline unto mine aid, O God."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\nGloria Patri, etc.",
-                "en-US": "℣. Incline unto mine aid, O God.\n℟. O Lord, make haste to help me.\nGlory be to the Father, etc."
+                "la": "Gloria Patri, etc.",
+                "en-US": "Glory be to the Father, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -170,7 +259,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum David (1 Par. 29, 10–13)",
                 "en-US": "Canticle of David (1 Par. 29:10–13)"
@@ -184,7 +273,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -198,7 +287,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum (Rom. 13, 12–13)",
                 "en-US": "Little Chapter (Rom. 13:12–13)"
@@ -207,12 +296,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Nox praecessit, dies autem appropinquavit: abjiciamus ergo opera tenebrarum, et induamur arma lucis: sicut in die honeste ambulemus.\n℟. Deo gratias.",
-                "en-US": "The night has passed and the day is at hand. Let us therefore cast off the works of darkness and put on the armour of light: let us walk honestly as in the day.\n℟. Thanks be to God."
+                "la": "Nox praecessit, dies autem appropinquavit: abjiciamus ergo opera tenebrarum, et induamur arma lucis: sicut in die honeste ambulemus.",
+                "en-US": "The night has passed and the day is at hand. Let us therefore cast off the works of darkness and put on the armour of light: let us walk honestly as in the day."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsorium Breve",
                 "en-US": "Short Responsory"
@@ -221,33 +317,62 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Sana animam meam, quia peccavi tibi. Sana animam meam, quia peccavi tibi.\n℣. Ego dixi, Domine, miserere mei. Quia peccavi tibi.\nGloria Patri, et Filio, et Spiritui Sancto.\n℟. Sana animam meam, quia peccavi tibi.",
-                "en-US": "℟. Heal my soul, for I have sinned against thee. Heal my soul, for I have sinned against thee.\n℣. I said, Lord, be merciful to me. For I have sinned against thee.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\n℟. Heal my soul, for I have sinned against thee."
+                "la": "Sana animam meam, quia peccavi tibi. Sana animam meam, quia peccavi tibi.",
+                "en-US": "Heal my soul, for I have sinned against thee. Heal my soul, for I have sinned against thee."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Ego dixi, Domine, miserere mei. Quia peccavi tibi.",
+                "en-US": "I said, Lord, be merciful to me. For I have sinned against thee."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.",
+                "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Sana animam meam, quia peccavi tibi.",
+                "en-US": "Heal my soul, for I have sinned against thee."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Tu, Trinitatis Unitas,\nOrbem potenter quae regis,\nAttende laudis canticum,\nQuod excubantes psallimus.\n\nOrtus refulget lucifer,\nPraeitque solem nuntius:\nCaduunt tenebrae noctium:\nLux sancta nos illuminat.\n\nDeo Patri sit gloria,\nEjusque soli Filio,\nCum Spiritu Paraclito,\nNunc et per omne saeculum. Amen.",
                 "en-US": "O Thou, who dost all nature sway,\nDread Trinity in Unity,\nAccept the trembling praise we pay\nTo Thy eternal majesty.\n\nThe star that heralds in the dawn\nIs slowly fading in the skies;\nThe darkness melts: O Thou true Light,\nUpon our darkened souls arise.\n\nTo God the Father glory be,\nAnd to the sole begotten Son,\nAnd Holy Ghost coequally,\nWhile everlasting ages run. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Repleti sumus mane misericordia tua.\n℟. Exsultavimus et delectati sumus.",
-                "en-US": "℣. We are filled in the morning with thy mercy.\n℟. We have rejoiced and are delighted."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Repleti sumus mane misericordia tua.",
+                    "en-US": "We are filled in the morning with thy mercy."
+                  },
+                  "r": {
+                    "la": "Exsultavimus et delectati sumus.",
+                    "en-US": "We have rejoiced and are delighted."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -261,7 +386,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Zachariae (Luc. 1, 68–79)",
                 "en-US": "Canticle of Zachary (Luke 1:68–79)"
@@ -275,7 +400,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -291,19 +416,48 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Kyrie eleison. Christe eleison. Kyrie eleison.\n\nPater noster (clara voce.)\n\n℣. Et ne nos inducas in tentationem.\n℟. Sed libera nos a malo.",
-                "en-US": "Lord, have mercy on us. Christ, have mercy on us. Lord, have mercy on us.\nOur Father (aloud).\n\n℣. And lead us not into temptation.\n℟. But deliver us from evil."
+                "la": "Kyrie eleison. Christe eleison. Kyrie eleison.\n\nPater noster (clara voce.)",
+                "en-US": "Lord, have mercy on us. Christ, have mercy on us. Lord, have mercy on us.\nOur Father (aloud)."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem.",
+                    "en-US": "And lead us not into temptation."
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo.",
+                    "en-US": "But deliver us from evil."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui per Unigenitum tuum aeternitatis nobis aditum devicta morte reserasti:\nvota nostra, quae praeveniendo aspiras, etiam adjuvando prosequere.\nPer eumdem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\n℟. Amen.",
-                "en-US": "Let us pray,\nO God, who through thine only begotten Son hast overcome death and opened to us the gates of everlasting life; grant that our holy desires, which have been stirred within us by thy grace, may by thy further aid be happily fulfilled. Through the same Jesus Christ thy Son, our Lord, Who liveth and reigneth with thee, in the unity of the Holy Ghost, one God, world without end.\n℟. Amen."
+                "la": "Deus, qui per Unigenitum tuum aeternitatis nobis aditum devicta morte reserasti:\nvota nostra, quae praeveniendo aspiras, etiam adjuvando prosequere.\nPer eumdem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum.",
+                "en-US": "O God, who through thine only begotten Son hast overcome death and opened to us the gates of everlasting life; grant that our holy desires, which have been stirred within us by thy grace, may by thy further aid be happily fulfilled. Through the same Jesus Christ thy Son, our Lord, Who liveth and reigneth with thee, in the unity of the Holy Ghost, one God, world without end."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -317,25 +471,82 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Justum deduxit Dominus per vias rectas.\n℟. Et ostendit illi regnum Dei.",
-                "en-US": "Let us pray,\nO beloved Shepherd, preserve thy flock, strengthen it with thy holy prayer, and under thy guidance lead it along the glorious path to heaven.\n\n℣. The Lord led the just through right ways.\n℟. And showed him the kingdom of God."
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nExcita Domine, in Ecclesia tua Spiritum, cui beatus Pater noster Benedictus Abbas servivit:\nut, eodem nos repleti, studeamus amare quod amavit, et opere exercere quod docuit.\nPer Christum Dominum nostrum.\n℟. Amen.",
-                "en-US": "Let us pray,\nRaise up, O Lord, in thy Church, the Spirit wherewith our holy Father, the Abbot Benedict, was animated:\nthat, filled with the same, we may strive to love what he loved, and to practice what he taught. Through Christ our Lord.\n℟. Amen."
+                "en-US": "O beloved Shepherd, preserve thy flock, strengthen it with thy holy prayer, and under thy guidance lead it along the glorious path to heaven."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Justum deduxit Dominus per vias rectas.",
+                    "en-US": "The Lord led the just through right ways."
+                  },
+                  "r": {
+                    "la": "Et ostendit illi regnum Dei.",
+                    "en-US": "And showed him the kingdom of God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Benedicamus Domino.\n℟. Deo gratias.\n\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.",
-                "en-US": "℣. Let us bless the Lord.\n℟. Thanks be to God.\n\n℣. May the souls of the faithful departed, through the mercy of God, rest in peace.\n℟. Amen."
+                "la": "Excita Domine, in Ecclesia tua Spiritum, cui beatus Pater noster Benedictus Abbas servivit:\nut, eodem nos repleti, studeamus amare quod amavit, et opere exercere quod docuit.\nPer Christum Dominum nostrum.",
+                "en-US": "Raise up, O Lord, in thy Church, the Spirit wherewith our holy Father, the Abbot Benedict, was animated:\nthat, filled with the same, we may strive to love what he loved, and to practice what he taught. Through Christ our Lord."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+                    "en-US": "May the souls of the faithful departed, through the mercy of God, rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -348,28 +559,50 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende.",
+                    "en-US": "O God, come to my assistance."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\nGloria Patri, etc.",
-                "en-US": "℣. O God, come to my assistance.\n℟. O Lord, make haste to help me.\nGlory be to the Father, etc."
+                "la": "Gloria Patri, etc.",
+                "en-US": "Glory be to the Father, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
+              "lang": "la",
               "inline": {
-                "la": "Jam lucis orto sidere\nDeum precemur supplices,\nUt in diurnis actibus\nNos servet a nocentibus.\n\nLinguam refrenans temperet,\nNe litis horror insonet:\nVisum fovendo contegat,\nNe vanitates hauriat.\n\nSint puris cordis intima,\nAbsistat et vecordia:\nCarnis terat superbiam\nPotus ciboque parcitas.\n\nUt cum dies abscesserit,\nNoctemque sors reduxerit,\nMundi per abstinentiam\nIpsi canamus gloriam.\n\nDeo Patri sit gloria,\nEj'usque soli Filio,\nCum Spiritu Paraclito,\nNunc, et per omne saeculum. Amen.",
+                "la": "Jam lucis orto sidere\nDeum precemur supplices,\nUt in diurnis actibus\nNos servet a nocentibus.\n\nLinguam refrenans temperet,\nNe litis horror insonet:\nVisum fovendo contegat,\nNe vanitates hauriat.\n\nSint puris cordis intima,\nAbsistat et vecordia:\nCarnis terat superbiam\nPotus ciboque parcitas.\n\nUt cum dies abscesserit,\nNoctemque sors reduxerit,\nMundi per abstinentiam\nIpsi canamus gloriam.\n\nDeo Patri sit gloria,\nEj'usque soli Filio,\nCum Spiritu Paraclito,\nNunc, et per omne saeculum. Amen."
+              }
+            },
+            {
+              "type": "hymn",
+              "lang": "en-US",
+              "inline": {
                 "en-US": "Now that the daylight fills the sky,\nWe lift our hearts to God on high,\nThat He, in all we do or say,\nWould keep us free from harm today.\n\nWould guard our hearts and tongues from strife,\nFrom anger's din would shield our life;\nFrom evil sights would turn our eyes,\nAnd close our ears to vanities.\n\nSo we, when this new day is gone\nAnd night in turn is drawing on,\nWith conscience by the world unstained\nShall praise His name for victory gained.\n\nAll praise to God the Father be,\nAll praise, Eternal Son, to Thee,\nWhom with the Spirit we adore,\nForever and forevermore. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus XXII",
                 "en-US": "Psalm 22 (23)"
@@ -383,7 +616,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum (1 Tim. 1, 17)",
                 "en-US": "Chapter (1 Tim. 1:17)"
@@ -392,54 +625,230 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Regi saeculorum immortali et invisibili, soli Deo honor et gloria in saecula saeculorum. Amen.\n℟. Deo gratias.\n℣. Exsurge, Christe, adjuva nos.\n℟. Et libera nos propter nomen tuum.",
-                "en-US": "To the King of ages, immortal, invisible, the only God, be honour and glory forever and ever. Amen.\n℟. Thanks be to God.\n℣. Arise, O Christ, and help us.\n℟. And deliver us for thy name's sake."
+                "la": "Regi saeculorum immortali et invisibili, soli Deo honor et gloria in saecula saeculorum. Amen.",
+                "en-US": "To the King of ages, immortal, invisible, the only God, be honour and glory forever and ever. Amen."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Kyrie eleison. Christe eleison. Kyrie eleison.\nPater noster (secreto).\n℣. Et ne nos inducas in tentationem.\n℟. Sed libera nos a malo.",
-                "en-US": "Lord, have mercy. Christ, have mercy. Lord, have mercy.\nOur Father (silently).\n℣. And lead us not into temptation.\n℟. But deliver us from evil."
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Exsurge, Christe, adjuva nos.",
+                    "en-US": "Arise, O Christ, and help us."
+                  },
+                  "r": {
+                    "la": "Et libera nos propter nomen tuum.",
+                    "en-US": "And deliver us for thy name's sake."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Deus omnipotens, qui ad principium hujus diei nos pervenire fecisti: tua nos hodie salva virtute; ut in hac die ad nullum declinemus peccatum, sed semper ad tuam justitiam faciendam nostra procedant eloquia, dirigantur cogitationes et opera.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\n℟. Amen.\n℣. Benedicamus Domino.\n℟. Deo gratias.",
-                "en-US": "Let us pray,\nO Lord God Almighty, who hast brought us to the beginning of this day, save us today by Thy strength, so that we may not fall into any sin this day, but that our words, thoughts, and deeds may all tend to the fulfilment of Thy righteousness.\nThrough our Lord Jesus Christ, Thy Son, who liveth and reigneth with Thee in the unity of the Holy Ghost, God, forever and ever.\n℟. Amen.\n℣. Let us bless the Lord.\n℟. Thanks be to God."
+                "la": "Kyrie eleison. Christe eleison. Kyrie eleison.\nPater noster (secreto).",
+                "en-US": "Lord, have mercy. Christ, have mercy. Lord, have mercy.\nOur Father (silently)."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Pretiosa in conspectu Domini.\n℟. Mors Sanctorum ejus.\n\nSancta Maria, et omnes Sancti intercedant pro nobis ad Dominum ut nos mereamur ab eo adjuvari et salvari, qui vivit et regnat in saecula saeculorum.\n\n℟. Amen.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri x3\n\nKyrie eleison. Christe eleison. Kyrie eleison.\nPater noster (secreto).\n℣. Et ne nos inducas in tentationem.\n℟. Sed libera nos a malo.",
-                "en-US": "℣. Precious in the sight of the Lord.\n℟. Is the death of His saints.\n\nHoly Mary and all the Saints intercede for us with the Lord, that we may merit to be helped and saved by Him who liveth and reigneth forever and ever.\n\n℟. Amen.\n℣. O God, come to my assistance.\n℟. O Lord, make haste to help me.\nGlory be to the Father x3\n\nLord, have mercy. Christ, have mercy. Lord, have mercy.\nOur Father (silently).\n℣. And lead us not into temptation.\n℟. But deliver us from evil."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Respice in servos tuos Domine, et in opera tua, et dirige filios eorum.\n℟. Et sit splendor Domini Dei nostri super nos, et opera manuum nostrarum dirige super nos, et opus manuum nostrarum dirige.\n℣. Gloria Patri, etc.\n℟. Sicut erat, etc.",
-                "en-US": "℣. Look down, O Lord, upon Thy servants and upon Thy works, and direct their children.\n℟. And let the splendour of the Lord our God be upon us, and direct the works of our hands over us; yea, the work of our hands do Thou direct.\n℣. Glory be to the Father, etc.\n℟. As it was in the beginning, etc."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDirigere et sanctificare, regere et gubernare dignare, Domine Deus Rex caeli et terrae, hodie corda et corpora nostra, sensus, sermones, et actus nostros in lege tua, et in operibus mandatorum tuorum: ut hic, et in aeternum, te auxiliant, salvi et liberi esse mereamur, Salvator mundi, qui vivis et regnas in saecula saeculorum.\n℟. Amen.",
-                "en-US": "Let us pray,\nDirect and sanctify, rule and govern our hearts and bodies, our thoughts, words, and actions, O Lord God, King of heaven and earth, this day; so that, with Thy help, we may be righteous and saved here and hereafter, O Saviour of the world, who livest and reignest forever and ever.\n℟. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Jube, Domine, benedicere.\nDies et actus nostros in sua pace disponat Dominus omnipotens.\n℟. Amen.",
-                "en-US": "℣. Pray, Lord, give Thy blessing.\nMay the Almighty Lord order our days and our deeds in His peace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem.",
+                    "en-US": "And lead us not into temptation."
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo.",
+                    "en-US": "But deliver us from evil."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Domine Deus omnipotens, qui ad principium hujus diei nos pervenire fecisti: tua nos hodie salva virtute; ut in hac die ad nullum declinemus peccatum, sed semper ad tuam justitiam faciendam nostra procedant eloquia, dirigantur cogitationes et opera.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.",
+                "en-US": "O Lord God Almighty, who hast brought us to the beginning of this day, save us today by Thy strength, so that we may not fall into any sin this day, but that our words, thoughts, and deeds may all tend to the fulfilment of Thy righteousness.\nThrough our Lord Jesus Christ, Thy Son, who liveth and reigneth with Thee in the unity of the Holy Ghost, God, forever and ever."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Pretiosa in conspectu Domini.",
+                    "en-US": "Precious in the sight of the Lord."
+                  },
+                  "r": {
+                    "la": "Mors Sanctorum ejus.",
+                    "en-US": "Is the death of His saints."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Sancta Maria, et omnes Sancti intercedant pro nobis ad Dominum ut nos mereamur ab eo adjuvari et salvari, qui vivit et regnat in saecula saeculorum.",
+                "en-US": "Holy Mary and all the Saints intercede for us with the Lord, that we may merit to be helped and saved by Him who liveth and reigneth forever and ever."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende.",
+                    "en-US": "O God, come to my assistance."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri x3\n\nKyrie eleison. Christe eleison. Kyrie eleison.\nPater noster (secreto).",
+                "en-US": "Glory be to the Father x3\n\nLord, have mercy. Christ, have mercy. Lord, have mercy.\nOur Father (silently)."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem.",
+                    "en-US": "And lead us not into temptation."
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo.",
+                    "en-US": "But deliver us from evil."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Respice in servos tuos Domine, et in opera tua, et dirige filios eorum.",
+                    "en-US": "Look down, O Lord, upon Thy servants and upon Thy works, and direct their children."
+                  },
+                  "r": {
+                    "la": "Et sit splendor Domini Dei nostri super nos, et opera manuum nostrarum dirige super nos, et opus manuum nostrarum dirige.",
+                    "en-US": "And let the splendour of the Lord our God be upon us, and direct the works of our hands over us; yea, the work of our hands do Thou direct."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, etc.",
+                    "en-US": "Glory be to the Father, etc."
+                  },
+                  "r": {
+                    "la": "Sicut erat, etc.",
+                    "en-US": "As it was in the beginning, etc."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Dirigere et sanctificare, regere et gubernare dignare, Domine Deus Rex caeli et terrae, hodie corda et corpora nostra, sensus, sermones, et actus nostros in lege tua, et in operibus mandatorum tuorum: ut hic, et in aeternum, te auxiliant, salvi et liberi esse mereamur, Salvator mundi, qui vivis et regnas in saecula saeculorum.",
+                "en-US": "Direct and sanctify, rule and govern our hearts and bodies, our thoughts, words, and actions, O Lord God, King of heaven and earth, this day; so that, with Thy help, we may be righteous and saved here and hereafter, O Saviour of the world, who livest and reignest forever and ever."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Jube, Domine, benedicere.",
+                "en-US": "Pray, Lord, give Thy blessing."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Dies et actus nostros in sua pace disponat Dominus omnipotens.",
+                "en-US": "May the Almighty Lord order our days and our deeds in His peace."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio brevis (Prol. Regulae S. Benedicti)",
                 "en-US": "Short reading (From the Prologue of the Rule of S. Benedict)"
@@ -447,34 +856,100 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Ex Regula Sancti Patris nostri Benedicti: Passionibus Christi per patientiam participemus ut et regni ejus mereamur esse consortes. Tu autem Domine, miserere nobis.\n℟. Deo gratias.\n℣. Adjutorium nostrum in nomine Domini.\n℟. Qui fecit caelum et terram.\n℣. Benedicite.\n℟. Deus.",
-                "en-US": "From the Rule of our holy Father Benedict:\nLet us participate through patience in the sufferings of Christ, that we may deserve also to be partakers in His Kingdom. But thou, O Lord, have mercy on us.\n℟. Thanks be to God.\n℣. Our help is in the name of the Lord.\n℟. Who made heaven and earth.\n℣. Bless ye the Lord.\n℟. God."
+                "la": "Ex Regula Sancti Patris nostri Benedicti: Passionibus Christi per patientiam participemus ut et regni ejus mereamur esse consortes. Tu autem Domine, miserere nobis."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "From the Rule of our holy Father Benedict:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Let us participate through patience in the sufferings of Christ, that we may deserve also to be partakers in His Kingdom. But thou, O Lord, have mercy on us."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Dominus nos benedicat, et ab omni malo defendat, et ad vitam perducat aeternam: et fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.",
-                "en-US": "May the Lord bless us, and keep us from all evil, and bring us to life everlasting; and may the souls of the faithful departed, through the mercy of God, rest in peace.\n℟. Amen."
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Adjutorium nostrum in nomine Domini.",
+                    "en-US": "Our help is in the name of the Lord."
+                  },
+                  "r": {
+                    "la": "Qui fecit caelum et terram.",
+                    "en-US": "Who made heaven and earth."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicite.",
+                    "en-US": "Bless ye the Lord."
+                  },
+                  "r": {
+                    "la": "Deus.",
+                    "en-US": "God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Dominus nos benedicat, et ab omni malo defendat, et ad vitam perducat aeternam: et fidelium animae per misericordiam Dei requiescant in pace.",
+                "en-US": "May the Lord bless us, and keep us from all evil, and bring us to life everlasting; and may the souls of the faithful departed, through the mercy of God, rest in peace."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Commemoratio omnium fratrum, familiarium Ordinis nostri, atque benefactorum nostrorum",
                 "en-US": "Commemoration of all brethren, relatives, and benefactors of our Order"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Requiescant in pace.\n℟. Amen.",
-                "en-US": "℣. May they rest in peace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Requiescant in pace.",
+                    "en-US": "May they rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 129",
                 "en-US": "Psalm 129 (130)"
@@ -483,16 +958,105 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "De profundis clamavi ad te Domine: Domine exaudi vocem meam.\nFiant aures tuae intendentes, in vocem deprecationis meae.\nSi iniquitates observaveris Domine: Domine quis sustinebit?\nQuia apud te propitiatio est: et propter legem tuam sustinui te Domine.\nSustinuit anima mea in verbo ejus: speravit anima mea in Domino.\nA custodia matutina usque ad noctem: speret Israel in Domino.\nQuia apud Dominum misericordia: et copiosa apud eum redemptio.\nEt ipse redimet Israel, ex omnibus iniquitatibus ejus.\nRequiem aeternam dona eis Domine.\nEt lux perpetua luceat eis.\n℣. A porta inferi.\n℟. Erue Domine animas eorum.\n℣. Requiescant in pace.\n℟. Amen.\n℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.",
-                "en-US": "Out of the depths I have cried to Thee, O Lord: Lord, hear my voice.\nLet Thine ears be attentive to the voice of my supplication.\nIf Thou, O Lord, wilt mark iniquities: Lord, who shall stand it?\nFor with Thee there is forgiveness: and by reason of Thy law I have waited for Thee, O Lord.\nMy soul hath relied on His word: my soul hath hoped in the Lord.\nFrom the morning watch even until night: let Israel hope in the Lord.\nBecause with the Lord there is mercy: and with Him plentiful redemption.\nAnd He shall redeem Israel from all his iniquities.\nEternal rest grant unto them, O Lord.\nAnd let perpetual light shine upon them.\n℣. From the gates of hell.\n℟. Deliver their souls, O Lord.\n℣. May they rest in peace.\n℟. Amen.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
+                "la": "De profundis clamavi ad te Domine: Domine exaudi vocem meam.\nFiant aures tuae intendentes, in vocem deprecationis meae.\nSi iniquitates observaveris Domine: Domine quis sustinebit?\nQuia apud te propitiatio est: et propter legem tuam sustinui te Domine.\nSustinuit anima mea in verbo ejus: speravit anima mea in Domino.\nA custodia matutina usque ad noctem: speret Israel in Domino.\nQuia apud Dominum misericordia: et copiosa apud eum redemptio.\nEt ipse redimet Israel, ex omnibus iniquitatibus ejus.\nRequiem aeternam dona eis Domine.\nEt lux perpetua luceat eis.",
+                "en-US": "Out of the depths I have cried to Thee, O Lord: Lord, hear my voice.\nLet Thine ears be attentive to the voice of my supplication.\nIf Thou, O Lord, wilt mark iniquities: Lord, who shall stand it?\nFor with Thee there is forgiveness: and by reason of Thy law I have waited for Thee, O Lord.\nMy soul hath relied on His word: my soul hath hoped in the Lord.\nFrom the morning watch even until night: let Israel hope in the Lord.\nBecause with the Lord there is mercy: and with Him plentiful redemption.\nAnd He shall redeem Israel from all his iniquities.\nEternal rest grant unto them, O Lord.\nAnd let perpetual light shine upon them."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "A porta inferi.",
+                    "en-US": "From the gates of hell."
+                  },
+                  "r": {
+                    "la": "Erue Domine animas eorum.",
+                    "en-US": "Deliver their souls, O Lord."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Requiescant in pace.",
+                    "en-US": "May they rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, veniae largitor et humanae salutis amator: quaesumus clementiam tuam; ut nostrae congregationis fratres, propinquos, et benefactores, qui ex hoc saeculo transierunt, beata Maria semper Virgine intercedente cum omnibus Sanctis tuis, ad perpetuae beatitudinis consortium pervenire concedas.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\n℟. Amen.\n℣. Requiem aeternam dona eis Domine.\n℟. Et lux perpetua luceat eis.\n℣. Requiescant in pace.\n℟. Amen.",
-                "en-US": "Let us pray,\nO God, the giver of pardon and the lover of human salvation, we beseech Thy clemency; that, through the intercession of the Blessed Mary ever Virgin and of all Thy Saints, Thou wouldst grant to the brethren, kindred, and benefactors of our congregation who have passed out of this life, to come to the fellowship of everlasting blessedness.\nThrough our Lord Jesus Christ, Thy Son, who liveth and reigneth with Thee in the unity of the Holy Ghost, God, forever and ever.\n℟. Amen.\n℣. Eternal rest grant unto them, O Lord.\n℟. And let perpetual light shine upon them.\n℣. May they rest in peace.\n℟. Amen."
+                "la": "Deus, veniae largitor et humanae salutis amator: quaesumus clementiam tuam; ut nostrae congregationis fratres, propinquos, et benefactores, qui ex hoc saeculo transierunt, beata Maria semper Virgine intercedente cum omnibus Sanctis tuis, ad perpetuae beatitudinis consortium pervenire concedas.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.",
+                "en-US": "O God, the giver of pardon and the lover of human salvation, we beseech Thy clemency; that, through the intercession of the Blessed Mary ever Virgin and of all Thy Saints, Thou wouldst grant to the brethren, kindred, and benefactors of our congregation who have passed out of this life, to come to the fellowship of everlasting blessedness.\nThrough our Lord Jesus Christ, Thy Son, who liveth and reigneth with Thee in the unity of the Holy Ghost, God, forever and ever."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Requiem aeternam dona eis Domine.",
+                    "en-US": "Eternal rest grant unto them, O Lord."
+                  },
+                  "r": {
+                    "la": "Et lux perpetua luceat eis.",
+                    "en-US": "And let perpetual light shine upon them."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Requiescant in pace.",
+                    "en-US": "May they rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -505,28 +1069,43 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende.",
+                    "en-US": "Incline unto mine aid, O God."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\nGloria Patri, etc.",
-                "en-US": "℣. Incline unto mine aid, O God.\n℟. O Lord, make haste to help me.\nGlory be to the Father (as at Matins)"
+                "la": "Gloria Patri, etc.",
+                "en-US": "Glory be to the Father (as at Matins)"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Nunc, Sancte nobis Spiritus,\nUnum Patri cum Filio,\nDignare promptus ingeri\nNostro refusus pectori.\n\nOs, lingua, mens, sensus, vigor,\nConfessionem personent,\nFlammescat igne caritas,\nAccendat ardor proximos.\n\nPraesta, Pater piissime,\nPatrique compar Unice,\nCum Spiritu Paraclito,\nRegnans per omne saeculum. Amen.",
                 "en-US": "Come, Holy Ghost, who ever one,\nReignest with Father and with Son,\nIt is the hour, our souls possess\nWith thy full flood of holiness.\n\nLet flesh, and heart, and lips, and mind,\nSound forth our witness to mankind;\nAnd love light up our mortal frame\nTill others catch the living flame.\n\nNow to the Father, to the Son,\nAnd to the Spirit, Three in One,\nBe praise, and thanks, and glory given,\nBy men on earth, by Saints in heaven. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 120",
                 "en-US": "Psalm 120"
@@ -540,7 +1119,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum (Jer. 17:14)",
                 "en-US": "Little Chapter (Jer. 17:14)"
@@ -549,23 +1128,104 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sana me, Domine, et sanabor: salvum me fac, et salvus ero: quoniam laus mea tu es.\n℟. Deo gratias.\n℣. Adjutor meus esto, ne derelinquas me.\n℟. Neque despicias me, Deus, salutaris meus.",
-                "en-US": "Heal me, O Lord, and I shall be healed: save me, and I shall be saved: for thou art my praise.\n℟. Thanks be to God.\n℣. Be thou my helper, forsake me not.\n℟. Nor despise me, O God, my Saviour."
+                "la": "Sana me, Domine, et sanabor: salvum me fac, et salvus ero: quoniam laus mea tu es.",
+                "en-US": "Heal me, O Lord, and I shall be healed: save me, and I shall be saved: for thou art my praise."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Kyrie eleison. Christe eleison. Kyrie eleison.\n\nPater noster (secreto).\n℣. Et ne nos inducas in tentationem.\n℟. Sed libera nos a malo.",
-                "en-US": "Lord, have mercy on us. Christ, have mercy on us. Lord, have mercy on us.\n\nPater noster (silently).\n℣. And lead us not into temptation.\n℟. But deliver us from evil."
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Adjutor meus esto, ne derelinquas me.",
+                    "en-US": "Be thou my helper, forsake me not."
+                  },
+                  "r": {
+                    "la": "Neque despicias me, Deus, salutaris meus.",
+                    "en-US": "Nor despise me, O God, my Saviour."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Kyrie eleison. Christe eleison. Kyrie eleison.\n\nPater noster (secreto).",
+                "en-US": "Lord, have mercy on us. Christ, have mercy on us. Lord, have mercy on us.\n\nPater noster (silently)."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem.",
+                    "en-US": "And lead us not into temptation."
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo.",
+                    "en-US": "But deliver us from evil."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus qui corda fidelium Sancti Spiritus illustratione docuisti: da nobis in eodem Spiritu recta sapere, et de ejus semper consolatione gaudere.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate ejusdem Spiritus Sancti Deus, per omnia saecula saeculorum.\n℟. Amen.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.",
-                "en-US": "Let us pray,\nO God, who didst instruct the hearts of the faithful by the light of the Holy Spirit; grant that by the light of the same Spirit we may be always truly wise and rejoice in his consolation.\nThrough our Lord Jesus Christ, thy Son, who liveth and reigneth with thee, in the unity of the same Holy Ghost, one God, world without end.\n℟. Amen.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed, through the mercy of God, rest in peace.\n℟. Amen."
+                "la": "Deus qui corda fidelium Sancti Spiritus illustratione docuisti: da nobis in eodem Spiritu recta sapere, et de ejus semper consolatione gaudere.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate ejusdem Spiritus Sancti Deus, per omnia saecula saeculorum.",
+                "en-US": "O God, who didst instruct the hearts of the faithful by the light of the Holy Spirit; grant that by the light of the same Spirit we may be always truly wise and rejoice in his consolation.\nThrough our Lord Jesus Christ, thy Son, who liveth and reigneth with thee, in the unity of the same Holy Ghost, one God, world without end."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+                    "en-US": "May the souls of the faithful departed, through the mercy of God, rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -578,28 +1238,43 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende.",
+                    "en-US": "Incline unto mine aid, O God."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc.",
-                "en-US": "℣. Incline unto mine aid, O God.\n℟. O Lord, make haste to help me.\nGlory be to the Father (as at Matins)."
+                "la": "Gloria Patri, etc.",
+                "en-US": "Glory be to the Father (as at Matins)."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Rector potens, verax Deus,\nQui temperas rerum vices,\nSplendore mane instruis,\nEt ignibus meridiem:",
                 "en-US": "O God, who canst not change nor fail,\nGuiding the hours, as they go by,\nBrightening with beams the morning pale,\nAnd burning in the mid-day sky:"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 123",
                 "en-US": "Psalm 123"
@@ -613,7 +1288,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum (Gal. 6, 2)",
                 "en-US": "Little Chapter (Gal. 6, 2)"
@@ -622,23 +1297,104 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Alter alterius onera portate, et sic adimplebitis legem Christi.\n℟. Deo gratias.\n℣. Dominus regit me, et nihil mihi deerit.\n℟. In loco pascuae ibi me collocavit.",
-                "en-US": "Bear ye one another's burdens: and so you shall fulfil the law of Christ.\n℟. Thanks be to God.\n℣. The Lord shall govern me and nothing shall be wanting unto me.\n℟. He hath set me in a place of pasture."
+                "la": "Alter alterius onera portate, et sic adimplebitis legem Christi.",
+                "en-US": "Bear ye one another's burdens: and so you shall fulfil the law of Christ."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Kyrie eleison. Christe eleison. Kyrie eleison.\nPater noster (secreto).\n℣. Et ne nos inducas in tentationem.\n℟. Sed libera nos a malo.",
-                "en-US": "Lord, have mercy on us. Christ, have mercy on us. Lord, have mercy on us.\nOur Father (silently).\n℣. And lead us not into temptation.\n℟. But deliver us from evil."
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus regit me, et nihil mihi deerit.",
+                    "en-US": "The Lord shall govern me and nothing shall be wanting unto me."
+                  },
+                  "r": {
+                    "la": "In loco pascuae ibi me collocavit.",
+                    "en-US": "He hath set me in a place of pasture."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Kyrie eleison. Christe eleison. Kyrie eleison.\nPater noster (secreto).",
+                "en-US": "Lord, have mercy on us. Christ, have mercy on us. Lord, have mercy on us.\nOur Father (silently)."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem.",
+                    "en-US": "And lead us not into temptation."
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo.",
+                    "en-US": "But deliver us from evil."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDa, quaesumus, Domine, populo tuo diabolica vitare contagia:\net te solum Deum pura mente sectari.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\n℟. Amen.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.",
-                "en-US": "Let us pray\nGrant to thy people, we beseech thee, O Lord, to avoid the defilements of the devil,\nand with a pure mind to follow thee, the only God.\nThrough our Lord Jesus Christ, thy Son, who liveth and reigneth with thee,\nin the unity of the Holy Ghost, one God, world without end.\n℟. Amen.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed, through the mercy of God, rest in peace.\n℟. Amen."
+                "la": "Da, quaesumus, Domine, populo tuo diabolica vitare contagia:\net te solum Deum pura mente sectari.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum.",
+                "en-US": "Grant to thy people, we beseech thee, O Lord, to avoid the defilements of the devil,\nand with a pure mind to follow thee, the only God.\nThrough our Lord Jesus Christ, thy Son, who liveth and reigneth with thee,\nin the unity of the Holy Ghost, one God, world without end."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+                    "en-US": "May the souls of the faithful departed, through the mercy of God, rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -651,28 +1407,43 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende.",
+                    "en-US": "Incline unto mine aid, O God."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc.",
-                "en-US": "℣. Incline unto mine aid, O God.\n℟. O Lord, make haste to help me.\nGlory be to the Father (as at Matins)."
+                "la": "Gloria Patri, etc.",
+                "en-US": "Glory be to the Father (as at Matins)."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Rerum, Deus, tenax vigor,\nImmotus in te permanens,\nLucis diurnae tempora\nSuccessibus determinans.\n\nLargire lumen vespere,\nQuo vita nusquam decidat,\nSed praemium mortis sacrae,\nPerennis instet gloria.\n\nPraesta, Pater piissime,\nPatrique compar Unice,\nCum Spiritu Paraclito,\nRegnans per omne saeculum. Amen.",
                 "en-US": "O God, unchangeable and true,\nOf all the light and power,\nDispensing light in silence through\nEvery successive hour.\n\nLord, brighten our declining day,\nThat it may never wane,\nTill death, when all things round decay,\nBrings back the morn again.\n\nThis grace on thy redeemed confer,\nFather, coequal Son,\nAnd Holy Ghost the Comforter,\nEternal Three in One. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 127",
                 "en-US": "Psalm 127"
@@ -686,7 +1457,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum (1 Cor. 6, 20)",
                 "en-US": "Little Chapter (1 Cor. 6, 20)"
@@ -695,23 +1466,104 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Empti enim estis pretio magno. Glorificate et portate Deum in corpore vestro.\n℟. Deo gratias.\n℣. Ab occultis meis munda me, Domine.\n℟. Et ab alienis parce servo tuo.",
-                "en-US": "For you are bought with a great price. Glorify and bear God in your body.\n℟. Thanks be to God.\n℣. Cleanse thou me from my secret faults, O Lord.\n℟. Preserve thy servant also from the sins of others."
+                "la": "Empti enim estis pretio magno. Glorificate et portate Deum in corpore vestro.",
+                "en-US": "For you are bought with a great price. Glorify and bear God in your body."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Kyrie eleison. Christe eleison. Kyrie eleison.\n\nPater Noster (secreto).\n℣. Et ne nos inducas in tentationem.\n℟. Sed libera nos a malo.",
-                "en-US": "Lord, have mercy on us. Christ, have mercy on us. Lord, have mercy on us.\n\nPater Noster (silently).\n℣. And lead us not into temptation.\n℟. But deliver us from evil."
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ab occultis meis munda me, Domine.",
+                    "en-US": "Cleanse thou me from my secret faults, O Lord."
+                  },
+                  "r": {
+                    "la": "Et ab alienis parce servo tuo.",
+                    "en-US": "Preserve thy servant also from the sins of others."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Kyrie eleison. Christe eleison. Kyrie eleison.\n\nPater Noster (secreto).",
+                "en-US": "Lord, have mercy on us. Christ, have mercy on us. Lord, have mercy on us.\n\nPater Noster (silently)."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem.",
+                    "en-US": "And lead us not into temptation."
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo.",
+                    "en-US": "But deliver us from evil."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui in Filii tui humilitate jacentem mundum erexisti: fidelibus tuis perpetuam concede laetitiam; ut, quos perpetuae mortis eripuisti casibus, gaudiis facias perfrui sempiternis.\nPer eumdem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\n℟. Amen.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.",
-                "en-US": "Let us pray,\nO God, who by the self-abasement of thy Son hast raised up a fallen world, grant to thy faithful people perpetual joy; and as thou hast delivered them from the danger of eternal death, so do thou give unto them the joys of everlasting happiness.\nThrough the same Jesus Christ thy Son our Lord, who liveth and reigneth with Thee, in the unity of the Holy Ghost, one God, world without end.\n℟. Amen.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed, through the mercy of God, rest in peace.\n℟. Amen."
+                "la": "Deus, qui in Filii tui humilitate jacentem mundum erexisti: fidelibus tuis perpetuam concede laetitiam; ut, quos perpetuae mortis eripuisti casibus, gaudiis facias perfrui sempiternis.\nPer eumdem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.",
+                "en-US": "O God, who by the self-abasement of thy Son hast raised up a fallen world, grant to thy faithful people perpetual joy; and as thou hast delivered them from the danger of eternal death, so do thou give unto them the joys of everlasting happiness.\nThrough the same Jesus Christ thy Son our Lord, who liveth and reigneth with Thee, in the unity of the Holy Ghost, one God, world without end."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+                    "en-US": "May the souls of the faithful departed, through the mercy of God, rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -724,14 +1576,29 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende.",
+                    "en-US": "Incline unto mine aid, O God."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc.",
-                "en-US": "℣. Incline unto mine aid, O God.\n℟. O Lord, make haste to help me.\nGlory be to the Father (as at Matins)."
+                "la": "Gloria Patri, etc.",
+                "en-US": "Glory be to the Father (as at Matins)."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 116",
                 "en-US": "Psalm 116"
@@ -745,21 +1612,28 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O lux beata Trinitas,\nEt principalis Unitas,\nJam sol recedet igneus,\nInfunde lumen cordibus.\nTe mane laudum carmine,\nTe deprecemur vespere,\nTe nostra supplex gloria\nPer cuncta laudet saecula.\nDeo Patri sit gloria,\nEjusque soli Filio,\nCum Spiritu Paraclito,\nEt nunc et in perpetuum. Amen.\nVespertina oratio ascendit ad te, Domine.\n℟. Et descendat super nos misericordia tua.",
-                "en-US": "O Trinity of blessed light,\nO Unity of princely might,\nThe fiery sun now goes his way.\nShed Thou within our hearts Thy ray.\nTo Thee our morning song of praise,\nTo Thee our evening prayer we raise;\nThy glory suppliant we adore\nForever and forevermore.\nAll praise to God the Father be;\nAll thanks, Eternal Son, to Thee;\nAll glory, as is ever meet,\nTo God the Holy Paraclete. Amen.\nMay our evening prayer ascend to thee, O Lord.\n℟. And may thy mercy descend upon us."
+                "la": "O lux beata Trinitas,\nEt principalis Unitas,\nJam sol recedet igneus,\nInfunde lumen cordibus.\nTe mane laudum carmine,\nTe deprecemur vespere,\nTe nostra supplex gloria\nPer cuncta laudet saecula.\nDeo Patri sit gloria,\nEjusque soli Filio,\nCum Spiritu Paraclito,\nEt nunc et in perpetuum. Amen.\nVespertina oratio ascendit ad te, Domine.",
+                "en-US": "O Trinity of blessed light,\nO Unity of princely might,\nThe fiery sun now goes his way.\nShed Thou within our hearts Thy ray.\nTo Thee our morning song of praise,\nTo Thee our evening prayer we raise;\nThy glory suppliant we adore\nForever and forevermore.\nAll praise to God the Father be;\nAll thanks, Eternal Son, to Thee;\nAll glory, as is ever meet,\nTo God the Holy Paraclete. Amen.\nMay our evening prayer ascend to thee, O Lord."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Et descendat super nos misericordia tua.",
+                "en-US": "And may thy mercy descend upon us."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -773,7 +1647,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum B.V.M. (Luc. 1, 46–55)",
                 "en-US": "Canticle of the B.V.M. (Luke 1, 46–55)"
@@ -787,7 +1661,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -803,15 +1677,44 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Kyrie eleison. Christe eleison. Kyrie eleison.\nPater noster (clara voce).\n℣. Et ne nos inducas in tentationem.\n℟. Sed libera nos a malo.",
-                "en-US": "Lord, have mercy on us. Christ, have mercy on us. Lord, have mercy on us.\nPater noster (aloud).\n℣. And lead us not into temptation.\n℟. But deliver us from evil."
+                "la": "Kyrie eleison. Christe eleison. Kyrie eleison.\nPater noster (clara voce).",
+                "en-US": "Lord, have mercy on us. Christ, have mercy on us. Lord, have mercy on us.\nPater noster (aloud)."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem.",
+                    "en-US": "And lead us not into temptation."
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo.",
+                    "en-US": "But deliver us from evil."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nAurem tuam, quaesumus, Domine, precibus nostris accomoda, et mentis nostrae tenebras gratia tuae visitationis illustra.\nQui vivis et regnas cum Deo Patre in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\n℟. Amen.",
-                "en-US": "Let us pray,\nIncline thine ear, O Lord, we beseech thee, to our prayers, and enlighten the darkness of our minds by the grace of thy visitation. Who livest and reignest with God the Father, in the unity of the Holy Ghost, one God, world without end.\n℟. Amen."
+                "la": "Aurem tuam, quaesumus, Domine, precibus nostris accomoda, et mentis nostrae tenebras gratia tuae visitationis illustra.\nQui vivis et regnas cum Deo Patre in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.",
+                "en-US": "Incline thine ear, O Lord, we beseech thee, to our prayers, and enlighten the darkness of our minds by the grace of thy visitation. Who livest and reignest with God the Father, in the unity of the Holy Ghost, one God, world without end."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
               }
             },
             {
@@ -824,16 +1727,75 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sanctissime Confessor Domini, monachorum Pater et Dux, Benedicte, intercede pro nostra omniumque salute.\n℣. Amavit eum Dominus et ornavit eum.\n℟. Stolam gloriae induit eum.",
-                "en-US": "Most holy Confessor of the Lord, Father and Guide of monks, Benedict, intercede for the salvation of ourselves, and of all.\n℣. The Lord hath loved and adorned him.\n℟. He hath invested him with the stole of glory."
+                "la": "Sanctissime Confessor Domini, monachorum Pater et Dux, Benedicte, intercede pro nostra omniumque salute.",
+                "en-US": "Most holy Confessor of the Lord, Father and Guide of monks, Benedict, intercede for the salvation of ourselves, and of all."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Amavit eum Dominus et ornavit eum.",
+                    "en-US": "The Lord hath loved and adorned him."
+                  },
+                  "r": {
+                    "la": "Stolam gloriae induit eum.",
+                    "en-US": "He hath invested him with the stole of glory."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nExcita, Domine, in Ecclesia tua Spiritum, cui beatus Pater noster Benedictus Abbas servivit, ut eodem nos repleti, studeamus amare quod amavit, et opere exercere quod docuit.\nPer Christum Dominum nostrum.\n℟. Amen.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.",
-                "en-US": "Let us pray,\nRaise up, O Lord, in thy Church, the Spirit wherewith our holy Father, the Abbot Benedict, was animated, that, filled with the same, we may strive to love what he loved, and to practice what he taught. Through Christ our Lord.\n℟. Amen.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed, through the mercy of God, rest in peace.\n℟. Amen."
+                "la": "Excita, Domine, in Ecclesia tua Spiritum, cui beatus Pater noster Benedictus Abbas servivit, ut eodem nos repleti, studeamus amare quod amavit, et opere exercere quod docuit.\nPer Christum Dominum nostrum.",
+                "en-US": "Raise up, O Lord, in thy Church, the Spirit wherewith our holy Father, the Abbot Benedict, was animated, that, filled with the same, we may strive to love what he loved, and to practice what he taught. Through Christ our Lord."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+                    "en-US": "May the souls of the faithful departed, through the mercy of God, rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -848,12 +1810,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Jube, Domne, benedicere.\nNoctem quietam, et finem perfectum concedat nobis Dominus omnipotens.\n℟. Amen.",
-                "en-US": "℣. Pray, O Lord, a blessing.\nThe Lord almighty grant us a peaceful night and a perfect end.\n℟. Amen."
+                "la": "Jube, Domne, benedicere.",
+                "en-US": "Pray, O Lord, a blessing."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Noctem quietam, et finem perfectum concedat nobis Dominus omnipotens.",
+                "en-US": "The Lord almighty grant us a peaceful night and a perfect end."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio brevis (I Pet. 5, 8–9)",
                 "en-US": "Short Lesson (I Pet. 5, 8–9)"
@@ -862,19 +1838,41 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Fratres: Sobrii estote, et vigilate: quia adversarius vester diabolus tamquam leo rugiens circuit, quaerens quem devoret: cui resistite fortes in fide. Tu autem Domine miserere nobis.\n℟. Deo gratias.",
-                "en-US": "Brethren: Be sober and watch: because your adversary the devil, as a roaring lion, goeth about, seeking whom he may devour: whom resist ye, strong in faith. But thou, O Lord, have mercy on us.\n℟. Thanks be to God."
+                "la": "Fratres: Sobrii estote, et vigilate: quia adversarius vester diabolus tamquam leo rugiens circuit, quaerens quem devoret: cui resistite fortes in fide. Tu autem Domine miserere nobis.",
+                "en-US": "Brethren: Be sober and watch: because your adversary the devil, as a roaring lion, goeth about, seeking whom he may devour: whom resist ye, strong in faith. But thou, O Lord, have mercy on us."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc.",
-                "en-US": "℣. Incline unto mine aid, O God.\n℟. O Lord, make haste to help me.\nGlory be to the Father (as at Matins)."
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende.",
+                    "en-US": "Incline unto mine aid, O God."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, etc.",
+                "en-US": "Glory be to the Father (as at Matins)."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 133",
                 "en-US": "Psalm 133"
@@ -888,21 +1886,21 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Te lucis ante terminum,\nRerum Creator, poscimus,\nUt pro tua clementia\nSis praesul et custodia.\nProcul recedant somnia,\nEt noctium phantasmata;\nHostemque nostrum comprime,\nNe polluantur corpora.\nPraesta Pater piissime,\nPatri­que compar Unice,\nCum Spiritu Paraclito\nRegnans per omne saeculum. Amen.",
                 "en-US": "Before the ending of the day,\nCreator of the world, we pray\nThat with Thy wonted favor Thou\nWouldst be our Guard and Keeper now.\nFrom all ill dreams defend our eyes,\nFrom nightly fears and fantasies;\nTread under foot our ghostly foe;\nThat no pollution we may know.\nO Father, what we ask be done,\nThrough Jesus Christ, Thine only Son;\nWho, with the Holy Ghost and Thee,\nDoth live and reign eternally. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum (Jer. 14, 9)",
                 "en-US": "Little Chapter (Jer. 14, 9)"
@@ -911,29 +1909,87 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Tu autem in nobis es, Domine, et nomen sanctum tuum invocatum est super nos: ne derelinquas nos, Domine Deus noster.\n℟. Deo gratias.\n\n℣. Custodi nos, Domine, ut pupillam oculi.\n℟. Sub umbra alarum tuarum protege nos.",
-                "en-US": "But thou, O Lord, art among us, and thy holy Name is invoked upon us: forsake us not, O Lord our God.\n℟. Thanks be to God.\n\n℣. Keep us, O Lord, as the apple of thine eye.\n℟. Protect us under the shadow of thy wings."
+                "la": "Tu autem in nobis es, Domine, et nomen sanctum tuum invocatum est super nos: ne derelinquas nos, Domine Deus noster.",
+                "en-US": "But thou, O Lord, art among us, and thy holy Name is invoked upon us: forsake us not, O Lord our God."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Kyrie eleison. Christe eleison. Kyrie eleison.\nPater noster (secreto).\n℣. Et ne nos inducas in tentationem.\n℟. Sed libera nos a malo.",
-                "en-US": "Lord, have mercy on us. Christ, have mercy on us. Lord, have mercy on us.\nOur Father (silently).\n℣. And lead us not into temptation.\n℟. But deliver us from evil."
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Custodi nos, Domine, ut pupillam oculi.",
+                    "en-US": "Keep us, O Lord, as the apple of thine eye."
+                  },
+                  "r": {
+                    "la": "Sub umbra alarum tuarum protege nos.",
+                    "en-US": "Protect us under the shadow of thy wings."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Kyrie eleison. Christe eleison. Kyrie eleison.\nPater noster (secreto).",
+                "en-US": "Lord, have mercy on us. Christ, have mercy on us. Lord, have mercy on us.\nOur Father (silently)."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem.",
+                    "en-US": "And lead us not into temptation."
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo.",
+                    "en-US": "But deliver us from evil."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nVisita, quaesumus, Domine, habitationem istam, et omnes insidias inimici ab ea longe repelle: Angeli tui sancti habitent in ea, qui nos in pace custodiant, et benedictio tua sit super nos semper.\nDefende, quaesumus, Domine, beata Maria semper Virgine intercedente, istam ab omni adversitate familiam, et toto corde tibi prostratam ab hostium propitius tuere clementer insidiis. Per Christum Dominum nostrum.\n℟. Amen.",
-                "en-US": "Let us pray,\nVisit, we beseech thee, O Lord, this house, and drive far from it all snares of the enemy; let thy holy Angels dwell therein, who may keep us in peace, and let thy blessing be always upon us.\nDo thou, we beseech thee, O Lord, by the intercession of blessed Mary ever Virgin, keep this family from all harm; and mercifully deign to protect from the snares of the enemy those who with their whole heart prostrate themselves before thee. Through Christ our Lord.\n℟. Amen."
+                "la": "Visita, quaesumus, Domine, habitationem istam, et omnes insidias inimici ab ea longe repelle: Angeli tui sancti habitent in ea, qui nos in pace custodiant, et benedictio tua sit super nos semper.\nDefende, quaesumus, Domine, beata Maria semper Virgine intercedente, istam ab omni adversitate familiam, et toto corde tibi prostratam ab hostium propitius tuere clementer insidiis. Per Christum Dominum nostrum.",
+                "en-US": "Visit, we beseech thee, O Lord, this house, and drive far from it all snares of the enemy; let thy holy Angels dwell therein, who may keep us in peace, and let thy blessing be always upon us.\nDo thou, we beseech thee, O Lord, by the intercession of blessed Mary ever Virgin, keep this family from all harm; and mercifully deign to protect from the snares of the enemy those who with their whole heart prostrate themselves before thee. Through Christ our Lord."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Benedicat et custodiat nos omnipotens et misericors Dominus, Pater, et Filius, et Spiritus Sanctus.\n℟. Amen.",
-                "en-US": "May the almighty and merciful Lord, the Father, the Son, and the Holy Ghost, bless and protect us.\n℟. Amen."
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Benedicat et custodiat nos omnipotens et misericors Dominus, Pater, et Filius, et Spiritus Sanctus.",
+                "en-US": "May the almighty and merciful Lord, the Father, the Son, and the Holy Ghost, bless and protect us."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
               }
             }
           ]

--- a/content/practices/little-office-blessed-sacrament/flow.json
+++ b/content/practices/little-office-blessed-sacrament/flow.json
@@ -10,8 +10,8 @@
     {
       "type": "prayer",
       "inline": {
-        "la": "℣. Panem Angelorum manducavit homo, et paratur ei mensa Domini.",
-        "en-US": "℣. Man hath eaten the bread of Angels, and the table of our Lord is prepared for him."
+        "la": "Panem Angelorum manducavit homo, et paratur ei mensa Domini.",
+        "en-US": "Man hath eaten the bread of Angels, and the table of our Lord is prepared for him."
       }
     },
     {
@@ -22,11 +22,19 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.",
-        "en-US": "℣. O Lord, open my lips.\n℟. And my mouth will announce Thy praise."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine labia mea aperies.",
+            "en-US": "O Lord, open my lips."
+          },
+          "r": {
+            "la": "Et os meum annuntiabit laudem tuam.",
+            "en-US": "And my mouth will announce Thy praise."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -36,11 +44,19 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis.",
-        "en-US": "℣. Convert us, O God our Saviour.\n℟. And turn away Thy wrath from us."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Converte nos, Deus salutaris noster.",
+            "en-US": "Convert us, O God our Saviour."
+          },
+          "r": {
+            "la": "Et averte iram tuam a nobis.",
+            "en-US": "And turn away Thy wrath from us."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -50,11 +66,34 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Deus in adiutorium meum intende.\n℟. Domine ad adiuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Alleluia.",
-        "en-US": "℣. O God, come to my aid.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Spirit.\n℟. As it was in the beginning, is now, and ever shall be, world without end. Alleluia."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Deus in adiutorium meum intende.",
+            "en-US": "O God, come to my aid."
+          },
+          "r": {
+            "la": "Domine ad adiuvandum me festina.",
+            "en-US": "O Lord, make haste to help me."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Gloria Patri, et Filio, et Spiritui Sancto.",
+            "en-US": "Glory be to the Father, and to the Son, and to the Holy Spirit."
+          },
+          "r": {
+            "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Alleluia.",
+            "en-US": "As it was in the beginning, is now, and ever shall be, world without end. Alleluia."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -211,9 +250,24 @@
     {
       "type": "prayer",
       "inline": {
-        "la": "O quam suavis est Domine spiritus tuus, qui ut dulcedinem tuam in filios demonstrares, pane suavissimo de caelo praestito esurientes reples bonis, fastidiosos divites dimittens inanes.\n℣. Panem de caelo praestitisti eis.\n℟. Omne delectamentum in se habentem.",
-        "en-US": "O how sweet, O Lord, is Thy Spirit, who, that Thou mightest show Thy sweetness towards Thy children, by most sweet bread sent from Heaven fillest the hungry with good things, send the rich away empty.\n℣. Thou hast given us bread from Heaven.\n℟. Filled with all sweetness and delight."
+        "la": "O quam suavis est Domine spiritus tuus, qui ut dulcedinem tuam in filios demonstrares, pane suavissimo de caelo praestito esurientes reples bonis, fastidiosos divites dimittens inanes.",
+        "en-US": "O how sweet, O Lord, is Thy Spirit, who, that Thou mightest show Thy sweetness towards Thy children, by most sweet bread sent from Heaven fillest the hungry with good things, send the rich away empty."
       }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Panem de caelo praestitisti eis.",
+            "en-US": "Thou hast given us bread from Heaven."
+          },
+          "r": {
+            "la": "Omne delectamentum in se habentem.",
+            "en-US": "Filled with all sweetness and delight."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",

--- a/content/practices/little-office-bvm-ambrosian/flow.json
+++ b/content/practices/little-office-bvm-ambrosian/flow.json
@@ -44,10 +44,30 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. Alleluia."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. Alleluia."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -62,43 +82,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Mysterium Ecclesiæ\nHymnum Christo referimus,\nQuem genuit Puerpera\nVerbum Patris in Filium."
+                "la": "Mysterium Ecclesiæ\nHymnum Christo referimus,\nQuem genuit Puerpera\nVerbum Patris in Filium.\n\nSola in sexu femina\nElecta es in saeculo,\nEt meruisti Dominum\nSancto portare in utero.\n\nVates antiqui temporis\nPrædixerat quod factum est:\nQuia Virgo conciperet,\nEt pareret Emmanuel.\n\nMysterium hoc magnum est,\nMariæ quod concessum est,\nUt Deum per quem omnia\nEx se videret progredi.\n\nDeo Patri sit gloria,\nEjusque soli Filio,\nCum Spiritu Paraclito,\nIn sempiterna secula. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sola in sexu femina\nElecta es in saeculo,\nEt meruisti Dominum\nSancto portare in utero."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Vates antiqui temporis\nPrædixerat quod factum est:\nQuia Virgo conciperet,\nEt pareret Emmanuel."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mysterium hoc magnum est,\nMariæ quod concessum est,\nUt Deum per quem omnia\nEx se videret progredi."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Deo Patri sit gloria,\nEjusque soli Filio,\nCum Spiritu Paraclito,\nIn sempiterna secula. Amen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Responsorium post hymnum:"
               }
@@ -106,7 +102,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Congratulamini mihi, omnes qui diligitis Dominum: quia, cum essem parvula, placui Altissimo: Et de meis visceribus genui Deum et hominem.\n℣. Ecce enim ex hoc beatam me dicent omnes generationes; quia ancillam humilem respexit Deus: Et de meis visceribus genui Deum et hominem."
+                "la": "Congratulamini mihi, omnes qui diligitis Dominum: quia, cum essem parvula, placui Altissimo: Et de meis visceribus genui Deum et hominem."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Ecce enim ex hoc beatam me dicent omnes generationes; quia ancillam humilem respexit Deus: Et de meis visceribus genui Deum et hominem."
               }
             },
             {
@@ -116,7 +118,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -134,13 +136,13 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona: Benedictus es, Domine Deus, patrum nostrorum, et laudabilis et gloriosus in saecula."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum: Dan. 3"
               }
@@ -158,16 +160,23 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "subheading",
+              "text": {
                 "la": "Antiphona: Laudabilis. Kyrie, eleison. Kyrie, eleison. Kyrie, eleison."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedictus es, Deus.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedictus es, Deus."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -176,7 +185,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -188,10 +197,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedictus es, Deus.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedictus es, Deus."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -206,7 +222,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -218,7 +234,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Annae 1 Reg. 2"
               }
@@ -230,7 +246,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -242,13 +258,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedictus es, Deus.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedictus es, Deus."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -272,7 +295,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -284,13 +307,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedictus es, Deus.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedictus es, Deus."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -314,7 +344,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -326,13 +356,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedictus es, Deus.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedictus es, Deus."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Benedictiones et lectiones, ut infra."
               }
@@ -350,7 +387,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -362,7 +399,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 8"
               }
@@ -374,7 +411,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -386,13 +423,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedictus es, Deus.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedictus es, Deus."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -404,7 +448,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 18"
               }
@@ -416,7 +460,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -428,13 +472,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedictus es, Deus.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedictus es, Deus."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -446,7 +497,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 23"
               }
@@ -458,7 +509,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -470,13 +521,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedictus es, Deus.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedictus es, Deus."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Benedictiones et lectiones, ut infra."
               }
@@ -494,7 +552,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -506,7 +564,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 44"
               }
@@ -518,7 +576,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -530,13 +588,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedictus es, Deus.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedictus es, Deus."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -548,7 +613,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 45"
               }
@@ -560,7 +625,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -572,13 +637,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedictus es, Deus.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedictus es, Deus."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -590,7 +662,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 86"
               }
@@ -602,7 +674,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -614,13 +686,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedictus es, Deus.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedictus es, Deus."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Benedictiones et lectiones, ut infra"
               }
@@ -638,7 +717,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -650,7 +729,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 95"
               }
@@ -662,7 +741,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -674,13 +753,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedictus es, Deus.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedictus es, Deus."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -692,7 +778,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 96"
               }
@@ -704,7 +790,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -716,13 +802,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedictus es, Deus.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedictus es, Deus."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -734,7 +827,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 97"
               }
@@ -746,7 +839,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -758,25 +851,39 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedictus es, Deus.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedictus es, Deus."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Lectiones"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Jube, Domine, benedicere. Qui natus est de Virgine purget nos ab omni crimine.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Jube, Domine, benedicere. Qui natus est de Virgine purget nos ab omni crimine."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Lectio I Eccli. 24"
               }
@@ -784,23 +891,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ego quasi vitis fructificavi suavitatem odoris: et flores mei, fructus honoris et honestatis. Ego mater pulchrae dilectionis et timoris et agnitionis et sanctae spei. In me omnis gratia viae et veritatis: in me omnis spes vitae et virtutus.\nTu autem Domine, nostri miserere.\n℟. Deo gratias."
+                "la": "Ego quasi vitis fructificavi suavitatem odoris: et flores mei, fructus honoris et honestatis. Ego mater pulchrae dilectionis et timoris et agnitionis et sanctae spei. In me omnis gratia viae et veritatis: in me omnis spes vitae et virtutus.\nTu autem Domine, nostri miserere."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Beata et venerabilis Virgo, quibus te laudibus praeferam, nescio: Quem caeli non capiunt, tuis gremiis continetur.\n℣. Benedicta tu inter mulieres, et benedictus fructus ventris tui, qui est Christus Dominus: Quem caeli non capiunt, tuis gremiis continetur."
+                "la": "Deo gratias."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Jube, Domine, benedicere. Per Virginem concedat nobis Dominus salutem et pacem.\n℟. Amen."
+                "la": "Beata et venerabilis Virgo, quibus te laudibus praeferam, nescio: Quem caeli non capiunt, tuis gremiis continetur."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Benedicta tu inter mulieres, et benedictus fructus ventris tui, qui est Christus Dominus: Quem caeli non capiunt, tuis gremiis continetur."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Jube, Domine, benedicere. Per Virginem concedat nobis Dominus salutem et pacem."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio II"
               }
@@ -808,23 +934,47 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Transite ad me, qui concupiscitis me, et a generationibus meis adimplemini. Spiritus enim meus super mel dulcis: et haereditas mea super mel et favum. Memoria mea in generationes saeculorum.\nTu autem, Domine, nostri miserere.\n℟. Deo Gratias"
+                "la": "Transite ad me, qui concupiscitis me, et a generationibus meis adimplemini. Spiritus enim meus super mel dulcis: et haereditas mea super mel et favum. Memoria mea in generationes saeculorum.\nTu autem, Domine, nostri miserere."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Sancta Domina, Dei Genitrìx, Intercede pro nobis.\n℣. Deprecare pro nobis Filium Dei: Intercede pro nobis."
+                "la": "Deo Gratias"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Jube, Domine, benedicere.\nPrecibus et meritis beatissimae Virginis Mariae perducate nos ad Dominus ad gaudia vitae aeternae.\n℟. Amen."
+                "la": "Sancta Domina, Dei Genitrìx, Intercede pro nobis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deprecare pro nobis Filium Dei: Intercede pro nobis."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Jube, Domine, benedicere."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Precibus et meritis beatissimae Virginis Mariae perducate nos ad Dominus ad gaudia vitae aeternae."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio III"
               }
@@ -832,11 +982,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Qui edunt me, adhuc esurient: et qui bibunt me, adhuc sitient. Qui audit me, non confundetur; et qui operantur in me, non peccabunt. Qui elucidant me, vitam aeternam habebunt. Tu autem, Domine, nostri miserere.\n℟. Deo Gratias."
+                "la": "Qui edunt me, adhuc esurient: et qui bibunt me, adhuc sitient. Qui audit me, non confundetur; et qui operantur in me, non peccabunt. Qui elucidant me, vitam aeternam habebunt. Tu autem, Domine, nostri miserere."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo Gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus Te Deum"
               }
@@ -848,13 +1004,13 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn. S. Ambrosii et S. Augustini."
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Te Deum laudamus te Dominum confitemur.\nTe æternum Patrem omnis terra veneratur.\nTibi omnes Angeli tibi caeli et universæ Potestates.\nTibi Cherubim et Seraphim incessabili voce proclamant.\nSanctus, Sanctus, Sanctus, Dominus Deus Sabaoth.\nPleni sunt cœli et terra majestatis gloriæ tuæ.\nTe gloriosus Apostolorum chorus.\nTe Prophetarum laudabilis numerus.\nTe Martyrum candidatus laudat exercitus.\nTe per orbem terrarum sancta confitetur Ecclesia.\nPatrem immensæ majestatis.\nVenerandum tuum verum et unicum Filium.\nSanctum quoque Paracletum Spiritum.\nTu, Rex gloriæ, Christe.\nTu Patris sempiternus es Filius.\nTu, ad liberandum suscepturus hominem non horruisti Virginis uterum.\nTu, devicto mortis aculeo aperuisti credentibus regna cœlorum.\nTu ad dexteram Dei sedes in gloria Patris.\nJudex crederis esse venturus.\nTe ergo quæsumus, tuis famulis subveni quos pretioso sanguine redemisti.\nÆterna fac cum Sanctis tuis gloria numerari.\nSalvum fac populum tuum, Domine et benedic hæreditati tuæ.\nEt rege eos et extolle illos usque in æternum.\nPer singulos dies benedicimus te.\nEt laudamus nomen tuum in aeternum et in saeculum saeculi.\nDignare, Domine die isto sine peccato nos custodire.\nMiserere nostri, Domine miserere nostri.\nFiat misericordia tua, Domine, super nos quemadmodum speravimus in te.\nIn te, Domine, speravi non confundar in æternum."
               }
@@ -866,13 +1022,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -880,14 +1043,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Epelle, Domine, tenebras a cordibus nostris: et lucem tuam mentibus nostris infunde. Per Christum Dominum nostrum.\n℟. Amen."
+                "la": "Epelle, Domine, tenebras a cordibus nostris: et lucem tuam mentibus nostris infunde. Per Christum Dominum nostrum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Benedicamus Domino.\n℟. Deo Gratias."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo Gratias."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -906,10 +1082,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. Alleluia."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. Alleluia."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -924,7 +1120,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -936,7 +1132,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Zachariae Luc 1"
               }
@@ -948,7 +1144,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -960,31 +1156,69 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio Secreta"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui tribus Pueris in camino ignius positis quartus adesse dignatus es, cui facillimum est ignium temperare naturas, et extinguere flammarum impetus: eamdem, Domine, ad protegendas et liberandas animas nostras extende virtutem. Per Dominum nostrum Jesum Christum Filium tuum qui tecum vivit et regnat (℣. Alta voce) Una cum Sancto Spiritu in saecula saeculorum.\n℟. Amen."
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+                "la": "Deus, qui tribus Pueris in camino ignius positis quartus adesse dignatus es, cui facillimum est ignium temperare naturas, et extinguere flammarum impetus: eamdem, Domine, ad protegendas et liberandas animas nostras extende virtutem. Per Dominum nostrum Jesum Christum Filium tuum qui tecum vivit et regnat"
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Alta voce."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Una cum Sancto Spiritu in saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -996,7 +1230,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum trium puerorum. Dan. 3."
               }
@@ -1008,7 +1242,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1020,13 +1254,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio I"
               }
@@ -1038,13 +1279,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1056,13 +1304,13 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmi Laudativi"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 148"
               }
@@ -1070,11 +1318,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudate Dominum de caelis laudate eum in excelsis.\nLaudate eum, omnes Angeli ejus; laudate eum, omnes Virtutes ejus.\nLaudate eum, sol et luna; laudate eum, omnes stellae et lumen.\nLaudate eum, caeli caelorum; et aquae omnes, quae super caelos sunt, laudent nomen Domini:\nQuia ipse dixit et facta sunt; ipse mandavit, et creata sunt.\nStatuit ea in aeternum et in saeculum saeculi: praeceptum posuit, et non praeteribit.\nLaudate Dominum de terra, dracones et omnes abyssi;\nIgnis, grando, nix, glacies, spiritus procellae, qui faciunt verbum ejus;\nMontes et omnes colles, ligna fructifera et omnes cedri;\nBestiae et omnia jumenta, serpentes et volucres pennatae.\nReges terrae et omnes populi, principes et omnes judices terrae;\nJuvenes et virgines, seniores cum junioribus laudent nomen Domini:\nQuia exaltatum est nomen ejus solius, confessio ejus super caelum et terram: et exaltabit cornu populi sui.\nHymnus omnibus sanctis ejus, filiis Israel, populo appropinquanti sibi."
+                "la": "Laudate Dominum de caelis laudate eum in excelsis.\nLaudate eum, omnes Angeli ejus; laudate eum, omnes Virtutes ejus.\nLaudate eum, sol et luna; laudate eum, omnes stellae et lumen.\nLaudate eum, caeli caelorum; et aquae omnes, quae super caelos sunt, laudent nomen Domini:\nQuia ipse dixit et facta sunt; ipse mandavit, et creata sunt.\nStatuit ea in aeternum et in saeculum saeculi: praeceptum posuit, et non praeteribit.\nLaudate Dominum de terra, dracones et omnes abyssi;\nIgnis, grando, nix, glacies, spiritus procellae, qui faciunt verbum ejus;\nMontes et omnes colles, ligna fructifera et omnes cedri;\nBestiae et omnia jumenta, serpentes et volucres pennatae.\nReges terrae et omnes populi, principes et omnes judices terrae;\nJuvenes et virgines, seniores cum junioribus laudent nomen Domini:\nQuia exaltatum est nomen ejus solius, confessio ejus super caelum et terram: et exaltabit cornu populi sui."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus omnibus sanctis ejus, filiis Israel, populo appropinquanti sibi."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 149"
               }
@@ -1086,7 +1340,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 150"
               }
@@ -1098,7 +1352,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 116"
               }
@@ -1110,7 +1364,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum"
               }
@@ -1122,7 +1376,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1134,19 +1388,26 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus Directus"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 86"
               }
@@ -1158,61 +1419,32 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Vere gratia plena es,\nEt gloriosa permanes,\nQuia ex te natus est Christus,\nPer quem facta sunt omnia."
+                "la": "Vere gratia plena es,\nEt gloriosa permanes,\nQuia ex te natus est Christus,\nPer quem facta sunt omnia.\n\nPastores, qui audierant\nCantari Deo gloriam,\nCucurrerunt in Bethlehem\nNatum videre Dominum.\n\nSic Magi ab ortu solis,\nPer sideris incidium,\nPortantes typum gentium,\nPrimi obtulerunt munera.\n\nRogemus ergo, populi,\nDei Matrem et Virginem,\nUt ipsa nobis impetret\nPacem et indulgentiam.\n\nDeo Patri sit gloria,\nEjusque soli Filio,\nCum Spiritu Paraclito\nIn sempiterna saecula.\n\nAmen.\n\nKyrie eleison, duodecies."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Pastores, qui audierant\nCantari Deo gloriam,\nCucurrerunt in Bethlehem\nNatum videre Dominum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sic Magi ab ortu solis,\nPer sideris incidium,\nPortantes typum gentium,\nPrimi obtulerunt munera."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Rogemus ergo, populi,\nDei Matrem et Virginem,\nUt ipsa nobis impetret\nPacem et indulgentiam."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Deo Patri sit gloria,\nEjusque soli Filio,\nCum Spiritu Paraclito\nIn sempiterna saecula."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Kyrie eleison, duodecies."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psall."
               }
@@ -1226,7 +1458,7 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Gloria Patri, et Filio, et Spiritui Sancto."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto."
               }
             },
             {
@@ -1236,7 +1468,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Compl."
               }
@@ -1248,7 +1480,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio II"
               }
@@ -1260,10 +1492,56 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat. Kyrie, eleison. Kyrie, eleison.\n℣. Benedicat et exaudiat nos, Deus:\n℟. Amen.\n℣. Procedamus cum pace:\n℟. In nomine Christi.\n℣. Benedicamus Domino.\n℟. Deo Gratias"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat. Kyrie, eleison. Kyrie, eleison."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicat et exaudiat nos, Deus:"
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Procedamus cum pace:"
+                  },
+                  "r": {
+                    "la": "In nomine Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo Gratias"
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -1272,9 +1550,41 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem:"
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sancta Trinitas nos semper salvet et benedicat:"
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Et ne nos inducas in tentationem:\n℟. Sed libera nos a malo.\n℣. Sancta Trinitas nos semper salvet et benedicat:\n℟. Amen.\n℣. Fidelium animae per Dei misericordiam requiescant in pace.\nAmen."
+                "la": "Fidelium animae per Dei misericordiam requiescant in pace."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             }
           ]
@@ -1288,10 +1598,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. Alleluia."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. Alleluia."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1306,31 +1636,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris."
+                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris.\n\nMaria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt mortis hora suscipe,\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre et Almo Spiritu\nIn sempiterna saecula. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt mortis hora suscipe,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre et Almo Spiritu\nIn sempiterna saecula. Amen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 53"
               }
@@ -1342,7 +1660,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 84"
               }
@@ -1354,7 +1672,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 116"
               }
@@ -1366,7 +1684,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Epistolella Sap. 8."
               }
@@ -1374,11 +1692,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sapientia vincit malitiam. Attingit ergo fine usque ad finem fortiter, et disponit omnia suaviter.\n℟. Deo gratias."
+                "la": "Sapientia vincit malitiam. Attingit ergo fine usque ad finem fortiter, et disponit omnia suaviter."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsorium breve:"
               }
@@ -1386,11 +1710,37 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ave, Maria, gratia plena.\nIter Ave, Maria, gratia plena: Dominus tecum.\n℣. Benedicta tu inter mulieres.\n℟. Dominus tecum.\n℣. Gloria Patri, et Filio, et Spiritui Sancto\n℟. Ave, Maria, gratia plena: Dominus tecum"
+                "la": "Ave, Maria, gratia plena.\nIter Ave, Maria, gratia plena: Dominus tecum."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicta tu inter mulieres."
+                  },
+                  "r": {
+                    "la": "Dominus tecum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto"
+                  },
+                  "r": {
+                    "la": "Ave, Maria, gratia plena: Dominus tecum"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Capitulum"
               }
@@ -1402,13 +1752,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -1420,10 +1777,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat"
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -1432,10 +1796,30 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedicamus Domino:\n℟. Deo gratias.\n℣. Fidelium animae per Dei misericordiam requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino:"
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per Dei misericordiam requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -1448,10 +1832,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. Alleluia."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. Alleluia."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1466,31 +1870,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris."
+                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris.\n\nMaria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt mortis hora suscipe,\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre et Almo Spiritu\nIn sempiterna saecula. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt mortis hora suscipe,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre et Almo Spiritu\nIn sempiterna saecula. Amen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 119"
               }
@@ -1502,7 +1894,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 120"
               }
@@ -1514,7 +1906,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 121"
               }
@@ -1526,7 +1918,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Epistolella Eccli. 24"
               }
@@ -1538,7 +1930,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Responsorium breve:"
               }
@@ -1546,11 +1938,37 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Post partum Virgo.\nIter Post partum Virgo Inviolata permansisti.\n℣. Dei Genitrix, intercede pro nobis.\n℟. Inviolata permansisti.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Post partum Virgo inviolata permansisti."
+                "la": "Post partum Virgo.\nIter Post partum Virgo Inviolata permansisti."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dei Genitrix, intercede pro nobis."
+                  },
+                  "r": {
+                    "la": "Inviolata permansisti."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Post partum Virgo inviolata permansisti."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Capitulum"
               }
@@ -1562,13 +1980,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -1580,10 +2005,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat"
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -1592,10 +2024,30 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedicamus Domino:\n℟. Deo gratias.\n℣. Fidelium animae per Dei misericordiam requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino:"
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per Dei misericordiam requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -1608,10 +2060,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. Alleluia."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. Alleluia."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1626,31 +2098,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris."
+                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris.\n\nMaria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt mortis hora suscipe,\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre et Almo Spiritu\nIn sempiterna saecula. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt mortis hora suscipe,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre et Almo Spiritu\nIn sempiterna saecula. Amen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 122"
               }
@@ -1662,7 +2122,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 123"
               }
@@ -1674,7 +2134,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 124"
               }
@@ -1686,7 +2146,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Epistolella Eccli. 24"
               }
@@ -1694,11 +2154,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "In omnibus requiem quaesivi et in haereditate Domini morabor. Tunc praecepit, et dixit mihi Creator omnium: et qui creavit me, requievit in tabernaculo meo.\n℟. Deo gratias."
+                "la": "In omnibus requiem quaesivi et in haereditate Domini morabor. Tunc praecepit, et dixit mihi Creator omnium: et qui creavit me, requievit in tabernaculo meo."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsorium breve:"
               }
@@ -1706,11 +2172,37 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Benedicta tu.\nIter Benedicta tu In mulieribus.\n℣. Et benedictus fructus ventris tui.\n℟. In mulieribus.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Benedicta tu in mulieribus."
+                "la": "Benedicta tu.\nIter Benedicta tu In mulieribus."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et benedictus fructus ventris tui."
+                  },
+                  "r": {
+                    "la": "In mulieribus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Benedicta tu in mulieribus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Capitulum"
               }
@@ -1722,13 +2214,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -1740,19 +2239,72 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat Kyrie, eleison. Kyrie, eleison. Kyrie, eleison.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per Dei misericordiam requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat Kyrie, eleison. Kyrie, eleison. Kyrie, eleison."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per Dei misericordiam requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
               "type": "divider"
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. Alleluia."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. Alleluia."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1767,31 +2319,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris."
+                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris.\n\nMaria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt mortis hora suscipe,\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre et Almo Spiritu\nIn sempiterna saecula. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt mortis hora suscipe,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre et Almo Spiritu\nIn sempiterna saecula. Amen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 125"
               }
@@ -1803,7 +2343,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 126"
               }
@@ -1815,7 +2355,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 127"
               }
@@ -1827,7 +2367,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Epistolella. Eccli. 24"
               }
@@ -1835,11 +2375,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Radicavi in populo honorificato: et in parte Dei mei haereditas illius: et in plenitudine sanctorum detentio rnea.\n℟. Deo gratias."
+                "la": "Radicavi in populo honorificato: et in parte Dei mei haereditas illius: et in plenitudine sanctorum detentio rnea."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsorium breve:"
               }
@@ -1847,11 +2393,37 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Elegit eam Deus\nIter Elegit eam Deus; Et praeelegit eam.\n℣. Et in tabernaculo habitare fecit eam.\n℟. Et praeelegit eam.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Elegit eam Deus, Et praeelegit eam."
+                "la": "Elegit eam Deus\nIter Elegit eam Deus; Et praeelegit eam."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et in tabernaculo habitare fecit eam."
+                  },
+                  "r": {
+                    "la": "Et praeelegit eam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Elegit eam Deus, Et praeelegit eam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Capitulum"
               }
@@ -1863,13 +2435,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -1881,10 +2460,49 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat"
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat\nKyrie, eleison. Kyrie, eleison. Kyrie, eleison.\n℣. Benedicamus Domino:\n℟. Deo gratias.\n℣. Fidelium animae per Dei misericordiam requiescant in pace.\n℟. Amen."
+                "la": "Kyrie, eleison. Kyrie, eleison. Kyrie, eleison."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino:"
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per Dei misericordiam requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -1897,13 +2515,20 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat"
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Lucernarium"
               }
@@ -1911,11 +2536,36 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quoniam tu illuminas lucernam meam, Domine; Deus meus, illumina tenebras meas.\n℣. Quoniam in te eripiar a tentatione; Deus meus, illumina tenebras meas.\nIter Quoniam tu illuminas lucernam meam, Domine; Deus meus, illumina tenebras meas.\n℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+                "la": "Quoniam tu illuminas lucernam meam, Domine; Deus meus, illumina tenebras meas."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Quoniam in te eripiar a tentatione; Deus meus, illumina tenebras meas."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Iter Quoniam tu illuminas lucernam meam, Domine; Deus meus, illumina tenebras meas."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphona in Choro:"
               }
@@ -1927,67 +2577,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Mysterium Ecclesiae!\nHymnum Christo referimus,\nQuem genuit Puerpera,\nVerbum Patris in Filio."
+                "la": "Mysterium Ecclesiae!\nHymnum Christo referimus,\nQuem genuit Puerpera,\nVerbum Patris in Filio.\n\nSola in sexu femina\nElecta es in saeculo.\nQuae meruisti Dominum\nSanctum portare in utero.\n\nVates antiqui temporis\nPraedixerat quod factum est,\nQuia Virgo conciperet\nEt pareret Emmanuel.\n\nMysterium hoc magnum est,\nMariae quod concessum est,\nUt Deum, per quem omnia,\nEx se videret progredi\n\nVere gratia plena es\nEt gloriosa permanes;\nQuia ex te natus est Christus,\nPer quem facta sunt omnia.\n\nPastores, qui audierant\nCantari Deo gloriam,\nCucurrerunt in Bethlehem\nNatum videre Dominum.\n\nSic Magi ab ortu solis,\nPer sideris indicium,\nPortantes typum Gentium,\nPrimi obtulerunt munera.\n\nRogemus ergo, populi,\nDei Matrem et Virginem,\nUt ipsa nobis impetret\nPacem et indulgentiam.\n\nDeo Patri sit gloria,\nEjusque soli Filio\nCum Spiritu Paraclito\nIn sempiterna saecula. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sola in sexu femina\nElecta es in saeculo.\nQuae meruisti Dominum\nSanctum portare in utero."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Vates antiqui temporis\nPraedixerat quod factum est,\nQuia Virgo conciperet\nEt pareret Emmanuel."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mysterium hoc magnum est,\nMariae quod concessum est,\nUt Deum, per quem omnia,\nEx se videret progredi"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Vere gratia plena es\nEt gloriosa permanes;\nQuia ex te natus est Christus,\nPer quem facta sunt omnia."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Pastores, qui audierant\nCantari Deo gloriam,\nCucurrerunt in Bethlehem\nNatum videre Dominum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sic Magi ab ortu solis,\nPer sideris indicium,\nPortantes typum Gentium,\nPrimi obtulerunt munera."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Rogemus ergo, populi,\nDei Matrem et Virginem,\nUt ipsa nobis impetret\nPacem et indulgentiam."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Deo Patri sit gloria,\nEjusque soli Filio\nCum Spiritu Paraclito\nIn sempiterna saecula. Amen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Responsorium in Choro:"
               }
@@ -1995,11 +2597,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancta Dei Genitrix, Intercede pro nobis. Alleluia.\n℣. Deprecare pro nobis Filium Dei: Intercede pro nobis. Alleluia.\n℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+                "la": "Sancta Dei Genitrix, Intercede pro nobis. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deprecare pro nobis Filium Dei: Intercede pro nobis. Alleluia."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -2011,7 +2632,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 114"
               }
@@ -2023,7 +2644,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 133"
               }
@@ -2035,7 +2656,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 116"
               }
@@ -2047,7 +2668,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -2059,13 +2680,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio I"
               }
@@ -2077,13 +2705,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -2095,7 +2730,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum B. Mariae Virg. Luc. 1"
               }
@@ -2107,7 +2742,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -2119,13 +2754,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio II"
               }
@@ -2137,13 +2779,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psall."
               }
@@ -2151,11 +2800,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Virgo Verbum concepit, Virgo permansit, Virgo genuit Regem omnium regum. Alleluia.\n℣. Gloria Patri, etc.\nIter Virgo Verbum concepit, Virgo permansit, Virgo genuit Regem omnium regum. Alleluia."
+                "la": "Virgo Verbum concepit, Virgo permansit, Virgo genuit Regem omnium regum. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, etc."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Iter Virgo Verbum concepit, Virgo permansit, Virgo genuit Regem omnium regum. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Compl."
               }
@@ -2167,7 +2828,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Compl. II"
               }
@@ -2179,7 +2840,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio III"
               }
@@ -2191,10 +2852,62 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\nKyrie, eleison. Kyrie, eleison. Kyrie, eleison.\n℣. Benedicat et exaudiat nos Deus:\n℟. Amen.\n℣. Procedamus cum pace:\n℟. In nomine Christi.\n℣. Benedicamus Domino.\n℟. Deo gratias."
+                "la": "Kyrie, eleison. Kyrie, eleison. Kyrie, eleison."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicat et exaudiat nos Deus:"
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Procedamus cum pace:"
+                  },
+                  "r": {
+                    "la": "In nomine Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -2203,10 +2916,43 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Et ne nos inducas in tentationem:\n℟. Sed libera nos a malo.\n℣. Sancta Trinitas nos semper salvet eet benedicat.\n℟. Amen.\n℣. Fidelium animae per Dei misericordiam requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem:"
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sancta Trinitas nos semper salvet eet benedicat."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per Dei misericordiam requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -2219,10 +2965,43 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. Alleluia."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos, Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. Alleluia."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -2237,31 +3016,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris."
+                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris.\n\nMaria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt mortis hora suscipe,\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre et Almo Spiritu\nIn sempiterna saecula. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt mortis hora suscipe,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre et Almo Spiritu\nIn sempiterna saecula. Amen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 128"
               }
@@ -2273,7 +3040,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 129"
               }
@@ -2285,7 +3052,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 130"
               }
@@ -2297,7 +3064,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Epistolella Eccli. 24"
               }
@@ -2305,11 +3072,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ab initio et ante saecula creata sum: et usque ad futurum saeculum non desinam: et in habitatione sancta coram ipso ministravi.\n℟. Deo gratias."
+                "la": "Ab initio et ante saecula creata sum: et usque ad futurum saeculum non desinam: et in habitatione sancta coram ipso ministravi."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsorium breve:"
               }
@@ -2317,11 +3090,37 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Specie tua.\nIter Specie tua Et pulchritudine tua.\n℣. Intende, prospera et regna.\n℟. Et pulchritudine tua.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Specie tua Et pulchritudine tua."
+                "la": "Specie tua.\nIter Specie tua Et pulchritudine tua."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Intende, prospera et regna."
+                  },
+                  "r": {
+                    "la": "Et pulchritudine tua."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Specie tua Et pulchritudine tua."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Capitulum"
               }
@@ -2333,13 +3132,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -2347,14 +3153,72 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Famulorum tuorum, quaesumus, Domine, delictis ignosce: et quia tibi de actibus nostris placere non valemus, Genitricis Filii tui Domini nostri intercessione salvemur. Per eumdem Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\n℟. Amen."
+                "la": "Famulorum tuorum, quaesumus, Domine, delictis ignosce: et quia tibi de actibus nostris placere non valemus, Genitricis Filii tui Domini nostri intercessione salvemur. Per eumdem Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\nKyrie, eleison. Kyrie, eleison. Kyrie, eleison.\n℣. Benedicat et exaudiat nos Deus:\n℟. Amen.\n℣. Dormiamus in pace.\n℟. Vigilemus in Christo.\n℣. Benedicamus Domino:\n℟. Deo gratias."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Kyrie, eleison. Kyrie, eleison. Kyrie, eleison."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicat et exaudiat nos Deus:"
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dormiamus in pace."
+                  },
+                  "r": {
+                    "la": "Vigilemus in Christo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino:"
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -2363,13 +3227,33 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Et ne nos inducas in tentationem.\n℟. Sed libera nos a malo\n℣. Noctem quietam et finem perfectum tribuat nobis divina Majestas.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem."
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo"
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Noctem quietam et finem perfectum tribuat nobis divina Majestas."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphonae Finales B. V. M."
               }
@@ -2387,13 +3271,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, sancta Dei Genitrix.\n℟. Ut digni efficiamur promissionibus Christi."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Dei Genitrix."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -2405,10 +3296,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Fidelium animae per Dei misericordia requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per Dei misericordia requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -2423,13 +3321,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis sancta Dei Genitrix.\n℟. Ut digni efficiamur promissionibus Christi."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis sancta Dei Genitrix."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -2437,7 +3342,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Porrige nobis, Deus, dexteram tuam; et, intercessione beatae Dei Genitricis Mariae, auxilium nobis supernae virtutis impende. Per eundem Christum Dominum nostrum.\n℟. Amen."
+                "la": "Porrige nobis, Deus, dexteram tuam; et, intercessione beatae Dei Genitricis Mariae, auxilium nobis supernae virtutis impende. Per eundem Christum Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
@@ -2453,13 +3364,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Post partum Virgo inviolata permansisti:\n℟. Dei Genitrix, intercede pro nobis."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Post partum Virgo inviolata permansisti:"
+                  },
+                  "r": {
+                    "la": "Dei Genitrix, intercede pro nobis."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -2471,10 +3389,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Fidelium animae per Dei misericordia requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per Dei misericordia requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -2489,13 +3414,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Dignare me laudare te, Virgo sacrata:\n℟. Da mihi virtutem contra hostes tups."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dignare me laudare te, Virgo sacrata:"
+                  },
+                  "r": {
+                    "la": "Da mihi virtutem contra hostes tups."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -2503,14 +3435,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Omnipotens sempiterne Deus, qui gloriosae Virginis Mariae Matris corpus et animam, ut dignum ilii tui habitaculum effici mereretur, Spiritu Sancto cooperante, praeparasti: da ut, cujus commemorationem laetamur, ejus pia intercessione ab instantibus periculus et a morte perpetua liberemur. Per eumdem Christum Dominum nostrum.\n℟. Amen."
+                "la": "Omnipotens sempiterne Deus, qui gloriosae Virginis Mariae Matris corpus et animam, ut dignum ilii tui habitaculum effici mereretur, Spiritu Sancto cooperante, praeparasti: da ut, cujus commemorationem laetamur, ejus pia intercessione ab instantibus periculus et a morte perpetua liberemur. Per eumdem Christum Dominum nostrum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Fidelium animae per Dei misericordia requiescant in pace.\n℟. Amen."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per Dei misericordia requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -2525,13 +3470,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Gaude et laetare, Virgo Maria, Alleluia.\n℟. Quia surrexit Dominus vere. Alleluia."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gaude et laetare, Virgo Maria, Alleluia."
+                  },
+                  "r": {
+                    "la": "Quia surrexit Dominus vere. Alleluia."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -2539,14 +3491,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Deus, qui per resurrectionem Filii tui Jesu Christi Domini nostri universum mundum laetificare dignatus es, tribue, quaesumus, ut per intercessionem beatissimae Virginis Mariae, pepetuae capiamus gaudia vitae. Per eumdem Christum Dominum nostrum.\n℟. Amen."
+                "la": "Deus, qui per resurrectionem Filii tui Jesu Christi Domini nostri universum mundum laetificare dignatus es, tribue, quaesumus, ut per intercessionem beatissimae Virginis Mariae, pepetuae capiamus gaudia vitae. Per eumdem Christum Dominum nostrum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Fidelium animae per Dei misericordia requiescant in pace.\n℟. Amen."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per Dei misericordia requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         }

--- a/content/practices/little-office-bvm-carmelite/flow.json
+++ b/content/practices/little-office-bvm-carmelite/flow.json
@@ -1,7 +1,7 @@
 {
   "sections": [
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Praenotanda"
       }
@@ -75,19 +75,65 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣.Ave Maria, gratia plena; Dominus tecum.\n℟.Benedicta tu in mulieribus, et benedictus fructus ventris tui.\n℣. Domine, labia ✠ ea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria, gratia plena; Dominus tecum."
+                  },
+                  "r": {
+                    "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia ✠ ea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Invitatory"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -99,7 +145,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -111,7 +157,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 94"
               }
@@ -123,7 +169,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -135,7 +181,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -147,39 +193,15 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Quem terra, pontus, aethera\nColunt, adorant, praedicant,\nTrinam regentem machinam,\nClaustrum Mariae bajulat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Cui luna, sol et omnia\nDeserviunt per tempora,\nPerfusa caeli gratia,\nGestant puellae viscera."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Beata Mater munere,\nCujus, supernus Artifex\nMundum pugillo continens,\nVentris sub arca clausus est."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Beata caeli nuntio,\nFecunda Sancto Spiritu,\nDesideratus gentibus\nCujus per alvum fusus est."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
+                "la": "Quem terra, pontus, aethera\nColunt, adorant, praedicant,\nTrinam regentem machinam,\nClaustrum Mariae bajulat.\n\nCui luna, sol et omnia\nDeserviunt per tempora,\nPerfusa caeli gratia,\nGestant puellae viscera.\n\nBeata Mater munere,\nCujus, supernus Artifex\nMundum pugillo continens,\nVentris sub arca clausus est.\n\nBeata caeli nuntio,\nFecunda Sancto Spiritu,\nDesideratus gentibus\nCujus per alvum fusus est.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
@@ -231,7 +253,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -243,7 +265,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 8"
               }
@@ -255,7 +277,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 18"
               }
@@ -267,7 +289,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 23"
               }
@@ -279,7 +301,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -291,10 +313,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Sancta Dei Genitrix, Virgo Semper Maria.\n℟. Intercede pro nobis, ad Dominum, Deum nostrum. (Alleluja)."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sancta Dei Genitrix, Virgo Semper Maria."
+                  },
+                  "r": {
+                    "la": "Intercede pro nobis, ad Dominum, Deum nostrum. (Alleluja)."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -303,7 +332,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -315,7 +344,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 44"
               }
@@ -327,7 +356,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 45"
               }
@@ -339,7 +368,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 86"
               }
@@ -351,7 +380,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -363,10 +392,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Post partum, Virgo, inviolata, permansisti.\n℟. Dei Genitrix, intercede pro nobis. (Alleluja)."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Post partum, Virgo, inviolata, permansisti."
+                  },
+                  "r": {
+                    "la": "Dei Genitrix, intercede pro nobis. (Alleluja)."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -375,7 +411,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -387,7 +423,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 95"
               }
@@ -399,7 +435,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 96"
               }
@@ -411,7 +447,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 97"
               }
@@ -423,7 +459,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -435,10 +471,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Speciosa facta es et suavis.\n℟. In deliciis tuis, sancta Dei Genitrix. (Alleluja)."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Speciosa facta es et suavis."
+                  },
+                  "r": {
+                    "la": "In deliciis tuis, sancta Dei Genitrix. (Alleluja)."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -447,13 +490,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Et ne nos inducas in tentationem:\n℟. Sed libera nos a malo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem:"
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Bend."
               }
@@ -461,17 +511,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Alma Virgo virginum intercedat pro nobis ad Dominum.\n℟. Amen."
+                "la": "Alma Virgo virginum intercedat pro nobis ad Dominum."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio i"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Cant. 3, 6; 4, 7 et 12"
               }
@@ -479,17 +535,41 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quae est ista, quae ascendit per desertum, sicut virgula fumi ex aromatibus myrrhae, et thuris, et universi pulveris pigmentarii? Tota pulchra es, amica mea, et macula non est in te. Hortus conclusus, soror mea sponsa, hortus conclusus, fons signatus.\nTu autem, Domine, miserere nostri.\n℟. Deo gratias."
+                "la": "Quae est ista, quae ascendit per desertum, sicut virgula fumi ex aromatibus myrrhae, et thuris, et universi pulveris pigmentarii? Tota pulchra es, amica mea, et macula non est in te. Hortus conclusus, soror mea sponsa, hortus conclusus, fons signatus.\nTu autem, Domine, miserere nostri."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Sancta et immaculata virginitas,\nquibus te laudibus efferam, nescio: Quia quem caeli capere non poterant, tuo gremio contulisti. (Alleluia).\n℣. Benedicta tu in mulieribus, et benedictus fructus ventris tui. Quia.\n℣. Jube, domne, benedicere."
+                "la": "Deo gratias."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Sancta et immaculata virginitas,"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "quibus te laudibus efferam, nescio: Quia quem caeli capere non poterant, tuo gremio contulisti. (Alleluia)."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui. Quia."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Jube, domne, benedicere."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Bened."
               }
@@ -497,11 +577,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Nos cum prole pia benedicat Virgo Maria.\n℟. Amen."
+                "la": "Nos cum prole pia benedicat Virgo Maria."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio ii"
               }
@@ -515,11 +601,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ego quasi terebinthus extendi ramos meos: et rami mei honoris et gratiae. Ego quasi vitis fructificavi suavitatem odoris, et flores mei fructus honoris et honestatis. Ego mater pulchrae dilectionis, et timoris, et agnitionis, et sanctae spei. In me gratia omnis viae et veritatis, in me omnis spes vitae et virtutis.\nTu autem, Domine, miserere nostri.\n℟. Deo gratias.\n℣. Beata es, Virgo Maria, quae Dominum portasti, Creatorem mundi: Genusisti qui te fecit, et in aeternum permanes Virgo. (Alleluia).\n℣. Ave, Maria, gratia plena; Dominus tecum. Genusisti.\n℣. Jube, domne, benedicere."
+                "la": "Ego quasi terebinthus extendi ramos meos: et rami mei honoris et gratiae. Ego quasi vitis fructificavi suavitatem odoris, et flores mei fructus honoris et honestatis. Ego mater pulchrae dilectionis, et timoris, et agnitionis, et sanctae spei. In me gratia omnis viae et veritatis, in me omnis spes vitae et virtutis.\nTu autem, Domine, miserere nostri."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Beata es, Virgo Maria, quae Dominum portasti, Creatorem mundi: Genusisti qui te fecit, et in aeternum permanes Virgo. (Alleluia)."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Ave, Maria, gratia plena; Dominus tecum. Genusisti."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Jube, domne, benedicere."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Bened."
               }
@@ -527,11 +637,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancta Dei Genetrix sit nobis auxiliatrix.\n℟. Amen."
+                "la": "Sancta Dei Genetrix sit nobis auxiliatrix."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio iii"
               }
@@ -545,29 +661,41 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Transite ad me, omnes, qui concupiscitis me; et a generationibus meis implemini. Spiritus enim meus super mel dulcis: et hereditas mea super mel et favum. Memoria mea in generationes saeculorum. Qui audit me, non confundetur; et qui operantur in me, non peccabunt. Qui elucidant me, vitam aeternam habebunt.\nTu autem, Domine, miserere nostri.\n℟. Deo gratias."
+                "la": "Transite ad me, omnes, qui concupiscitis me; et a generationibus meis implemini. Spiritus enim meus super mel dulcis: et hereditas mea super mel et favum. Memoria mea in generationes saeculorum. Qui audit me, non confundetur; et qui operantur in me, non peccabunt. Qui elucidant me, vitam aeternam habebunt.\nTu autem, Domine, miserere nostri."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Felix namque es, sacra Virgo Maria, et omni laude dignissima: Quia ex te ortus est sol justitiae, Christus, Deus noster. (Alleluia).\n℣. Ora pro populo, interveni pro clero, intercede pro devoto femineo sexu: sentiant omnes tuum juvamen, quicumque celebrant tuam sanctam commemorationem. Quia. Gloria Patri. Quia."
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Felix namque es, sacra Virgo Maria, et omni laude dignissima: Quia ex te ortus est sol justitiae, Christus, Deus noster. (Alleluia)."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Ora pro populo, interveni pro clero, intercede pro devoto femineo sexu: sentiant omnes tuum juvamen, quicumque celebrant tuam sanctam commemorationem. Quia. Gloria Patri. Quia."
               }
             },
             {
               "type": "rubric",
               "text": {
-                "la": "Sequens Hymnus Te Deum omittitur a Dominica Septuagesimae usque ad Sabbatum sanctum inclusive, praeter quam in Festis B. Mariae Virginis; quo omisso non repetitur ℣. Felix namque es."
+                "la": "Sequens Hymnus Te Deum omittitur a Dominica Septuagesimae usque ad Sabbatum sanctum inclusive, praeter quam in Festis B. Mariae Virginis; quo omisso non repetitur versus Felix namque es."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus Ambrosianus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Te Deum laudamus: te Dominum confitemur.\nTe aeternum Patrem omnis terra veneratur.\nTibi omnes angeli, tibi Caeli, et universae Potestates:\nTibi Cherubim et Seraphim incessabili voce proclamant:\nSanctus, Sanctus, Sanctus Dominus Deus Sabaoth.\nPleni sunt caeli et terra maiestatis gloriae tuae.\nTe gloriosus Apostolorum chorus,\nTe Prophetarum laudabilis numerus,\nTe Martyrum candidatus laudat exercitus.\nTe per orbem terrarum sancta confitetur Ecclesia,\nPatrem immensae maiestatis;\nVenerandum tuum verum et unicum Filium;\nSanctum quoque Paraclitum Spiritum.\nTu Rex gloriae, Christe.\nTu Patris sempiternus es Filius.\nTu, ad liberandum suscepturus hominem: non horruisti Virginis uterum.\nTu, devicto mortis aculeo, aperuisti credentibus regna caelorum.\nTu ad dexteram Dei sedes, in gloria Patris.\nJudex crederis esse venturus."
               }
@@ -585,21 +713,28 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Sacerd."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, sancta Dei Genitrix.\n℟. Ut digni efficiamur promissionibus Christi. (Alleluja)."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Dei Genitrix."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi. (Alleluja)."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
               "text": {
-                "la": "Si Matutinum a Laudibus separetur, post Versum Sacerdotalem dicitur ℣. Domine, exaudi, Oratio Deus, qui et reliqua sicut in fine Laudum 28, et in principio Laudum dicitur ℣. Ave, Maria, ut in ceteris Horis."
+                "la": "Si Matutinum a Laudibus separetur, post Versum Sacerdotalem dicitur versus Domine, exaudi, Oratio Deus, qui et reliqua sicut in fine Laudum 28, et in principio Laudum dicitur versus Ave, Maria, ut in ceteris Horis."
               }
             },
             {
@@ -608,11 +743,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Jube, Domine, benedicere.\nBened. Alma Virgo virginum intercedat pro nobis ad Dominum.\n℟. Amen."
+                "la": "Jube, Domine, benedicere."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Bened. Alma Virgo virginum intercedat pro nobis ad Dominum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio i - Luc. 1, 26-38"
               }
@@ -620,23 +767,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Issus est Angelus Gabriel a Deo in civitatem Galilaeae, cui nomen Nazareth, ad Virginem desponsatam viro, cui nomen erat Joseph, de domo David, et nomen Virginis Maria. Et, ingressus Angelus ad eam, dixit: Ave, gratia plena; Dominus tecum: Benedicta tu in mulieribus. Tu autem, Domine, miserere nostri.\n℟. Deo gratias."
+                "la": "Issus est Angelus Gabriel a Deo in civitatem Galilaeae, cui nomen Nazareth, ad Virginem desponsatam viro, cui nomen erat Joseph, de domo David, et nomen Virginis Maria. Et, ingressus Angelus ad eam, dixit: Ave, gratia plena; Dominus tecum: Benedicta tu in mulieribus. Tu autem, Domine, miserere nostri."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Missus est Angelus Gabriel ad Mariam Virginem desponsatam Joseph, nuntians ei verbum; et expavescit Virgo de lumine: ne timeas, Maria; invenisti enim gratiam apud Deum:\n℣. Ecce, concipies et paries, et Filius Altissimi vocabitur.\n℟. Dabit illi Dominus Deus sedem David, patris ejus; et regnabit in domo Jacob in aeternum. Ecce."
+                "la": "Deo gratias."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Jube, Domine, benedicere."
+                "la": "Missus est Angelus Gabriel ad Mariam Virginem desponsatam Joseph, nuntians ei verbum; et expavescit Virgo de lumine: ne timeas, Maria; invenisti enim gratiam apud Deum:"
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ecce, concipies et paries, et Filius Altissimi vocabitur."
+                  },
+                  "r": {
+                    "la": "Dabit illi Dominus Deus sedem David, patris ejus; et regnabit in domo Jacob in aeternum. Ecce."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Jube, Domine, benedicere."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Bened."
               }
@@ -644,11 +810,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Nos cum prole pia benedicat Virgo Maria.\n℟. Amen."
+                "la": "Nos cum prole pia benedicat Virgo Maria."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio ij"
               }
@@ -656,23 +828,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quae cum audisset, turbata est in sermone ejus, et cogitabat qualis esset ista salutatio. Et ait Angelus ei: Ne timeas, Maria; invenisti enim gratiam apud Deum: ecce, concipies in utero et paries filium, et vocabis nomen ejus Jesum. Hic erit magnus, et Filius Altissimi vocabitur; et dabit illi Dominus Deus sedem David, patris ejus; et regnabit in domo Jacob in aeternum, et regni ejus non erit finis. Tu autem, Domine, miserere nostri.\n℟. Deo gratias."
+                "la": "Quae cum audisset, turbata est in sermone ejus, et cogitabat qualis esset ista salutatio. Et ait Angelus ei: Ne timeas, Maria; invenisti enim gratiam apud Deum: ecce, concipies in utero et paries filium, et vocabis nomen ejus Jesum. Hic erit magnus, et Filius Altissimi vocabitur; et dabit illi Dominus Deus sedem David, patris ejus; et regnabit in domo Jacob in aeternum, et regni ejus non erit finis. Tu autem, Domine, miserere nostri."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Ave, Maria, gratia plena; Dominus tecum:\n℣. Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi: ideoque et quod nascetur ex te Sanctum, vocabitur Filius Dei.\n℟. Quomodo fiet istud, quoniam virum non cognosco? Et respondens Angelus, dixit ei: Spiritus Sanctus."
+                "la": "Deo gratias."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Jube, Domine, benedicere."
+                "la": "Ave, Maria, gratia plena; Dominus tecum:"
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi: ideoque et quod nascetur ex te Sanctum, vocabitur Filius Dei."
+                  },
+                  "r": {
+                    "la": "Quomodo fiet istud, quoniam virum non cognosco? Et respondens Angelus, dixit ei: Spiritus Sanctus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Jube, Domine, benedicere."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Bened."
               }
@@ -680,11 +871,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancta Dei Genitrix sit nobis auxilatrix.\n℟. Amen."
+                "la": "Sancta Dei Genitrix sit nobis auxilatrix."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio iij"
               }
@@ -692,7 +889,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Dixit autem Maria ad Angelum: Quomodo fiet istud, quoniam virum non cognosco? Et respondens Angelus dixit ei: Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi: ideoque et quod nascetur ex te Sanctum, vocabitur Filius Dei. Et ecce, Elisabeth, cognata tua, et ipsa concepit filium in senectute sua, et hic mensis sextus est illi, quae vocatur sterilis; quia non erit impossibile apud Deum omne verbum. Dixit autem Maria: Ecce ancilla Domini: fiat mihi secundum verbum tuum.\nTu autem, Domine, miserere nostri.\n℟. Deo gratias.\n℣. Suscipe verbum, Virgo Maria, quod tibi a Domino per Angelum transmissum est: con."
+                "la": "Dixit autem Maria ad Angelum: Quomodo fiet istud, quoniam virum non cognosco? Et respondens Angelus dixit ei: Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi: ideoque et quod nascetur ex te Sanctum, vocabitur Filius Dei. Et ecce, Elisabeth, cognata tua, et ipsa concepit filium in senectute sua, et hic mensis sextus est illi, quae vocatur sterilis; quia non erit impossibile apud Deum omne verbum. Dixit autem Maria: Ecce ancilla Domini: fiat mihi secundum verbum tuum.\nTu autem, Domine, miserere nostri."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Suscipe verbum, Virgo Maria, quod tibi a Domino per Angelum transmissum est: con."
               }
             },
             {
@@ -704,20 +913,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Suscipe verbum."
+                "la": "Suscipe verbum."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Sacerd."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, sancta Dei Genitrix.\n℟. Ut digni efficiamur promissionibus Christi. (Alleluja)."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Dei Genitrix."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi. (Alleluja)."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -730,13 +946,33 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (Outside Lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (Outside Lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -748,7 +984,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 92"
               }
@@ -760,7 +996,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 99"
               }
@@ -772,7 +1008,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 62"
               }
@@ -784,7 +1020,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Trium Puerorum"
               }
@@ -796,7 +1032,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 148"
               }
@@ -804,11 +1040,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudate Dominum de caelis: laudate eum in excelsis.\nLaudate eum, omnes angeli ejus: laudate eum, omnes virtutes ejus.\nLaudate eum, sol et luna: laudate eum, omnes stellae et lumen.\nLaudate eum, caeli caelorum: et aquae omnes, quae super caelos sunt, laudent nomen Domini.\nQuia ipse dixit, et facta sunt: ipse mandavit, et creata sunt.\nStatuit ea in aeternum, et in saeculum saeculi: praeceptum posuit, et non praeteribit.\nLaudate Dominum de terra, dracones, et omnes abyssi.\nIgnis, grando, nix, glacies, spiritus procellarum: quae faciunt verbum ejus:\nMontes, et omnes colles: ligna fructifera, et omnes cedri.\nBestiae, et universa pecora: serpentes, et volucres pennatae:\nReges terrae, et omnes populi: principes, et omnes judices terrae.\nJuvenes, et virgines: senes cum junioribus laudent nomen Domini: quia exaltatum est nomen ejus solius.\nConfessio ejus super caelum et terram: et exaltavit cornu populi sui.\nHymnus omnibus sanctis ejus: filiis Israel, populo appropinquanti sibi.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Laudate Dominum de caelis: laudate eum in excelsis.\nLaudate eum, omnes angeli ejus: laudate eum, omnes virtutes ejus.\nLaudate eum, sol et luna: laudate eum, omnes stellae et lumen.\nLaudate eum, caeli caelorum: et aquae omnes, quae super caelos sunt, laudent nomen Domini.\nQuia ipse dixit, et facta sunt: ipse mandavit, et creata sunt.\nStatuit ea in aeternum, et in saeculum saeculi: praeceptum posuit, et non praeteribit.\nLaudate Dominum de terra, dracones, et omnes abyssi.\nIgnis, grando, nix, glacies, spiritus procellarum: quae faciunt verbum ejus:\nMontes, et omnes colles: ligna fructifera, et omnes cedri.\nBestiae, et universa pecora: serpentes, et volucres pennatae:\nReges terrae, et omnes populi: principes, et omnes judices terrae.\nJuvenes, et virgines: senes cum junioribus laudent nomen Domini: quia exaltatum est nomen ejus solius.\nConfessio ejus super caelum et terram: et exaltavit cornu populi sui."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus omnibus sanctis ejus: filiis Israel, populo appropinquanti sibi."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -820,7 +1068,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Little Chapter - Cant vi"
               }
@@ -828,37 +1076,25 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Viderunt eam filiae Sion, et beatissimam praedicaverunt et reginae laudaverunt eam.\n℟. Deo gratias."
+                "la": "Viderunt eam filiae Sion, et beatissimam praedicaverunt et reginae laudaverunt eam."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O gloriosa Domina,\nExcelsa super sidera,\nQui te creavit, provide\nLactasti sacro ubere."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Quod Heva tristis abstulit,\nTu reddis almo germine:\nIntrent ut astra flebiles,\nCaeli fenestra facta es."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Tu Regis alti janua\nEt porta lucis fulgida:\nVitam datam per Virginem,\nGentes redemptae, plaudite."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
+                "la": "O gloriosa Domina,\nExcelsa super sidera,\nQui te creavit, provide\nLactasti sacro ubere.\n\nQuod Heva tristis abstulit,\nTu reddis almo germine:\nIntrent ut astra flebiles,\nCaeli fenestra facta es.\n\nTu Regis alti janua\nEt porta lucis fulgida:\nVitam datam per Virginem,\nGentes redemptae, plaudite.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
@@ -904,10 +1140,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Elegit eam Deus, et praelegit eam.\n℟. Et habitare eam facit in tabernaculo suo. (Alleluia)."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Elegit eam Deus, et praelegit eam."
+                  },
+                  "r": {
+                    "la": "Et habitare eam facit in tabernaculo suo. (Alleluia)."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -928,7 +1171,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -946,7 +1189,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -964,7 +1207,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -976,31 +1219,64 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui de beatae Mariae Virginis utero Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis; ut, qui vere eam Genitricem Dei credimus, ejus apud te intercessionibus adjuvemur. Per eundem Dominum nostrum Jesum Christum, Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia saecula saeculorum.\n℟. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedicamus Domino. (Alleluia, alleluia).\n℟. Deo gratias. (Alleluia, alleluia)."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui de beatae Mariae Virginis utero Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis; ut, qui vere eam Genitricem Dei credimus, ejus apud te intercessionibus adjuvemur. Per eundem Dominum nostrum Jesum Christum, Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino. (Alleluia, alleluia)."
+                  },
+                  "r": {
+                    "la": "Deo gratias. (Alleluia, alleluia)."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1008,20 +1284,45 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Virgo Maria, non est tibi similis orta in mundo inter mulieres: florens ut rosa, fragrans sicut lilium: ora pro nobis, sancta Dei Genitrix. (Alleluia).\n℣. Dignare me laudare te, Virgo sacrata.\n℟. Da mihi virtutem contra hostes tuos. (Alleluia)."
+                "la": "Virgo Maria, non est tibi similis orta in mundo inter mulieres: florens ut rosa, fragrans sicut lilium: ora pro nobis, sancta Dei Genitrix. (Alleluia)."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dignare me laudare te, Virgo sacrata."
+                  },
+                  "r": {
+                    "la": "Da mihi virtutem contra hostes tuos. (Alleluia)."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nBeatae et gloriosae semperque Virginis Mariae, quaesumus, Domine, intercessio gloriosa nos protegat: et ad vitam perducat aeternam. Per Christum, Dominum nostrum.\n℟. Amen."
+                "la": "Beatae et gloriosae semperque Virginis Mariae, quaesumus, Domine, intercessio gloriosa nos protegat: et ad vitam perducat aeternam. Per Christum, Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
               "type": "divider"
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1033,7 +1334,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum - Is. 11, 1-2"
               }
@@ -1041,7 +1342,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Egreditur virga de radice Jesse, et flos de radice ejus ascendet. Et requiescet super eum Spiritus Domini.\n℟. Deo gratias."
+                "la": "Egreditur virga de radice Jesse, et flos de radice ejus ascendet. Et requiescet super eum Spiritus Domini."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
               }
             },
             {
@@ -1057,9 +1364,21 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui de beatae Mariae Virginis utero Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis; ut, qui vere eam Genitricem Dei credimus, ejus apud te intercessionibus adjuvemur.\nPer eumdem Dominum nostrum Jesum Christum, Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia saecula saeculorum.\n℟. Amen."
+                "la": "Deus, qui de beatae Mariae Virginis utero Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis; ut, qui vere eam Genitricem Dei credimus, ejus apud te intercessionibus adjuvemur.\nPer eumdem Dominum nostrum Jesum Christum, Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
@@ -1072,7 +1391,7 @@
               "type": "divider"
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1096,9 +1415,21 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere Dominum nostrum Jesum Christum, Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia saecula saeculorum.\n℟. Amen."
+                "la": "Deus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere Dominum nostrum Jesum Christum, Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
@@ -1118,33 +1449,54 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣.Ave Maria, gratia plena; Dominus tecum.\n℟.Benedicta tu in mulieribus, et benedictus fructus ventris tui.\n℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria, gratia plena; Dominus tecum."
+                  },
+                  "r": {
+                    "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
+                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris.\n\nMaria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege\nEt hora mortis suscipe.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
@@ -1190,7 +1542,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1202,7 +1554,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 53"
               }
@@ -1214,7 +1566,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 116"
               }
@@ -1226,7 +1578,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 117"
               }
@@ -1238,7 +1590,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1250,7 +1602,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum - Cant. 6, 9"
               }
@@ -1258,20 +1610,66 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quae est ista, quae progreditur quasi aurora consurgens, pulchra ut luna, electa ut sol, terribilis ut castrorum acies ordinata?\n℟. Deo gratias."
+                "la": "Quae est ista, quae progreditur quasi aurora consurgens, pulchra ut luna, electa ut sol, terribilis ut castrorum acies ordinata?"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Sancta Maria, Mater Christi, Audi rogantes servulos.\n℟. Sancta.\n℣. Et impetratam nobis caelitus tu defer indulgentiam.\n℟. Audi.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sancta."
+                "la": "Deo gratias."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Sancta Dei Genitrix, Virgo semper Maria.\n℟. Intercede pro nobis ad Dominum, Deum nostrum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sancta Maria, Mater Christi, Audi rogantes servulos."
+                  },
+                  "r": {
+                    "la": "Sancta."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et impetratam nobis caelitus tu defer indulgentiam."
+                  },
+                  "r": {
+                    "la": "Audi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sancta."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sancta Dei Genitrix, Virgo semper Maria."
+                  },
+                  "r": {
+                    "la": "Intercede pro nobis ad Dominum, Deum nostrum."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1280,43 +1678,114 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sancta Maria, Mater Christi, audi rogantes servulos, Alleluja, alleluja."
+                  },
+                  "r": {
+                    "la": "Sancta."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Sancta Maria, Mater Christi, audi rogantes servulos, Alleluja, alleluja.\n℟. Sancta.\nEt impetratam nobis caelitus tu defer indulgentiam.\n℟. Alleluja, alleluja.\n℣. Gloria Patri.\n℟. Sancta.\n℣. Sancta Dei Genitrix, Virgo semper Maria."
+                "la": "Et impetratam nobis caelitus tu defer indulgentiam."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Intercede pro nobis ad Dominum, Deum nostrum, alleluja."
+                "la": "Alleluja, alleluja."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri."
+                  },
+                  "r": {
+                    "la": "Sancta."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Sancta Dei Genitrix, Virgo semper Maria."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+                "la": "Intercede pro nobis ad Dominum, Deum nostrum, alleluja."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nConcede, misericors Deus, fragilitati nostrae praesidium: ut, qui sanctae Dei Genitricis memoriam agimus: intercessionis ejus auxilio, a nostris iniquitatibus resurgamus. Per eundem Dominum nostrum Jesum Christum, Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia saecula saeculorum.\n℟. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te véniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedicamus Domino. (Alleluja, alleluja).\n℟. Deo gratias. (Alleluja, alleluja)."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Concede, misericors Deus, fragilitati nostrae praesidium: ut, qui sanctae Dei Genitricis memoriam agimus: intercessionis ejus auxilio, a nostris iniquitatibus resurgamus. Per eundem Dominum nostrum Jesum Christum, Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te véniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino. (Alleluja, alleluja)."
+                  },
+                  "r": {
+                    "la": "Deo gratias. (Alleluja, alleluja)."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1328,22 +1797,41 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Dignare me laudare te, Virgo sacrata.\n℟. Da mihi virtutem contra hostes tuos. (Alleluja)."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dignare me laudare te, Virgo sacrata."
+                  },
+                  "r": {
+                    "la": "Da mihi virtutem contra hostes tuos. (Alleluja)."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nBeatae et gloriosae semperque Virginis Mariae, quaesumus, Domine, intercéssio gloriosa nos protegat: et ad vitam perducat aetérnam. Per Christum, Dominum nostrum.\n℟. Amen."
+                "la": "Beatae et gloriosae semperque Virginis Mariae, quaesumus, Domine, intercéssio gloriosa nos protegat: et ad vitam perducat aetérnam. Per Christum, Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
               "type": "divider"
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1355,7 +1843,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum - Is. 45, 8"
               }
@@ -1363,14 +1851,20 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Orate, caeli, desuper, et nubes pluant justum: aperiat terra, et germinet Salvatorem: et justitia oriatum simul. Ego Dominus creavi eum.\n℟. Deo gratias."
+                "la": "Orate, caeli, desuper, et nubes pluant justum: aperiat terra, et germinet Salvatorem: et justitia oriatum simul. Ego Dominus creavi eum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
               }
             },
             {
               "type": "divider"
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1392,33 +1886,54 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣.Ave Maria, gratia plena; Dominus tecum.\n℟.Benedicta tu in mulieribus, et benedictus fructus ventris tui.\n℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria, gratia plena; Dominus tecum."
+                  },
+                  "r": {
+                    "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine Nascendo,\nformam sumpseris."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
+                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine Nascendo,\nformam sumpseris.\n\nMaria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege\nEt hora mortis suscipe.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
@@ -1464,7 +1979,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1476,7 +1991,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 119"
               }
@@ -1488,7 +2003,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 120"
               }
@@ -1500,7 +2015,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 121"
               }
@@ -1512,7 +2027,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1524,7 +2039,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum - Eccli. 24, 15"
               }
@@ -1532,14 +2047,39 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Et sic in Sion firmata sum, et in civitate sanctificata similiter requievi, et in Jerusalem potestas mea.\n℟. Deo gratias."
+                "la": "Et sic in Sion firmata sum, et in civitate sanctificata similiter requievi, et in Jerusalem potestas mea."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Sancta Dei Genitrix, Virgo semper Maria. Sancta.\n℣. Intercede pro nobis ad Dominum, Deum nostrum. Virgo. Gloria Patri, et Filio, et Spiritui Sancto. Sancta.\n℣. Post partum, Virgo, inviolata permansisti.\n℟. Dei Genitrix, intercede pro nobis."
+                "la": "Deo gratias."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Sancta Dei Genitrix, Virgo semper Maria. Sancta."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Intercede pro nobis ad Dominum, Deum nostrum. Virgo. Gloria Patri, et Filio, et Spiritui Sancto. Sancta."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Post partum, Virgo, inviolata permansisti."
+                  },
+                  "r": {
+                    "la": "Dei Genitrix, intercede pro nobis."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1550,35 +2090,87 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Sancta Dei Genitrix, Virgo semper Maria, Alleluja, alleluja. Sancta.\n℣. Intercede pro nobis ad Dominum, Deum nostrum. Alleluja, alleluja. Gloria Patri. Sancta.\n℣. Post partum, Virgo, inviolata permansisti.\n℟. Dei Genitrix, intercede pro nobis, alleluja."
+                "la": "Sancta Dei Genitrix, Virgo semper Maria, Alleluja, alleluja. Sancta."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+                "la": "Intercede pro nobis ad Dominum, Deum nostrum. Alleluja, alleluja. Gloria Patri. Sancta."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui salutis aeternæ, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum, Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia saecula saeculorum.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Post partum, Virgo, inviolata permansisti."
+                  },
+                  "r": {
+                    "la": "Dei Genitrix, intercede pro nobis, alleluja."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedicamus Domino. (Alleluja).\n℟. Deo gratias."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui salutis aeternæ, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum, Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino. (Alleluja)."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1590,22 +2182,41 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Dignare me laudare te, Virgo sacrata.\n℟. Da mihi virtutem contra hostes tuos. (Alleluja)."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dignare me laudare te, Virgo sacrata."
+                  },
+                  "r": {
+                    "la": "Da mihi virtutem contra hostes tuos. (Alleluja)."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nBeatae et gloriosae semperque Virginis Mariae, quaesumus, Domine, intercessio gloriosa nos protegat: et ad vitam perducat aeternam. Per Christum, Dominum nostrum.\n℟. Amen."
+                "la": "Beatae et gloriosae semperque Virginis Mariae, quaesumus, Domine, intercessio gloriosa nos protegat: et ad vitam perducat aeternam. Per Christum, Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
               "type": "divider"
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1617,7 +2228,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum - Is. 7, 14-15"
               }
@@ -1625,14 +2236,20 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce, Virgo concipiet et pariet filium, et vocabitur nomen ejus Emmanuel. Butyrum et mel comedet, ut sciat reprobare malum, et eligere bonum.\n℟. Deo gratias."
+                "la": "Ecce, Virgo concipiet et pariet filium, et vocabitur nomen ejus Emmanuel. Butyrum et mel comedet, ut sciat reprobare malum, et eligere bonum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
               }
             },
             {
               "type": "divider"
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1654,33 +2271,54 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣.Ave Maria, gratia plena; Dominus tecum.\n℟.Benedicta tu in mulieribus, et benedictus fructus ventris tui.\n℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria, gratia plena; Dominus tecum."
+                  },
+                  "r": {
+                    "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterno saecula.\nAmen."
+                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris.\n\nMaria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege\nEt hora mortis suscipe.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterno saecula.\nAmen."
               }
             },
             {
@@ -1732,7 +2370,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 122"
               }
@@ -1744,7 +2382,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 123"
               }
@@ -1756,7 +2394,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 124"
               }
@@ -1768,7 +2406,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1780,7 +2418,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum Eccli. 24, 16"
               }
@@ -1788,20 +2426,39 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Et radicavi in populo honorificato, et in parte Dei mei hereditas illius, et in plenitudine sanctorum detentio mea.\n℟. Deo gratias."
+                "la": "Et radicavi in populo honorificato, et in parte Dei mei hereditas illius, et in plenitudine sanctorum detentio mea."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Post partum, Virgo, Inviolata permansisti. Post.\n℟. Dei Genitrix, intercede pro nobis. Inviolata. Gloria Patri, et Filio, et Spiritui Sancto. Post."
+                "la": "Deo gratias."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Speciosa facta es et suavis.\n℟. In deliciis tuis, sancta Dei Genitrix."
+                "la": "Post partum, Virgo, Inviolata permansisti. Post."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Dei Genitrix, intercede pro nobis. Inviolata. Gloria Patri, et Filio, et Spiritui Sancto. Post."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Speciosa facta es et suavis."
+                  },
+                  "r": {
+                    "la": "In deliciis tuis, sancta Dei Genitrix."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1812,29 +2469,87 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Post partum, Virgo, inviolata permansisti, Alleluia, alleluia. Post.\n℣. Dei Genitrix, intercede pro nobis. Alleluia, alleluia. Gloria Patri. Post.\n℣. Speciosa facta es et suavis.\n℟. In deliciis tuis, sancta Dei Genitrix, alleluia."
+                "la": "Post partum, Virgo, inviolata permansisti, Alleluia, alleluia. Post."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+                "la": "Dei Genitrix, intercede pro nobis. Alleluia, alleluia. Gloria Patri. Post."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui virginalem aulam beatae Mariae Virginis, in qua habitare, eligere dignatus es: da, quaesumus; ut sua nos defensione muniamus, jucundos suae facias interesse commemorationi: Qui vivis et regnas cum Deo Patre in unitate Spiritus Sancti Deus: per omnia saecula saeculorum.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Speciosa facta es et suavis."
+                  },
+                  "r": {
+                    "la": "In deliciis tuis, sancta Dei Genitrix, alleluia."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino. (Alleluia).\n℟. Deo gratias. (Alleluia)."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui virginalem aulam beatae Mariae Virginis, in qua habitare, eligere dignatus es: da, quaesumus; ut sua nos defensione muniamus, jucundos suae facias interesse commemorationi: Qui vivis et regnas cum Deo Patre in unitate Spiritus Sancti Deus: per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino. (Alleluia)."
+                  },
+                  "r": {
+                    "la": "Deo gratias. (Alleluia)."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1846,22 +2561,41 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Dignare me laudare te, Virgo sacrata.\n℟. Da mihi virtutem contra hostes tuos. (Alleluia)."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dignare me laudare te, Virgo sacrata."
+                  },
+                  "r": {
+                    "la": "Da mihi virtutem contra hostes tuos. (Alleluia)."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nBeate et gloriosae semperque Virginis Mariae, quaesumus, Domine, intercessio gloriosa nos protegat: et ad vitam perducat aeternam. Per Christum, Dominum nostrum.\n℟. Amen."
+                "la": "Beate et gloriosae semperque Virginis Mariae, quaesumus, Domine, intercessio gloriosa nos protegat: et ad vitam perducat aeternam. Per Christum, Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
               "type": "divider"
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1873,7 +2607,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum - Is. 11, 1-2"
               }
@@ -1881,14 +2615,20 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Egreditur virga de radice Jesse, et flos de radice ejus ascendet. Et requiescet super eum Spiritus Domini.\n℟. Deo gratias."
+                "la": "Egreditur virga de radice Jesse, et flos de radice ejus ascendet. Et requiescet super eum Spiritus Domini."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
               }
             },
             {
               "type": "divider"
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1910,33 +2650,54 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣.Ave Maria, gratia plena; Dominus tecum.\n℟.Benedicta tu in mulieribus, et benedictus fructus ventris tui.\n℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria, gratia plena; Dominus tecum."
+                  },
+                  "r": {
+                    "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterno saecula.\nAmen."
+                "la": "Memento, salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris.\n\nMaria, Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege\nEt hora mortis suscipe.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterno saecula.\nAmen."
               }
             },
             {
@@ -1982,7 +2743,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1994,7 +2755,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 125"
               }
@@ -2006,7 +2767,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 126"
               }
@@ -2018,7 +2779,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 127"
               }
@@ -2030,7 +2791,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2042,7 +2803,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum - Eccli. 24, 19-20"
               }
@@ -2050,14 +2811,40 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "In plateis sicut cinnamomum et balsamum aromatizans odorem dedi: quasi myrrha electa dedi suavitatem odoris.\n℟. Deo gratias."
+                "la": "In plateis sicut cinnamomum et balsamum aromatizans odorem dedi: quasi myrrha electa dedi suavitatem odoris."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Speciosa facta es et suavis.\n℟. In deliciis tuis, sancta Dei Genitrix.\n℣. Eligit eam Deus, et praelegit eam.\n℟. Et habitare eam facit in tabernaculo suo."
+                "la": "Deo gratias."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Speciosa facta es et suavis."
+                  },
+                  "r": {
+                    "la": "In deliciis tuis, sancta Dei Genitrix."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Eligit eam Deus, et praelegit eam."
+                  },
+                  "r": {
+                    "la": "Et habitare eam facit in tabernaculo suo."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -2066,37 +2853,90 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Speciosa facta es et suavis, Alleluja, alleluja.\n℟. In deliciis tuis, sancta Dei Genitrix. Alleluja, alleluja. Gloria Patri. Speciosa.\n℣. Eligit eam Deus, et praelegit eam.\n℟. Et habitare eam facit in tabernaculo suo, alleluja."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Speciosa facta es et suavis, Alleluja, alleluja."
+                  },
+                  "r": {
+                    "la": "In deliciis tuis, sancta Dei Genitrix. Alleluja, alleluja. Gloria Patri. Speciosa."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Eligit eam Deus, et praelegit eam."
+                  },
+                  "r": {
+                    "la": "Et habitare eam facit in tabernaculo suo, alleluja."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nAmulorum tuorum, quaesumus, Domine, delictis ignosce: ut, qui placere de actibus nostris vellemus, Genitricis Filii tui intercessione salvemur. Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia saecula saeculorum.\n℟. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedicamus Domino. (Alleluja).\n℟. Deo gratias. (Alleluja)."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amulorum tuorum, quaesumus, Domine, delictis ignosce: ut, qui placere de actibus nostris vellemus, Genitricis Filii tui intercessione salvemur. Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino. (Alleluja)."
+                  },
+                  "r": {
+                    "la": "Deo gratias. (Alleluja)."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2104,20 +2944,45 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Virgo Maria, non est tibi similis orta in mundo inter mulieres: florens ut rosa, fragrans sicut lilium: ora pro nobis, sancta Dei Genitrix. (Alleluja).\n℣. Dignare me laudare te, Virgo sacrata.\n℟. Da mihi virtutem contra hostes tuos. (Alleluja)."
+                "la": "Virgo Maria, non est tibi similis orta in mundo inter mulieres: florens ut rosa, fragrans sicut lilium: ora pro nobis, sancta Dei Genitrix. (Alleluja)."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dignare me laudare te, Virgo sacrata."
+                  },
+                  "r": {
+                    "la": "Da mihi virtutem contra hostes tuos. (Alleluja)."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nBeatae et gloriosae semperque Virginis Mariae, quaesumus, Domine, intercessio gloriosa nos protegat: et ad vitam perducat aeternam. Per Christum, Dominum nostrum.\n℟. Amen."
+                "la": "Beatae et gloriosae semperque Virginis Mariae, quaesumus, Domine, intercessio gloriosa nos protegat: et ad vitam perducat aeternam. Per Christum, Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
               "type": "divider"
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2137,14 +3002,20 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Dabit illi Dominus Deus sedem David, patris ejus; et regnabit in domo Jacob in aeternum, et regni ejus non erit finis.\n℟. Deo gratias."
+                "la": "Dabit illi Dominus Deus sedem David, patris ejus; et regnabit in domo Jacob in aeternum, et regni ejus non erit finis."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
               }
             },
             {
               "type": "divider"
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2172,10 +3043,43 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣.Ave Maria, gratia plena; Dominus tecum.\n℟.Benedicta tu in mulieribus, et benedictus fructus ventris tui.\n℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria, gratia plena; Dominus tecum."
+                  },
+                  "r": {
+                    "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -2184,7 +3088,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 109"
               }
@@ -2196,7 +3100,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 112"
               }
@@ -2208,7 +3112,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 121"
               }
@@ -2220,7 +3124,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 126"
               }
@@ -2232,7 +3136,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 147"
               }
@@ -2244,7 +3148,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2256,7 +3160,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum Eccli. 24, 14"
               }
@@ -2264,62 +3168,39 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ab initio et ante saecula creata sum, et usque ad futurum saeculum non desinam, et in habitatione sancta coram ipso ministravi.\n℟. Deo gratias."
+                "la": "Ab initio et ante saecula creata sum, et usque ad futurum saeculum non desinam, et in habitatione sancta coram ipso ministravi."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ave, maris stella,\nDei Mater alma,\nAtque semper Virgo,\nFelix caeli porta."
+                "la": "Ave, maris stella,\nDei Mater alma,\nAtque semper Virgo,\nFelix caeli porta.\n\nSumens illud Ave\nGabrielis ore,\nFunda nos in pace,\nMutans Evae nomen.\n\nSolve vincula reis,\nProfer lumen caecis,\nMala nostra pelle,\nBona cuncta posse.\n\nMonstra te esse matrem,\nSumat per te preces,\nQui pro nobis natus\nTulit esse tuus.\n\nVirgo singularis,\nInter omnes mitis,\nNos, culpis solutos,\nMites fac et castos.\n\nVitram praesta puram,\nIter para tutum,\nUt, videntes Jesum,\nSemper collaetemur.\n\nSit laus Deo Patri,\nSummo Christo decus,\nSpiritui Sancto,\nTribus honor unus.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sumens illud Ave\nGabrielis ore,\nFunda nos in pace,\nMutans Evae nomen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Solve vincula reis,\nProfer lumen caecis,\nMala nostra pelle,\nBona cuncta posse."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Monstra te esse matrem,\nSumat per te preces,\nQui pro nobis natus\nTulit esse tuus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Virgo singularis,\nInter omnes mitis,\nNos, culpis solutos,\nMites fac et castos."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Vitram praesta puram,\nIter para tutum,\nUt, videntes Jesum,\nSemper collaetemur."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit laus Deo Patri,\nSummo Christo decus,\nSpiritui Sancto,\nTribus honor unus.\nAmen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, sancta Dei Genitrix.\n℟. Ut digni efficiamur promissionibus Christi. (Alleluja)."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Dei Genitrix."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi. (Alleluja)."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -2346,7 +3227,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canricum B.M.V - Luc. 1, 46-55"
               }
@@ -2358,7 +3239,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2382,25 +3263,51 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nConcede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis sanitate gaudere: et, gloriosa beatae Mariae semper Virginis intercessione, a praesentii liberari tristitia et aeterna perfrui laetitia. Per Dominum nostrum Jesum Christum, Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia saecula saeculorum.\n℟. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Concede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis sanitate gaudere: et, gloriosa beatae Mariae semper Virginis intercessione, a praesentii liberari tristitia et aeterna perfrui laetitia. Per Dominum nostrum Jesum Christum, Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2412,22 +3319,47 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dignare me laudare te, Virgo sacrata."
+                  },
+                  "r": {
+                    "la": "Da mihi virtutem contra hostes tuos."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Dignare me laudare te, Virgo sacrata.\n℟. Da mihi virtutem contra hostes tuos.\n(Alleluja)."
+                "la": "(Alleluja)."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nBeatae et gloriosae semperque Virginis Mariae, quaesumus, Domine, intercessio gloriosa nos protegat: et ad vitam perducat aeternam. Per Christum, Dominum nostrum.\n℟. Amen."
+                "la": "Beatae et gloriosae semperque Virginis Mariae, quaesumus, Domine, intercessio gloriosa nos protegat: et ad vitam perducat aeternam. Per Christum, Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
               "type": "divider"
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2439,7 +3371,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum - Is. 7, 14-15"
               }
@@ -2447,7 +3379,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce, Virgo concipiet et pariet filium, et vocabitur nomen ejus Emmanuel. Butyrum et mel comedet, ut sciat reprobare malum, et eligere bonum.\n℟. Deo gratias."
+                "la": "Ecce, Virgo concipiet et pariet filium, et vocabitur nomen ejus Emmanuel. Butyrum et mel comedet, ut sciat reprobare malum, et eligere bonum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
               }
             },
             {
@@ -2466,7 +3404,7 @@
               "type": "divider"
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2500,13 +3438,59 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣.Ave Maria, gratia plena; Dominus tecum.\n℟.Benedicta tu in mulieribus, et benedictus fructus ventris tui.\n℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria, gratia plena; Dominus tecum."
+                  },
+                  "r": {
+                    "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos, Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2518,7 +3502,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 12"
               }
@@ -2530,7 +3514,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 42"
               }
@@ -2542,7 +3526,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 128"
               }
@@ -2554,7 +3538,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 130"
               }
@@ -2566,7 +3550,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2578,7 +3562,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum- Eccli. 24, 24"
               }
@@ -2586,41 +3570,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ego mater pulchrae dilectionis, et timoris, et agnitionis, et sanctae spei.\n℟. Deo gratias."
+                "la": "Ego mater pulchrae dilectionis, et timoris, et agnitionis, et sanctae spei."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Virgo singularis,\nInter omnes mitis,\nNos, culpis solutos,\nMites fac et castos."
+                "la": "Virgo singularis,\nInter omnes mitis,\nNos, culpis solutos,\nMites fac et castos.\n\nVitam praesta puram,\nIter para tutum,\nUt, videntes Jesum,\nSemper collaetemur.\n\nSit laus Deo Patri,\nSummo Christo decus,\nSpiritui Sancto,\nTribus honor unus.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Vitam praesta puram,\nIter para tutum,\nUt, videntes Jesum,\nSemper collaetemur."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ecce ancilla Domini."
+                  },
+                  "r": {
+                    "la": "Fiat mihi secundum verbum tuum. (Alleluja)."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit laus Deo Patri,\nSummo Christo decus,\nSpiritui Sancto,\nTribus honor unus.\nAmen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ecce ancilla Domini.\n℟. Fiat mihi secundum verbum tuum. (Alleluja)."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2632,7 +3617,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Simeonis - Luc, 2, 29-32"
               }
@@ -2644,7 +3629,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2656,25 +3641,51 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nGratiam tuam, quaesumus, Domine, mentibus nostris infunde: ut qui, Angelo nuntiantes, Christi Filii tui Incarnationem cognovimus; per passionem ejus et crucem, ad resurrectionis gloriam perducamur. Per eumdem Dominum nostrum Jesum Christum, Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia saecula saeculorum.\n℟. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gratiam tuam, quaesumus, Domine, mentibus nostris infunde: ut qui, Angelo nuntiantes, Christi Filii tui Incarnationem cognovimus; per passionem ejus et crucem, ad resurrectionis gloriam perducamur. Per eumdem Dominum nostrum Jesum Christum, Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2682,13 +3693,38 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Virgo Maria, non est tibi similis orta in mundo inter mulieres: florens ut rosa, fragrans sicut lilium: ora pro nobis, sancta Dei Genitrix. (Alleluja).\n℣. Dignare me laudare te, Virgo sacrata.\n℟. Da mihi virtutem contra hostes tuos. (Alleluja)."
+                "la": "Virgo Maria, non est tibi similis orta in mundo inter mulieres: florens ut rosa, fragrans sicut lilium: ora pro nobis, sancta Dei Genitrix. (Alleluja)."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dignare me laudare te, Virgo sacrata."
+                  },
+                  "r": {
+                    "la": "Da mihi virtutem contra hostes tuos. (Alleluja)."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nBeatae et gloriosae semperque Virginis Mariae, quaesumus, Domine, intercessio gloriosa nos protegat: et ad vitam perducat aeternam. Per Christum, Dominum nostrum.\n℟. Amen."
+                "la": "Beatae et gloriosae semperque Virginis Mariae, quaesumus, Domine, intercessio gloriosa nos protegat: et ad vitam perducat aeternam. Per Christum, Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             }
           ]

--- a/content/practices/little-office-bvm-carthusian/flow.json
+++ b/content/practices/little-office-bvm-carthusian/flow.json
@@ -38,9 +38,48 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nAlleluja."
+                "la": "Alleluja."
               }
             },
             {
@@ -56,7 +95,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Invitatorium."
               }
@@ -68,7 +107,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -80,7 +119,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -92,7 +131,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -104,7 +143,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -116,7 +155,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -128,7 +167,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -140,7 +179,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -152,7 +191,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -164,43 +203,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Mysterium Ecclesiae Hymnum\nChristo referimus\nQuem genuit puerpera\nVerbum Patris in Filium."
+                "la": "Mysterium Ecclesiae Hymnum\nChristo referimus\nQuem genuit puerpera\nVerbum Patris in Filium.\n\nSola in sexu femina\nElecta es in saeculo:\nEt meruisti Dominum\nSancto portare in utero.\n\nVates antiqui temporis\nPraedixerant quod factum est:\nQuia Virgo conciperet,\nEt pareret Emmanuël.\n\nMysterium hoc magnum est,\nMariae quod concessum est,\nUt Deum per quem omnia\nEx se prodire cerneret.\n\nGloria tibi Domine,\nGloria Unigenito,\nUna cum Sancto Spiritu\nIn sempiterna saecula.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sola in sexu femina\nElecta es in saeculo:\nEt meruisti Dominum\nSancto portare in utero."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Vates antiqui temporis\nPraedixerant quod factum est:\nQuia Virgo conciperet,\nEt pareret Emmanuël."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mysterium hoc magnum est,\nMariae quod concessum est,\nUt Deum per quem omnia\nEx se prodire cerneret."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi Domine,\nGloria Unigenito,\nUna cum Sancto Spiritu\nIn sempiterna saecula.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -218,7 +233,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 8"
               }
@@ -230,7 +245,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 18"
               }
@@ -242,7 +257,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 23"
               }
@@ -254,7 +269,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -266,10 +281,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Diffusa est gratia in labiis tuis.\n℟. Propterea benedixit te Deus in aeternum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Diffusa est gratia in labiis tuis."
+                  },
+                  "r": {
+                    "la": "Propterea benedixit te Deus in aeternum."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -278,7 +300,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -290,7 +312,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 44."
               }
@@ -302,7 +324,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 45"
               }
@@ -314,7 +336,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 86."
               }
@@ -326,7 +348,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -338,10 +360,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Specie tua et pulchritudine tua.\n℟. Intende prospere, procede, et regna."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Specie tua et pulchritudine tua."
+                  },
+                  "r": {
+                    "la": "Intende prospere, procede, et regna."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -350,7 +379,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -362,7 +391,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 95."
               }
@@ -374,7 +403,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 96."
               }
@@ -386,7 +415,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 97."
               }
@@ -398,7 +427,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -410,16 +439,49 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Adducentur regi virgines post eam.\n℟. Proximae ejus afferentur tibi."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Adducentur regi virgines post eam."
+                  },
+                  "r": {
+                    "la": "Proximae ejus afferentur tibi."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater noster. Ave Maria. etc.\n℣. Et ne nos inducas in tentationem.\n℟. Sed libera nos a malo.\n℣. Ostende nobis Domine misericordiam tuam.\n℟. Et salutare tuum da nobis."
+                "la": "Pater noster. Ave Maria. etc."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem."
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ostende nobis Domine misericordiam tuam."
+                  },
+                  "r": {
+                    "la": "Et salutare tuum da nobis."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -428,7 +490,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Benedictio."
               }
@@ -446,7 +508,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Lectio prima"
               }
@@ -454,17 +516,36 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Missus est Angelus Gabriël a Deo in civitatem Galilaeae, cui nomen Nazareth, ad Virginem desponsatam viro,\ncui nomen erat Joseph de domo David: et nomen Virginis Maria. Et ingressus Angelus ad eam, dixit: (Hic accipimus veniam) Ave gratia plena, Dominus tecum: benedicta tu in mulieribus. Quae cum audisset, turbata est in sermone ejus, et cogitabat qualis esset ista salutatio. Et ait Angelus ei: Ne timeas, Maria, invenisti enim gratiam apud Deum. Ecce concipies in utero, et paries Filium: et vocabis nomen ejus Jesum. Hic erit magnus, et Filius Altissimi vocabitur. Et dabit illi Dominus Deus sedem David patris ejus: et regnabit in domo Jacob in aeternum, et regni ejus non erit finis.\n℣. Tu autem, Domine, miserere nostri.\n℟. Deo gratias."
+                "la": "Missus est Angelus Gabriël a Deo in civitatem Galilaeae, cui nomen Nazareth, ad Virginem desponsatam viro,\ncui nomen erat Joseph de domo David: et nomen Virginis Maria. Et ingressus Angelus ad eam, dixit: (Hic accipimus veniam) Ave gratia plena, Dominus tecum: benedicta tu in mulieribus. Quae cum audisset, turbata est in sermone ejus, et cogitabat qualis esset ista salutatio. Et ait Angelus ei: Ne timeas, Maria, invenisti enim gratiam apud Deum. Ecce concipies in utero, et paries Filium: et vocabis nomen ejus Jesum. Hic erit magnus, et Filius Altissimi vocabitur. Et dabit illi Dominus Deus sedem David patris ejus: et regnabit in domo Jacob in aeternum, et regni ejus non erit finis."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Tu autem, Domine, miserere nostri."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Vidi speciosam sicut columbam, ascendentem desuper rivos aquarum, cujus inaestimabilis odor erat nimis in vestimentis ejus. Et sicut dies verni circumdabant eam flores rosarum, et lilia convallium."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Vidi speciosam sicut columbam, ascendentem desuper rivos aquarum, cujus inaestimabilis odor erat nimis in vestimentis ejus. Et sicut dies verni circumdabant eam flores rosarum, et lilia convallium.\n℣. Viderunt illam filiae Sion, beatissimam praedicaverunt, et reginae laudaverunt eam. Et sicut dies verni circumdabant eam flores rosarum, et lilia convallium."
+                "la": "Viderunt illam filiae Sion, beatissimam praedicaverunt, et reginae laudaverunt eam. Et sicut dies verni circumdabant eam flores rosarum, et lilia convallium."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Lectio secunda."
               }
@@ -472,11 +553,37 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Dixit autem Maria ad Angelum. Quomodo fiet istud, quoniam virum non cognosco? Et respondens Angelus\ndixit ei. Spiritus Sanctus superveniet in te: et virtus Altissimi obumbrabit tibi. Ideoque et quod nascetur ex te Sanctum vocabitur Filius Dei. Et ecce Elizabeth cognata tua, et ipsa concepit filium in senectute sua. Et hic mensis sextus est illi, quae vocatur sterilis: quia non erit impossibile apud Deum omne verbum. Dixit autem Maria. Ecce ancilla Domini, fiat mihi secundum verbum tuum.\n℣. Tu autem, Domine, miserere nostri.\n℟. Deo gratias.\n℣. Quae est ista quae ascendit per desertum sicut virgula fumi ex aromatibus myrrhae, et thuris. Et universi pulveris pigmentarii.\n℟. Mel et lac sub lingua tua, et odor vestimentorum tuorum sicut odor thuris. Et universi pulveris pigmentarii."
+                "la": "Dixit autem Maria ad Angelum. Quomodo fiet istud, quoniam virum non cognosco? Et respondens Angelus\ndixit ei. Spiritus Sanctus superveniet in te: et virtus Altissimi obumbrabit tibi. Ideoque et quod nascetur ex te Sanctum vocabitur Filius Dei. Et ecce Elizabeth cognata tua, et ipsa concepit filium in senectute sua. Et hic mensis sextus est illi, quae vocatur sterilis: quia non erit impossibile apud Deum omne verbum. Dixit autem Maria. Ecce ancilla Domini, fiat mihi secundum verbum tuum."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Tu autem, Domine, miserere nostri."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Quae est ista quae ascendit per desertum sicut virgula fumi ex aromatibus myrrhae, et thuris. Et universi pulveris pigmentarii."
+                  },
+                  "r": {
+                    "la": "Mel et lac sub lingua tua, et odor vestimentorum tuorum sicut odor thuris. Et universi pulveris pigmentarii."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio tertia."
               }
@@ -484,26 +591,80 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Exurgens Maria, abiit in montana cum festinatione in civitatem Juda et intravit in domum Zachariae: et\nsalutavit Elizabeth. Et factum est ut audivit saluationem Mariae Elizabeth, exultavit infans in utero ejus: et repleta est Spiritu Sancto Elizabeth: et exclamavit voce magna, et dixit. Benedicta tu inter mulieres, et benedictus fructus ventris tui. Et unde hoc mihi, ut veniat Mater Domini mei ad me? Ecce enim ut facta est vox salutationis tuae in auribus meis: exultavit in gaudio infans in utero meo. Et beata, quae credidisti: quoniam perficientur ea quae dicta sunt tibi a Domino.\n℣. Tu autem, Domine, miserere nostri.\n℟. Deo gratias.\n℣. Beatam me dicent omnes generationes: Quia fecit mihi Dominus magna qui potens est, et sanctum nomen ejus.\n℟. Magnificat anima mea Dominum, et exultavit spiritus meus in Deo salutari meo. Quia fecit mihi Dominus magna qui potens est, et sanctum nomen ejus.\n℣. Gloria Patri, et Filio, et Spiritui Sancto. Et sanctum nomen ejus."
+                "la": "Exurgens Maria, abiit in montana cum festinatione in civitatem Juda et intravit in domum Zachariae: et\nsalutavit Elizabeth. Et factum est ut audivit saluationem Mariae Elizabeth, exultavit infans in utero ejus: et repleta est Spiritu Sancto Elizabeth: et exclamavit voce magna, et dixit. Benedicta tu inter mulieres, et benedictus fructus ventris tui. Et unde hoc mihi, ut veniat Mater Domini mei ad me? Ecce enim ut facta est vox salutationis tuae in auribus meis: exultavit in gaudio infans in utero meo. Et beata, quae credidisti: quoniam perficientur ea quae dicta sunt tibi a Domino."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Tu autem, Domine, miserere nostri."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Beatam me dicent omnes generationes: Quia fecit mihi Dominus magna qui potens est, et sanctum nomen ejus."
+                  },
+                  "r": {
+                    "la": "Magnificat anima mea Dominum, et exultavit spiritus meus in Deo salutari meo. Quia fecit mihi Dominus magna qui potens est, et sanctum nomen ejus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto. Et sanctum nomen ejus."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Canticum."
               }
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Te Deum laudamus: te Dominum confitemur.\nTe aeternum Patrem: omnis terra veneratur.\nTibi omnes Angeli: tibi caeli et universae Potestates.\nTibi Cherubim et Seraphim incessabili voce proclamant.\nSanctus.\nSanctus.\nSanctus.\nDominus Deus Sabaoth.\nPleni sunt caeli et terra: majestatis gloriae tuae.\nTe gloriosus Apostolorum chorus.\nTe Prophetarum laudabilis numerus.\nTe Martyrum candidatus laudat exercitus.\nTe per orbem terrarum: sancta confitetur Ecclesia.\nPatrem immensae majestatis.\nVenerandum tuum verum: et unicum Filium.\nSanctum quoque Paracletum Spiritum.\nTu rex gloriae Christe.\nTu Patris sempiternus es Filius.\nTu ad liberandum suscepturus hominem: non horruisti Virginis uterum.\nTu devicto mortis aculeo: aperuisti credentibus regna caelorum.\nTu ad dexteram Dei sedes: in gloria Patris.\nJudex crederis esse venturus.\nHic accipimus veniam.\nTe ergo quaesumus, tuis famulis subveni: quos pretioso sanguine redemisti.\nAeterna fac cum Sanctis tuis gloria munerari.\nSalvum fac populum tuum Domine: et benedic haereditati tuae.\nEt rege eos: et extolle illos usque in aeternum.\nPer singulos dies benedicimus te.\nEt laudamus nomen tuum in seculum: et in seculum seculi.\nDignare Domine die isto: sine peccato nos custodire.\nMiserere nostri Domine: miserere nostri.\nFiat misericordia tua Domine super nos: quemadmodum speravimus in te.\nIn te Domine speravi: non confundar in aeternum."
+                "la": "Te Deum laudamus: te Dominum confitemur.\nTe aeternum Patrem: omnis terra veneratur.\nTibi omnes Angeli: tibi caeli et universae Potestates.\nTibi Cherubim et Seraphim incessabili voce proclamant.\nSanctus.\nSanctus.\nSanctus.\nDominus Deus Sabaoth.\nPleni sunt caeli et terra: majestatis gloriae tuae.\nTe gloriosus Apostolorum chorus.\nTe Prophetarum laudabilis numerus.\nTe Martyrum candidatus laudat exercitus.\nTe per orbem terrarum: sancta confitetur Ecclesia.\nPatrem immensae majestatis.\nVenerandum tuum verum: et unicum Filium.\nSanctum quoque Paracletum Spiritum.\nTu rex gloriae Christe.\nTu Patris sempiternus es Filius.\nTu ad liberandum suscepturus hominem: non horruisti Virginis uterum.\nTu devicto mortis aculeo: aperuisti credentibus regna caelorum.\nTu ad dexteram Dei sedes: in gloria Patris.\nJudex crederis esse venturus."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Hic accipimus veniam."
               }
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "℣. Adjuvabit eam Deus vultu suo.\n℟. Deus in medio ejus non commovebitur."
+                "la": "Te ergo quaesumus, tuis famulis subveni: quos pretioso sanguine redemisti.\nAeterna fac cum Sanctis tuis gloria munerari.\nSalvum fac populum tuum Domine: et benedic haereditati tuae.\nEt rege eos: et extolle illos usque in aeternum.\nPer singulos dies benedicimus te.\nEt laudamus nomen tuum in seculum: et in seculum seculi.\nDignare Domine die isto: sine peccato nos custodire.\nMiserere nostri Domine: miserere nostri.\nFiat misericordia tua Domine super nos: quemadmodum speravimus in te.\nIn te Domine speravi: non confundar in aeternum."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Adjuvabit eam Deus vultu suo."
+                  },
+                  "r": {
+                    "la": "Deus in medio ejus non commovebitur."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -515,13 +676,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℣. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℣. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nAlleluja. (vel Laus tibi, Domine, Rex aeternae gloriae.)"
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Alleluja. (vel Laus tibi, Domine, Rex aeternae gloriae.)"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -533,7 +719,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 92."
               }
@@ -545,7 +731,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 99."
               }
@@ -557,7 +743,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 62."
               }
@@ -569,7 +755,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 66."
               }
@@ -581,7 +767,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum. Daniel 3."
               }
@@ -593,7 +779,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 148."
               }
@@ -601,11 +787,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudate Dominum de caelis: laudate eum in excelsis.\nLaudate eum omnes Angeli ejus: laudate eum omnes Virtutes ejus.\nLaudate eum sol et luna: laudate eum omnes stellae et lumen.\nLaudate eum caeli caelorum: et aquae omnes quae super caelos sunt, laudent nomen Domini.\nQuia ipse dixit et facta sunt: ipse mandavit, et creata sunt. Statuit ea in aeternum, et in seculum seculi: praeceptum posuit, et non praeteribit.\nLaudate Dominum de terra: dracones et omnes abyssi.\nIgnis, grando, nix, glacies, spiritus procellarum: quae faciunt verbum ejus.\nMontes et omnes colles: ligna fructifera, et omnes cedri.\nBestiae et universa pecora: serpentes, et volucres pennatae. Reges terrae, et omnes populi: principes, et omnes judices terrae.\nJuvenes, et virgines, senes cum junioribus, laudent nomen Domini: quia exaltatum est nomen ejus solius.\nConfessio ejus super caelum et terram: et exaltavit cornu populi sui.\nHymnus omnibus sanctis ejus: filiis Israël, populo appropinquanti sibi."
+                "la": "Laudate Dominum de caelis: laudate eum in excelsis.\nLaudate eum omnes Angeli ejus: laudate eum omnes Virtutes ejus.\nLaudate eum sol et luna: laudate eum omnes stellae et lumen.\nLaudate eum caeli caelorum: et aquae omnes quae super caelos sunt, laudent nomen Domini.\nQuia ipse dixit et facta sunt: ipse mandavit, et creata sunt. Statuit ea in aeternum, et in seculum seculi: praeceptum posuit, et non praeteribit.\nLaudate Dominum de terra: dracones et omnes abyssi.\nIgnis, grando, nix, glacies, spiritus procellarum: quae faciunt verbum ejus.\nMontes et omnes colles: ligna fructifera, et omnes cedri.\nBestiae et universa pecora: serpentes, et volucres pennatae. Reges terrae, et omnes populi: principes, et omnes judices terrae.\nJuvenes, et virgines, senes cum junioribus, laudent nomen Domini: quia exaltatum est nomen ejus solius.\nConfessio ejus super caelum et terram: et exaltavit cornu populi sui."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus omnibus sanctis ejus: filiis Israël, populo appropinquanti sibi."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 149."
               }
@@ -617,7 +809,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 150."
               }
@@ -629,7 +821,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -641,7 +833,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum."
               }
@@ -649,53 +841,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ego quasi vitis fructificavi suavitatem odoris: et flores mei fructus honoris et honestatis.\n℟. Deo gratias."
+                "la": "Ego quasi vitis fructificavi suavitatem odoris: et flores mei fructus honoris et honestatis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Vere gratia plena es,\nEt gloriosa permanes:\nQuia ex te nobis natus est Christus,\nper quem sunt omnia."
+                "la": "Vere gratia plena es,\nEt gloriosa permanes:\nQuia ex te nobis natus est Christus,\nper quem sunt omnia.\n\nPastores qui audierunt,\nGloriam Deo cantarunt,\nConcurrerunt in Bethlehem\nNatum videre Dominum.\n\nSic Magi ab ortu solis\nPropter stellae indicium\nPortantes typum Gentium,\nPrimi offerunt munera.\n\nRogemus ergo populi\nDei Matrem et Virginem,\nUt ipsa nobis impetret\nPacem et indulgentiam.\n\nGloria tibi Domine,\nGloria Unigenito,\nUna cum Sancto Spiritu\nIn sempiterna secula. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Pastores qui audierunt,\nGloriam Deo cantarunt,\nConcurrerunt in Bethlehem\nNatum videre Dominum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicta tu in mulieribus."
+                  },
+                  "r": {
+                    "la": "Et benedictus fructus ventris tui."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sic Magi ab ortu solis\nPropter stellae indicium\nPortantes typum Gentium,\nPrimi offerunt munera."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Rogemus ergo populi\nDei Matrem et Virginem,\nUt ipsa nobis impetret\nPacem et indulgentiam."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi Domine,\nGloria Unigenito,\nUna cum Sancto Spiritu\nIn sempiterna secula. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedicta tu in mulieribus.\n℟. Et benedictus fructus ventris tui."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -707,7 +888,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum. Luc. 1."
               }
@@ -719,7 +900,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -731,25 +912,58 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui salutis aeternae beatae Mariae virginitate foecunda, humano generi praemia praestitisti: tribue\nquaesumus, ut ipsam pro nobis intercedere sentiamus, per quam meruimus authorem vitae suscipere Dominum nostrum Jesum Christum Filium tuum. Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n(vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui salutis aeternae beatae Mariae virginitate foecunda, humano generi praemia praestitisti: tribue\nquaesumus, ut ipsam pro nobis intercedere sentiamus, per quam meruimus authorem vitae suscipere Dominum nostrum Jesum Christum Filium tuum. Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum. Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 78."
               }
@@ -761,7 +975,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 122."
               }
@@ -785,19 +999,110 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Et ne nos inducas in tentationem.\n℟. Sed libera nos a malo.\n℣. Exurgat Deus et dissipentur inimici ejus.\n℟. Et fugiant qui oderunt eum a facie ejus.\n℣. Non nobis Domine non nobis.\n℟. Sed nomini tuo da gloriam.\n℣. Exurge Domine adjuva nos.\n℟. Et libera nos propter nomen tuum.\n℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Domine Deus virtutum converte nos.\n℟. Et ostende faciem tuam, et salvi erimus.\n℣. Domine exaudi orationem meam. (vel Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem."
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui ad exhibenda nostrae redemptionis mysteria terram promissionis elegisti, libera eam quaesumus ab instantia paganorum, et restitue eam cultui Christiano: ut Gentilium incredulitate confusa, populus tuus Christianus in te confidens, de tuae virtutis potentia glorietur."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Exurgat Deus et dissipentur inimici ejus."
+                  },
+                  "r": {
+                    "la": "Et fugiant qui oderunt eum a facie ejus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Non nobis Domine non nobis."
+                  },
+                  "r": {
+                    "la": "Sed nomini tuo da gloriam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Exurge Domine adjuva nos."
+                  },
+                  "r": {
+                    "la": "Et libera nos propter nomen tuum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine Deus virtutum converte nos."
+                  },
+                  "r": {
+                    "la": "Et ostende faciem tuam, et salvi erimus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui ad exhibenda nostrae redemptionis mysteria terram promissionis elegisti, libera eam quaesumus ab instantia paganorum, et restitue eam cultui Christiano: ut Gentilium incredulitate confusa, populus tuus Christianus in te confidens, de tuae virtutis potentia glorietur."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -809,7 +1114,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -833,7 +1138,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -845,7 +1150,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -857,13 +1162,46 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Animae omnium fidelium defunctorum per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Animae omnium fidelium defunctorum per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -875,19 +1213,32 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ave Maria gratia plena.\n℟. Dominus tecum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nFamulorum tuorum, Domine, delictis ignosce, ut qui tibi placere de actibus nostris non valemus, genitricis Filii tui Domini Dei nostri intercessione salvemur."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria gratia plena."
+                  },
+                  "r": {
+                    "la": "Dominus tecum."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Famulorum tuorum, Domine, delictis ignosce, ut qui tibi placere de actibus nostris non valemus, genitricis Filii tui Domini Dei nostri intercessione salvemur."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -899,7 +1250,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -907,14 +1258,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ineffabilem misericordiam tuam Domine nobis clementer ostende: ut simul nos et a peccatis exuas, et a poenis et a tribulationibus quas pro his meremur eripias, et pacem tuam nostris concede temporibus: et nos famulos tuos ab omni adversitate custodi. Per Dominum nostrum Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum.\n℟. Amen."
+                "la": "Ineffabilem misericordiam tuam Domine nobis clementer ostende: ut simul nos et a peccatis exuas, et a poenis et a tribulationibus quas pro his meremur eripias, et pacem tuam nostris concede temporibus: et nos famulos tuos ab omni adversitate custodi. Per Dominum nostrum Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Benedicamus Domino.\n℟. Deo gratias."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -926,55 +1290,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nAlleluja. (vel Laus tibi, Domine, Rex aeternae gloriae.)"
+                "la": "Alleluja. (vel Laus tibi, Domine, Rex aeternae gloriae.)"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento salutis Author,\nQuod nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris."
+                "la": "Memento salutis Author,\nQuod nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris.\n\nMaria Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt hora mortis suscipe.\n\nMaria Mater Domini\nAeterni Patris Filii,\nFer opem nobis omnibus\nAd te confugientibus.\n\nPer tuum Virgo Filium,\nPer Patrem, per Paracletum,\nAdsis praesens ad obitum,\nNostrumque muni exitum.\n\nGloria tibi Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna secula.\n\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater Domini\nAeterni Patris Filii,\nFer opem nobis omnibus\nAd te confugientibus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Per tuum Virgo Filium,\nPer Patrem, per Paracletum,\nAdsis praesens ad obitum,\nNostrumque muni exitum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna secula."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Amen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 53."
               }
@@ -986,7 +1346,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (1)."
               }
@@ -998,7 +1358,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (2)"
               }
@@ -1010,7 +1370,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1022,7 +1382,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum. Eccles. 24."
               }
@@ -1030,7 +1390,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ego mater pulchrae dilectionis, et timoris, et agnitionis, et sanctae spei: in me gratia omnis viae et veritatis: in me omnis spes vitae et virtutis.\n℟. Deo gratias."
+                "la": "Ego mater pulchrae dilectionis, et timoris, et agnitionis, et sanctae spei: in me gratia omnis viae et veritatis: in me omnis spes vitae et virtutis."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
               }
             },
             {
@@ -1040,22 +1406,113 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ave Maria gratia plena.\n℟. Ave Maria gratia plena.\n℣. Dominus tecum.\n℟. Ave Maria gratia plena.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Ave Maria gratia plena.\n℣. Benedicta tu in mulieribus.\n℟. Et benedictus fructus ventris tui.\n℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria gratia plena."
+                  },
+                  "r": {
+                    "la": "Ave Maria gratia plena."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus tecum."
+                  },
+                  "r": {
+                    "la": "Ave Maria gratia plena."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Ave Maria gratia plena."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicta tu in mulieribus."
+                  },
+                  "r": {
+                    "la": "Et benedictus fructus ventris tui."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui de beatae Mariae Virginis utero verbum tuum\nAngelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis, ut qui verè eam Genetricem Dei credimus, ejus apud te intercessionibus adjuvemur. Per eundem Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum."
+                "la": "Deus, qui de beatae Mariae Virginis utero verbum tuum\nAngelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis, ut qui verè eam Genetricem Dei credimus, ejus apud te intercessionibus adjuvemur. Per eundem Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Amen.\n℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1073,55 +1530,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nAlleluja. (vel Laus tibi, Domine, Rex aeternae gloriae.)"
+                "la": "Alleluja. (vel Laus tibi, Domine, Rex aeternae gloriae.)"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento salutis Author,\nQuod nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris."
+                "la": "Memento salutis Author,\nQuod nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris.\n\nMaria Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt hora mortis suscipe.\n\nMaria Mater Domini\nAeterni Patris Filii,\nFer opem nobis omnibus\nAd te confugientibus.\n\nPer tuum Virgo Filium,\nPer Patrem, per Paracletum,\nAdsis praesens ad obitum,\nNostrumque muni exitum.\n\nGloria tibi Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna secula.\n\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater Domini\nAeterni Patris Filii,\nFer opem nobis omnibus\nAd te confugientibus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Per tuum Virgo Filium,\nPer Patrem, per Paracletum,\nAdsis praesens ad obitum,\nNostrumque muni exitum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna secula."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Amen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (3)."
               }
@@ -1133,7 +1586,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (4)."
               }
@@ -1145,7 +1598,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (5)."
               }
@@ -1157,7 +1610,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1169,7 +1622,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum. - Eccles. 24."
               }
@@ -1177,41 +1630,135 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "In omnibus requiem quaesivi: et in haereditate Domini morabor: tunc praecepit, et dixit mihi Creator omnium: et qui creavit me, requievit in tabernaculo meo.\n℟. Deo gratias."
+                "la": "In omnibus requiem quaesivi: et in haereditate Domini morabor: tunc praecepit, et dixit mihi Creator omnium: et qui creavit me, requievit in tabernaculo meo."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Benedicta tu in mulieribus.\nBenedicta tu in mulieribus.\n℟. Et benedictus fructus ventris tui.\nBenedicta tu in mulieribus.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\nBenedicta tu in mulieribus."
+                "la": "Deo gratias."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Diffusa est gratia in labiis tuis.\n℣. Propterea benedixit te Deus in aeternum."
+                "la": "Benedicta tu in mulieribus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
+                "la": "Benedicta tu in mulieribus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede nos famulos tuos, quaesumus Domine Deus, perpetua mentis et corporis prosperitate gaudere: et\ngloriosa beatae Mariae semper Virginis intercessione a praesenti liberari tristitia, et aeterna perfrui laetitia. Per Dominum nostrum Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum.\n℟. Amen."
+                "la": "Et benedictus fructus ventris tui."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Animae omnium fidelium defunctorum per misericordiam Dei requiescant in pace.\n℟. Amen."
+                "la": "Benedicta tu in mulieribus."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Benedicta tu in mulieribus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Diffusa est gratia in labiis tuis."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Propterea benedixit te Deus in aeternum."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Concede nos famulos tuos, quaesumus Domine Deus, perpetua mentis et corporis prosperitate gaudere: et\ngloriosa beatae Mariae semper Virginis intercessione a praesenti liberari tristitia, et aeterna perfrui laetitia. Per Dominum nostrum Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Animae omnium fidelium defunctorum per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1223,19 +1770,32 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ave Maria gratia plena.\n℟. Dominus tecum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nFamulorum tuorum, Domine, delictis ignosce, ut qui tibi placere de actibus nostris non valemus, genetricis Filii\ntui Domini Dei nostri intercessione salvemur."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria gratia plena."
+                  },
+                  "r": {
+                    "la": "Dominus tecum."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Famulorum tuorum, Domine, delictis ignosce, ut qui tibi placere de actibus nostris non valemus, genetricis Filii\ntui Domini Dei nostri intercessione salvemur."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -1247,7 +1807,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -1255,14 +1815,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ineffabilem misericordiam tuam Domine nobis clementer ostende: ut simul nos et a peccatis exuas, et a poenis et a\ntribulationibus quas pro his meremur eripias, et pacem tuam nostris concede temporibus: et nos famulos tuos ab omni adversitate custodi. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum.\n℟. Amen."
+                "la": "Ineffabilem misericordiam tuam Domine nobis clementer ostende: ut simul nos et a peccatis exuas, et a poenis et a\ntribulationibus quas pro his meremur eripias, et pacem tuam nostris concede temporibus: et nos famulos tuos ab omni adversitate custodi. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Benedicamus Domino.\n℟. Deo gratias."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -1274,49 +1847,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nAlleluja. (vel Laus tibi, Domine, Rex aeternae gloriae.)"
+                "la": "Alleluja. (vel Laus tibi, Domine, Rex aeternae gloriae.)"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento salutis Author,\nQuòd nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris."
+                "la": "Memento salutis Author,\nQuòd nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris.\n\nMaria Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt hora mortis suscipe.\n\nMaria Mater Domini\nAeterni Patris Filii,\nFer opem nobis omnibus\nAd te confugientibus.\n\nPer tuum Virgo Filium,\nPer Patrem, per Paracletum,\nAdsis praesens ad obitum,\nNostrumque muni exitum.\n\nGloria tibi Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna secula. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater Domini\nAeterni Patris Filii,\nFer opem nobis omnibus\nAd te confugientibus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Per tuum Virgo Filium,\nPer Patrem, per Paracletum,\nAdsis praesens ad obitum,\nNostrumque muni exitum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna secula. Amen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (6)."
               }
@@ -1328,7 +1903,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (7)."
               }
@@ -1340,7 +1915,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (8)."
               }
@@ -1352,7 +1927,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1364,7 +1939,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum. – Eccles. 24."
               }
@@ -1372,41 +1947,118 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Et sic in Sion firmata sum, et in civitate sanctificata similiter requievi: et in Jerusalem potestas mea.\n℟. Deo gratias."
+                "la": "Et sic in Sion firmata sum, et in civitate sanctificata similiter requievi: et in Jerusalem potestas mea."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Diffusa est gratia in labiis tuis. Diffusa est gratia in labiis tuis.\n℣. Propterea benedixit te Deus in aeternum. Diffusa est gratia in labiis tuis.\n℣. Gloria Patri, et Filio, et Spiritui Sancto. Diffusa est gratia in labiis tuis."
+                "la": "Deo gratias."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Specie tua et pulchritudine tua.\n℟. Intende prosperè, procede, et regna."
+                "la": "Diffusa est gratia in labiis tuis. Diffusa est gratia in labiis tuis."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
+                "la": "Propterea benedixit te Deus in aeternum. Diffusa est gratia in labiis tuis."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede misericors Deus fragilitati nostrae subsidium: ut qui sanctae Dei Genitricis memoriam agimus: intercessionis ejus auxilio, a nostris iniquitatibus resurgamus. Per eumdem Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum.\n℟. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto. Diffusa est gratia in labiis tuis."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Animae omnium fidelium defunctorum per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Specie tua et pulchritudine tua."
+                  },
+                  "r": {
+                    "la": "Intende prosperè, procede, et regna."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Concede misericors Deus fragilitati nostrae subsidium: ut qui sanctae Dei Genitricis memoriam agimus: intercessionis ejus auxilio, a nostris iniquitatibus resurgamus. Per eumdem Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Animae omnium fidelium defunctorum per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1418,19 +2070,32 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ave Maria gratia plena.\n℟. Dominus tecum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nFamulorum tuorum, Domine, delictis ignosce, ut qui tibi placere de actibus nostris non valemus, genetricis Filii tui Domini Dei nostri intercessione salvemur."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria gratia plena."
+                  },
+                  "r": {
+                    "la": "Dominus tecum."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Famulorum tuorum, Domine, delictis ignosce, ut qui tibi placere de actibus nostris non valemus, genetricis Filii tui Domini Dei nostri intercessione salvemur."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -1442,7 +2107,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -1450,14 +2115,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ineffabilem misericordiam tuam Domine nobis clementer ostende: ut simul nos et a peccatis exuas, et a poenis et a tribulationibus quas pro his meremur eripias, et pacem tuam nostris concede temporibus: et nos famulos tuos ab omni adversitate custodi. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum.\n℟. Amen."
+                "la": "Ineffabilem misericordiam tuam Domine nobis clementer ostende: ut simul nos et a peccatis exuas, et a poenis et a tribulationibus quas pro his meremur eripias, et pacem tuam nostris concede temporibus: et nos famulos tuos ab omni adversitate custodi. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Benedicamus Domino.\n℟. Deo gratias."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -1469,49 +2147,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nAlleluja. (vel Laus tibi, Domine, Rex aeternae gloriae.)"
+                "la": "Alleluja. (vel Laus tibi, Domine, Rex aeternae gloriae.)"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento salutis Author,\nQuòd nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris."
+                "la": "Memento salutis Author,\nQuòd nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris.\n\nMaria Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt hora mortis suscipe.\n\nMaria Mater Domini\nAeterni Patris Filii,\nFer opem nobis omnibus\nAd te confugientibus.\n\nPer tuum Virgo Filium,\nPer Patrem, per Paracletum,\nAdsis praesens ad obitum,\nNostrumque muni exitum.\n\nGloria tibi Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna secula. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater Domini\nAeterni Patris Filii,\nFer opem nobis omnibus\nAd te confugientibus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Per tuum Virgo Filium,\nPer Patrem, per Paracletum,\nAdsis praesens ad obitum,\nNostrumque muni exitum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna secula. Amen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (9)."
               }
@@ -1523,7 +2203,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (10)."
               }
@@ -1535,7 +2215,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (11)."
               }
@@ -1547,7 +2227,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1559,7 +2239,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum. – Eccles. 24."
               }
@@ -1567,41 +2247,118 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Et radicavi in populo honorificato, et in parte Dei mei haereditas illius: et in plenitudine sanctorum detentio mea.\n℟. Deo gratias."
+                "la": "Et radicavi in populo honorificato, et in parte Dei mei haereditas illius: et in plenitudine sanctorum detentio mea."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Specie tua et pulchritudine tua. Specie tua et pulchritudine tua.\n℣. Intende prosperè, procede, et regna. Specie tua et pulchritudine tua.\n℣. Gloria Patri, et Filio, et Spiritui Sancto. Specie tua et pulchritudine tua."
+                "la": "Deo gratias."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Adducentur regi virgines post eam.\n℟. Proximae ejus afferentur tibi."
+                "la": "Specie tua et pulchritudine tua. Specie tua et pulchritudine tua."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
+                "la": "Intende prosperè, procede, et regna. Specie tua et pulchritudine tua."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nOmnipotens Deus nos famulos tuos dextra potentiae tuae: a cunctis protege periculis: et beata Maria semper Virgine intercedente, fac nos praesenti gaudere prosperitate et futura. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum.\n℟. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto. Specie tua et pulchritudine tua."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Animae omnium fidelium defunctorum per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Adducentur regi virgines post eam."
+                  },
+                  "r": {
+                    "la": "Proximae ejus afferentur tibi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Omnipotens Deus nos famulos tuos dextra potentiae tuae: a cunctis protege periculis: et beata Maria semper Virgine intercedente, fac nos praesenti gaudere prosperitate et futura. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Animae omnium fidelium defunctorum per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1613,19 +2370,32 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ave Maria gratia plena.\n℟. Dominus tecum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nFamulorum tuorum, Domine, delictis ignosce, ut qui tibi placere de actibus nostris non valemus, genetricis Filii tui Domini Dei nostri intercessione salvemur."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria gratia plena."
+                  },
+                  "r": {
+                    "la": "Dominus tecum."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Famulorum tuorum, Domine, delictis ignosce, ut qui tibi placere de actibus nostris non valemus, genetricis Filii tui Domini Dei nostri intercessione salvemur."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -1637,7 +2407,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -1645,14 +2415,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ineffabilem misericordiam tuam Domine nobis clementer ostende: ut simul nos et a peccatis exuas, et a poenis et a tribulationibus quas pro his meremur eripias, et pacem tuam nostris concede temporibus: et nos famulos tuos ab omni adversitate custodi. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum.\n℟. Amen."
+                "la": "Ineffabilem misericordiam tuam Domine nobis clementer ostende: ut simul nos et a peccatis exuas, et a poenis et a tribulationibus quas pro his meremur eripias, et pacem tuam nostris concede temporibus: et nos famulos tuos ab omni adversitate custodi. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Benedicamus Domino.\n℟. Deo gratias."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -1664,13 +2447,39 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nAlleluja. (vel Laus tibi, Domine, Rex aeternae gloriae.)"
+                "la": "Alleluja. (vel Laus tibi, Domine, Rex aeternae gloriae.)"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1682,7 +2491,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 109."
               }
@@ -1694,7 +2503,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 112."
               }
@@ -1706,7 +2515,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 121."
               }
@@ -1718,7 +2527,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 126."
               }
@@ -1730,7 +2539,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 147."
               }
@@ -1742,7 +2551,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1754,7 +2563,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum. – Eccles. 24."
               }
@@ -1762,55 +2571,31 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quasi cedrus exaltata sum in Libano, et quasi cypressus in monte Sion, quasi palma exaltata sum in Cades: et quasi plantatio rosae in Jericho.\n℟. Deo gratias."
+                "la": "Quasi cedrus exaltata sum in Libano, et quasi cypressus in monte Sion, quasi palma exaltata sum in Cades: et quasi plantatio rosae in Jericho."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
               }
             },
             {
               "type": "rubric",
               "text": {
-                "la": "Hymnus.\n(Hic sumimus veniam.)"
+                "la": "Hic sumimus veniam."
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ave maris stella,\nDei Mater alma,\nAtque semper Virgo,\nFelix caeli porta."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sumens illud ave,\nGabrielis ore,\nFunda nos in pace,\nMutans nomen Hevae."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Solve vincla reis,\nProfer lumen caecis,\nMala nostra pelle,\nBona cuncta posce."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Monstra te esse matrem,\nSumat per te preces,\nQui pro nobis natus\nTulit esse tuus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Virgo singularis\nInter omnes mitis,\nNos culpis solutos\nMites fac et castos."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Vitam praesta puram,\nIter para tutum,\nUt videntes Jesum,\nSemper collaetemur."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit laus Deo Patri,\nSummo Christo decus,\nSpiritui Sancto,\nTribus honor unus. Amen."
+                "la": "Ave maris stella,\nDei Mater alma,\nAtque semper Virgo,\nFelix caeli porta.\n\nSumens illud ave,\nGabrielis ore,\nFunda nos in pace,\nMutans nomen Hevae.\n\nSolve vincla reis,\nProfer lumen caecis,\nMala nostra pelle,\nBona cuncta posce.\n\nMonstra te esse matrem,\nSumat per te preces,\nQui pro nobis natus\nTulit esse tuus.\n\nVirgo singularis\nInter omnes mitis,\nNos culpis solutos\nMites fac et castos.\n\nVitam praesta puram,\nIter para tutum,\nUt videntes Jesum,\nSemper collaetemur.\n\nSit laus Deo Patri,\nSummo Christo decus,\nSpiritui Sancto,\nTribus honor unus. Amen."
               }
             },
             {
@@ -1820,13 +2605,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ave Maria gratia plena.\n℟. Dominus tecum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria gratia plena."
+                  },
+                  "r": {
+                    "la": "Dominus tecum."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1838,7 +2630,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum beatissimae Virginis Mariae. – Luc. 1."
               }
@@ -1850,7 +2642,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1862,25 +2654,77 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui salutis aeternae beatae Mariae virginitate foecunda, humano generi praemia praestitisti: tribue quaesumus, ut ipsam pro nobis intercedere sentiamus, per quam meruimus authorem vitae suscipere Dominum nostrum Jesum Christum Filium tuum. Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum.\n℟. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Animae omnium fidelium defunctorum per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui salutis aeternae beatae Mariae virginitate foecunda, humano generi praemia praestitisti: tribue quaesumus, ut ipsam pro nobis intercedere sentiamus, per quam meruimus authorem vitae suscipere Dominum nostrum Jesum Christum Filium tuum. Qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Animae omnium fidelium defunctorum per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1892,19 +2736,32 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ave Maria gratia plena.\n℟. Dominus tecum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nFamulorum tuorum, Domine, delictis ignosce, ut qui tibi placere de actibus nostris non valemus, genetricis Filii tui Domini Dei nostri intercessione salvemur."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria gratia plena."
+                  },
+                  "r": {
+                    "la": "Dominus tecum."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Famulorum tuorum, Domine, delictis ignosce, ut qui tibi placere de actibus nostris non valemus, genetricis Filii tui Domini Dei nostri intercessione salvemur."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -1916,7 +2773,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -1924,14 +2781,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ineffabilem misericordiam tuam Domine nobis clementer ostende: ut simul nos et a peccatis exuas, et a poenis et a tribulationibus quas pro his meremur eripias, et pacem tuam nostris concede temporibus: et nos famulos tuos ab omni adversitate custodi. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum.\n℟. Amen."
+                "la": "Ineffabilem misericordiam tuam Domine nobis clementer ostende: ut simul nos et a peccatis exuas, et a poenis et a tribulationibus quas pro his meremur eripias, et pacem tuam nostris concede temporibus: et nos famulos tuos ab omni adversitate custodi. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Benedicamus Domino.\n℟. Deo gratias."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -1943,13 +2813,52 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in secula seculorum. Amen."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in secula seculorum. Amen.\nAlleluja. (vel Laus tibi, Domine, Rex aeternae gloriae.)"
+                "la": "Alleluja. (vel Laus tibi, Domine, Rex aeternae gloriae.)"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 4."
               }
@@ -1961,7 +2870,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 30."
               }
@@ -1973,7 +2882,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 133."
               }
@@ -1985,7 +2894,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1997,43 +2906,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento salutis Author,\nQuòd nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris."
+                "la": "Memento salutis Author,\nQuòd nostri quondam corporis\nEx illibata Virgine\nNascendo formam sumpseris.\n\nMaria Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt hora mortis suscipe.\n\nMaria Mater Domini\nAeterni Patris Filii,\nFer opem nobis omnibus\nAd te confugientibus.\n\nPer tuum Virgo Filium,\nPer Patrem, per Paracletum,\nAdsis praesens ad obitum,\nNostrumque muni exitum.\n\nGloria tibi Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna secula. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater Domini\nAeterni Patris Filii,\nFer opem nobis omnibus\nAd te confugientibus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Per tuum Virgo Filium,\nPer Patrem, per Paracletum,\nAdsis praesens ad obitum,\nNostrumque muni exitum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna secula. Amen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum. – Eccles. 24."
               }
@@ -2041,17 +2926,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sicut cinnamomum et balsamum aromatizans odorem dedi: quasi myrrha electa dedi suavitatem odoris.\n℟. Deo gratias."
+                "la": "Sicut cinnamomum et balsamum aromatizans odorem dedi: quasi myrrha electa dedi suavitatem odoris."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Adjuvabit eam Deus vultu suo.\n℟. Deus in medio ejus non commovebitur."
+                "la": "Deo gratias."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Adjuvabit eam Deus vultu suo."
+                  },
+                  "r": {
+                    "la": "Deus in medio ejus non commovebitur."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2063,7 +2961,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum. – Luc. 2."
               }
@@ -2075,7 +2973,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2087,25 +2985,64 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nFamulorum tuorum Domine delictis ignosce: ut qui tibi placere de actibus nostris non valemus genetricis Filii tui, Domini Dei nostri intercessione salvemur. Per eumdem Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum.\n℟. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Famulorum tuorum Domine delictis ignosce: ut qui tibi placere de actibus nostris non valemus genetricis Filii tui, Domini Dei nostri intercessione salvemur. Per eumdem Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Ant. (Hic accipimus veniam.)"
               }
@@ -2117,15 +3054,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Dignare me laudare te Virgo sacrata.\n℟. Da mihi virtutem contra hostes tuos."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dignare me laudare te Virgo sacrata."
+                  },
+                  "r": {
+                    "la": "Da mihi virtutem contra hostes tuos."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede nos famulos tuos, quaesumus Domine Deus, perpetua mentis et corporis prosperitate gaudere: et gloriosa beatae Mariae semper Virginis intercessione: a praesenti liberari tristitia: et aeterna perfrui laetitia. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum.\n℟. Amen."
+                "la": "Concede nos famulos tuos, quaesumus Domine Deus, perpetua mentis et corporis prosperitate gaudere: et gloriosa beatae Mariae semper Virginis intercessione: a praesenti liberari tristitia: et aeterna perfrui laetitia. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
@@ -2135,15 +3091,34 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
+                "la": "Initium sancti Evangelii secundum Joannem. – Joann. 1."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Initium sancti Evangelii secundum Joannem. – Joann. 1.\n℟. Gloria tibi Domine.\nIn principio erat Verbum, et Verbum erat apud Deum: et Deus erat Verbum. Hoc erat in principio apud Deum.\nOmnia per ipsum facta sunt: et sine ipso factum est nihil. Quod factum est, in ipso vita erat, et vita erat lux hominum, et lux in tenebris lucet: et tenebrae eam non comprehenderunt.\nFuit homo missus a Deo, cui nomen erat Joannes. Hic venit in testimonium, ut testimonium perhiberet de lumine, ut omnes crederent per illum.\nNon erat ille lux, sed ut testimonium perhiberet de lumine.\nErat lux vera, quae illuminat omnem hominem venientem in hunc mundum. In mundo erat, et mundus per ipsum factus est: et mundus eum non cognovit.\nIn propria venit: et sui eum non receperunt.\nQuotquot autem receperunt eum, dedit eis potestatem filios Dei fieri, his qui credunt in nomine ejus.\nQui non ex sanguinibus, neque ex voluntate carnis, neque ex voluntate viri: sed ex Deo nati sunt."
+                "la": "Gloria tibi Domine."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "In principio erat Verbum, et Verbum erat apud Deum: et Deus erat Verbum. Hoc erat in principio apud Deum.\nOmnia per ipsum facta sunt: et sine ipso factum est nihil. Quod factum est, in ipso vita erat, et vita erat lux hominum, et lux in tenebris lucet: et tenebrae eam non comprehenderunt.\nFuit homo missus a Deo, cui nomen erat Joannes. Hic venit in testimonium, ut testimonium perhiberet de lumine, ut omnes crederent per illum.\nNon erat ille lux, sed ut testimonium perhiberet de lumine.\nErat lux vera, quae illuminat omnem hominem venientem in hunc mundum. In mundo erat, et mundus per ipsum factus est: et mundus eum non cognovit.\nIn propria venit: et sui eum non receperunt.\nQuotquot autem receperunt eum, dedit eis potestatem filios Dei fieri, his qui credunt in nomine ejus.\nQui non ex sanguinibus, neque ex voluntate carnis, neque ex voluntate viri: sed ex Deo nati sunt."
               }
             },
             {
@@ -2161,11 +3136,11 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Amen."
+                "la": "Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2177,13 +3152,19 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nConcede quaesumus omnipotens Deus, ut nos Unigeniti tui nova per carnem nativitas liberet: quos sub peccati jugo vetusta servitus tenet."
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Concede quaesumus omnipotens Deus, ut nos Unigeniti tui nova per carnem nativitas liberet: quos sub peccati jugo vetusta servitus tenet."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -2195,7 +3176,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -2203,17 +3184,56 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Protector in te sperantium Deus, sine quo nihil est validum, nihil sanctum: multiplica super nos misericordiam tuam: ut te rectore, te duce, sic transeamus per bona temporalia, ut non amittamus aeterna. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum.\n℟. Amen."
+                "la": "Protector in te sperantium Deus, sine quo nihil est validum, nihil sanctum: multiplica super nos misericordiam tuam: ut te rectore, te duce, sic transeamus per bona temporalia, ut non amittamus aeterna. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Animae omnium fidelium defunctorum per misericordiam Dei requiescant in pace.\n℟. Amen."
+                "la": "Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Animae omnium fidelium defunctorum per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2225,19 +3245,32 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ave Maria gratia plena.\n℟. Dominus tecum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nFamulorum tuorum, Domine, delictis ignosce, ut qui tibi placere de actibus nostris non valemus, genetricis Filii tui Domini Dei nostri intercessione salvemur."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria gratia plena."
+                  },
+                  "r": {
+                    "la": "Dominus tecum."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Famulorum tuorum, Domine, delictis ignosce, ut qui tibi placere de actibus nostris non valemus, genetricis Filii tui Domini Dei nostri intercessione salvemur."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -2249,7 +3282,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -2257,14 +3290,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ineffabilem misericordiam tuam Domine nobis clementer ostende: ut simul nos et a peccatis exuas, et a poenis et a tribulationibus quas pro his meremur eripias, et pacem tuam nostris concede temporibus: et nos famulos tuos ab omni adversitate custodi. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum.\n℟. Amen."
+                "la": "Ineffabilem misericordiam tuam Domine nobis clementer ostende: ut simul nos et a peccatis exuas, et a poenis et a tribulationibus quas pro his meremur eripias, et pacem tuam nostris concede temporibus: et nos famulos tuos ab omni adversitate custodi. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Benedicamus Domino.\n℟. Deo gratias."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
             }
           ]
         }
@@ -2284,574 +3330,1053 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Introitus."
       }
     },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Salve sancta Parens, enixa puerpera Regem, qui caelum terramque regit in secula seculorum.\n℣. Quia concupivit Rex decorem tuum, quoniam ipse est Dominus Deus tuus, et adorabut eum.\n℣. Gloria Patri, et Filio, et Spiritui Sancto. Sicut erat in principio, et nunc, et semper, et in secula seculorum. Amen.\nSalve sancta Parens, enixa puerpera Regem, qui caelum terramque regit in secula seculorum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Kyrie eleison. Kyrie eleison. Kyrie eleison.\nChriste eleison. Christe eleison. Christe eleison.\nKyrie eleison. Kyrie eleison. Kyrie eleison."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria in excelsis Deo. Et in terra pax hominibus bonae voluntatis. Laudamus te. Benedicimus te. Adoramus te. Glorificamus te. Gratias agimus tibi propter gloriam tuam magnam. Domine Deus, Rex caelestis, Deus Pater omnipotens. Domine Fili Unigenite Jesu Christe. Domine Deus, Agnus Dei, Filius Patris. Qui tollis peccata mundi, miserere nobis. Qui tollis peccata mundi, suscipe deprecationem nostram. Qui sedes ad dexteram Patris, miserere nobis. Quoniam tu solus sanctus. Tu solus Dominus. Tu solus Altissimus Jesu Christe, cum sancto Spiritu in gloria Dei Patris. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nConcede nos famulos tuos, quaesumus Domine Deus, perpetua mentis et corporis prosperitate gaudere: et\ngloriosa beatae Mariae semper Virginis intercessione: a\npraesenti liberari tristitia: et aeterna perfrui laetitia. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum.\n℟. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Lectio libri Ecclesiastici."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Cap. 24"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Ab initio, et ante secula creata sum: et usque ad futurum seculum non desinam: et in habitatione sancta coram ipso ministravi. Et sic in Sion firmata sum, et in civitate sanctificata similiter requievi: et in Jerusalem potestas mea. Et radicavi in populo honorificato, et in parte Dei mei haereditas illius, et in plenitudine sanctorum detentio mea.\n℟. Deo gratias."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℟. Benedicta et venerabilis es Virgo Maria, quae sine tactu pudoris inventa es Mater Salvatoris. Virgo Dei Genitrix, quem totus non capit orbis, in tua se clausit viscera factus homo."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Alleluja.\n℣. Post partum Virgo inviolata permansisti: Dei Genitrix intercede pro nobis, alleluja."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "A Septuagesima usque ad Pascha loco (Alleluja) dicitur Tractus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ave Maria gratia plena, Dominus tecum.\n℣. Benedicta tu in mulieribus, et benedictus fructus ventris tui.\n℣. Ecce concipies, et paries Filium, et vocabitur nomen ejus Emmanuël.\n℣. Quomodo, inquit, fiet istud, quoniam virum non cognosco? Et respondens Angelus, dixit ei.\n℣. Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi.\n℣. Ideoque et quod nascetur ex te sanctum, vocabitur Filius Dei."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "A Paschate usque ad Ascensionem Domini, omisso ℟. Benedicta et ven. dicuntur duo Alleluja."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Alleluja.\n℣. Post partum Virgo inviolata permansisti: Dei Genitrix intercede pro nobis, alleluja.\nAlleluja.\n℣. Non vos relinquam orphanos, vado et venio ad vos: et gaudebit cor vestrum, alleluja."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Per Octavas Pentecostes."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Alleluja.\n℣. Post partum Virgo inviolata permansisti: Dei Genitrix intercede pro nobis, alleluja.\nAlleluja."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hic accipimus veniam."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Veni Sancte Spiritus, reple tuorum corda fidelium: et tui amoris in eis ignem acćende, alleluja."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Diaconus, vel Sacerdos dicunt, ℣. Dominus vobiscum, solus non respondet, Et cum spiritu tuo.\nAlii dicunt, ℣. Domine exaudi orationem meam. ℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sequentia sancti Evangelii: secundum Lucam."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Luc. 11."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℟. Gloria tibi Domine.\nIn illo tempore: Extollens vocem quaedam mulier de turba: dixit Jesu. Beatus venter, qui te portavit: et ubera quae suxisti. At ille dixit. Quinimmo, beati qui audiunt verbum Dei, et custodiunt illud.\n℟. Laus tibi, Christe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Offertorium."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hic accipimus veniam."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Ave Maria gratia plena, Dominus tecum: benedicta tu in mulieribus, et benedictus fructus ventris tui."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Communio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Beata viscera Mariae Virginis, quae portaverunt aeterni Patris Filium.\n℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nGratiam tuam Domine mentibus nostris infunde: ut quiAngelo nuntiante, Christi Filii tui Incarnationem cognovimus: per Passionem ejus et Crucem, ad resurrectionis gloriam perducamur: Per eumdem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum.\n℟. Amen.\n℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Initium sancti Evangelii: secundum Joannem."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Joann. 1."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℟. Gloria tibi Domine."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "In principio erat Verbum, et Verbum erat apud Deum: et Deus erat Verbum. Hoc erat in principio apud Deum. Omnia per ipsum facta sunt: et sine ipso factum est nihil. Quod factum est, in ipso vita erat, et vita erat lux hominum, et lux in tenebris lucet: et tenebrae eam non\ncomprehenderunt. Fuit homo missus a Deo, cui nomen erat Joannes. Hic venit in testimonium, ut testimonium perhiberet de lumine, ut omnes crederent per illum. Non erat ille lux, sed ut testimonium perhiberet de lumine. Erat lux vera, quae illuminat omnem hominem venientem in hunc mundum. In mundo erat, et mundus per ipsum factus est: et mundus eum non cognovit. In propria venit: et sui eum non receperunt. Quotquot autem receperunt eum, dedit eis potestatem filios\nDei fieri, his qui credunt in nomine ejus. Qui non ex sanguinibus, neque ex voluntate carnis, neque ex voluntate viri: sed ex Deo nati sunt. Hic accipimus veniam. Et Verbum caro factum est, et habitavit in nobis. Et vidimus gloriam ejus, gloriam quasi Unigeniti a Patre plenum gratiae et veritatis.\n℟. Amen."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Antiphon"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Te decet laus, te decet hymnus, tibi gloria Deo Patri, et Filio, cum Sancto Spiritu in secula seculorum. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nConcede quaesumus omnipotens Deus, ut nos Unigeniti tui nova per carnem nativitas liberet: quos sub peccati jugo\nvetusta servitus tenet."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Oratio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Deus illuminator omnium gentium, da populis tuis perpetua pace gaudere: et illud lumen splendidum\ninfunde cordibus nostris: quod trium Magorum mentibus aspirasti Dominum nostrum Jesum Christum Filium tuum."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Oratio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Protector in te sperantium Deus, sine quo nihil est validum, nihil sanctum: multiplica super nos\nmisericordiam tuam: ut te rectore, te duce, sic transeamus per bona temporalia, ut non amittamus aeterna. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum.\n℟. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Animae omnium fidelium defunctorum per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Antiphon"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Salve Regina misericordiae, vitae dulcedo, et spes nostra salve: ad te clamamus exules filii Hevae, ad te suspiramus, gementes et flentes, in hac lacrymarum valle. Eia ergo advocata nostra, illos tuos misericordes oculos ad nos converte. Et Jesum benedictum fructum ventris tui nobis post hoc exilium ostende benignum. O clemens, o pia, o dulcis Maria."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ave Maria gratia plena.\n℟. Dominus tecum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nFamulorum tuorum, Domine, delictis ignosce, ut qui tibi placere de actibus nostris non valemus, genetricis Filii tui Domini Dei nostri intercessione salvemur."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Oratio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Ecclesiae tuae Domine, preces placatus admitte: ut destructis adversitatibus et erroribus universis, secura\ntibi serviat libertate."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Oratio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Ineffabilem misericordiam tuam Domine nobis clementer ostende: ut simul nos et a peccatis exuas, et a poenis et a tribulationibus quas pro his meremur eripias, et pacem tuam nostris concede temporibus: et nos famulos tuos ab omni adversitate custodi. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum.\n℟. Amen.\n℣. Benedicamus Domino.\n℟. Deo gratias."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Tempus Adventus"
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Introitus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Rorate caeli desuper, et nubes pluant justum: aperiantur terra, et germinet Salvatorem.\nPsalm. Caeli enarrant gloriam Dei: et opera manuum ejus annuntiat firmamentum.\n℟. Gloria Patri, et Filio, et Spiritui Sancto. Sicut erat in principio, et nunc, et semper, et in secula seculorum. Amen.\nRorate caeli desuper, et nubes pluant justum: aperiantur terra, et germinet Salvatorem."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Kyrie eleison. Kyrie eleison. Kyrie eleison.\nChriste eleison. Christe eleison. Christe eleison.\nKyrie eleison. Kyrie eleison. Kyrie eleison."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui de beatae Mariae Virginis utero Verbum tuum,\nAngelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis, ut qui verè eam Genitricem Dei credimus: ejus apud te intercessionibus adjuvemur. Per eumdem Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum.\n℟. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Lectio Isaiae Prophetae."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Cap. 7."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "In diebus illis: Locutus est Dominus ad Achaz, dicens. Pete tibi signum a Domino Deo tuo in profundum inferni, sive in excelsum supra. Et dixit Achaz. Non petam, et non tentabo Dominum. Et dixit. Audite ergo domus David. Nunquid parum vobis est molestos esse hominibus, quia molesti estis et Deo meo? Propter hoc, dabit Dominus ipse vobis signum. Ecce virgo concipiet, et pariet filium: et vocabitur nomen ejus Emmanuël. Butyrum et mel comedet: ut sciat reprobare malum, et eligere bonum.\n℟. Deo gratias."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℟. Prope est Dominus omnibus invocantibus eum: omnibus qui invocant eum in veritate.\n℣. Laudem Domini loquetur os meum, et benedicat omnis caro nomen sanctum ejus. Alleluja.\n℣. Excita Domine potentiam tuam, et veni: ut salvos facias nos. Alleluja."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sequentia sancti Evangelii: secundum Lucam."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Luc. 1."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℟. Gloria tibi Domine.\nIn illo tempore: Missus est Angelus Gabriël a Deo in civitatem Galilaeae, cui nomen Nazareth ad Virginem desponsatam viro, cui nomen erat Joseph, de domo David: et nomen Virginis Maria. Et ingressus Angelus ad eam: dixit. Ave gratia plena, Dominus tecum: benedicta tu in mulieribus. Quae cum audisset, turbata est in sermone ejus: et cogitabat qualis esset ista salutatio. Et ait Angelus ei. Ne timeas Maria: invenisti enim gratiam apud Deum. Ecce concipies in utero, et paries Filium: et vocabis nomen ejus Jesum. Hic erit magnus: et Filius Altissimi vocabitur. Et dabit illi Dominus Deus sedem David patris ejus, et regnabit in domo Jacob in aeternum: et regni ejus non erit finis. Dixit autem Maria ad Angelum. Quomodo fiet istud, quoniam virum non cognosco? Et respondens Angelus, dixit ei. Spiritus Sanctus superveniet in te: et virtus Altissimi obumbrabit tibi. Ideoque et quod nascetur ex te sanctum, vocabitur Filius Dei. Et ecce Elizabeth cognata tua, et ipsa concepit filium in senectute sua. Et hic mensis sextus est illi, quae vocatur sterilis: quia non erit impossibile apud Deum omne verbum. Dixit autem Maria. Ecce Ancilla Domini: fiat mihi secundum verbum tuum.\n℟. Laus tibi, Christe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Offertorium."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hic accipimus veniam."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Ave Maria gratia plena, Dominus tecum, benedicta tu in mulieribus, et benedictus fructus ventris tui."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Communio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Ecce virgo concipiet, et pariet filium, et vocabitur nomen ejus Emmanuël."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nGratiam tuam Domine mentibus nostris infunde: ut qui Angelo nuntiante, Christi Filii tui Incarnationem cognovimus: per Passionem ejus et Crucem, ad resurrectionis gloriam perducamur: Per eumdem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum.\n℟. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Initium sancti Evangelii: secundum Joannem."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Joann. 1."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℟. Gloria tibi Domine.\nIn principio erat Verbum, et Verbum erat apud Deum: et Deus erat Verbum. Hoc erat in principio apud Deum. Omnia per ipsum facta sunt: et sine ipso factum est nihil. Quod factum est, in ipso vita erat, et vita erat lux hominum, et lux in tenebris lucet: et tenebrae eam non\ncomprehenderunt. Fuit homo missus a Deo, cui nomen erat Joannes. Hic venit in testimonium, ut testimonium perhiberet de lumine, ut omnes crederent per illum. Non erat ille lux, sed ut testimonium perhiberet de lumine. Erat lux vera, quae illuminat omnem hominem venientem in hunc mundum. In mundo erat, et mundus per ipsum factus est: et mundus eum non cognovit. In propria venit: et sui eum non receperunt. Quotquot autem receperunt eum, dedit eis potestatem filios\nDei fieri, his qui credunt in nomine ejus. Qui non ex sanguinibus, neque ex voluntate carnis, neque ex voluntate viri: sed ex Deo nati sunt. Hic accipimus veniam. Et Verbum caro factum est, et habitavit in nobis. Et vidimus gloriam ejus, gloriam quasi Unigeniti a Patre plenum gratiae et veritatis.\n℟. Amen."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Antiphon"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Te decet laus, te decet hymnus, tibi gloria Deo Patri, et Filio, cum Sancto Spiritu in secula seculorum. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nConcede quaesumus omnipotens Deus, ut nos Unigeniti tui nova per carnem nativitas liberet: quos sub peccati jugo\nvetusta servitus tenet."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Oratio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Deus illuminator omnium gentium, da populis tuis perpetua pace gaudere: et illud lumen splendidum\ninfunde cordibus nostris: quod trium Magorum mentibus aspirasti Dominum nostrum Jesum Christum Filium tuum.]]"
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Oratio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Protector in te sperantium Deus, sine quo nihil est validum, nihil sanctum: multiplica super nos misericordiam tuam: ut te rectore, te duce, sic transeamus per bona temporalia, ut non amittamus aeterna. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum.\n℟. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam. (vel ℣. Dominus vobiscum.)\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Animae omnium fidelium defunctorum per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Antiphon"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Salve Regina misericordiae, vitae dulcedo, et spes nostra salve: ad te clamamus exules filii Hevae, ad te suspiramus, gementes et flentes, in hac lacrymarum valle. Eia ergo advocata nostra, illos tuos misericordes oculos ad nos converte. Et Jesum benedictum fructum ventris tui nobis post hoc exilium ostende benignum. O clemens, o pia, o dulcis Maria."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ave Maria gratia plena.\n℟. Dominus tecum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nFamulorum tuorum, Domine, delictis ignosce, ut qui tibi placere de actibus nostris non valemus, genetricis Filii tui Domini Dei nostri intercessione salvemur."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Oratio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Ecclesiae tuae Domine, preces placatus admitte: ut destructis adversitatibus et erroribus universis, secura\ntibi serviat libertate."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Oratio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Ineffabilem misericordiam tuam Domine nobis clementer ostende: ut simul nos et a peccatis exuas, et a poenis et a\ntribulationibus quas pro his meremur eripias, et pacem tuam nostris concede temporibus: et nos famulos tuos ab omni adversitate custodi. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum.\n℟. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedicamus Domino.\n℟. Deo gratias."
-              }
-            }
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Salve sancta Parens, enixa puerpera Regem, qui caelum terramque regit in secula seculorum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Quia concupivit Rex decorem tuum, quoniam ipse est Dominus Deus tuus, et adorabut eum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Gloria Patri, et Filio, et Spiritui Sancto. Sicut erat in principio, et nunc, et semper, et in secula seculorum. Amen."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Salve sancta Parens, enixa puerpera Regem, qui caelum terramque regit in secula seculorum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Kyrie eleison. Kyrie eleison. Kyrie eleison.\nChriste eleison. Christe eleison. Christe eleison.\nKyrie eleison. Kyrie eleison. Kyrie eleison."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Gloria in excelsis Deo. Et in terra pax hominibus bonae voluntatis. Laudamus te. Benedicimus te. Adoramus te. Glorificamus te. Gratias agimus tibi propter gloriam tuam magnam. Domine Deus, Rex caelestis, Deus Pater omnipotens. Domine Fili Unigenite Jesu Christe. Domine Deus, Agnus Dei, Filius Patris. Qui tollis peccata mundi, miserere nobis. Qui tollis peccata mundi, suscipe deprecationem nostram. Qui sedes ad dexteram Patris, miserere nobis. Quoniam tu solus sanctus. Tu solus Dominus. Tu solus Altissimus Jesu Christe, cum sancto Spiritu in gloria Dei Patris. Amen."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+          },
+          "r": {
+            "la": "Et clamor meus ad te veniat."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Concede nos famulos tuos, quaesumus Domine Deus, perpetua mentis et corporis prosperitate gaudere: et\ngloriosa beatae Mariae semper Virginis intercessione: a\npraesenti liberari tristitia: et aeterna perfrui laetitia. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Amen."
+      }
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Lectio libri Ecclesiastici."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Cap. 24"
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Ab initio, et ante secula creata sum: et usque ad futurum seculum non desinam: et in habitatione sancta coram ipso ministravi. Et sic in Sion firmata sum, et in civitate sanctificata similiter requievi: et in Jerusalem potestas mea. Et radicavi in populo honorificato, et in parte Dei mei haereditas illius, et in plenitudine sanctorum detentio mea."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Deo gratias."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Benedicta et venerabilis es Virgo Maria, quae sine tactu pudoris inventa es Mater Salvatoris. Virgo Dei Genitrix, quem totus non capit orbis, in tua se clausit viscera factus homo."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Alleluja."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Post partum Virgo inviolata permansisti: Dei Genitrix intercede pro nobis, alleluja."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "A Septuagesima usque ad Pascha loco (Alleluja) dicitur Tractus."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Ave Maria gratia plena, Dominus tecum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Ecce concipies, et paries Filium, et vocabitur nomen ejus Emmanuël."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Quomodo, inquit, fiet istud, quoniam virum non cognosco? Et respondens Angelus, dixit ei."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Ideoque et quod nascetur ex te sanctum, vocabitur Filius Dei."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "A Paschate usque ad Ascensionem Domini, omisso responsum Benedicta et ven. dicuntur duo Alleluja."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Alleluja."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Post partum Virgo inviolata permansisti: Dei Genitrix intercede pro nobis, alleluja."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Alleluja."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Non vos relinquam orphanos, vado et venio ad vos: et gaudebit cor vestrum, alleluja."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Per Octavas Pentecostes."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Alleluja."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Post partum Virgo inviolata permansisti: Dei Genitrix intercede pro nobis, alleluja."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Alleluja."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Hic accipimus veniam."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Veni Sancte Spiritus, reple tuorum corda fidelium: et tui amoris in eis ignem acćende, alleluja."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Diaconus, vel Sacerdos dicunt, versus Dominus vobiscum, solus non respondet, Et cum spiritu tuo.\nAlii dicunt, versus Domine exaudi orationem meam. responsum Et clamor meus ad te veniat."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Sequentia sancti Evangelii: secundum Lucam."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Luc. 11."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Gloria tibi Domine."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "In illo tempore: Extollens vocem quaedam mulier de turba: dixit Jesu. Beatus venter, qui te portavit: et ubera quae suxisti. At ille dixit. Quinimmo, beati qui audiunt verbum Dei, et custodiunt illud."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Laus tibi, Christe."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+          },
+          "r": {
+            "la": "Et clamor meus ad te veniat."
+          }
+        }
+      ]
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Offertorium."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Hic accipimus veniam."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Ave Maria gratia plena, Dominus tecum: benedicta tu in mulieribus, et benedictus fructus ventris tui."
+      }
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Communio."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Beata viscera Mariae Virginis, quae portaverunt aeterni Patris Filium."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+          },
+          "r": {
+            "la": "Et clamor meus ad te veniat."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Gratiam tuam Domine mentibus nostris infunde: ut quiAngelo nuntiante, Christi Filii tui Incarnationem cognovimus: per Passionem ejus et Crucem, ad resurrectionis gloriam perducamur: Per eumdem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Amen."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+          },
+          "r": {
+            "la": "Et clamor meus ad te veniat."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Benedicamus Domino."
+          },
+          "r": {
+            "la": "Deo gratias."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+          },
+          "r": {
+            "la": "Et clamor meus ad te veniat."
+          }
+        }
+      ]
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Initium sancti Evangelii: secundum Joannem."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Joann. 1."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Gloria tibi Domine."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "In principio erat Verbum, et Verbum erat apud Deum: et Deus erat Verbum. Hoc erat in principio apud Deum. Omnia per ipsum facta sunt: et sine ipso factum est nihil. Quod factum est, in ipso vita erat, et vita erat lux hominum, et lux in tenebris lucet: et tenebrae eam non\ncomprehenderunt. Fuit homo missus a Deo, cui nomen erat Joannes. Hic venit in testimonium, ut testimonium perhiberet de lumine, ut omnes crederent per illum. Non erat ille lux, sed ut testimonium perhiberet de lumine. Erat lux vera, quae illuminat omnem hominem venientem in hunc mundum. In mundo erat, et mundus per ipsum factus est: et mundus eum non cognovit. In propria venit: et sui eum non receperunt. Quotquot autem receperunt eum, dedit eis potestatem filios\nDei fieri, his qui credunt in nomine ejus. Qui non ex sanguinibus, neque ex voluntate carnis, neque ex voluntate viri: sed ex Deo nati sunt. Hic accipimus veniam. Et Verbum caro factum est, et habitavit in nobis. Et vidimus gloriam ejus, gloriam quasi Unigeniti a Patre plenum gratiae et veritatis."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Amen."
+      }
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Antiphon"
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Te decet laus, te decet hymnus, tibi gloria Deo Patri, et Filio, cum Sancto Spiritu in secula seculorum. Amen."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Concede quaesumus omnipotens Deus, ut nos Unigeniti tui nova per carnem nativitas liberet: quos sub peccati jugo\nvetusta servitus tenet."
+      }
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Oratio."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Deus illuminator omnium gentium, da populis tuis perpetua pace gaudere: et illud lumen splendidum\ninfunde cordibus nostris: quod trium Magorum mentibus aspirasti Dominum nostrum Jesum Christum Filium tuum."
+      }
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Oratio."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Protector in te sperantium Deus, sine quo nihil est validum, nihil sanctum: multiplica super nos\nmisericordiam tuam: ut te rectore, te duce, sic transeamus per bona temporalia, ut non amittamus aeterna. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Amen."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+          },
+          "r": {
+            "la": "Et clamor meus ad te veniat."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Benedicamus Domino."
+          },
+          "r": {
+            "la": "Deo gratias."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Animae omnium fidelium defunctorum per misericordiam Dei requiescant in pace."
+          },
+          "r": {
+            "la": "Amen."
+          }
+        }
+      ]
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Antiphon"
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Salve Regina misericordiae, vitae dulcedo, et spes nostra salve: ad te clamamus exules filii Hevae, ad te suspiramus, gementes et flentes, in hac lacrymarum valle. Eia ergo advocata nostra, illos tuos misericordes oculos ad nos converte. Et Jesum benedictum fructum ventris tui nobis post hoc exilium ostende benignum. O clemens, o pia, o dulcis Maria."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ave Maria gratia plena."
+          },
+          "r": {
+            "la": "Dominus tecum."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Famulorum tuorum, Domine, delictis ignosce, ut qui tibi placere de actibus nostris non valemus, genetricis Filii tui Domini Dei nostri intercessione salvemur."
+      }
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Oratio."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Ecclesiae tuae Domine, preces placatus admitte: ut destructis adversitatibus et erroribus universis, secura\ntibi serviat libertate."
+      }
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Oratio."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Ineffabilem misericordiam tuam Domine nobis clementer ostende: ut simul nos et a peccatis exuas, et a poenis et a tribulationibus quas pro his meremur eripias, et pacem tuam nostris concede temporibus: et nos famulos tuos ab omni adversitate custodi. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Amen."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Benedicamus Domino."
+          },
+          "r": {
+            "la": "Deo gratias."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Tempus Adventus"
+      }
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Introitus."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Rorate caeli desuper, et nubes pluant justum: aperiantur terra, et germinet Salvatorem."
+      }
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Psalm. Caeli enarrant gloriam Dei: et opera manuum ejus annuntiat firmamentum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Gloria Patri, et Filio, et Spiritui Sancto. Sicut erat in principio, et nunc, et semper, et in secula seculorum. Amen."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Rorate caeli desuper, et nubes pluant justum: aperiantur terra, et germinet Salvatorem."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Kyrie eleison. Kyrie eleison. Kyrie eleison.\nChriste eleison. Christe eleison. Christe eleison.\nKyrie eleison. Kyrie eleison. Kyrie eleison."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+          },
+          "r": {
+            "la": "Et clamor meus ad te veniat."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Deus, qui de beatae Mariae Virginis utero Verbum tuum,\nAngelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis, ut qui verè eam Genitricem Dei credimus: ejus apud te intercessionibus adjuvemur. Per eumdem Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Amen."
+      }
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Lectio Isaiae Prophetae."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Cap. 7."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "In diebus illis: Locutus est Dominus ad Achaz, dicens. Pete tibi signum a Domino Deo tuo in profundum inferni, sive in excelsum supra. Et dixit Achaz. Non petam, et non tentabo Dominum. Et dixit. Audite ergo domus David. Nunquid parum vobis est molestos esse hominibus, quia molesti estis et Deo meo? Propter hoc, dabit Dominus ipse vobis signum. Ecce virgo concipiet, et pariet filium: et vocabitur nomen ejus Emmanuël. Butyrum et mel comedet: ut sciat reprobare malum, et eligere bonum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Deo gratias."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Prope est Dominus omnibus invocantibus eum: omnibus qui invocant eum in veritate."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Laudem Domini loquetur os meum, et benedicat omnis caro nomen sanctum ejus. Alleluja."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Excita Domine potentiam tuam, et veni: ut salvos facias nos. Alleluja."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+          },
+          "r": {
+            "la": "Et clamor meus ad te veniat."
+          }
+        }
+      ]
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Sequentia sancti Evangelii: secundum Lucam."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Luc. 1."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Gloria tibi Domine."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "In illo tempore: Missus est Angelus Gabriël a Deo in civitatem Galilaeae, cui nomen Nazareth ad Virginem desponsatam viro, cui nomen erat Joseph, de domo David: et nomen Virginis Maria. Et ingressus Angelus ad eam: dixit. Ave gratia plena, Dominus tecum: benedicta tu in mulieribus. Quae cum audisset, turbata est in sermone ejus: et cogitabat qualis esset ista salutatio. Et ait Angelus ei. Ne timeas Maria: invenisti enim gratiam apud Deum. Ecce concipies in utero, et paries Filium: et vocabis nomen ejus Jesum. Hic erit magnus: et Filius Altissimi vocabitur. Et dabit illi Dominus Deus sedem David patris ejus, et regnabit in domo Jacob in aeternum: et regni ejus non erit finis. Dixit autem Maria ad Angelum. Quomodo fiet istud, quoniam virum non cognosco? Et respondens Angelus, dixit ei. Spiritus Sanctus superveniet in te: et virtus Altissimi obumbrabit tibi. Ideoque et quod nascetur ex te sanctum, vocabitur Filius Dei. Et ecce Elizabeth cognata tua, et ipsa concepit filium in senectute sua. Et hic mensis sextus est illi, quae vocatur sterilis: quia non erit impossibile apud Deum omne verbum. Dixit autem Maria. Ecce Ancilla Domini: fiat mihi secundum verbum tuum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Laus tibi, Christe."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+          },
+          "r": {
+            "la": "Et clamor meus ad te veniat."
+          }
+        }
+      ]
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Offertorium."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Hic accipimus veniam."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Ave Maria gratia plena, Dominus tecum, benedicta tu in mulieribus, et benedictus fructus ventris tui."
+      }
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Communio."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Ecce virgo concipiet, et pariet filium, et vocabitur nomen ejus Emmanuël."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+          },
+          "r": {
+            "la": "Et clamor meus ad te veniat."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Gratiam tuam Domine mentibus nostris infunde: ut qui Angelo nuntiante, Christi Filii tui Incarnationem cognovimus: per Passionem ejus et Crucem, ad resurrectionis gloriam perducamur: Per eumdem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Amen."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+          },
+          "r": {
+            "la": "Et clamor meus ad te veniat."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Benedicamus Domino."
+          },
+          "r": {
+            "la": "Deo gratias."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+          },
+          "r": {
+            "la": "Et clamor meus ad te veniat."
+          }
+        }
+      ]
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Initium sancti Evangelii: secundum Joannem."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Joann. 1."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Gloria tibi Domine."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "In principio erat Verbum, et Verbum erat apud Deum: et Deus erat Verbum. Hoc erat in principio apud Deum. Omnia per ipsum facta sunt: et sine ipso factum est nihil. Quod factum est, in ipso vita erat, et vita erat lux hominum, et lux in tenebris lucet: et tenebrae eam non\ncomprehenderunt. Fuit homo missus a Deo, cui nomen erat Joannes. Hic venit in testimonium, ut testimonium perhiberet de lumine, ut omnes crederent per illum. Non erat ille lux, sed ut testimonium perhiberet de lumine. Erat lux vera, quae illuminat omnem hominem venientem in hunc mundum. In mundo erat, et mundus per ipsum factus est: et mundus eum non cognovit. In propria venit: et sui eum non receperunt. Quotquot autem receperunt eum, dedit eis potestatem filios\nDei fieri, his qui credunt in nomine ejus. Qui non ex sanguinibus, neque ex voluntate carnis, neque ex voluntate viri: sed ex Deo nati sunt. Hic accipimus veniam. Et Verbum caro factum est, et habitavit in nobis. Et vidimus gloriam ejus, gloriam quasi Unigeniti a Patre plenum gratiae et veritatis."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Amen."
+      }
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Antiphon"
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Te decet laus, te decet hymnus, tibi gloria Deo Patri, et Filio, cum Sancto Spiritu in secula seculorum. Amen."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Concede quaesumus omnipotens Deus, ut nos Unigeniti tui nova per carnem nativitas liberet: quos sub peccati jugo\nvetusta servitus tenet."
+      }
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Oratio."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Deus illuminator omnium gentium, da populis tuis perpetua pace gaudere: et illud lumen splendidum\ninfunde cordibus nostris: quod trium Magorum mentibus aspirasti Dominum nostrum Jesum Christum Filium tuum.]]"
+      }
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Oratio."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Protector in te sperantium Deus, sine quo nihil est validum, nihil sanctum: multiplica super nos misericordiam tuam: ut te rectore, te duce, sic transeamus per bona temporalia, ut non amittamus aeterna. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus: per omnia secula seculorum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Amen."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine exaudi orationem meam. (vel Dominus vobiscum.)"
+          },
+          "r": {
+            "la": "Et clamor meus ad te veniat."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Benedicamus Domino."
+          },
+          "r": {
+            "la": "Deo gratias."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Animae omnium fidelium defunctorum per misericordiam Dei requiescant in pace."
+          },
+          "r": {
+            "la": "Amen."
+          }
+        }
+      ]
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Antiphon"
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Salve Regina misericordiae, vitae dulcedo, et spes nostra salve: ad te clamamus exules filii Hevae, ad te suspiramus, gementes et flentes, in hac lacrymarum valle. Eia ergo advocata nostra, illos tuos misericordes oculos ad nos converte. Et Jesum benedictum fructum ventris tui nobis post hoc exilium ostende benignum. O clemens, o pia, o dulcis Maria."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ave Maria gratia plena."
+          },
+          "r": {
+            "la": "Dominus tecum."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Famulorum tuorum, Domine, delictis ignosce, ut qui tibi placere de actibus nostris non valemus, genetricis Filii tui Domini Dei nostri intercessione salvemur."
+      }
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Oratio."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Ecclesiae tuae Domine, preces placatus admitte: ut destructis adversitatibus et erroribus universis, secura\ntibi serviat libertate."
+      }
+    },
+    {
+      "type": "subheading",
+      "text": {
+        "la": "Oratio."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Ineffabilem misericordiam tuam Domine nobis clementer ostende: ut simul nos et a peccatis exuas, et a poenis et a\ntribulationibus quas pro his meremur eripias, et pacem tuam nostris concede temporibus: et nos famulos tuos ab omni adversitate custodi. Per Dominum nostrum, Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia secula seculorum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Amen."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Benedicamus Domino."
+          },
+          "r": {
+            "la": "Deo gratias."
+          }
+        }
+      ]
+    }
   ]
 }

--- a/content/practices/little-office-bvm-cistercian/flow.json
+++ b/content/practices/little-office-bvm-cistercian/flow.json
@@ -45,19 +45,52 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, labia ✠ ea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia ✠ ea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Invitatory"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -69,7 +102,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -81,7 +114,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm 94"
               }
@@ -93,7 +126,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -105,7 +138,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -117,43 +150,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Quem terra, pontus, aethera\nColunt, adorant, praedicant,\nTrinam regentem machinam,\nClaustrum Mariae bajulat."
+                "la": "Quem terra, pontus, aethera\nColunt, adorant, praedicant,\nTrinam regentem machinam,\nClaustrum Mariae bajulat.\n\nCui luna, sol, et omnia\nDeserviunt per tempora,\nPerfusa caeli gratia,\nGestant puellae viscera.\n\nBeata Mater munere,\nCujus supernus artifex\nMundum pugillo continens,\nVentris sub arca clausus est.\n\nBeata caeli nuntio,\nFoecunda sancto Spiritu,\nDesideratus gentibus,\nCujus per alvum fusus est.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Cui luna, sol, et omnia\nDeserviunt per tempora,\nPerfusa caeli gratia,\nGestant puellae viscera."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Beata Mater munere,\nCujus supernus artifex\nMundum pugillo continens,\nVentris sub arca clausus est."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Beata caeli nuntio,\nFoecunda sancto Spiritu,\nDesideratus gentibus,\nCujus per alvum fusus est."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm 8"
               }
@@ -165,7 +174,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 18"
               }
@@ -177,7 +186,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 23"
               }
@@ -189,7 +198,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -201,13 +210,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ave, Maria, gratia plena.\n℟. Dominus tecum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave, Maria, gratia plena."
+                  },
+                  "r": {
+                    "la": "Dominus tecum."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "The Blessing"
               }
@@ -215,11 +231,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Jube, domne, benedicere.\nAlma Virgo virginum, intercedat pro nobis ad Dominum.\n℟. Amen."
+                "la": "Jube, domne, benedicere."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Alma Virgo virginum, intercedat pro nobis ad Dominum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio Brevis - S. Aug. Serm. 18. de Sacntis."
               }
@@ -227,13 +255,25 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Admitte, piissima Dei Genetrix, preces nostras infra sacrarium exauditionis et reporta nobis antidotum reconciliationis. Sit per te excusabile, quod per te ingerimus: fiat impetrabile, quod fida mente poscimus. Accipe quod offerimus, redona quod rogamus, excusa quod timemus.\nTu autem, Domine, miserere nobis.\n℟. Deo gratias."
+                "la": "Admitte, piissima Dei Genetrix, preces nostras infra sacrarium exauditionis et reporta nobis antidotum reconciliationis. Sit per te excusabile, quod per te ingerimus: fiat impetrabile, quod fida mente poscimus. Accipe quod offerimus, redona quod rogamus, excusa quod timemus.\nTu autem, Domine, miserere nobis."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. br. Dignare me laudare te. Virgo sacrata. Dignare me.\n℣. Da mihi virtutem contra hostes tuos. Virgo."
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "br. Dignare me laudare te. Virgo sacrata. Dignare me."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Da mihi virtutem contra hostes tuos. Virgo."
               }
             }
           ]
@@ -259,13 +299,33 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (Outside Lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (Outside Lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Psalm 92"
               }
@@ -277,7 +337,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 99"
               }
@@ -289,7 +349,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 62"
               }
@@ -301,7 +361,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Trium Puerorum"
               }
@@ -313,7 +373,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 148"
               }
@@ -321,11 +381,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudate Dominum de caelis: laudate eum in excelsis.\nLaudate eum, omnes angeli ejus: laudate eum, omnes virtutes ejus.\nLaudate eum, sol et luna: laudate eum, omnes stellae et lumen.\nLaudate eum, caeli caelorum: et aquae omnes, quae super caelos sunt, laudent nomen Domini.\nQuia ipse dixit, et facta sunt: ipse mandavit, et creata sunt.\nStatuit ea in aeternum, et in saeculum saeculi: praeceptum posuit, et non praeteribit.\nLaudate Dominum de terra, dracones, et omnes abyssi.\nIgnis, grando, nix, glacies, spiritus procellarum: quae faciunt verbum ejus:\nMontes, et omnes colles: ligna fructifera, et omnes cedri.\nBestiae, et universa pecora: serpentes, et volucres pennatae:\nReges terrae, et omnes populi: principes, et omnes judices terrae.\nJuvenes, et virgines: senes cum junioribus laudent nomen Domini: quia exaltatum est nomen ejus solius.\nConfessio ejus super caelum et terram: et exaltavit cornu populi sui.\nHymnus omnibus sanctis ejus: filiis Israel, populo appropinquanti sibi."
+                "la": "Laudate Dominum de caelis: laudate eum in excelsis.\nLaudate eum, omnes angeli ejus: laudate eum, omnes virtutes ejus.\nLaudate eum, sol et luna: laudate eum, omnes stellae et lumen.\nLaudate eum, caeli caelorum: et aquae omnes, quae super caelos sunt, laudent nomen Domini.\nQuia ipse dixit, et facta sunt: ipse mandavit, et creata sunt.\nStatuit ea in aeternum, et in saeculum saeculi: praeceptum posuit, et non praeteribit.\nLaudate Dominum de terra, dracones, et omnes abyssi.\nIgnis, grando, nix, glacies, spiritus procellarum: quae faciunt verbum ejus:\nMontes, et omnes colles: ligna fructifera, et omnes cedri.\nBestiae, et universa pecora: serpentes, et volucres pennatae:\nReges terrae, et omnes populi: principes, et omnes judices terrae.\nJuvenes, et virgines: senes cum junioribus laudent nomen Domini: quia exaltatum est nomen ejus solius.\nConfessio ejus super caelum et terram: et exaltavit cornu populi sui."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus omnibus sanctis ejus: filiis Israel, populo appropinquanti sibi."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Psalm 149"
               }
@@ -337,7 +403,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 150"
               }
@@ -349,7 +415,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -361,7 +427,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum - Eccli. 24"
               }
@@ -369,53 +435,54 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "In omnibus requiem quaesivi, et in hereditate Domini morabor. Tunc praecepit, et dixit mihi Creator omnium, et qui creavit me, requievit in tabernaculo meo.\n℟. Deo gratias."
+                "la": "In omnibus requiem quaesivi, et in hereditate Domini morabor. Tunc praecepit, et dixit mihi Creator omnium, et qui creavit me, requievit in tabernaculo meo."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. b. Ave Maria, gratia plena: Dominus tecum. Ave Maria.\n℣. Benedicta tu in mulieribus. Dominus tecum."
+                "la": "Deo gratias."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "b. Ave Maria, gratia plena: Dominus tecum. Ave Maria."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Benedicta tu in mulieribus. Dominus tecum."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O gloriosa Domina,\nExcelsa super sidera:\nQui te creavit, provide\nLactasti sacro ubere."
+                "la": "O gloriosa Domina,\nExcelsa super sidera:\nQui te creavit, provide\nLactasti sacro ubere.\n\nQuod Heva tristis abstulit,\nTu reddis almo germine:\nIntrent ut astra flebiles,\nCaeli fenestra facta es.\n\nTu Regis alti janua,\nEt porta lucis fulgida:\nVitam datam per Virginem,\nGentes redemptae, plaudite.\n\nGloria tibi Domine,\nQui natus es de Virgine,\nCum Patre et Sancto Spiritu,\nIn sempiterna saecula. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Quod Heva tristis abstulit,\nTu reddis almo germine:\nIntrent ut astra flebiles,\nCaeli fenestra facta es."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Speciosa facta es et suavis."
+                  },
+                  "r": {
+                    "la": "In deliciis tuis, sancta Dei Genitrix."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Tu Regis alti janua,\nEt porta lucis fulgida:\nVitam datam per Virginem,\nGentes redemptae, plaudite."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi Domine,\nQui natus es de Virgine,\nCum Patre et Sancto Spiritu,\nIn sempiterna saecula. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Speciosa facta es et suavis.\n℟. In deliciis tuis, sancta Dei Genitrix."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Canticle of the Zachary - Lk 1"
               }
@@ -427,7 +494,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -439,22 +506,42 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Collect"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis sanitate gaudere: et gloriosa beatae Mariae semper virginis intercessione, a praesenti liberari tristitia, et aeterna perfrui laetitia. Per Christum Dominum nostrum.\n℟. Amen."
+                "la": "Concede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis sanitate gaudere: et gloriosa beatae Mariae semper virginis intercessione, a praesenti liberari tristitia, et aeterna perfrui laetitia. Per Christum Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
@@ -464,13 +551,13 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Commemoration of the Saints"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -478,19 +565,44 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancti Dei omnes, intercedere dignemini pro nostra omniumque salute.\n℣. Laetamini in Domino et exsultate, justi.\n℟. Et gloriamini, omnes recti corde."
+                "la": "Sancti Dei omnes, intercedere dignemini pro nostra omniumque salute."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Laetamini in Domino et exsultate, justi."
+                  },
+                  "r": {
+                    "la": "Et gloriamini, omnes recti corde."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nInfirmitatem nostram, quaesumus, Domine, propitius respice: et mala omnia quae juste meremur, omnium Sanctorum tuorum intercessione averte. Per Christum Dominum nostrum.\n℟. Amen."
+                "la": "Infirmitatem nostram, quaesumus, Domine, propitius respice: et mala omnia quae juste meremur, omnium Sanctorum tuorum intercessione averte. Per Christum Dominum nostrum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Dulce nomen Domini nostri Jesu Christi, et beatissimae matris ejus, sit benedictum in saecula saeculorum."
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Dulce nomen Domini nostri Jesu Christi, et beatissimae matris ejus, sit benedictum in saecula saeculorum."
               }
             },
             {
@@ -510,7 +622,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Introduction"
               }
@@ -522,27 +634,15 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
+                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris.\n\nMaria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
@@ -552,7 +652,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 53"
               }
@@ -564,7 +664,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 84"
               }
@@ -576,7 +676,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 116"
               }
@@ -594,7 +694,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (I)"
               }
@@ -606,7 +706,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (II)"
               }
@@ -618,7 +718,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (III)"
               }
@@ -630,7 +730,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -642,7 +742,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter - Eccli. 24"
               }
@@ -650,23 +750,43 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ab initio et ante saecula creata sum, et usque ad futurum saeculum non desinam,\net in habitatione sancta coram ipso ministravi.\n℟. Deo gratias."
+                "la": "Ab initio et ante saecula creata sum, et usque ad futurum saeculum non desinam,\net in habitatione sancta coram ipso ministravi."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Ora pro nobis, sancta Dei Genitrix.\n℟. Ut digni efficiamur promissionibus Christi."
+                "la": "Deo gratias."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Dominus vobiscum.\n℟. Et cum spiritu tuo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Dei Genitrix."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -674,7 +794,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Deus, qui de beatae Mariae Virginis utero, Verbum tuum, Angelo nuntiante,\ncarnem suscipere voluisti: praesta supplicibus tuis, ut qui vere eam Genitricem Dei credimus,\nejus apud te intercessionibus adjuvemur. Per eumdem Christum Dominum nostrum.\n℟. Amen."
+                "la": "Deus, qui de beatae Mariae Virginis utero, Verbum tuum, Angelo nuntiante,\ncarnem suscipere voluisti: praesta supplicibus tuis, ut qui vere eam Genitricem Dei credimus,\nejus apud te intercessionibus adjuvemur. Per eumdem Christum Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             }
           ]
@@ -688,7 +814,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Introduction"
               }
@@ -700,27 +826,15 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
+                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris.\n\nMaria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
@@ -730,7 +844,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 119"
               }
@@ -742,7 +856,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 120"
               }
@@ -754,7 +868,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 121"
               }
@@ -772,7 +886,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (V)"
               }
@@ -784,7 +898,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (VI)"
               }
@@ -796,7 +910,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (VII)"
               }
@@ -814,7 +928,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (XIV)"
               }
@@ -826,7 +940,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (XV)"
               }
@@ -838,7 +952,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (XVI)"
               }
@@ -850,7 +964,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -862,7 +976,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum - Eccli. 24."
               }
@@ -870,17 +984,43 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "In omnibus requiem quaesivi, et in haereditate Domini morabor. Tunc praecepit, et dixit mihi Creator omnium, et qui creavit me, requievit in tabernaculo meo.\n℟. Deo gratias."
+                "la": "In omnibus requiem quaesivi, et in haereditate Domini morabor. Tunc praecepit, et dixit mihi Creator omnium, et qui creavit me, requievit in tabernaculo meo."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Ave, Maria, gratia plena.\n℟. Dominus tecum.\n℣. Dominus vobiscum.\n℟. Et cum spiritu tuo."
+                "la": "Deo gratias."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave, Maria, gratia plena."
+                  },
+                  "r": {
+                    "la": "Dominus tecum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -888,7 +1028,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Concede nos famulos tuos.\n℣. Dulce nomen Domini. ut supra."
+                "la": "Concede nos famulos tuos."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Dulce nomen Domini. ut supra."
               }
             }
           ]
@@ -902,7 +1048,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Introduction"
               }
@@ -914,27 +1060,15 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
+                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris.\n\nMaria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
@@ -944,7 +1078,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 122"
               }
@@ -956,7 +1090,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 123"
               }
@@ -968,7 +1102,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 124"
               }
@@ -986,7 +1120,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (VIII)"
               }
@@ -998,7 +1132,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (IX)"
               }
@@ -1010,7 +1144,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (X)"
               }
@@ -1028,7 +1162,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (XVII)"
               }
@@ -1040,7 +1174,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (XVIII) — Justus es, Domine"
               }
@@ -1052,7 +1186,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (XIX)"
               }
@@ -1064,7 +1198,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1076,7 +1210,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum - Eccli. 24."
               }
@@ -1088,13 +1222,26 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicta tu in mulieribus."
+                  },
+                  "r": {
+                    "la": "Et benedictus fructus ventris tui."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Benedicta tu in mulieribus.\n℟. Et benedictus fructus ventris tui.\n℣. Dominus vobiscum."
+                "la": "Dominus vobiscum."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -1102,12 +1249,18 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Deus, qui salutis aeternae beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus, ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere Dominum nostrum Jesum Christum Filium tuum.\n℟. Amen."
+                "la": "Deus, qui salutis aeternae beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus, ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere Dominum nostrum Jesum Christum Filium tuum."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
                 "la": "Dulce nomen. ut supra."
               }
             }
@@ -1122,7 +1275,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Introduction"
               }
@@ -1134,27 +1287,15 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
+                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris.\n\nMaria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
@@ -1164,7 +1305,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 125"
               }
@@ -1176,7 +1317,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 126"
               }
@@ -1188,7 +1329,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 127"
               }
@@ -1206,7 +1347,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (XI)"
               }
@@ -1218,7 +1359,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (XII)"
               }
@@ -1230,7 +1371,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (XIII)"
               }
@@ -1248,7 +1389,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (XX)"
               }
@@ -1260,7 +1401,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (XXI)"
               }
@@ -1272,7 +1413,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 118 (XXII)"
               }
@@ -1284,7 +1425,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1296,7 +1437,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum - Eccli. 24."
               }
@@ -1308,13 +1449,26 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Post partum virgo inviolata permansisti."
+                  },
+                  "r": {
+                    "la": "Dei Genitrix, intercede pro nobis."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Post partum virgo inviolata permansisti.\n℟. Dei Genitrix, intercede pro nobis.\n℣. Dominus vobiscum."
+                "la": "Dominus vobiscum."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -1322,12 +1476,18 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Famulatorum tuorum, quaesumus, Domine, delictis ignosce: ut qui tibi placere de actibus nostris non valemus, Genitricis Filii tui Domini nostri intercessione salvemur. Per eumdem Christum Dominum nostrum. ℟. Amen."
+                "la": "Famulatorum tuorum, quaesumus, Domine, delictis ignosce: ut qui tibi placere de actibus nostris non valemus, Genitricis Filii tui Domini nostri intercessione salvemur. Per eumdem Christum Dominum nostrum."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
                 "la": "Dulce nomen. ut supra."
               }
             }
@@ -1342,7 +1502,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Introduction"
               }
@@ -1354,7 +1514,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 109"
               }
@@ -1366,7 +1526,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 112"
               }
@@ -1378,7 +1538,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 121"
               }
@@ -1390,7 +1550,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 126"
               }
@@ -1402,7 +1562,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1414,43 +1574,49 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Chapter"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "In omnibus requiem. ut supra"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. br. Post partum virgo, Inviolata permansisti. Post partum.\n℣. Dei Genitrix, intercede pro nobis. * Inviolata permansisti."
+                "la": "br. Post partum virgo, Inviolata permansisti. Post partum."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Dei Genitrix, intercede pro nobis. * Inviolata permansisti."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Ave, maris stella."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Speciosa facta es. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Speciosa facta es. ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Canticle of the Blessed Virgin Mary - Lk 1"
               }
@@ -1462,7 +1628,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1474,7 +1640,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -1504,17 +1670,50 @@
             {
               "type": "rubric",
               "text": {
-                "en-US": "In the first ℣, the sign of the cross is made with the thumb over the heart, instead of the usual manner."
+                "en-US": "In the first versicle, the sign of the cross is made with the thumb over the heart, instead of the usual manner."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Converte nos ✠ Deus, salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos ✠ Deus, salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 12"
               }
@@ -1526,7 +1725,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 128"
               }
@@ -1538,7 +1737,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 130"
               }
@@ -1550,7 +1749,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1562,7 +1761,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum - Eccli. 24."
               }
@@ -1570,41 +1769,55 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sicut cinnamomum et balsamum aromatizans odorem dedi: quasi myrrha electa dedi suavitatem odoris.\n℟. Deo gratias."
+                "la": "Sicut cinnamomum et balsamum aromatizans odorem dedi: quasi myrrha electa dedi suavitatem odoris."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus."
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Nixa est puerpéra,\nQuam Gabriel praedixerat,\nQuem matris alvo gestiens,\nClausus Joannes senserat."
+                "la": "Nixa est puerpéra,\nQuam Gabriel praedixerat,\nQuem matris alvo gestiens,\nClausus Joannes senserat.\n\nMaria mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt hora mortis suscipe.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt hora mortis suscipe."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ecce ancilla Domini."
+                  },
+                  "r": {
+                    "la": "Fiat mihi secundum verbum tuum."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ecce ancilla Domini.\n℟. Fiat mihi secundum verbum tuum.\n℣. Dominus vobiscum.\n℟. Et cum spiritu tuo."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -1612,13 +1825,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Concede, misericors Deus, fragilitati nostrae praesidium, ut qui sanctae Dei Genitricis memoriam agimus, intercessionis ejus auxilio, a nostris iniquitatibus resurgamus. Per eundem Christum Dominum nostrum.\n℟. Amen."
+                "la": "Concede, misericors Deus, fragilitati nostrae praesidium, ut qui sanctae Dei Genitricis memoriam agimus, intercessionis ejus auxilio, a nostris iniquitatibus resurgamus. Per eundem Christum Dominum nostrum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Dulce nomen Domini nostri."
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Dulce nomen Domini nostri."
               }
             }
           ]

--- a/content/practices/little-office-bvm-dominican/flow.json
+++ b/content/practices/little-office-bvm-dominican/flow.json
@@ -27,28 +27,238 @@
           },
           "sections": [
             {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave, Maria, gratia plena, Dominus tecum."
+                  },
+                  "r": {
+                    "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui, Jesus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "℣. Ave, Maria, gratia plena, Dominus tecum.\n℟. Benedicta tu in mulieribus, et benedictus fructus ventris tui, Jesus.\n℣. Domine, labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. Alleluia.\nA Septuagesima vero usque ad Pascha dicitur: Laus tibi, Domine, Rex aeternae gloriae.\nInvitatorium\nRegem Virginis Filium, Venite, adoremus.\nPsalmus 94\nVenite, exsultemus Domino, jubilemus Deo salutari nostro:\npraeoccupemus faciem ejus in confessione, et in psalmis jubilemus ei.\nRegem Virginis Filium, Venite, adoremus.\nQuoniam Deus magnus Dominus, et rex magnus super omnes deos:\nquoniam non repellet Dominus plebem suam; quia in manu ejus sunt omnes fines terrae, et altitudines montium ipse conspicit.\nVenite, adoremus.\nQuoniam ipsius est mare, et ipse fecit illud, et aridam fundaverunt manus ejus:\nvenite, adoremus, et procidamus ante Deum; ploremus coram Domino, qui fecit nos:\nquia ipse est Dominus Deus noster, nos autem populus ejus et oves pascuae ejus.\nRegem Virginis Filium, Venite, adoremus.\nHodie si vocem ejus audieritis, nolite obdurare corda vestra, sicut in exacerbatione secundum diem tentationis in deserto:\nubi tenterunt me patres vestri, probaverunt, et viderunt opera mea.\nVenite, adoremus.\nQuadraginta annis proximus fui generationi huic, et dixi:\nSemper hi errant corde; ipsi vero non cognoverunt vias meas; quibus juravi in ira mea: si intrabunt in requiem meam.\nRegem Virginis Filium, Venite, adoremus.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nVenite, adoremus.\nRegem Virginis Filium, Venite, adoremus.",
-                "en-US": "℣. Hail Mary, full of grace, the Lord is with thee.\n℟. Blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus.\n℣. O Lord, open my lips.\n℟. And my mouth shall announce thy praise.\n℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, world without end, Amen. Alleluia.\nFrom Septuagesima until Easter, instead of Alleluia is said: Praise be to Thee, O Lord, King of everlasting glory.\nInvitatory\nOur King, a Virgin's Son: Come, let us adore.\nPsalm 94\nCome let us praise the Lord with joy: let us joyfully sing to God our Saviour:\nlet us approach to his presence in confession, and in Psalms let us make joy unto him.\nOur King, a Virgin's Son: Come, let us adore.\nFor God is a great Lord, and a great King above all Gods:\nbecause our Lord repelleth not his people:\nfor that in his hand are all the bounds of the earth, and he beholdeth the heights of the mountains.\nCome, let us adore.\nFor the sea is his, and he made it: and his hands founded the dry land:\ncome let us adore, and fall down before God:\nlet us weep before our Lord, that made us:\nbecause he is the Lord our God: we are his people, and the sheep of his pasture.\nOur King, a Virgin's Son: Come, let us adore.\nToday if ye shall hear his voice, harden not your hearts,\nas in the provocation according to the day of temptation in the wilderness: where your fathers tempted me:\nproved, and saw my works.\nCome, let us adore.\nForty years was I nigh unto this generation: and said, they always err in heart:\nand they have not known my ways, to whom I swear in my wrath, if they shall enter into my rest.\nOur King, a Virgin's Son: Come, let us adore.\nGlory be to the Father, and to the Son: and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall\nbe, world without end, Amen.\nCome, let us adore.\nOur King, a Virgin's Son: Come, let us adore."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. Alleluia."
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "A Septuagesima vero usque ad Pascha dicitur: Laus tibi, Domine, Rex aeternae gloriae."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Invitatorium"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Regem Virginis Filium, Venite, adoremus."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Psalmus 94"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Venite, exsultemus Domino, jubilemus Deo salutari nostro:\npraeoccupemus faciem ejus in confessione, et in psalmis jubilemus ei.\nRegem Virginis Filium, Venite, adoremus.\nQuoniam Deus magnus Dominus, et rex magnus super omnes deos:\nquoniam non repellet Dominus plebem suam; quia in manu ejus sunt omnes fines terrae, et altitudines montium ipse conspicit.\nVenite, adoremus.\nQuoniam ipsius est mare, et ipse fecit illud, et aridam fundaverunt manus ejus:\nvenite, adoremus, et procidamus ante Deum; ploremus coram Domino, qui fecit nos:\nquia ipse est Dominus Deus noster, nos autem populus ejus et oves pascuae ejus.\nRegem Virginis Filium, Venite, adoremus.\nHodie si vocem ejus audieritis, nolite obdurare corda vestra, sicut in exacerbatione secundum diem tentationis in deserto:\nubi tenterunt me patres vestri, probaverunt, et viderunt opera mea.\nVenite, adoremus.\nQuadraginta annis proximus fui generationi huic, et dixi:\nSemper hi errant corde; ipsi vero non cognoverunt vias meas; quibus juravi in ira mea: si intrabunt in requiem meam.\nRegem Virginis Filium, Venite, adoremus.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nVenite, adoremus.\nRegem Virginis Filium, Venite, adoremus."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Hail Mary, full of grace, the Lord is with thee."
+                  },
+                  "r": {
+                    "en-US": "Blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, open my lips."
+                  },
+                  "r": {
+                    "en-US": "And my mouth shall announce thy praise."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now, and ever shall be, world without end, Amen. Alleluia."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "From Septuagesima until Easter, instead of Alleluia is said: Praise be to Thee, O Lord, King of everlasting glory."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Invitatory"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Our King, a Virgin's Son: Come, let us adore."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Psalm 94"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Come let us praise the Lord with joy: let us joyfully sing to God our Saviour:\nlet us approach to his presence in confession, and in Psalms let us make joy unto him.\nOur King, a Virgin's Son: Come, let us adore.\nFor God is a great Lord, and a great King above all Gods:\nbecause our Lord repelleth not his people:\nfor that in his hand are all the bounds of the earth, and he beholdeth the heights of the mountains.\nCome, let us adore.\nFor the sea is his, and he made it: and his hands founded the dry land:\ncome let us adore, and fall down before God:\nlet us weep before our Lord, that made us:\nbecause he is the Lord our God: we are his people, and the sheep of his pasture.\nOur King, a Virgin's Son: Come, let us adore.\nToday if ye shall hear his voice, harden not your hearts,\nas in the provocation according to the day of temptation in the wilderness: where your fathers tempted me:\nproved, and saw my works.\nCome, let us adore.\nForty years was I nigh unto this generation: and said, they always err in heart:\nand they have not known my ways, to whom I swear in my wrath, if they shall enter into my rest.\nOur King, a Virgin's Son: Come, let us adore.\nGlory be to the Father, and to the Son: and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall\nbe, world without end, Amen.\nCome, let us adore.\nOur King, a Virgin's Son: Come, let us adore."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Quem terra, pontus, aethera\nColunt, adorant, praedicant,\nTrinam regentem machinam\nClaustrum Mariae bajulat.\nCui luna, sol, et omnia\nDeserviunt per tempora,\nPerfusa caeli gratia,\nGestant puellae viscera.\nBeata Mater munere,\nCujus supernus artifex,\nMundum pugillo continens,\nVentris sub arca clausus est.\nBeata caeli nuntio,\nFecunda Sancto Spiritu,\nDesideratus gentibus\nCujus per alvum fusus est.\nMaria, mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt hora mortis suscipe.\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre et Sancto Spiritu,\nIn sempiterna saecula. Amen.\nPsalmus 8\nDomine, Dominus noster, quam admirabile est nomen tuum in universa terra!\nQuoniam elevata est magnificentia tua super caelos.\nEx ore infantium et lactentium perfecisti laudem propter inimicos tuos, ut destruas inimicum et ultorem.\nQuoniam videbo caelos tuos, opera digitorum tuorum: lunam et stellas, quae tu fundasti.\nQuid est homo, quod memor es ejus? aut filius hominis, quoniam visitas eum?\nMinuisti eum paulo minus ab Angelis, gloria et honore coronasti eum: et constituisti eum super opera manuum tuarum.\nOmnia subjecisti sub pedibus ejus, oves et boves universas: insuper et pecora campi.\nVolucres caeli, et pisces maris, qui perambulant semitas maris.\nDomine, Dominus noster, quam admirabile est nomen tuum in universa terra!\nGloria Patri.\nPsalmus 18\nCaeli enarrant gloriam Dei, et opera manuum ejus annuntiat firmamentum.\nDies diei eructat verbum, et nox nocti indicat scientiam.\nNon sunt loquelae, neque sermones quorum non audiantur voces eorum.\nIn omnem terram exivit sonus eorum: et in fines orbis terrae verba eorum.\nIn sole posuit tabernaculum suum: et ipse tamquam sponsus procedens de thalamo suo.\nExsultavit ut gigas ad currendam viam, a summo caelo egressio ejus.\nEt occursus ejus usque ad summum ejus: nec est qui se abscondat a calore ejus.\nLex Domini immaculata, convertens animas: testimonium Domini fidele, sapientiam praestans parvulis.\nJustitiae Domini rectae, laetificantes corda: praeceptum Domini lucidum, illuminans oculos.\nTimor Domini sanctus, permanens in saeculum saeculi: judicia Domini vera, justificata in semetipsa.\nDesiderabilia super aurum et lapidem pretiosum multum: et dulciora super mel et favum.\nEtenim servus tuus custodit ea, in custodiendis illis retributio multa.\nDelicta quis intelligit? ab occultis meis munda me: et ab alienis parce servo tuo.\nSi mei non fuerint dominati, tunc immaculatus ero: et emundabor a delicto maximo.\nEt erunt ut complaceant eloquia oris mei: et meditatio cordis mei in conspectu tuo semper.\nDomine, adjutor meus, et redemptor meus.\nGloria Patri.\nPsalmus 23\nDomini est terra, et plenitudo ejus: orbis terrarum et universi qui habitant in eo.\nQuia ipse super maria fundavit eum: et super flumina praeparavit eum.\nQuis ascendet in montem Domini? aut quis stabit in loco sancto ejus?\nInnocens manibus et mundo corde, qui non accepit in vano animam suam, nec juravit in dolo proximo suo.\nHic accipiet benedictionem a Domino: et misericordiam a Deo, salutari suo.\nHaec est generatio quaerentium eum, quaerentium faciem Dei Jacob.\nAttollite portas, principes, vestras, et elevamini, portae aeternales: et introibit rex gloriae.\nQuis est iste rex gloriae? Dominus fortis et potens: Dominus potens in proelio.\nAttollite portas, principes, vestras, et elevamini, portae aeternales: et introibit rex gloriae.\nQuis est iste rex gloriae? Dominus virtutum ipse est rex gloriae.\nGloria Patri.",
-                "en-US": "Whom earth, and sea, and sky proclaim,\nThe ruler of the triple frame,\nHe unto Whom their praises,\nWithin the womb of Mary lies.\nHer womb, the seat of every grace,\nIs now the Lord's abiding place,\nThat Lord's to Whom the sun by day,\nThe moon by night, their service pay.\nO Happy Mother that thou art,\nClose underneath thy beating heart,\nLies thy Creator-God, who plann'd,\nThe world He holds within His hand.\nBlest by herald angel's tongue,\nO'er thee God's shadowing Spirit hung,\nAnd fill'd thy womb which issued forth,\nThe long-desir'd of all the earth.\nO Mary, Mother of all grace,\nMother of Mercy to our race,\nProtect us now from Satan's power,\nAnd own us at life's closing hour.\nAll glory be Thee, O Lord,\nThe Virgin's son, by all ador'd,\nAnd equal praise forever greet,\nThe Father and the Paraclete. Amen.\nPsalm 8\nO Lord our Governor, how excellent is thy Name in all the world.\nFor thou hast set thy glory above the heavens.\nOut of the mouth of very babes and sucklings hast thou perfected praise, because of thine enemies, that thou mightest destroy the enemy and the avenger.\nFor I will consider thy heavens, even the works of thy fingers; the moon and the stars which thou hast ordained.\nWhat is man, that thou art mindful of him? And the son of man, that thou visitest him.\nThou madest him lower than the Angels, thou hast crowned him with glory and worship: thou makest him to have dominion over the works of thy hands.\nThou hast put all things in subjection under his feet: all sheep and oxen, yea, and the beasts of the field.\nThe fowls of the air, and the fishes of the sea; and whatsoever walketh through the paths of the seas.\nO Lord our Governor, how excellent is thy Name in all the world.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be: world without end. Amen.\nPsalm 18\nThe heavens declare the glory of God; and the firmament sheweth his handywork.\nDay to day uttereth speech; and night to night sheweth knowledge.\nThere is neither speech nor language; where their voices are not heard.\nTheir sound is gone out into all lands; and their words into the ends of the world.\nIn the sun hath he set his tabernacle: and he, as a bridegroom coming out of his chamber.\nHath rejoiced as a giant to run his course, his going forth is from the uttermost part of the heaven.\nAnd his circuit even unto the end thereof; and there is no one that can hide himself from his heat.\nThe law of the Lord is an undefiled law, converting the soul: the testimony of the Lord is sure, and giveth wisdom unto the simple.\nThe statutes of the Lord are right, and rejoice the heart: the commandment of the Lord is pure, and giveth light unto the eyes.\nThe fear of the Lord is holy, and endureth for ever: the judgments of the Lord are true, justified in themselves.\nMore to be desired are they than gold, yea, than much precious stone; sweeter also than honey, and the honeycomb.\nFor thy servant keepeth them, and in keeping of them there is great reward.\nWho can tell how oft he offendeth? O cleanse thou me from my secret faults.\nSave thy servant also from the sins of others. If they get not the dominion over me, so shall I be undefiled, and innocent from the great offence.\nAnd the words of my mouth shall be such as may please, and the meditation of my heart be always in thy sight.\nO Lord, my strength and my redeemer.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 23\nThe earth is the Lord's, and all the fullness thereof, the compass of the world, and they that dwell therein.\nFor he hath founded it upon the seas, and established it upon the rivers.\nWho shall ascend into the mountain of the Lord? Or who shall stand in his holy place?\nEven he that hath clean hands, and a pure heart, and that hath not lift up his soul unto vanity, nor deceitfully sworn to his neighbour.\nHe shall receive a blessing from the Lord: and mercy from God his saviour.\nThis is the generation of them that seek him, even of them that seek the face of the God of Jacob.\nLift up your gates, O ye princes, and be ye lift up, ye everlasting gates, and the King of glory shall come in.\nWho is this King of glory? It is the Lord strong and mighty, even the Lord mighty in battle.\nLift up your gates, O ye princes, and be ye lift up, ye everlasting gates, and the King of glory shall come in.\nWho is this King of glory? Even the Lord of hosts, he is the King of glory.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Quem terra, pontus, aethera\nColunt, adorant, praedicant,\nTrinam regentem machinam\nClaustrum Mariae bajulat.\nCui luna, sol, et omnia\nDeserviunt per tempora,\nPerfusa caeli gratia,\nGestant puellae viscera.\nBeata Mater munere,\nCujus supernus artifex,\nMundum pugillo continens,\nVentris sub arca clausus est.\nBeata caeli nuntio,\nFecunda Sancto Spiritu,\nDesideratus gentibus\nCujus per alvum fusus est.\nMaria, mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt hora mortis suscipe.\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre et Sancto Spiritu,\nIn sempiterna saecula. Amen.",
+                "en-US": "Whom earth, and sea, and sky proclaim,\nThe ruler of the triple frame,\nHe unto Whom their praises,\nWithin the womb of Mary lies.\nHer womb, the seat of every grace,\nIs now the Lord's abiding place,\nThat Lord's to Whom the sun by day,\nThe moon by night, their service pay.\nO Happy Mother that thou art,\nClose underneath thy beating heart,\nLies thy Creator-God, who plann'd,\nThe world He holds within His hand.\nBlest by herald angel's tongue,\nO'er thee God's shadowing Spirit hung,\nAnd fill'd thy womb which issued forth,\nThe long-desir'd of all the earth.\nO Mary, Mother of all grace,\nMother of Mercy to our race,\nProtect us now from Satan's power,\nAnd own us at life's closing hour.\nAll glory be Thee, O Lord,\nThe Virgin's son, by all ador'd,\nAnd equal praise forever greet,\nThe Father and the Paraclete. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 8",
+                "en-US": "Psalm 8"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Domine, Dominus noster, quam admirabile est nomen tuum in universa terra!\nQuoniam elevata est magnificentia tua super caelos.\nEx ore infantium et lactentium perfecisti laudem propter inimicos tuos, ut destruas inimicum et ultorem.\nQuoniam videbo caelos tuos, opera digitorum tuorum: lunam et stellas, quae tu fundasti.\nQuid est homo, quod memor es ejus? aut filius hominis, quoniam visitas eum?\nMinuisti eum paulo minus ab Angelis, gloria et honore coronasti eum: et constituisti eum super opera manuum tuarum.\nOmnia subjecisti sub pedibus ejus, oves et boves universas: insuper et pecora campi.\nVolucres caeli, et pisces maris, qui perambulant semitas maris.\nDomine, Dominus noster, quam admirabile est nomen tuum in universa terra!\nGloria Patri.",
+                "en-US": "O Lord our Governor, how excellent is thy Name in all the world.\nFor thou hast set thy glory above the heavens.\nOut of the mouth of very babes and sucklings hast thou perfected praise, because of thine enemies, that thou mightest destroy the enemy and the avenger.\nFor I will consider thy heavens, even the works of thy fingers; the moon and the stars which thou hast ordained.\nWhat is man, that thou art mindful of him? And the son of man, that thou visitest him.\nThou madest him lower than the Angels, thou hast crowned him with glory and worship: thou makest him to have dominion over the works of thy hands.\nThou hast put all things in subjection under his feet: all sheep and oxen, yea, and the beasts of the field.\nThe fowls of the air, and the fishes of the sea; and whatsoever walketh through the paths of the seas.\nO Lord our Governor, how excellent is thy Name in all the world.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be: world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 18",
+                "en-US": "Psalm 18"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Caeli enarrant gloriam Dei, et opera manuum ejus annuntiat firmamentum.\nDies diei eructat verbum, et nox nocti indicat scientiam.\nNon sunt loquelae, neque sermones quorum non audiantur voces eorum.\nIn omnem terram exivit sonus eorum: et in fines orbis terrae verba eorum.\nIn sole posuit tabernaculum suum: et ipse tamquam sponsus procedens de thalamo suo.\nExsultavit ut gigas ad currendam viam, a summo caelo egressio ejus.\nEt occursus ejus usque ad summum ejus: nec est qui se abscondat a calore ejus.\nLex Domini immaculata, convertens animas: testimonium Domini fidele, sapientiam praestans parvulis.\nJustitiae Domini rectae, laetificantes corda: praeceptum Domini lucidum, illuminans oculos.\nTimor Domini sanctus, permanens in saeculum saeculi: judicia Domini vera, justificata in semetipsa.\nDesiderabilia super aurum et lapidem pretiosum multum: et dulciora super mel et favum.\nEtenim servus tuus custodit ea, in custodiendis illis retributio multa.\nDelicta quis intelligit? ab occultis meis munda me: et ab alienis parce servo tuo.\nSi mei non fuerint dominati, tunc immaculatus ero: et emundabor a delicto maximo.\nEt erunt ut complaceant eloquia oris mei: et meditatio cordis mei in conspectu tuo semper.\nDomine, adjutor meus, et redemptor meus.\nGloria Patri.",
+                "en-US": "The heavens declare the glory of God; and the firmament sheweth his handywork.\nDay to day uttereth speech; and night to night sheweth knowledge.\nThere is neither speech nor language; where their voices are not heard.\nTheir sound is gone out into all lands; and their words into the ends of the world.\nIn the sun hath he set his tabernacle: and he, as a bridegroom coming out of his chamber.\nHath rejoiced as a giant to run his course, his going forth is from the uttermost part of the heaven.\nAnd his circuit even unto the end thereof; and there is no one that can hide himself from his heat.\nThe law of the Lord is an undefiled law, converting the soul: the testimony of the Lord is sure, and giveth wisdom unto the simple.\nThe statutes of the Lord are right, and rejoice the heart: the commandment of the Lord is pure, and giveth light unto the eyes.\nThe fear of the Lord is holy, and endureth for ever: the judgments of the Lord are true, justified in themselves.\nMore to be desired are they than gold, yea, than much precious stone; sweeter also than honey, and the honeycomb.\nFor thy servant keepeth them, and in keeping of them there is great reward.\nWho can tell how oft he offendeth? O cleanse thou me from my secret faults.\nSave thy servant also from the sins of others. If they get not the dominion over me, so shall I be undefiled, and innocent from the great offence.\nAnd the words of my mouth shall be such as may please, and the meditation of my heart be always in thy sight.\nO Lord, my strength and my redeemer.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 23",
+                "en-US": "Psalm 23"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Domini est terra, et plenitudo ejus: orbis terrarum et universi qui habitant in eo.\nQuia ipse super maria fundavit eum: et super flumina praeparavit eum.\nQuis ascendet in montem Domini? aut quis stabit in loco sancto ejus?\nInnocens manibus et mundo corde, qui non accepit in vano animam suam, nec juravit in dolo proximo suo.\nHic accipiet benedictionem a Domino: et misericordiam a Deo, salutari suo.\nHaec est generatio quaerentium eum, quaerentium faciem Dei Jacob.\nAttollite portas, principes, vestras, et elevamini, portae aeternales: et introibit rex gloriae.\nQuis est iste rex gloriae? Dominus fortis et potens: Dominus potens in proelio.\nAttollite portas, principes, vestras, et elevamini, portae aeternales: et introibit rex gloriae.\nQuis est iste rex gloriae? Dominus virtutum ipse est rex gloriae.\nGloria Patri.",
+                "en-US": "The earth is the Lord's, and all the fullness thereof, the compass of the world, and they that dwell therein.\nFor he hath founded it upon the seas, and established it upon the rivers.\nWho shall ascend into the mountain of the Lord? Or who shall stand in his holy place?\nEven he that hath clean hands, and a pure heart, and that hath not lift up his soul unto vanity, nor deceitfully sworn to his neighbour.\nHe shall receive a blessing from the Lord: and mercy from God his saviour.\nThis is the generation of them that seek him, even of them that seek the face of the God of Jacob.\nLift up your gates, O ye princes, and be ye lift up, ye everlasting gates, and the King of glory shall come in.\nWho is this King of glory? It is the Lord strong and mighty, even the Lord mighty in battle.\nLift up your gates, O ye princes, and be ye lift up, ye everlasting gates, and the King of glory shall come in.\nWho is this King of glory? Even the Lord of hosts, he is the King of glory.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -56,13 +266,159 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui.\n℣. Diffusa est gratia in labiis tuis.\n℟. Propterea benedixit te Deus in aeternum.\nPater noster secreto.\nEt ne nos inducas in tentationem.\n℟. Sed libera nos a malo.\nJube, domne, benedicere.\nBenedictio.\nAlma Virgo virginum intercedat pro nobis ad Dominum.\n℟. Amen.",
-                "en-US": "Blessed art thou amongst women, and blessed is the fruit of thy womb.\n℣. Grace is poured forth on thy lips.\n℟. Therefore God hath blessed thee forever.\nOur Father (silently)\n℟. But deliver us from evil. Amen.\n℣. We pray thee, vouchsafe us a blessing.\nBlessing.\nMay the tender Virgin of virgins intercede for us with the Lord.\n℟. Amen.\nLesson I\nO Holy Mary, Virgin of virgins, Mother and daughter of the King of Kings! Bestow upon us thy consolation, that through thee we may deserve the reward of the heavenly kingdom, and reign with the elect of God unto all eternity.\nBut thou, O Lord, have mercy on us.\n℟. Thanks be to God."
+                "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Diffusa est gratia in labiis tuis."
+                  },
+                  "r": {
+                    "la": "Propterea benedixit te Deus in aeternum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Pater noster secreto.\nEt ne nos inducas in tentationem."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Sed libera nos a malo."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Jube, domne, benedicere."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Benedictio."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Alma Virgo virginum intercedat pro nobis ad Dominum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Blessed art thou amongst women, and blessed is the fruit of thy womb."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Grace is poured forth on thy lips."
+                  },
+                  "r": {
+                    "en-US": "Therefore God hath blessed thee forever."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Our Father (silently)"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "But deliver us from evil. Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "We pray thee, vouchsafe us a blessing."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Blessing."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "May the tender Virgin of virgins intercede for us with the Lord."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Lesson I"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O Holy Mary, Virgin of virgins, Mother and daughter of the King of Kings! Bestow upon us thy consolation, that through thee we may deserve the reward of the heavenly kingdom, and reign with the elect of God unto all eternity.\nBut thou, O Lord, have mercy on us."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Reading",
                 "en-US": "Reading"
@@ -70,13 +426,140 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Sancta Maria, Virgo virginum, mater et filia Regis regum omnium, tuum nobis impende solatium: ut caelestis regni per te mereamur habere praemium, et cum electis Dei regnare in perpetuum. Tu autem, Domine, miserere nostri.\n℟. Deo gratias.\nResponsorium\nSancta et immaculata virginitas, quibus te laudibus efferam, nescio: quia quem caeli capere non poterant, tuo gremio contulisti.\n℣. Benedicta tu in mulieribus, et benedictus fructus ventris tui. Quia.\nJube, domne, benedicere.\nBenedictio.\nSancta Dei Genitrix sit nobis auxiliatrix.\n℟. Amen.",
-                "en-US": "O Holy Mary, Virgin of virgins, Mother and daughter of the King of Kings! Bestow upon us thy consolation, that through thee we may deserve the reward of the heavenly kingdom, and reign with the elect of God unto all eternity.\nBut thou, O Lord, have mercy on us.\n℟. Thanks be to God.\nResponsory\n℟. O holy and immaculate Virginity, with what praises to extol thee, I know not: For thou gavest from thy bosom Him Whom the heavens could not contain.\n℣. Blessed art thou among women, and blessed is the fruit of thy womb. For thou gavest from thy bosom Him Whom the heavens could not contain.\n℣. We pray thee, vouchsafe us a blessing.\nBlessing.\nMay the Holy Mother of God be our helper.\n℟. Amen."
+                "la": "Sancta Maria, Virgo virginum, mater et filia Regis regum omnium, tuum nobis impende solatium: ut caelestis regni per te mereamur habere praemium, et cum electis Dei regnare in perpetuum. Tu autem, Domine, miserere nostri."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Responsorium"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Sancta et immaculata virginitas, quibus te laudibus efferam, nescio: quia quem caeli capere non poterant, tuo gremio contulisti."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui. Quia."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Jube, domne, benedicere."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Benedictio."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Sancta Dei Genitrix sit nobis auxiliatrix."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O Holy Mary, Virgin of virgins, Mother and daughter of the King of Kings! Bestow upon us thy consolation, that through thee we may deserve the reward of the heavenly kingdom, and reign with the elect of God unto all eternity.\nBut thou, O Lord, have mercy on us."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Responsory"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "O holy and immaculate Virginity, with what praises to extol thee, I know not: For thou gavest from thy bosom Him Whom the heavens could not contain."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "Blessed art thou among women, and blessed is the fruit of thy womb. For thou gavest from thy bosom Him Whom the heavens could not contain."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "We pray thee, vouchsafe us a blessing."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Blessing."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "May the Holy Mother of God be our helper."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Reading",
                 "en-US": "Reading"
@@ -84,13 +567,124 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Sancta Maria, piarum piissima, intercede pro nobis, sanctarum sanctissima: per te, Virgo, nostra sumat precamina, qui pro nobis ex te natus regnat super aethera: ut sua caritate nostra deleantur peccamina. Tu autem.\nResponsorium\nBeata es, Virgo Maria, quae Dominum portasti creatorem mundi: genuisti eum, qui te fecit, et in aeternum permanes virgo.\n℣. Ave, Maria, gratia plena, Dominus tecum. Genuisti.\nJube, domne, benedicere.\nBenedictio.\nNos cum Prole pia benedicat Virgo Maria.\n℟. Amen.",
-                "en-US": "O Holy Mary, most compassionate of all the compassionate, and holiest of all the holy, make intercession for us. Through thee, O Virgin, may He receive our prayers, Who, born for us of thee, reigneth above the skies; that so, by His loving-kindness, our sins may be cleansed away.\nBut thou, O Lord, have mercy on us.\nResponsory\n℟. Blessed art thou, O Virgin Mary, who didst bear the Lord, the Creator of the world: Thou gavest birth unto Him Who made thee, and remainest a virgin evermore.\n℣. Hail Mary, full of grace, the Lord is with thee. Thou gavest birth unto Him Who made thee, and remainest a virgin evermore.\n℣. We pray thee, vouchsafe us a blessing.\nBlessing.\nMay the Virgin Mary, with her loving Child, bless us.\n℟. Amen."
+                "la": "Sancta Maria, piarum piissima, intercede pro nobis, sanctarum sanctissima: per te, Virgo, nostra sumat precamina, qui pro nobis ex te natus regnat super aethera: ut sua caritate nostra deleantur peccamina. Tu autem."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Responsorium"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Beata es, Virgo Maria, quae Dominum portasti creatorem mundi: genuisti eum, qui te fecit, et in aeternum permanes virgo."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Ave, Maria, gratia plena, Dominus tecum. Genuisti."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Jube, domne, benedicere."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Benedictio."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Nos cum Prole pia benedicat Virgo Maria."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O Holy Mary, most compassionate of all the compassionate, and holiest of all the holy, make intercession for us. Through thee, O Virgin, may He receive our prayers, Who, born for us of thee, reigneth above the skies; that so, by His loving-kindness, our sins may be cleansed away.\nBut thou, O Lord, have mercy on us."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Responsory"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Blessed art thou, O Virgin Mary, who didst bear the Lord, the Creator of the world: Thou gavest birth unto Him Who made thee, and remainest a virgin evermore."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "Hail Mary, full of grace, the Lord is with thee. Thou gavest birth unto Him Who made thee, and remainest a virgin evermore."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "We pray thee, vouchsafe us a blessing."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Blessing."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "May the Virgin Mary, with her loving Child, bless us."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Reading",
                 "en-US": "Reading"
@@ -98,27 +692,122 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Sancta Dei Genitrix, quae digne meruisti concipere, quem totus orbis nequit comprehendere, tuo pio interventu culpas nostras ablue: ut redempti perennis sedem gloriae per te valeamus scandere, ubi regnas cum eodem Filio tuo sine tempore. Tu autem.\nResponsorium\nFelix namque es, sacra Virgo Maria, et omni laude dignissima, quia ex te ortus est Sol justitiae, Christus Deus noster.\n℣. Ora pro populo, interveni pro clero, intercede pro devoto femineo sexu: sentiant omnes tuum juvamen, quicumque celebrant tuam commemorationem. Quia. Gloria. Christus.",
-                "en-US": "O holy Mother of God, who didst worthily deserve to conceive Him Whom the whole world cannot contain, cleanse away our sins by thy loving intercession that we who have been redeemed may through thee be able to ascend to the seat of perpetual glory, where, with Him, thy Son, thou reignest forever.\nBut thou, O Lord, have mercy on us.\nResponsory\n℟. Happy thou, O sacred Virgin Mary, and most worthy of all praise: For out of thee arose the Sun of Justice, Christ our God.\n℣. Pray for the people, plead for the clergy, make intercession for the devout female sex; let all feel thy helping power who celebrate thy blessed memory. For out of thee arose the Sun of Justice, Christ our God.\nGlory be to the Father, and to the Son, and to the Holy Ghost:\nChrist our God."
+                "la": "Sancta Dei Genitrix, quae digne meruisti concipere, quem totus orbis nequit comprehendere, tuo pio interventu culpas nostras ablue: ut redempti perennis sedem gloriae per te valeamus scandere, ubi regnas cum eodem Filio tuo sine tempore. Tu autem."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Responsorium"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Felix namque es, sacra Virgo Maria, et omni laude dignissima, quia ex te ortus est Sol justitiae, Christus Deus noster."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Ora pro populo, interveni pro clero, intercede pro devoto femineo sexu: sentiant omnes tuum juvamen, quicumque celebrant tuam commemorationem. Quia. Gloria. Christus."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O holy Mother of God, who didst worthily deserve to conceive Him Whom the whole world cannot contain, cleanse away our sins by thy loving intercession that we who have been redeemed may through thee be able to ascend to the seat of perpetual glory, where, with Him, thy Son, thou reignest forever.\nBut thou, O Lord, have mercy on us."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Responsory"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Happy thou, O sacred Virgin Mary, and most worthy of all praise: For out of thee arose the Sun of Justice, Christ our God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "Pray for the people, plead for the clergy, make intercession for the devout female sex; let all feel thy helping power who celebrate thy blessed memory. For out of thee arose the Sun of Justice, Christ our God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost:\nChrist our God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Te Deum laudamus, te Dominum confitemur.\nTe aeternum Patrem omnis terra veneratur.\nTibi omnes Angeli, tibi Caeli, et universae Potestates.\nTibi Cherubim et Seraphim incessabili voce proclamant:\nSanctus, Sanctus, Sanctus Dominus Deus Sabaoth.\nPleni sunt caeli et terra majestatis gloriae tuae.\nTe gloriosus Apostolorum chorus.\nTe Prophetarum laudabilis numerus.\nTe Martyrum candidatus laudat exercitus.\nTe per orbem terrarum sancta confitetur Ecclesia:\nPatrem immensae majestatis.\nVenerandum tuum verum et unicum Filium.\nSanctum quoque Paraclitum Spiritum.\nTu Rex gloriae, Christe.\nTu Patris sempiternus es Filius.\nTu ad liberandum suscepturus hominem, non horruisti Virginis uterum.\nTu devicto mortis aculeo, aperuisti credentibus regna caelorum.\nTu ad dexteram Dei sedes in gloria Patris.\nJudex crederis esse venturus.\nTe ergo quaesumus, tuis famulis subveni, quos pretioso sanguine redemisti.\nAeterna fac cum sanctis tuis in gloria numerari.\nSalvum fac populum tuum, Domine, et benedic hereditati tuae.\nEt rege eos, et extolle illos usque in aeternum.\nPer singulos dies benedicimus te.\nEt laudamus nomen tuum in saeculum, et in saeculum saeculi.\nDignare, Domine, die isto sine peccato nos custodire.\nMiserere nostri, Domine, miserere nostri.\nFiat misericordia tua, Domine, super nos, quemadmodum speravimus in te.\nIn te, Domine, speravi: non confundar in aeternum.\nHymnus Te Deum, dicitur semper quando in aliis Matutinis dicitur; vel ultimum usque ad ℣. exclusive repetendum erit, quando in aliis Matutinis repetitur.\nAnte Laudes\n℣. Ora pro nobis, sancta Dei Genitrix.\n℟. Ut digni efficiamur promissionibus Christi.",
-                "en-US": "We praise thee, O God, we acknowledge thee to be the Lord.\nAll the earth doth worship thee, the Father everlasting.\nTo thee all Angels cry aloud, the Heavens, and all the Powers therein.\nTo thee Cherubim and Seraphim continually do cry:\nHoly, Holy, Holy, * Lord God of Sabaoth.\nHeaven and earth are full of the Majesty of thy glory.\nThe glorious company of the Apostles praise thee.\nThe goodly fellowship of the Prophets praise thee.\nThe noble army of Martyrs praise thee.\nThe holy Church throughout all the world doth acknowledge thee:\nThe Father, of an infinite Majesty;\nThine honorable, true, and only Son;\nAlso the Holy Ghost, the Comforter.\nThou art the King of Glory, * O Christ.\nThou art the everlasting Son of the Father.\nWhen thou tookest upon thee to deliver man, thou didst not abhor the Virgin's womb.\nWhen thou hadst overcome the sharpness of death, thou didst open the Kingdom of Heaven to all believers.\nThou sittest at the right hand of God, in the glory of the Father.\nWe believe that thou shalt come to be our Judge.\nWe therefore pray thee, help thy servants, whom thou hast redeemed with thy precious Blood.\nMake them to be numbered with thy Saints, in glory everlasting.\nO Lord, save thy people, and bless thine heritage.\nGovern them, and lift them up for ever.\nDay by day we magnify thee;\nAnd we worship thy Name ever, world without end.\nVouchsafe, O Lord, to keep us this day without sin.\nO Lord, have mercy upon us, have mercy upon us.\nO Lord, let thy mercy lighten upon us, as our trust is in thee.\nO Lord, in thee have I trusted, let me never be confounded.\nBefore Lauds\n℣. Pray for us, O holy Mother of God.\n℟. That we may be made worthy of the promises of Christ."
+                "la": "Te Deum laudamus, te Dominum confitemur.\nTe aeternum Patrem omnis terra veneratur.\nTibi omnes Angeli, tibi Caeli, et universae Potestates.\nTibi Cherubim et Seraphim incessabili voce proclamant:\nSanctus, Sanctus, Sanctus Dominus Deus Sabaoth.\nPleni sunt caeli et terra majestatis gloriae tuae.\nTe gloriosus Apostolorum chorus.\nTe Prophetarum laudabilis numerus.\nTe Martyrum candidatus laudat exercitus.\nTe per orbem terrarum sancta confitetur Ecclesia:\nPatrem immensae majestatis.\nVenerandum tuum verum et unicum Filium.\nSanctum quoque Paraclitum Spiritum.\nTu Rex gloriae, Christe.\nTu Patris sempiternus es Filius.\nTu ad liberandum suscepturus hominem, non horruisti Virginis uterum.\nTu devicto mortis aculeo, aperuisti credentibus regna caelorum.\nTu ad dexteram Dei sedes in gloria Patris.\nJudex crederis esse venturus.\nTe ergo quaesumus, tuis famulis subveni, quos pretioso sanguine redemisti.\nAeterna fac cum sanctis tuis in gloria numerari.\nSalvum fac populum tuum, Domine, et benedic hereditati tuae.\nEt rege eos, et extolle illos usque in aeternum.\nPer singulos dies benedicimus te.\nEt laudamus nomen tuum in saeculum, et in saeculum saeculi.\nDignare, Domine, die isto sine peccato nos custodire.\nMiserere nostri, Domine, miserere nostri.\nFiat misericordia tua, Domine, super nos, quemadmodum speravimus in te.\nIn te, Domine, speravi: non confundar in aeternum.",
+                "en-US": "We praise thee, O God, we acknowledge thee to be the Lord.\nAll the earth doth worship thee, the Father everlasting.\nTo thee all Angels cry aloud, the Heavens, and all the Powers therein.\nTo thee Cherubim and Seraphim continually do cry:\nHoly, Holy, Holy, * Lord God of Sabaoth.\nHeaven and earth are full of the Majesty of thy glory.\nThe glorious company of the Apostles praise thee.\nThe goodly fellowship of the Prophets praise thee.\nThe noble army of Martyrs praise thee.\nThe holy Church throughout all the world doth acknowledge thee:\nThe Father, of an infinite Majesty;\nThine honorable, true, and only Son;\nAlso the Holy Ghost, the Comforter.\nThou art the King of Glory, * O Christ.\nThou art the everlasting Son of the Father.\nWhen thou tookest upon thee to deliver man, thou didst not abhor the Virgin's womb.\nWhen thou hadst overcome the sharpness of death, thou didst open the Kingdom of Heaven to all believers.\nThou sittest at the right hand of God, in the glory of the Father.\nWe believe that thou shalt come to be our Judge.\nWe therefore pray thee, help thy servants, whom thou hast redeemed with thy precious Blood.\nMake them to be numbered with thy Saints, in glory everlasting.\nO Lord, save thy people, and bless thine heritage.\nGovern them, and lift them up for ever.\nDay by day we magnify thee;\nAnd we worship thy Name ever, world without end.\nVouchsafe, O Lord, to keep us this day without sin.\nO Lord, have mercy upon us, have mercy upon us.\nO Lord, let thy mercy lighten upon us, as our trust is in thee.\nO Lord, in thee have I trusted, let me never be confounded."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Before Lauds"
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Te Deum dicitur semper quando in aliis Matutinis dicitur; vel ultimum usque ad versus exclusive repetendum erit, quando in aliis Matutinis repetitur."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Ante Laudes"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Dei Genitrix.",
+                    "en-US": "Pray for us, O holy Mother of God."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi.",
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsory",
                 "en-US": "Responsory"
@@ -126,13 +815,37 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Sancta et immaculata virginitas, quibus te laudibus efferam, nescio: quia quem caeli capere non poterant, tuo gremio contulisti.\n℣. Benedicta tu in mulieribus, et benedictus fructus ventris tui. Quia.",
-                "en-US": "℟. O holy and immaculate Virginity, with what praises to extol thee, I know not: For thou gavest from thy bosom Him Whom the heavens could not contain.\n℣. Blessed art thou among women, and blessed is the fruit of thy womb. For thou gavest from thy bosom Him Whom the heavens could not contain."
+                "la": "Sancta et immaculata virginitas, quibus te laudibus efferam, nescio: quia quem caeli capere non poterant, tuo gremio contulisti."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui. Quia."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "O holy and immaculate Virginity, with what praises to extol thee, I know not: For thou gavest from thy bosom Him Whom the heavens could not contain."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "Blessed art thou among women, and blessed is the fruit of thy womb. For thou gavest from thy bosom Him Whom the heavens could not contain."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsory",
                 "en-US": "Responsory"
@@ -140,13 +853,37 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Beata es, Virgo Maria, quae Dominum portasti creatorem mundi: genuisti eum, qui te fecit, et in aeternum permanes virgo.\n℣. Ave, Maria, gratia plena, Dominus tecum. Genuisti.",
-                "en-US": "℟. Blessed art thou, O Virgin Mary, who didst bear the Lord, the Creator of the world: Thou gavest birth unto Him Who made thee, and remainest a virgin evermore.\n℣. Hail Mary, full of grace, the Lord is with thee. Thou gavest birth unto Him Who made thee, and remainest a virgin evermore."
+                "la": "Beata es, Virgo Maria, quae Dominum portasti creatorem mundi: genuisti eum, qui te fecit, et in aeternum permanes virgo."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Ave, Maria, gratia plena, Dominus tecum. Genuisti."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Blessed art thou, O Virgin Mary, who didst bear the Lord, the Creator of the world: Thou gavest birth unto Him Who made thee, and remainest a virgin evermore."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "Hail Mary, full of grace, the Lord is with thee. Thou gavest birth unto Him Who made thee, and remainest a virgin evermore."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsory",
                 "en-US": "Responsory"
@@ -154,9 +891,55 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Felix namque es, sacra Virgo Maria, et omni laude dignissima, quia ex te ortus est Sol justitiae, Christus Deus noster.\n℣. Ora pro populo, interveni pro clero, intercede pro devoto femineo sexu: sentiant omnes tuum juvamen, quicumque celebrant tuam commemorationem. Quia. Gloria. Christus.",
-                "en-US": "℟. Happy thou, O sacred Virgin Mary, and most worthy of all praise: For out of thee arose the Sun of Justice, Christ our God.\n℣. Pray for the people, plead for the clergy, make intercession for the devout female sex; let all feel thy helping power who celebrate thy blessed memory. For out of thee arose the Sun of Justice, Christ our God.\nGlory be to the Father, and to the Son, and to the Holy Ghost:\nChrist our God.\nOn those Sundays and feast days when the Te Deum is omitted, the following is added:\n℟. Yea, happy art thou, O Holy Mother of God, and most worthy of all praise: For out of thee arose the Sun of Justice, even Christ our Lord."
+                "la": "Felix namque es, sacra Virgo Maria, et omni laude dignissima, quia ex te ortus est Sol justitiae, Christus Deus noster."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Ora pro populo, interveni pro clero, intercede pro devoto femineo sexu: sentiant omnes tuum juvamen, quicumque celebrant tuam commemorationem. Quia. Gloria. Christus."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Happy thou, O sacred Virgin Mary, and most worthy of all praise: For out of thee arose the Sun of Justice, Christ our God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "Pray for the people, plead for the clergy, make intercession for the devout female sex; let all feel thy helping power who celebrate thy blessed memory. For out of thee arose the Sun of Justice, Christ our God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost:\nChrist our God."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "On those Sundays and feast days when the Te Deum is omitted, the following is added:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Yea, happy art thou, O Holy Mother of God, and most worthy of all praise: For out of thee arose the Sun of Justice, even Christ our Lord."
               }
             }
           ]
@@ -170,14 +953,278 @@
           },
           "sections": [
             {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\nGloria Patri. Sicut erat.\nPsalmus 92\nDominus regnavit, decorem indutus est: indutus est Dominus fortitudinem, et praecinxit se.\nEtenim firmavit orbem terrae, qui non commovebitur.\nParata sedes tua ex tunc: a saeculo tu es.\nElevaverunt flumina, Domine: elevaverunt flumina vocem suam.\nElevaverunt flumina fluctus suos, a vocibus aquarum multarum.\nMirabiles elationes maris: mirabilis in altis Dominus.\nTestimonia tua credibilia facta sunt nimis: domum tuam decet sanctitudo, Domine, in longitudinem dierum.\nGloria Patri.\nPsalmus 99\nJubilate Deo, omnis terra: servite Domino in laetitia.\nIntroite in conspectu ejus, in exsultatione.\nScitote quoniam Dominus ipse est Deus: ipse fecit nos, et non ipsi nos.\nPopulus ejus, et oves pascuae ejus: introite portas ejus in confessione, atria ejus in hymnis: confitemini illi.\nLaudate nomen ejus: quoniam suavis est Dominus, in aeternum misericordia ejus, et usque in generationem et generationem veritas ejus.\nGloria Patri.\nPsalmus 62\nDeus, Deus meus, ad te de luce vigilo.\nSitivit in te anima mea, quam multipliciter tibi caro mea.\nIn terra deserta et invia, et inaquosa: sic in sancto apparui tibi, ut viderem virtutem tuam, et gloriam tuam.\nQuoniam melior est misericordia tua super vitas: labia mea laudabunt te.\nSic benedicam te in vita mea: et in nomine tuo levabo manus meas.\nSicut adipe et pinguedine repleatur anima mea: et labiis exsultationis laudabit os meum.\nSi memor fui tui super stratum meum, in matutinis meditabor in te: quia fuisti adjutor meus.\nEt in velamento alarum tuarum exsultabo, adhaesit anima mea post te: me suscepit dextera tua.\nIpsi vero in vanum quaesierunt animam meam, introibunt in inferiora terrae: tradentur in manus gladii, partes vulpium erunt.\nRex vero laetabitur in Deo, laudabuntur omnes qui jurant in eo: quia obstructum est os loquentium iniqua.\nGloria Patri.\nCanticum trium Puerorum (Dan. 3)\nBenedicite, omnia opera Domini, Domino: laudate et superexaltate eum in saecula.\nBenedicite, Angeli Domini, Domino: benedicite, caeli, Domino.\nBenedicite, aquae omnes quae super caelos sunt, Domino: benedicite, omnes virtutes Domini, Domino.\nBenedicite, sol et luna, Domino: benedicite, stellae caeli, Domino.\nBenedicite, omnis imber et ros, Domino: benedicite, omnes spiritus Dei, Domino.\nBenedicite, ignis et aestus, Domino: benedicite, frigus et aestus, Domino.\nBenedicite, rores et pruina, Domino: benedicite, gelu et frigus, Domino.\nBenedicite, glacies et nives, Domino: benedicite, noctes et dies, Domino.\nBenedicite, lux et tenebrae, Domino: benedicite, fulgura et nubes, Domino.\nBenedicat terra Dominum: laudet et superexaltet eum in saecula.\nBenedicite, montes et colles, Domino: benedicite, universa germinantia in terra, Domino.\nBenedicite, fontes, Domino: benedicite, maria et flumina, Domino.\nBenedicite, cete et omnia quae moventur in aquis, Domino: benedicite, omnes volucres caeli, Domino.\nBenedicite, omnes bestiae et pecora, Domino: benedicite, filii hominum, Domino.\nBenedicat Israel Dominum: laudet et superexaltet eum in saecula.\nBenedicite, sacerdotes Domini, Domino: benedicite, servi Domini, Domino.\nBenedicite, spiritus et animae justorum, Domino: benedicite, sancti et humiles corde, Domino.\nBenedicite, Anania, Azaria, Misaël, Domino: laudate et superexaltate eum in saecula.\nBenedicamus Patrem et Filium cum Sancto Spiritu: laudemus et superexaltemus eum in saecula.\nBenedictus es, Domine, in firmamento caeli: et laudabilis, et gloriosus, et superexaltatus in saecula.\nHic non dicitur Gloria Patri neque Amen.\nPsalmus 148\nLaudate Dominum de caelis: laudate eum in excelsis.\nLaudate eum, omnes Angeli ejus: laudate eum, omnes virtutes ejus.\nLaudate eum, sol et luna: laudate eum, omnes stellae et lumen.\nLaudate eum, caeli caelorum: et aquae omnes, quae super caelos sunt, laudent nomen Domini.\nQuia ipse dixit, et facta sunt: ipse mandavit, et creata sunt.\nStatuit ea in aeternum et in saeculum saeculi: praeceptum posuit, et non praeteribit.\nLaudate Dominum de terra, dracones et omnes abyssi.\nIgnis, grando, nix, glacies, spiritus procellarum: quae faciunt verbum ejus.\nMontes et omnes colles: ligna fructifera et omnes cedri.\nBestiae et universa pecora: serpentes et volucres pennatae.\nReges terrae et omnes populi: principes et omnes judices terrae.\nJuvenes et virgines: senes cum junioribus laudent nomen Domini.\nQuia exaltatum est nomen ejus solius.\nConfessio ejus super caelum et terram: et exaltavit cornu populi sui.\nHymnus omnibus sanctis ejus: filiis Israel, populo appropinquanti sibi.\nPsalm 149\nCantate Domino canticum novum: laus ejus in ecclesia sanctorum.\nLaetetur Israel in eo, qui fecit eum: et filii Sion exsultent in rege suo.\nLaudent nomen ejus in choro: in tympano, et psalterio psallant ei.\nQuia beneplacitum est Domino in populo suo: et exaltabit mansuetos in salutem.\nExsultabunt sancti in gloria: laetabuntur in cubilibus suis.\nExaltationes Dei in gutture eorum: et gladii ancipites in manibus eorum.\nAd faciendam vindictam in nationibus: increpationes in populis.\nAd alligandos reges eorum in compedibus: et nobiles eorum in manicis ferreis.\nUt faciant in eis judicium conscriptum: gloria haec est omnibus sanctis ejus.\nPsalm 150\nLaudate Dominum in sanctis ejus: laudate eum in firmamento virtutis ejus.\nLaudate eum in virtutibus ejus: laudate eum secundum multitudinem magnitudinis ejus.\nLaudate eum in sono tubae: laudate eum in psalterio, et cithara.\nLaudate eum in tympano, et choro: laudate eum in chordis, et organo.\nLaudate eum in cymbalis benesonantibus: laudate eum in cymbalis jubilationis: omnis spiritus laudet Dominum.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, world without end, Amen. Alleluia (or Praise to thee.)\nPsalm 92\nThe Lord hath reigned, and hath put on glorious apparel: the Lord hath put on his apparel, and girded himself with strength.\nFor he hath established the round world, that it cannot be moved.\nThy throne is prepared from of old: thou art from everlasting.\nThe floods have lift up, O Lord: yea, the floods have lift up their voice.\nThe floods have lift up their waves, with the noise of many waters.\nThe waves of the sea are mighty: glorious is the Lord, who dwelleth on high.\nThy testimonies are become exceeding credible: holiness becometh thine house, O Lord, unto length of days.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 99\nO be joyful in the Lord, all ye lands: serve the Lord with gladness.\nCome before his presence with exceeding great joy.\nKnow ye that the Lord he is God; it is he that hath made us, and not we ourselves.\nWe are his people, and the sheep of his pasture: O go your way into his gates with thanksgiving, and into his courts with praise; be ye thankful unto him.\nGive praises unto his Name: for the Lord is gracious, his mercy is everlasting; and his truth endureth from generation to generation.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 62\nO God, thou art my God, to thee do I watch at break of day.\nMy soul hath thirsted for thee, my flesh also in many different ways.\nIn a barren and dry land where no water is: so in the sanctuary have I come before thee, that I might behold thy power and thy glory.\nFor thy mercy is better than the life itself: my lips shall praise thee.\nThus will I bless thee as long as I live: and I will lift up my hands in thy Name.\nMy soul shall be filled as with marrow and fatness, and my mouth shall praise thee with joyful lips.\nIf I have remembered thee in my bed, I will think upon thee in the morning: because thou hast been my helper.\nAnd under the shadow of thy wings will I rejoice, my soul hath hung upon thee; thy right hand hath upholden me.\nBut they have sought my soul in vain, they shall go down into the nether parts of the earth: they shall be delivered into the hands of the sword, they shall be a portion for foxes.\nBut the king shall rejoice in God; all they also that swear by him shall be commended; for the mouth of them that speak wicked things shall be stopped.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 66\nMay God have mercy on us, and bless us: may he shew us the light of his countenance, and be merciful unto us.\nThat thy way may be known upon earth: thy salvation in all nations.\nLet people confess to thee, O God: let all the people give praise to thee.\nLet the nations be glad and rejoice: for thou judgest the folk righteously, and govern the nations upon earth.\nLet the people, O God, confess to thee: let all the people give praise to thee. Then shall the earth bring forth her increase.\nMay God, our God bless us. May God bless us: and all the ends of the world shall fear him.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nCanticle of the Three Youths\nO all ye Works of the Lord, bless ye the Lord: praise him, and magnify him for ever.\nO ye Angels of the Lord, bless ye the Lord: O ye Heavens, bless ye the Lord.\nO ye Waters that be above the Firmament, bless ye the Lord: O all ye Powers of the Lord, bless ye the Lord.\nO ye Sun and Moon, bless ye the Lord: O ye Stars of Heaven, bless ye the Lord.\nO ye Showers and Dew, bless ye the Lord: O ye winds of God, bless ye the Lord.\nO ye Fire and Heat, bless ye the Lord: O ye Winter and Summer, bless ye the Lord.\nO ye Dews and Frosts, bless ye the Lord: O ye Frost and Cold, bless ye the Lord.\nO ye Ice and Snow, bless ye the Lord: O ye Nights and Days, bless ye the Lord.\nO ye Light and Darkness, bless ye the Lord: O ye Lightnings and Clouds, bless ye the Lord.\nO let the Earth bless the Lord; yea, let it praise him, and magnify him for ever.\nO ye Mountains and Hills, bless ye the Lord: O all ye Green Things upon the earth, bless ye the Lord.\nO ye Wells, bless ye the Lord: O ye Seas and Floods, bless ye the Lord.\nO ye Whales, and all that move in the waters, bless ye the Lord: O all ye Fowls of the Air, bless ye the Lord.\nO all ye Beasts and Cattle, bless ye the Lord: O ye Children of Men, bless ye the Lord.\nO let Israel bless the Lord; praise him, and magnify him for ever.\nO ye Priests of the Lord, bless ye the Lord: O ye Servants of the Lord, bless ye the Lord.\nO ye Spirits and Souls of the Righteous, bless ye the Lord: O ye holy and humble Men of heart, bless ye the Lord.\nO Ananias, Azarias, and Misael, bless ye the Lord: praise him and magnify him for ever.\nLet us bless the Father and the Son, with the Holy Ghost: let us praise him and magnify him for ever.\nBlessed art thou, O Lord, in the firmament of heaven; and to be praised and exalted above all for ever.\nPsalm 148\nO praise ye the Lord from the heavens: praise ye him in the height.\nPraise him, all ye Angels of his: praise him, all his host.\nPraise ye him, O sun and moon: praise him, all ye stars and light.\nPraise him, all ye heavens of heavens, and ye waters that are above the heavens, praise the Name of the Lord.\nFor he spake the word, and they were made: he commanded, and they were created.\nHe hath established them for ever, yea, unto ages of ages: he hath set forth a law, and it shall not pass away.\nPraise the Lord from the earth, ye dragons and all deeps.\nFire and hail, snow and ice, wind and storm, fulfilling his word.\nMountains and all hills; fruitful trees and all cedars.\nBeasts and all cattle; creeping things and flying fowls.\nKings of the earth, and all people; princes, and all judges of the world.\nYoung men and maidens, old men and children, praise the Name of the Lord: for his Name only is exalted.\nHis praise is above heaven and earth: and he shall exalt the horn of his people.\nA hymn unto all his saints: even unto the children of Israel, a people that draw nigh unto him.\nPsalm 149\nO sing unto the Lord a new song: let his praise be in the church of the saints.\nLet Israel rejoice in him that made him: and let the children of Sion be joyful in their king.\nLet them praise his name in choir: let them sing praises unto him with tabret and harp.\nFor the Lord hath pleasure in his people: and he will exalt the meek unto salvation.\nThe saints shall rejoice in glory: let them rejoice in their beds.\nThe high praise of God shall be in their mouth: and a two-edged sword in their hands.\nTo execute vengeance upon the nations, and to rebuke the people.\nTo bind their kings with fetters, and their nobles with links of iron.\nTo execute upon them the judgment that is written: Such honour have all his saints.\nPsalm 150\nPraise ye the Lord in his holy places: praise him in the firmament of his power.\nPraise ye him for his mighty acts: praise him according to his excellent greatness.\nPraise him with the sound of the trumpet: praise him with psaltery and harp.\nPraise him with timbrel and choir: praise him upon the strings and organs.\nPraise him upon the well-tuned cymbals: praise him on cymbals of joy.\nLet every thing that hath breath, praise the Lord.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Gloria Patri. Sicut erat."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Psalmus 92"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Dominus regnavit, decorem indutus est: indutus est Dominus fortitudinem, et praecinxit se.\nEtenim firmavit orbem terrae, qui non commovebitur.\nParata sedes tua ex tunc: a saeculo tu es.\nElevaverunt flumina, Domine: elevaverunt flumina vocem suam.\nElevaverunt flumina fluctus suos, a vocibus aquarum multarum.\nMirabiles elationes maris: mirabilis in altis Dominus.\nTestimonia tua credibilia facta sunt nimis: domum tuam decet sanctitudo, Domine, in longitudinem dierum.\nGloria Patri."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Psalmus 99"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Jubilate Deo, omnis terra: servite Domino in laetitia.\nIntroite in conspectu ejus, in exsultatione.\nScitote quoniam Dominus ipse est Deus: ipse fecit nos, et non ipsi nos.\nPopulus ejus, et oves pascuae ejus: introite portas ejus in confessione, atria ejus in hymnis: confitemini illi.\nLaudate nomen ejus: quoniam suavis est Dominus, in aeternum misericordia ejus, et usque in generationem et generationem veritas ejus.\nGloria Patri."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Psalmus 62"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Deus, Deus meus, ad te de luce vigilo.\nSitivit in te anima mea, quam multipliciter tibi caro mea.\nIn terra deserta et invia, et inaquosa: sic in sancto apparui tibi, ut viderem virtutem tuam, et gloriam tuam.\nQuoniam melior est misericordia tua super vitas: labia mea laudabunt te.\nSic benedicam te in vita mea: et in nomine tuo levabo manus meas.\nSicut adipe et pinguedine repleatur anima mea: et labiis exsultationis laudabit os meum.\nSi memor fui tui super stratum meum, in matutinis meditabor in te: quia fuisti adjutor meus.\nEt in velamento alarum tuarum exsultabo, adhaesit anima mea post te: me suscepit dextera tua.\nIpsi vero in vanum quaesierunt animam meam, introibunt in inferiora terrae: tradentur in manus gladii, partes vulpium erunt.\nRex vero laetabitur in Deo, laudabuntur omnes qui jurant in eo: quia obstructum est os loquentium iniqua.\nGloria Patri."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Canticum trium Puerorum (Dan. 3)"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Benedicite, omnia opera Domini, Domino: laudate et superexaltate eum in saecula.\nBenedicite, Angeli Domini, Domino: benedicite, caeli, Domino.\nBenedicite, aquae omnes quae super caelos sunt, Domino: benedicite, omnes virtutes Domini, Domino.\nBenedicite, sol et luna, Domino: benedicite, stellae caeli, Domino.\nBenedicite, omnis imber et ros, Domino: benedicite, omnes spiritus Dei, Domino.\nBenedicite, ignis et aestus, Domino: benedicite, frigus et aestus, Domino.\nBenedicite, rores et pruina, Domino: benedicite, gelu et frigus, Domino.\nBenedicite, glacies et nives, Domino: benedicite, noctes et dies, Domino.\nBenedicite, lux et tenebrae, Domino: benedicite, fulgura et nubes, Domino.\nBenedicat terra Dominum: laudet et superexaltet eum in saecula.\nBenedicite, montes et colles, Domino: benedicite, universa germinantia in terra, Domino.\nBenedicite, fontes, Domino: benedicite, maria et flumina, Domino.\nBenedicite, cete et omnia quae moventur in aquis, Domino: benedicite, omnes volucres caeli, Domino.\nBenedicite, omnes bestiae et pecora, Domino: benedicite, filii hominum, Domino.\nBenedicat Israel Dominum: laudet et superexaltet eum in saecula.\nBenedicite, sacerdotes Domini, Domino: benedicite, servi Domini, Domino.\nBenedicite, spiritus et animae justorum, Domino: benedicite, sancti et humiles corde, Domino.\nBenedicite, Anania, Azaria, Misaël, Domino: laudate et superexaltate eum in saecula.\nBenedicamus Patrem et Filium cum Sancto Spiritu: laudemus et superexaltemus eum in saecula.\nBenedictus es, Domine, in firmamento caeli: et laudabilis, et gloriosus, et superexaltatus in saecula."
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Hic non dicitur Gloria Patri neque Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Psalmus 148"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Laudate Dominum de caelis: laudate eum in excelsis.\nLaudate eum, omnes Angeli ejus: laudate eum, omnes virtutes ejus.\nLaudate eum, sol et luna: laudate eum, omnes stellae et lumen.\nLaudate eum, caeli caelorum: et aquae omnes, quae super caelos sunt, laudent nomen Domini.\nQuia ipse dixit, et facta sunt: ipse mandavit, et creata sunt.\nStatuit ea in aeternum et in saeculum saeculi: praeceptum posuit, et non praeteribit.\nLaudate Dominum de terra, dracones et omnes abyssi.\nIgnis, grando, nix, glacies, spiritus procellarum: quae faciunt verbum ejus.\nMontes et omnes colles: ligna fructifera et omnes cedri.\nBestiae et universa pecora: serpentes et volucres pennatae.\nReges terrae et omnes populi: principes et omnes judices terrae.\nJuvenes et virgines: senes cum junioribus laudent nomen Domini.\nQuia exaltatum est nomen ejus solius.\nConfessio ejus super caelum et terram: et exaltavit cornu populi sui."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus omnibus sanctis ejus: filiis Israel, populo appropinquanti sibi."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Psalm 149"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Cantate Domino canticum novum: laus ejus in ecclesia sanctorum.\nLaetetur Israel in eo, qui fecit eum: et filii Sion exsultent in rege suo.\nLaudent nomen ejus in choro: in tympano, et psalterio psallant ei.\nQuia beneplacitum est Domino in populo suo: et exaltabit mansuetos in salutem.\nExsultabunt sancti in gloria: laetabuntur in cubilibus suis.\nExaltationes Dei in gutture eorum: et gladii ancipites in manibus eorum.\nAd faciendam vindictam in nationibus: increpationes in populis.\nAd alligandos reges eorum in compedibus: et nobiles eorum in manicis ferreis.\nUt faciant in eis judicium conscriptum: gloria haec est omnibus sanctis ejus."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Psalm 150"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Laudate Dominum in sanctis ejus: laudate eum in firmamento virtutis ejus.\nLaudate eum in virtutibus ejus: laudate eum secundum multitudinem magnitudinis ejus.\nLaudate eum in sono tubae: laudate eum in psalterio, et cithara.\nLaudate eum in tympano, et choro: laudate eum in chordis, et organo.\nLaudate eum in cymbalis benesonantibus: laudate eum in cymbalis jubilationis: omnis spiritus laudet Dominum.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now, and ever shall be, world without end, Amen. Alleluia (or Praise to thee.)"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Psalm 92"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "The Lord hath reigned, and hath put on glorious apparel: the Lord hath put on his apparel, and girded himself with strength.\nFor he hath established the round world, that it cannot be moved.\nThy throne is prepared from of old: thou art from everlasting.\nThe floods have lift up, O Lord: yea, the floods have lift up their voice.\nThe floods have lift up their waves, with the noise of many waters.\nThe waves of the sea are mighty: glorious is the Lord, who dwelleth on high.\nThy testimonies are become exceeding credible: holiness becometh thine house, O Lord, unto length of days.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Psalm 99"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O be joyful in the Lord, all ye lands: serve the Lord with gladness.\nCome before his presence with exceeding great joy.\nKnow ye that the Lord he is God; it is he that hath made us, and not we ourselves.\nWe are his people, and the sheep of his pasture: O go your way into his gates with thanksgiving, and into his courts with praise; be ye thankful unto him.\nGive praises unto his Name: for the Lord is gracious, his mercy is everlasting; and his truth endureth from generation to generation.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Psalm 62"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, thou art my God, to thee do I watch at break of day.\nMy soul hath thirsted for thee, my flesh also in many different ways.\nIn a barren and dry land where no water is: so in the sanctuary have I come before thee, that I might behold thy power and thy glory.\nFor thy mercy is better than the life itself: my lips shall praise thee.\nThus will I bless thee as long as I live: and I will lift up my hands in thy Name.\nMy soul shall be filled as with marrow and fatness, and my mouth shall praise thee with joyful lips.\nIf I have remembered thee in my bed, I will think upon thee in the morning: because thou hast been my helper.\nAnd under the shadow of thy wings will I rejoice, my soul hath hung upon thee; thy right hand hath upholden me.\nBut they have sought my soul in vain, they shall go down into the nether parts of the earth: they shall be delivered into the hands of the sword, they shall be a portion for foxes.\nBut the king shall rejoice in God; all they also that swear by him shall be commended; for the mouth of them that speak wicked things shall be stopped.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Psalm 66"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "May God have mercy on us, and bless us: may he shew us the light of his countenance, and be merciful unto us.\nThat thy way may be known upon earth: thy salvation in all nations.\nLet people confess to thee, O God: let all the people give praise to thee.\nLet the nations be glad and rejoice: for thou judgest the folk righteously, and govern the nations upon earth.\nLet the people, O God, confess to thee: let all the people give praise to thee. Then shall the earth bring forth her increase.\nMay God, our God bless us. May God bless us: and all the ends of the world shall fear him.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Canticle of the Three Youths"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O all ye Works of the Lord, bless ye the Lord: praise him, and magnify him for ever.\nO ye Angels of the Lord, bless ye the Lord: O ye Heavens, bless ye the Lord.\nO ye Waters that be above the Firmament, bless ye the Lord: O all ye Powers of the Lord, bless ye the Lord.\nO ye Sun and Moon, bless ye the Lord: O ye Stars of Heaven, bless ye the Lord.\nO ye Showers and Dew, bless ye the Lord: O ye winds of God, bless ye the Lord.\nO ye Fire and Heat, bless ye the Lord: O ye Winter and Summer, bless ye the Lord.\nO ye Dews and Frosts, bless ye the Lord: O ye Frost and Cold, bless ye the Lord.\nO ye Ice and Snow, bless ye the Lord: O ye Nights and Days, bless ye the Lord.\nO ye Light and Darkness, bless ye the Lord: O ye Lightnings and Clouds, bless ye the Lord.\nO let the Earth bless the Lord; yea, let it praise him, and magnify him for ever.\nO ye Mountains and Hills, bless ye the Lord: O all ye Green Things upon the earth, bless ye the Lord.\nO ye Wells, bless ye the Lord: O ye Seas and Floods, bless ye the Lord.\nO ye Whales, and all that move in the waters, bless ye the Lord: O all ye Fowls of the Air, bless ye the Lord.\nO all ye Beasts and Cattle, bless ye the Lord: O ye Children of Men, bless ye the Lord.\nO let Israel bless the Lord; praise him, and magnify him for ever.\nO ye Priests of the Lord, bless ye the Lord: O ye Servants of the Lord, bless ye the Lord.\nO ye Spirits and Souls of the Righteous, bless ye the Lord: O ye holy and humble Men of heart, bless ye the Lord.\nO Ananias, Azarias, and Misael, bless ye the Lord: praise him and magnify him for ever.\nLet us bless the Father and the Son, with the Holy Ghost: let us praise him and magnify him for ever.\nBlessed art thou, O Lord, in the firmament of heaven; and to be praised and exalted above all for ever."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Psalm 148"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O praise ye the Lord from the heavens: praise ye him in the height.\nPraise him, all ye Angels of his: praise him, all his host.\nPraise ye him, O sun and moon: praise him, all ye stars and light.\nPraise him, all ye heavens of heavens, and ye waters that are above the heavens, praise the Name of the Lord.\nFor he spake the word, and they were made: he commanded, and they were created.\nHe hath established them for ever, yea, unto ages of ages: he hath set forth a law, and it shall not pass away.\nPraise the Lord from the earth, ye dragons and all deeps.\nFire and hail, snow and ice, wind and storm, fulfilling his word.\nMountains and all hills; fruitful trees and all cedars.\nBeasts and all cattle; creeping things and flying fowls.\nKings of the earth, and all people; princes, and all judges of the world.\nYoung men and maidens, old men and children, praise the Name of the Lord: for his Name only is exalted.\nHis praise is above heaven and earth: and he shall exalt the horn of his people.\nA hymn unto all his saints: even unto the children of Israel, a people that draw nigh unto him."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Psalm 149"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O sing unto the Lord a new song: let his praise be in the church of the saints.\nLet Israel rejoice in him that made him: and let the children of Sion be joyful in their king.\nLet them praise his name in choir: let them sing praises unto him with tabret and harp.\nFor the Lord hath pleasure in his people: and he will exalt the meek unto salvation.\nThe saints shall rejoice in glory: let them rejoice in their beds.\nThe high praise of God shall be in their mouth: and a two-edged sword in their hands.\nTo execute vengeance upon the nations, and to rebuke the people.\nTo bind their kings with fetters, and their nobles with links of iron.\nTo execute upon them the judgment that is written: Such honour have all his saints."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Psalm 150"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Praise ye the Lord in his holy places: praise him in the firmament of his power.\nPraise ye him for his mighty acts: praise him according to his excellent greatness.\nPraise him with the sound of the trumpet: praise him with psaltery and harp.\nPraise him with timbrel and choir: praise him upon the strings and organs.\nPraise him upon the well-tuned cymbals: praise him on cymbals of joy.\nLet every thing that hath breath, praise the Lord.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -191,7 +1238,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Chapter",
                 "en-US": "Chapter"
@@ -200,26 +1247,132 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ego quasi vitis fructificavi suavitatem odoris: et flores mei fructus honoris et honestatis.\n℟. Deo gratias.",
-                "en-US": "Like a vine, I gave forth an odor of sweetness: and my flowers are the fruits of honor and riches.\n℟. Thanks be to God."
+                "la": "Ego quasi vitis fructificavi suavitatem odoris: et flores mei fructus honoris et honestatis.",
+                "en-US": "Like a vine, I gave forth an odor of sweetness: and my flowers are the fruits of honor and riches."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O gloriosa Domina,\nExcelsa supra sidera,\nQui te creavit provide,\nLactasti sacro ubere.\nQuod Heva tristis abstulit,\nTu reddis almo germine:\nIntrent ut astra flebiles,\nCaeli fenestra facta es.\nTu Regis alti janua,\nEt porta lucis fulgida:\nVitam datam per Virginem,\nGentes redemptae plaudite.\nMaria, mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt hora mortis suscipe.\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre et Sancto Spiritu,\nIn sempiterna saecula. Amen.\n℣. Elegit eam Deus, et praelegit eam.\n℟. Et habitare eam facit in tabernaculo suo.\nCanticum Zachariae (Luc. 1)\nBenedictus Dominus, Deus Israel, quia visitavit, et fecit redemptionem plebis suae:\nEt erexit cornu salutis nobis, in domo David pueri sui.\nSicut locutus est per os sanctorum, qui a saeculo sunt, prophetarum ejus:\nSalutem ex inimicis nostris, et de manu omnium, qui oderunt nos:\nAd faciendam misericordiam cum patribus nostris: et memorari testamenti sui sancti.\nJusjurandum, quod juravit ad Abraham patrem nostrum, datum se nobis:\nUt sine timore, de manu inimicorum nostrorum liberati, serviamus illi.\nIn sanctitate et justitia coram ipso, omnibus diebus nostris.\nEt tu, puer, propheta Altissimi vocaberis: praeibis enim ante faciem Domini parare vias ejus:\nAd dandam scientiam salutis plebi ejus: in remissionem peccatorum eorum:\nPer viscera misericordiae Dei nostri: in quibus visitavit nos Oriens ex alto.\nIlluminare his, qui in tenebris et in umbra mortis sedent: ad dirigendos pedes nostros in viam pacis.\nGloria Patri.",
-                "en-US": "O glorious Lady, throned in light,\nSublime above the starry height:\nThine arms thy great Creator pressed,\nA suckling at thy sacred breast.\nThrough the dear Blossom of thy womb,\nThou changest hapless Eva's doom:\nThrough thee to contrite souls is given,\nAn opening to their home in heaven.\nThou art the great King's portal bright,\nWith pearls and stones of living light:\nCome then, ye ransomed nations, sing,\nThe life divine 'twas hers to bring.\nO Mary, Mother of all grace,\nMother of Mercy to our race,\nProtect us now from Satan's power,\nAnd own us at life's closing hour.\nAll glory be Thee, O Lord,\nThe Virgin's son, by all ador'd,\nAnd equal praise forever greet,\nThe Father and the Paraclete. Amen.\n℣. God hath chosen her, and preferred her.\n℟. And He maketh her dwell in His tabernacle.\nCanticle of Zachary\nBlessed be the Lord God of Israel, for he hath visited and redeemed his people.\nAnd hath raised up a mighty salvation for us, in the house of his servant David.\nAs he spake by the mouth of his holy Prophets, which have been since the world began.\nThat we should be saved from our enemies, and from the hand of all that hate us.\nTo perform the mercy promised to our forefathers, and to remember his holy Covenant.\nTo perform the oath which he swore to our forefather Abraham, that he would give us.\nThat we being delivered out of the hand of our enemies might serve him without fear.\nIn holiness and righteousness before him, all the days of our life.\nAnd thou, child, shalt be called the Prophet of the Highest: for thou shalt go before the face of the Lord to prepare his ways.\nTo give knowledge of salvation unto his people for the remission of their sins.\nThrough the tender mercy of our God; whereby the Day-Spring from on high hath visited us.\nTo give light to them that sit in darkness, and in the shadow of death, and to guide our feet into the way of peace.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "O gloriosa Domina,\nExcelsa supra sidera,\nQui te creavit provide,\nLactasti sacro ubere.\nQuod Heva tristis abstulit,\nTu reddis almo germine:\nIntrent ut astra flebiles,\nCaeli fenestra facta es.\nTu Regis alti janua,\nEt porta lucis fulgida:\nVitam datam per Virginem,\nGentes redemptae plaudite.\nMaria, mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege,\nEt hora mortis suscipe.\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre et Sancto Spiritu,\nIn sempiterna saecula. Amen.",
+                "en-US": "O glorious Lady, throned in light,\nSublime above the starry height:\nThine arms thy great Creator pressed,\nA suckling at thy sacred breast.\nThrough the dear Blossom of thy womb,\nThou changest hapless Eva's doom:\nThrough thee to contrite souls is given,\nAn opening to their home in heaven.\nThou art the great King's portal bright,\nWith pearls and stones of living light:\nCome then, ye ransomed nations, sing,\nThe life divine 'twas hers to bring.\nO Mary, Mother of all grace,\nMother of Mercy to our race,\nProtect us now from Satan's power,\nAnd own us at life's closing hour.\nAll glory be Thee, O Lord,\nThe Virgin's son, by all ador'd,\nAnd equal praise forever greet,\nThe Father and the Paraclete. Amen."
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Elegit eam Deus, et praelegit eam.",
+                    "en-US": "God hath chosen her, and preferred her."
+                  },
+                  "r": {
+                    "la": "Et habitare eam facit in tabernaculo suo.",
+                    "en-US": "And He maketh her dwell in His tabernacle."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Canticum Zachariae (Luc. 1)",
+                "en-US": "Canticle of Zachary"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Benedictus Dominus, Deus Israel, quia visitavit, et fecit redemptionem plebis suae:\nEt erexit cornu salutis nobis, in domo David pueri sui.\nSicut locutus est per os sanctorum, qui a saeculo sunt, prophetarum ejus:\nSalutem ex inimicis nostris, et de manu omnium, qui oderunt nos:\nAd faciendam misericordiam cum patribus nostris: et memorari testamenti sui sancti.\nJusjurandum, quod juravit ad Abraham patrem nostrum, datum se nobis:\nUt sine timore, de manu inimicorum nostrorum liberati, serviamus illi.\nIn sanctitate et justitia coram ipso, omnibus diebus nostris.\nEt tu, puer, propheta Altissimi vocaberis: praeibis enim ante faciem Domini parare vias ejus:\nAd dandam scientiam salutis plebi ejus: in remissionem peccatorum eorum:\nPer viscera misericordiae Dei nostri: in quibus visitavit nos Oriens ex alto.\nIlluminare his, qui in tenebris et in umbra mortis sedent: ad dirigendos pedes nostros in viam pacis.\nGloria Patri.",
+                "en-US": "Blessed be the Lord God of Israel, for he hath visited and redeemed his people.\nAnd hath raised up a mighty salvation for us, in the house of his servant David.\nAs he spake by the mouth of his holy Prophets, which have been since the world began.\nThat we should be saved from our enemies, and from the hand of all that hate us.\nTo perform the mercy promised to our forefathers, and to remember his holy Covenant.\nTo perform the oath which he swore to our forefather Abraham, that he would give us.\nThat we being delivered out of the hand of our enemies might serve him without fear.\nIn holiness and righteousness before him, all the days of our life.\nAnd thou, child, shalt be called the Prophet of the Highest: for thou shalt go before the face of the Lord to prepare his ways.\nTo give knowledge of salvation unto his people for the remission of their sins.\nThrough the tender mercy of our God; whereby the Day-Spring from on high hath visited us.\nTo give light to them that sit in darkness, and in the shadow of death, and to guide our feet into the way of peace.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Antiphon",
+                "en-US": "Antiphon"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "O gloriosa Dei Genitrix, Virgo semper Maria, quae Dominum omnium meruisti portare, et Regem Angelorum sola virgo lactare: nostri, quaesumus, pia memorae, et pro nobis Christum deprecare, ut tuis fulti patrociniis ad caelestia regna mereamur pervenire."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
+            },
+            {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Vel"
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O glorious Mother of God, Mary, ever virgin, who alone wast found worthy to bear the Lord of all, and though a virgin, to nurse the King of angels: be graciously mindful of us, we beseech thee, and pray to Christ for us, that we, being upheld by thy care, may deserve to attain to heavenly kingdoms."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come onto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -228,12 +1381,151 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "O gloriosa Dei Genitrix, Virgo semper Maria, quae Dominum omnium meruisti portare, et Regem Angelorum sola virgo lactare: nostri, quaesumus, pia memorae, et pro nobis Christum deprecare, ut tuis fulti patrociniis ad caelestia regna mereamur pervenire.\n℣. Dominus vobiscum.\n℟. Et cum spiritu tuo.\nVel ℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.",
-                "en-US": "O glorious Mother of God, Mary, ever virgin, who alone wast found worthy to bear the Lord of all, and though a virgin, to nurse the King of angels: be graciously mindful of us, we beseech thee, and pray to Christ for us, that we, being upheld by thy care, may deserve to attain to heavenly kingdoms.\n℣. O Lord, hear my prayer.\n℟. And let my cry come onto Thee."
+                "la": "Benedictus Redemptor omnium, qui saluti providens hominum, mundo dedit sanctum Dominicum.",
+                "en-US": "Blessed be the Redeemer of all, Who, in providing for the salvation of men, gave Saint Dominic to the world."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Lex Dei ejus in corde ipsius.",
+                    "en-US": "The law of his God is in his heart."
+                  },
+                  "r": {
+                    "la": "Et non supplantabuntur gressus ejus.",
+                    "en-US": "And his steps shall not fail."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Prayer",
+                "en-US": "Prayer"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Concede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis salute gaudere: et, gloriosa beatae Mariae semper Virginis intercessione, a praesenti liberari tristitia et aeterna perfrui laetitia. Per Christum Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Memoria B. P. N. Dominici"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Grant, we beseech Thee, O Lord God, that we, Thy servants, may enjoy continual health of mind and body; and that through the glorious intercession of blessed Mary, ever virgin, we may be delivered from present sorrow and enjoy eternal happiness. Through Christ our Lord.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Commemoration of Our Holy Father, Saint Dominic"
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Antiphon",
+                "en-US": "Antiphon"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Benedictus Redemptor omnium, qui saluti providens hominum, mundo dedit sanctum Dominicum."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Lex Dei ejus in corde ipsius."
+                  },
+                  "r": {
+                    "la": "Et non supplantabuntur gressus ejus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O what happiness and glory belong always to the saints, how distinguished the merits of the Preachers, by whose words and deeds the world is adorned, by whose works the mind grows\nstronger."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "The Saints shall be joyful in glory."
+                  },
+                  "r": {
+                    "en-US": "They shall sing for joy on their"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "couches."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Prayer",
+                "en-US": "Prayer"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Deus, qui Ecclesiam tuam beati Dominici Confessoris tui, Patris nostri, illuminare dignatus es meritis et doctrinis: concede, ut ejus intercessione, temporalibus non destituatur auxiliis, et spiritualibus semper proficiat incrementis. Per Christum.\nMemoria SS. Ordinis"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who didst vouchsafe to enlighten Thy Church by the merits and teachings of Thy blessed Confessor, Our Father Dominic, grant through his intercession that it may never be destitute of temporal help, and may always increase in spiritual growth. Through Christ our Lord."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Commemoration of all the Saints of the Dominican Order"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -242,12 +1534,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Benedictus Redemptor omnium, qui saluti providens hominum, mundo dedit sanctum Dominicum.\n℣. Lex Dei ejus in corde ipsius.\n℟. Et non supplantabuntur gressus ejus.",
-                "en-US": "Blessed be the Redeemer of all, Who, in providing for the salvation of men, gave Saint Dominic to the world.\n℣. The law of his God is in his heart.\n℟. And his steps shall not fail."
+                "la": "O quam felix gloria semper est Sanctorum, quam praeclara merita sunt Praedicatorum! quorum verbo et opere mundus decoratur, eorumque munere mens consolidatur.",
+                "en-US": "O what happiness and glory belong always to the saints, how distinguished the merits of the Preachers, by whose words and deeds the world is adorned, by whose works the mind grows stronger."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Exsultabunt Sancti in gloria.",
+                    "en-US": "The Saints shall be joyful in glory."
+                  },
+                  "r": {
+                    "la": "Laetabuntur in cubilibus suis.",
+                    "en-US": "They shall sing for joy on their couches."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -255,13 +1562,27 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Concede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis salute gaudere: et, gloriosa beatae Mariae semper Virginis intercessione, a praesenti liberari tristitia et aeterna perfrui laetitia. Per Christum Dominum nostrum.\n℟. Amen.\nMemoria B. P. N. Dominici",
-                "en-US": "Grant, we beseech Thee, O Lord God, that we, Thy servants, may enjoy continual health of mind and body; and that through the glorious intercession of blessed Mary, ever virgin, we may be delivered from present sorrow and enjoy eternal happiness. Through Christ our Lord.\nAmen.\nCommemoration of Our Holy Father, Saint Dominic"
+                "la": "Concede, quaesumus, omnipotens Deus, ut ad meliorem vitam Sanctorum Ordinis nostri exempla nos provocent: quatenus, quorum memoriam agimus, etiam actus imitemur. Per Christum.\nMemoria Omnium Sanctorum"
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Grant, we beseech Thee, almighty God: that the examples of the saints of our Order may incite us to a better life; that we may imitate the deeds of them whose memory we celebrate. Through Christ our Lord."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Commemoration of all Saints"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -270,12 +1591,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Benedictus Redemptor omnium, qui saluti providens hominum, mundo dedit sanctum Dominicum.\n℣. Lex Dei ejus in corde ipsius.\n℟. Et non supplantabuntur gressus ejus.",
-                "en-US": "O what happiness and glory belong always to the saints, how distinguished the merits of the Preachers, by whose words and deeds the world is adorned, by whose works the mind grows\nstronger.\n℣. The Saints shall be joyful in glory.\n℟. They shall sing for joy on their\ncouches."
+                "la": "Sancti Dei omnes intercedere dignemini pro nostra omniumque salute.",
+                "en-US": "All ye saints of God vouchsafe to make intercession for our salvation, and for that of all."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Orate pro nobis, omnes Sancti Dei.",
+                    "en-US": "Pray for us, all ye saints of God."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi.",
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -283,13 +1619,27 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Deus, qui Ecclesiam tuam beati Dominici Confessoris tui, Patris nostri, illuminare dignatus es meritis et doctrinis: concede, ut ejus intercessione, temporalibus non destituatur auxiliis, et spiritualibus semper proficiat incrementis. Per Christum.\nMemoria SS. Ordinis",
-                "en-US": "O God, Who didst vouchsafe to enlighten Thy Church by the merits and teachings of Thy blessed Confessor, Our Father Dominic, grant through his intercession that it may never be destitute of temporal help, and may always increase in spiritual growth. Through Christ our Lord.\nCommemoration of all the Saints of the Dominican Order"
+                "la": "Tribue, quaesumus, Domine, omnes Sanctos tuos jugiter pro nobis orare: et eos clementer exaudire digneris. Per Christum.\nMemoria de Pace"
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Grant, we beseech Thee, O Lord, that all Thy saints may pray for us unceasingly, and vouchsafe in Thy clemency to hear them. Through Christ our Lord."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Commemoration for Peace"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -298,12 +1648,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "O quam felix gloria semper est Sanctorum, quam praeclara merita sunt Praedicatorum! quorum verbo et opere mundus decoratur, eorumque munere mens consolidatur.\n℣. Exsultabunt Sancti in gloria.\n℟. Laetabuntur in cubilibus suis.",
-                "en-US": "O what happiness and glory belong always to the saints, how distinguished the merits of the Preachers, by whose words and deeds the world is adorned, by whose works the mind grows stronger.\n℣. The Saints shall be joyful in glory.\n℟. They shall sing for joy on their couches."
+                "la": "Da pacem, Domine, in diebus nostris: quia non est alius, qui pugnet pro nobis, nisi tu Deus noster.",
+                "en-US": "Give peace, O Lord, in our days, because there is no other who will fight for us, except Thee, our God."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fiat pax in virtute tua.",
+                    "en-US": "Let peace be in thy strength."
+                  },
+                  "r": {
+                    "la": "Et abundantia in turribus tuis.",
+                    "en-US": "And abundance in thy towers."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -311,27 +1676,139 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Concede, quaesumus, omnipotens Deus, ut ad meliorem vitam Sanctorum Ordinis nostri exempla nos provocent: quatenus, quorum memoriam agimus, etiam actus imitemur. Per Christum.\nMemoria Omnium Sanctorum",
-                "en-US": "Grant, we beseech Thee, almighty God: that the examples of the saints of our Order may incite us to a better life; that we may imitate the deeds of them whose memory we celebrate. Through Christ our Lord.\nCommemoration of all Saints"
+                "la": "Deus, a quo sancta desideria, recta consilia, et justa sunt opera: da servis tuis illam, quam mundus dare non potest, pacem: ut et corda nostra mandatis tuis dedita, et, hostium sublata formidine, tempora sint tua protectione tranquilla. Per Dominum."
               }
             },
             {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
+            },
+            {
               "type": "rubric",
+              "lang": "la",
               "text": {
-                "la": "Antiphon",
-                "en-US": "Antiphon"
+                "la": "Vel"
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave, Maria, gratia plena, Dominus tecum."
+                  },
+                  "r": {
+                    "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui, Jesus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Per totum Adventum:\nAd Bened. Ant.\nSpiritus Sanctus in te descendet, Maria: ne timeas, habebis in utero Filium Dei, alleluia."
               }
             },
             {
               "type": "prayer",
+              "lang": "en-US",
               "inline": {
-                "la": "Sancti Dei omnes intercedere dignemini pro nostra omniumque salute.\n℣. Orate pro nobis, omnes Sancti Dei.\n℟. Ut digni efficiamur promissionibus Christi.",
-                "en-US": "All ye saints of God vouchsafe to make intercession for our salvation, and for that of all.\n℣. Pray for us, all ye saints of God.\n℟. That we may be made worthy of the promises of Christ."
+                "en-US": "O God, from Whom are holy desires, right counsels, and just works, grant to Thy servants that peace which the world cannot give; that our hearts being devoted to Thy commandments, and the fear of enemies being taken away, the times may, by Thy protection, be peaceful. Through our Lord Jesus Christ, Thy Son, Who with Thee liveth and reigneth in the unity of the Holy Ghost, God, world without end.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Hail Mary, full of grace, the Lord is with thee."
+                  },
+                  "r": {
+                    "en-US": "Blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "For Advent\nBenedictus Antiphon:\nThe Holy Ghost shall come down upon thee, O Mary: fear not, thou shalt bear within thy womb the Son of God, alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -339,27 +1816,62 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Tribue, quaesumus, Domine, omnes Sanctos tuos jugiter pro nobis orare: et eos clementer exaudire digneris. Per Christum.\nMemoria de Pace",
-                "en-US": "Grant, we beseech Thee, O Lord, that all Thy saints may pray for us unceasingly, and vouchsafe in Thy clemency to hear them. Through Christ our Lord.\nCommemoration for Peace"
+                "la": "Deus, qui de beatae Mariae Virginis utero Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis, ut qui vere eam Genitricem Dei credimus, ejus apud te intercessionibus adjuvemur. Per eundem Christum."
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
               "text": {
-                "la": "Antiphon",
-                "en-US": "Antiphon"
+                "la": "Haec Oratio dicitur ad Tertiam, et ad Vesperas eo tempore."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Nativitate Domini usque ad Purificationem inclusive:"
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Ad Bened. Ant."
               }
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Da pacem, Domine, in diebus nostris: quia non est alius, qui pugnet pro nobis, nisi tu Deus noster.\n℣. Fiat pax in virtute tua.\n℟. Et abundantia in turribus tuis.",
-                "en-US": "Give peace, O Lord, in our days, because there is no other who will fight for us, except Thee, our God.\n℣. Let peace be in thy strength.\n℟. And abundance in thy towers."
+                "la": "Genuit puerpera Regem, cui nomen aeternum: et gaudia matris habens cum virginitatis honore, nec primam similem visa est, nec habere sequentem."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who wast pleased that, at the message of an angel, Thy Word should take flesh from the womb of the Blessed Virgin Mary, grant that we, Thy suppliants, who believe her to be truly the Mother of God, may be helped through her intercession with Thee. Through the same Christ our Lord. Amen."
               }
             },
             {
               "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "From Christmas to Purification"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Benedictus Antiphon:\nA Woman in childbirth brought forth a King Whose name is eternal: and, possessing a mother's joy with a virgin's honor, her like hath not appeared before nor since."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -367,41 +1879,41 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Deus, a quo sancta desideria, recta consilia, et justa sunt opera: da servis tuis illam, quam mundus dare non potest, pacem: ut et corda nostra mandatis tuis dedita, et, hostium sublata formidine, tempora sint tua protectione tranquilla. Per Dominum.\n℣. Dominus vobiscum.\n℟. Et cum spiritu tuo.\nVel ℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Ave, Maria, gratia plena, Dominus tecum.\n℟. Benedicta tu in mulieribus, et benedictus fructus ventris tui, Jesus.\nPer totum Adventum:\nAd Bened. Ant.\nSpiritus Sanctus in te descendet, Maria: ne timeas, habebis in utero Filium Dei, alleluia.",
-                "en-US": "O God, from Whom are holy desires, right counsels, and just works, grant to Thy servants that peace which the world cannot give; that our hearts being devoted to Thy commandments, and the fear of enemies being taken away, the times may, by Thy protection, be peaceful. Through our Lord Jesus Christ, Thy Son, Who with Thee liveth and reigneth in the unity of the Holy Ghost, God, world without end.\nAmen.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. Hail Mary, full of grace, the Lord is with thee.\n℟. Blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus.\nFor Advent\nBenedictus Antiphon:\nThe Holy Ghost shall come down upon thee, O Mary: fear not, thou shalt bear within thy womb the Son of God, alleluia."
+                "la": "Deus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus, ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Christum Dominum nostrum."
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
               "text": {
-                "la": "Prayer",
-                "en-US": "Prayer"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Deus, qui de beatae Mariae Virginis utero Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis, ut qui vere eam Genitricem Dei credimus, ejus apud te intercessionibus adjuvemur. Per eundem Christum.\nHaec Oratio dicitur ad Tertiam, et ad Vesperas eo tempore.\nNativitate Domini usque ad Purificationem inclusive:\nAd Bened. Ant.\nGenuit puerpera Regem, cui nomen aeternum: et gaudia matris habens cum virginitatis honore, nec primam similem visa est, nec habere sequentem.",
-                "en-US": "O God, Who wast pleased that, at the message of an angel, Thy Word should take flesh from the womb of the Blessed Virgin Mary, grant that we, Thy suppliants, who believe her to be truly the Mother of God, may be helped through her intercession with Thee. Through the same Christ our Lord. Amen.\nFrom Christmas to Purification\nBenedictus Antiphon:\nA Woman in childbirth brought forth a King Whose name is eternal: and, possessing a mother's joy with a virgin's honor, her like hath not appeared before nor since."
+                "la": "Haec Oratio dicitur ad Tertiam, et ad Vesperas eo tempore."
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
               "text": {
-                "la": "Prayer",
-                "en-US": "Prayer"
+                "la": "Tempore Paschali:"
               }
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Deus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus, ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Christum Dominum nostrum.\nHaec Oratio dicitur ad Tertiam, et ad Vesperas eo tempore.\nTempore Paschali:\nAd Bened. Ant.\nBeata Dei Genitrix Maria, Virgo perpetua, templum Domini, sacrarium Spiritus Sancti, tu sola sine exemplo placuisti Domino nostro Jesu Christo: ora pro populo, interveni pro clero, intercede pro devoto femineo sexu, alleluia, alleluia.",
+                "la": "Ad Bened. Ant.\nBeata Dei Genitrix Maria, Virgo perpetua, templum Domini, sacrarium Spiritus Sancti, tu sola sine exemplo placuisti Domino nostro Jesu Christo: ora pro populo, interveni pro clero, intercede pro devoto femineo sexu, alleluia, alleluia."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
                 "en-US": "O God, Who through the fruitful virginity of blessed Mary, hast given to mankind the reward of eternal salvation, grant, we beseech Thee, that we may feel the intercession she makes for us, through whom we have been made worthy to receive the Author of life, Christ our Lord. Amen.\nPaschaltide\nBenedictus Antiphon:\nO blessed Mary, Mother of God, perpetual virgin, temple of the Lord, sanctuary of the Holy Ghost, thou alone without equal wast pleasing to our Lord Jesus Christ: pray for the people, plead for the clergy, make intercession for the devout female sex.\nAlleluia, Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -409,8 +1921,23 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Concede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis salute gaudere: et gloriosa beatae Mariae semper Virginis intercessione, a praesenti liberari tristitia et aeterna perfrui laetitia. Per Christum Dominum nostrum.\n℟. Amen.",
+                "la": "Concede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis salute gaudere: et gloriosa beatae Mariae semper Virginis intercessione, a praesenti liberari tristitia et aeterna perfrui laetitia. Per Christum Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
                 "en-US": "Grant, we beseech Thee, O Lord God, that we, Thy servants, may enjoy continual health of mind and body; and that through the glorious intercession of blessed Mary, ever virgin, we may be delivered from present sorrow and enjoy eternal happiness. Through Christ our Lord.\nAmen."
               }
             }
@@ -425,28 +1952,182 @@
           },
           "sections": [
             {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave, Maria, gratia plena, Dominus tecum."
+                  },
+                  "r": {
+                    "la": "Benedicta tu."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "℣. Ave, Maria, gratia plena, Dominus tecum.\n℟. Benedicta tu.\n℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\nGloria Patri. Alleluia, vel Laus tibi, Domine.\n℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\nGloria Patri. Sicut erat.",
-                "en-US": "℣. Hail Mary, full of grace, the Lord is with thee.\n℟. Blessed art thou.\n℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, world without end, Amen. Alleluia (or Praise to thee.)\n℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Gloria Patri. Alleluia, vel Laus tibi, Domine."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Gloria Patri. Sicut erat."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Hail Mary, full of grace, the Lord is with thee."
+                  },
+                  "r": {
+                    "en-US": "Blessed art thou."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now, and ever shall be, world without end, Amen. Alleluia (or Praise to thee.)"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento, salutis auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris.\nMaria, mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege\nEt hora mortis suscipe.\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre et Sancto Spiritu,\nIn sempiterna saecula. Amen.\nPsalmus 119\nAd Dominum cum tribularer clamavi: et exaudivit me.\nDomine, libera animam meam a labiis iniquis, et a lingua dolosa.\nQuid detur tibi aut quid apponatur tibi ad linguam dolosam?\nSagittae potentis acutae, cum carbonibus desolatoriis.\nHeu mihi quia incolatus meus prolongatus est: habitavi cum habitantibus Cedar: multum incola fuit anima mea.\nCum his, qui oderunt pacem, eram pacificus: cum loquebar illis, impugnabant me gratis.\nGloria Patri.\nPsalmus 120\nLevavi oculos meos in montes, unde veniet auxilium mihi.\nAuxilium meum a Domino, qui fecit caelum et terram.\nNon det in commotionem pedem tuum: neque dormitet qui custodit te.\nEcce non dormitabit neque dormiet, qui custodit Israel.\nDominus custodit te, Dominus protectio tua, super manum dexteram tuam.\nPer diem sol non uret te: neque luna per noctem.\nDominus custodit te ab omni malo: custodiat animam tuam Dominus.\nDominus custodiat introitum tuum, et exitum tuum: ex hoc nunc, et usque in saeculum.\nGloria Patri.\nPsalmus 121\nLaetatus sum in his, quae dicta sunt mihi: In domum Domini ibimus.\nStantes erant pedes nostri, in atriis tuis, Jerusalem.\nJerusalem, quae aedificatur ut civitas: cujus participatio ejus in idipsum.\nIlluc enim ascenderunt tribus, tribus Domini: testimonium Israel ad confitendum nomini Domini.\nQuia illic sederunt sedes in judicio, sedes super domum David.\nRogate quae ad pacem sunt Jerusalem: et abundantia diligentibus te.\nFiat pax in virtute tua: et abundantia in turribus tuis.\nPropter fratres meos, et proximos meos, loquebar pacem de te.\nPropter domum Domini Dei nostri, quaesivi bona tibi.\nGloria Patri.",
-                "en-US": "Author of grace, sweet Saviour mine,\nRemember that Thy flesh divine,\nFrom the unsullied Virgin came,\nMade like unto our mortal frame.\nO Mary, Mother of all grace,\nMother of Mercy to our race,\nProtect us now from Satan's power,\nAnd own us at life's closing hour.\nAll glory be Thee, O Lord,\nThe Virgin's son, by all ador'd,\nAnd equal praise forever greet,\nThe Father and the Paraclete. Amen.\nPsalm 119\nWhen I was in trouble, I called upon the Lord, and he heard me.\nDeliver my soul, O Lord, from lying lips, and from a deceitful tongue.\nWhat shall be given unto thee, or what shall be added unto thee, to a deceitful tongue?\nEven the sharp arrows of the mighty, with hot burning coals.\nWoe is me, that I sojourning is prolonged; I have dwelt with the inhabitants of Kedar.\nMy soul hath long dwelt among them. With them that hated peace I was peaceable: when I spake unto them, they fought against me without cause.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 120\nI have lifted up mine eyes unto the hills; from whence cometh my help.\nMy help cometh even from the Lord, who hath made heaven and earth.\nMay he not suffer thy foot to be moved; neither let him slumber that keepeth thee.\nBehold, he that keepeth Israel shall neither slumber nor sleep.\nThe Lord is thy keeper, the Lord is thy defence upon thy right hand.\nThe sun shall not burn thee by day, neither the moon by night.\nThe Lord shall preserve thee from all evil: yea, it is even he that shall keep thy soul.\nThe Lord shall preserve thy going out, and thy coming in: from this time forth for evermore.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 121\nI rejoiced at the things that were said unto me: We will go into the house of the Lord.\nOur feet shall stand in thy gates, O Jerusalem.\nJerusalem is built as a city that is at unity in itself.\nFor thither did the tribes go up, even the tribes of the Lord, to testify unto Israel, to give thanks unto the Name of the Lord.\nFor their seats have sat in judgment, even the seats upon the house of David.\nO pray for the peace of Jerusalem; they shall prosper that love thee.\nPeace be within thy walls, and plenteousness within thy palaces.\nFor my brethren and companions' sakes, I spake peace of thee.\nYea, because of the house of the Lord our God, I have sought to do thee good.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Memento, salutis auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris.\nMaria, mater gratiae,\nMater misericordiae,\nTu nos ab hoste protege\nEt hora mortis suscipe.\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre et Sancto Spiritu,\nIn sempiterna saecula. Amen.",
+                "en-US": "Author of grace, sweet Saviour mine,\nRemember that Thy flesh divine,\nFrom the unsullied Virgin came,\nMade like unto our mortal frame.\nO Mary, Mother of all grace,\nMother of Mercy to our race,\nProtect us now from Satan's power,\nAnd own us at life's closing hour.\nAll glory be Thee, O Lord,\nThe Virgin's son, by all ador'd,\nAnd equal praise forever greet,\nThe Father and the Paraclete. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 119",
+                "en-US": "Psalm 119"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Ad Dominum cum tribularer clamavi: et exaudivit me.\nDomine, libera animam meam a labiis iniquis, et a lingua dolosa.\nQuid detur tibi aut quid apponatur tibi ad linguam dolosam?\nSagittae potentis acutae, cum carbonibus desolatoriis.\nHeu mihi quia incolatus meus prolongatus est: habitavi cum habitantibus Cedar: multum incola fuit anima mea.\nCum his, qui oderunt pacem, eram pacificus: cum loquebar illis, impugnabant me gratis.\nGloria Patri.",
+                "en-US": "When I was in trouble, I called upon the Lord, and he heard me.\nDeliver my soul, O Lord, from lying lips, and from a deceitful tongue.\nWhat shall be given unto thee, or what shall be added unto thee, to a deceitful tongue?\nEven the sharp arrows of the mighty, with hot burning coals.\nWoe is me, that I sojourning is prolonged; I have dwelt with the inhabitants of Kedar.\nMy soul hath long dwelt among them. With them that hated peace I was peaceable: when I spake unto them, they fought against me without cause.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 120",
+                "en-US": "Psalm 120"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Levavi oculos meos in montes, unde veniet auxilium mihi.\nAuxilium meum a Domino, qui fecit caelum et terram.\nNon det in commotionem pedem tuum: neque dormitet qui custodit te.\nEcce non dormitabit neque dormiet, qui custodit Israel.\nDominus custodit te, Dominus protectio tua, super manum dexteram tuam.\nPer diem sol non uret te: neque luna per noctem.\nDominus custodit te ab omni malo: custodiat animam tuam Dominus.\nDominus custodiat introitum tuum, et exitum tuum: ex hoc nunc, et usque in saeculum.\nGloria Patri.",
+                "en-US": "I have lifted up mine eyes unto the hills; from whence cometh my help.\nMy help cometh even from the Lord, who hath made heaven and earth.\nMay he not suffer thy foot to be moved; neither let him slumber that keepeth thee.\nBehold, he that keepeth Israel shall neither slumber nor sleep.\nThe Lord is thy keeper, the Lord is thy defence upon thy right hand.\nThe sun shall not burn thee by day, neither the moon by night.\nThe Lord shall preserve thee from all evil: yea, it is even he that shall keep thy soul.\nThe Lord shall preserve thy going out, and thy coming in: from this time forth for evermore.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 121",
+                "en-US": "Psalm 121"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Laetatus sum in his, quae dicta sunt mihi: In domum Domini ibimus.\nStantes erant pedes nostri, in atriis tuis, Jerusalem.\nJerusalem, quae aedificatur ut civitas: cujus participatio ejus in idipsum.\nIlluc enim ascenderunt tribus, tribus Domini: testimonium Israel ad confitendum nomini Domini.\nQuia illic sederunt sedes in judicio, sedes super domum David.\nRogate quae ad pacem sunt Jerusalem: et abundantia diligentibus te.\nFiat pax in virtute tua: et abundantia in turribus tuis.\nPropter fratres meos, et proximos meos, loquebar pacem de te.\nPropter domum Domini Dei nostri, quaesivi bona tibi.\nGloria Patri.",
+                "en-US": "I rejoiced at the things that were said unto me: We will go into the house of the Lord.\nOur feet shall stand in thy gates, O Jerusalem.\nJerusalem is built as a city that is at unity in itself.\nFor thither did the tribes go up, even the tribes of the Lord, to testify unto Israel, to give thanks unto the Name of the Lord.\nFor their seats have sat in judgment, even the seats upon the house of David.\nO pray for the peace of Jerusalem; they shall prosper that love thee.\nPeace be within thy walls, and plenteousness within thy palaces.\nFor my brethren and companions' sakes, I spake peace of thee.\nYea, because of the house of the Lord our God, I have sought to do thee good.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -460,7 +2141,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Chapter",
                 "en-US": "Chapter"
@@ -468,13 +2149,168 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Ab initio et ante saecula creata sum, et usque ad futurum saeculum non desinam, et in habitatione sancta coram ipso ministravi.\n℟. Deo gratias.\n℟. Post partum, Virgo, inviolata permansisti. Repetendum est totum. Post partum. ℣. Dei Genitrix, intercede pro nobis. Inviolata. Gloria. Post partum.\n℣. Benedicta tu in mulieribus.\n℟. Et benedictus fructus ventris tui.\n℟. Dominus vobiscum.\n℟. Et cum spiritu tuo.\nVel ℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.",
-                "en-US": "From the beginning and before the world, was I created, and unto the world to come I shall not cease to be; and in the holy dwelling-place I ministered before Him.\n℟. Thanks be to God.\n℟. After childbirth, a virgin, thou still didst remain undefiled.\n℟. After childbirth, a virgin, thou still didst remain undefiled.\n℣. Mother of God, intercede for us: thou still didst remain undefiled.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\n℟. After childbirth, a virgin, * thou still didst remain undefiled.\n℣. Blessed art thou amongst women.\n℟. And blessed is the fruit of thy womb.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
+                "la": "Ab initio et ante saecula creata sum, et usque ad futurum saeculum non desinam, et in habitatione sancta coram ipso ministravi."
               }
             },
             {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Post partum, Virgo, inviolata permansisti. Repetendum est totum. Post partum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Dei Genitrix, intercede pro nobis. Inviolata. Gloria. Post partum."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicta tu in mulieribus."
+                  },
+                  "r": {
+                    "la": "Et benedictus fructus ventris tui."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
+            },
+            {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Vel"
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "From the beginning and before the world, was I created, and unto the world to come I shall not cease to be; and in the holy dwelling-place I ministered before Him."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "After childbirth, a virgin, thou still didst remain undefiled."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "After childbirth, a virgin, thou still didst remain undefiled."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "Mother of God, intercede for us: thou still didst remain undefiled."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "After childbirth, a virgin, * thou still didst remain undefiled."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Blessed art thou amongst women."
+                  },
+                  "r": {
+                    "en-US": "And blessed is the fruit of thy womb."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -482,10 +2318,94 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Gratiam tuam, quaesumus, Domine, mentibus nostris infunde: ut qui Angelo nuntiante Christi Filii tui incarnationem cognovimus, per passionem ejus et crucem ad resurrectionis gloriam perducamur. Per eundem Christum.\n℟. Dominus vobiscum.\n℟. Et cum spiritu tuo.\nVel ℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\nBenedicamus Domino.\n℟. Deo gratias.",
-                "en-US": "Pour forth, we beseech thee, O Lord, thy grace into our hearts, that we to whom the Incarnation of Christ thy Son was made known by the message of an Angel, may by his Passion and Cross be brought to the glory of the Resurrection. Through the same Jesus Christ our Lord, Thy Son, Who with Thee liveth and reigneth in the unity of the Holy Ghost, God, world without end. Amen.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God."
+                "la": "Gratiam tuam, quaesumus, Domine, mentibus nostris infunde: ut qui Angelo nuntiante Christi Filii tui incarnationem cognovimus, per passionem ejus et crucem ad resurrectionis gloriam perducamur. Per eundem Christum."
               }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Vel"
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Pour forth, we beseech thee, O Lord, thy grace into our hearts, that we to whom the Incarnation of Christ thy Son was made known by the message of an Angel, may by his Passion and Cross be brought to the glory of the Resurrection. Through the same Jesus Christ our Lord, Thy Son, Who with Thee liveth and reigneth in the unity of the Holy Ghost, God, world without end. Amen."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -498,28 +2418,107 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave, Maria, gratia plena, Dominus tecum.",
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "la": "Benedicta tu.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende.",
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina.",
+                    "en-US": "As it was in the beginning, is now, and ever shall be, world without end, Amen. Alleluia."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "℣. Ave, Maria, gratia plena, Dominus tecum.\n℟. Benedicta tu.\n℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\nGloria Patri.",
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, world without end, Amen. Alleluia.\nFrom Septuagesima until Easter, instead of Alleluia is said: Praise be to Thee, O Lord, King of everlasting glory."
+                "la": "Gloria Patri."
               }
             },
             {
               "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "From Septuagesima until Easter, instead of Alleluia is said: Praise be to Thee, O Lord, King of everlasting glory."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento, salutis auctor.\nPsalmus 122\nAd te levavi oculos meos, qui habitas in caelis.\nEcce sicut oculi servorum, in manibus dominorum suorum.\nSicut oculi ancillae in manibus dominae suae: ita oculi nostri ad Dominum Deum nostrum donec misereatur nostri.\nMiserere nostri, Domine, miserere nostri: quia multum repleti sumus despectione:\nQuia multum repleta est anima nostra: opprobrium abundantibus, et despectio superbis.\nGloria Patri.\nPsalmus 123\nNisi quia Dominus erat in nobis, dicat nunc Israel: nisi quia Dominus erat in nobis.\nCum exsurgerent homines in nos, forte vivos deglutissent nos:\nCum irasceretur furor eorum in nos, forsitan aqua absorbuisset nos.\nTorrentem pertransivit anima nostra: forsitan pertransisset anima nostra aquam intolerabilem.\nBenedictus Dominus, qui non dedit nos in captionem dentibus eorum.\nAnima nostra sicut passer erepta est de laqueo venantium. Laqueus contritus est, et nos liberati sumus.\nAdjutorium nostrum in nomine Domini, qui fecit caelum et terram.\nGloria Patri.\nPsalmus 124\nQui confidunt in Domino, sicut mons Sion: non commovebitur in aeternum, qui habitat in Jerusalem.\nMontes in circuitu ejus: et Dominus in circuitu populi sui, ex hoc nunc et usque in saeculum.\nQuia non relinquet Dominus virgam peccatorum super sortem justorum: ut non extendant justi ad iniquitatem manus suas.\nBenefac, Domine, bonis, et rectis corde.\nDeclinantes autem in obligationes, adducet Dominus cum operantibus iniquitatem: pax super Israel.\nGloria Patri.",
-                "en-US": "Author of grace.\nPsalm 122\nUnto thee have I lift up mine eyes, O thou that dwellest in the heavens.\nBehold, even as the eyes of servants look unto the hand of their masters.\nAnd as the eyes of a maiden are on the hands of her mistress, even so our eyes wait upon the Lord our God, until he have mercy upon us.\nHave mercy upon us, O Lord, have mercy upon us; for we are utterly despised.\nOur soul is greatly filled; we are a reproof to the wealthy, and contempt to the proud.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 123\nIf the Lord himself had not been on our side, let Israel now say: if the Lord himself had not been on our side.\nWhen men rose up against us, perchance they had swallowed us up alive.\nWhen they were so wrathfully displeased at us, perchance their waters had drowned us.\nOur soul hath passed through the torrent: perchance our soul had passed through a water insupportable.\nBlessed be the Lord, who hath not given us over for a prey unto their teeth.\nOur soul is escaped even as a bird, out of the snare of the fowler.\nThe snare is broken, and we are delivered.\nOur help is in the Name of the Lord, who hath made heaven and earth.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 124\nThey that put their trust in the Lord shall be even as the mount Sion: he shall stand fast for ever, that dwelleth in Jerusalem.\nMountains stand round about: even so standeth the Lord round about his people, from this time forth for evermore.\nFor the Lord shall not leave the rod of sinners upon the lot of the just: that the righteous may not stretch forth their hand unto wickedness.\nDo well, O Lord, unto those that are good and true of heart.\nBut such as turn aside unto bonds, the Lord shall lead them forth with the evil doers: peace upon Israel.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Memento, salutis auctor.",
+                "en-US": "Author of grace."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 122",
+                "en-US": "Psalm 122"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Ad te levavi oculos meos, qui habitas in caelis.\nEcce sicut oculi servorum, in manibus dominorum suorum.\nSicut oculi ancillae in manibus dominae suae: ita oculi nostri ad Dominum Deum nostrum donec misereatur nostri.\nMiserere nostri, Domine, miserere nostri: quia multum repleti sumus despectione:\nQuia multum repleta est anima nostra: opprobrium abundantibus, et despectio superbis.\nGloria Patri.",
+                "en-US": "Unto thee have I lift up mine eyes, O thou that dwellest in the heavens.\nBehold, even as the eyes of servants look unto the hand of their masters.\nAnd as the eyes of a maiden are on the hands of her mistress, even so our eyes wait upon the Lord our God, until he have mercy upon us.\nHave mercy upon us, O Lord, have mercy upon us; for we are utterly despised.\nOur soul is greatly filled; we are a reproof to the wealthy, and contempt to the proud.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 123",
+                "en-US": "Psalm 123"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Nisi quia Dominus erat in nobis, dicat nunc Israel: nisi quia Dominus erat in nobis.\nCum exsurgerent homines in nos, forte vivos deglutissent nos:\nCum irasceretur furor eorum in nos, forsitan aqua absorbuisset nos.\nTorrentem pertransivit anima nostra: forsitan pertransisset anima nostra aquam intolerabilem.\nBenedictus Dominus, qui non dedit nos in captionem dentibus eorum.\nAnima nostra sicut passer erepta est de laqueo venantium. Laqueus contritus est, et nos liberati sumus.\nAdjutorium nostrum in nomine Domini, qui fecit caelum et terram.\nGloria Patri.",
+                "en-US": "If the Lord himself had not been on our side, let Israel now say: if the Lord himself had not been on our side.\nWhen men rose up against us, perchance they had swallowed us up alive.\nWhen they were so wrathfully displeased at us, perchance their waters had drowned us.\nOur soul hath passed through the torrent: perchance our soul had passed through a water insupportable.\nBlessed be the Lord, who hath not given us over for a prey unto their teeth.\nOur soul is escaped even as a bird, out of the snare of the fowler.\nThe snare is broken, and we are delivered.\nOur help is in the Name of the Lord, who hath made heaven and earth.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 124",
+                "en-US": "Psalm 124"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Qui confidunt in Domino, sicut mons Sion: non commovebitur in aeternum, qui habitat in Jerusalem.\nMontes in circuitu ejus: et Dominus in circuitu populi sui, ex hoc nunc et usque in saeculum.\nQuia non relinquet Dominus virgam peccatorum super sortem justorum: ut non extendant justi ad iniquitatem manus suas.\nBenefac, Domine, bonis, et rectis corde.\nDeclinantes autem in obligationes, adducet Dominus cum operantibus iniquitatem: pax super Israel.\nGloria Patri.",
+                "en-US": "They that put their trust in the Lord shall be even as the mount Sion: he shall stand fast for ever, that dwelleth in Jerusalem.\nMountains stand round about: even so standeth the Lord round about his people, from this time forth for evermore.\nFor the Lord shall not leave the rod of sinners upon the lot of the just: that the righteous may not stretch forth their hand unto wickedness.\nDo well, O Lord, unto those that are good and true of heart.\nBut such as turn aside unto bonds, the Lord shall lead them forth with the evil doers: peace upon Israel.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -533,7 +2532,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Chapter",
                 "en-US": "Chapter"
@@ -541,13 +2540,148 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Et sic in Sion firmata sum, et in civitate sanctificata similiter requievi, et in Jerusalem potestas mea.\n℟. Deo gratias.\n℟. Sancta Maria, mater Christi, Audi rogantes servulos. Sancta. ℣. Et impetratam nobis caelitus tu defer indulgentiam. Audi. Gloria. Sancta Maria.\n℣. Ora pro nobis, sancta Dei Genitrix.\n℟. Ut digni efficiamur promissionibus Christi.\n℣. Dominus vobiscum.\nVel ℣. Domine, exaudi, etc.",
-                "en-US": "And so in Sion was I established, and in the holy city likewise did I rest, and in Jerusalem was my power.\n℟. Thanks be to God.\n℟. Holy Mary, Mother of Christ, hear thy servants imploring thee.\n℣. And bring to us from heaven the pardon thou obtainest: hear thy servants imploring thee.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\n℟. Holy Mary, Mother of Christ, hear thy servants imploring thee.\n℣. Pray for us, O holy Mother of God.\n℟. That we may be made worthy of the promises of Christ.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
+                "la": "Et sic in Sion firmata sum, et in civitate sanctificata similiter requievi, et in Jerusalem potestas mea."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Sancta Maria, mater Christi, Audi rogantes servulos. Sancta."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Et impetratam nobis caelitus tu defer indulgentiam. Audi. Gloria. Sancta Maria."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Dei Genitrix."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Dominus vobiscum."
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Vel"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Domine, exaudi, etc."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "And so in Sion was I established, and in the holy city likewise did I rest, and in Jerusalem was my power."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Holy Mary, Mother of Christ, hear thy servants imploring thee."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "And bring to us from heaven the pardon thou obtainest: hear thy servants imploring thee."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Holy Mary, Mother of Christ, hear thy servants imploring thee."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Pray for us, O holy Mother of God."
+                  },
+                  "r": {
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -555,10 +2689,68 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Concede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis salute gaudere: et, gloriosa beatae Mariae semper Virginis intercessione, a praesenti liberari tristitia et aeterna perfrui laetitia. Per Dominum.\n℣. Dominus vobiscum. Vel ℣. Domine, exaudi, etc.",
-                "en-US": "Grant, we beseech Thee, O Lord God, that we, Thy servants, may enjoy continual health of mind and body; and that through the glorious intercession of blessed Mary, ever virgin, we may be delivered from present sorrow and enjoy eternal happiness. Through Christ our Lord.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God."
+                "la": "Concede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis salute gaudere: et, gloriosa beatae Mariae semper Virginis intercessione, a praesenti liberari tristitia et aeterna perfrui laetitia. Per Dominum."
               }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Dominus vobiscum."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Vel:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Domine, exaudi, etc."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Grant, we beseech Thee, O Lord God, that we, Thy servants, may enjoy continual health of mind and body; and that through the glorious intercession of blessed Mary, ever virgin, we may be delivered from present sorrow and enjoy eternal happiness. Through Christ our Lord."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -571,28 +2763,107 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave, Maria, gratia plena, Dominus tecum.",
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "la": "Benedicta tu.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende.",
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina.",
+                    "en-US": "As it was in the beginning, is now, and ever shall be, world without end, Amen. Alleluia."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "℣. Ave, Maria, gratia plena, Dominus tecum.\n℟. Benedicta tu.\n℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\nGloria Patri.",
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, world without end, Amen. Alleluia.\nFrom Septuagesima until Easter, instead of Alleluia is said: Praise be to Thee, O Lord, King of everlasting glory."
+                "la": "Gloria Patri."
               }
             },
             {
               "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "From Septuagesima until Easter, instead of Alleluia is said: Praise be to Thee, O Lord, King of everlasting glory."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento, salutis auctor.\nPsalmus 125\nIn convertendo Dominus captivitatem Sion: facti sumus sicut consolati.\nTunc repletum est gaudio os nostrum: et lingua nostra exsultatione.\nTunc dicent inter gentes: Magnificavit Dominus facere cum eis.\nMagnificavit Dominus facere nobiscum: facti sumus laetantes.\nConverte, Domine, captivitatem nostram sicut torrens in austro.\nQui seminant in lacrimis, in exsultatione metent.\nEuntes ibant et flebant, mittentes semina sua.\nVenientes autem venient cum exsultatione, portantes manipulos suos.\nGloria Patri.\nPsalmus 126\nNisi Dominus aedificaverit domum, in vanum laboraverunt qui aedificant eam.\nNisi Dominus custodierit civitatem, frustra vigilat qui custodit eam.\nVanum est vobis ante lucem surgere: surgite postquam sederitis, qui manducatis panem doloris.\nCum dederit dilectis suis somnum: ecce hereditas Domini filii: merces, fructus ventris.\nSicut sagittae in manu potentis: ita filii excussorum.\nBeatus vir qui implevit desiderium suum ex ipsis: non confundetur cum loquetur inimicis suis in porta.\nGloria Patri.\nPsalmus 127\nBeati omnes qui timent Dominum, qui ambulant in viis ejus.\nLabores manuum tuarum quia manducabis: beatus es, et bene tibi erit.\nUxor tua sicut vitis abundans, in lateribus domus tuae.\nFilii tui sicut novellae olivarum, in circuitu mensae tuae.\nEcce sic benedicetur homo, qui timet Dominum.\nBenedicat tibi Dominus ex Sion: et videas bona Jerusalem omnibus diebus vitae tuae.\nEt videas filios filiorum tuorum, pacem super Israel.\nGloria Patri.",
-                "en-US": "Author of grace.\nPsalm 125\nWhen the Lord brought back the captives of Sion, then we became like men comforted.\nThen was our mouth filled with gladness, and our tongue with joy.\nThen shall they say among the heathen: The Lord hath done great things for them.\nYea, the Lord hath done great things for us; whereof we rejoice.\nTurn again our captivity, O Lord, as the rivers in the south.\nThey that sow in tears shall reap in joy.\nGoing they went and wept, casting their seed.\nBut coming they shall come again with joyfulness, carrying their sheaves.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 126\nExcept the Lord build the house, they labor in vain that build it.\nExcept the Lord keep the city, the watchman waketh but in vain.\nIt is vain for you to rise up before the light: rise ye after ye have taken your rest, ye that eat the bread of sorrow.\nWhen he giveth his beloved sleep: behold, children are the heritage of the Lord: the reward, and the fruit of the womb.\nLike as the arrows in the hand of the mighty, even so are the children of them that have been shaken.\nBlessed is the man that hath filled the desire with them: he shall not be confounded when he shall speak with his enemies in the gate.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 127\nBlessed are all they that fear the Lord, and walk in his ways.\nFor thou shalt eat the labors of thine hands: blessed art thou, and it shall be well with thee.\nThy wife shall be as the fruitful vine upon the walls of thine house.\nThy children like the olive-branches round about thy table.\nLo, thus shall the man be blessed, that feareth the Lord.\nThe Lord bless thee out of Sion, that thou shalt see Jerusalem in prosperity all the days of thy life.\nYea, that thou shalt see thy children's children, and peace upon Israel.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Memento, salutis auctor.",
+                "en-US": "Author of grace."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 125",
+                "en-US": "Psalm 125"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "In convertendo Dominus captivitatem Sion: facti sumus sicut consolati.\nTunc repletum est gaudio os nostrum: et lingua nostra exsultatione.\nTunc dicent inter gentes: Magnificavit Dominus facere cum eis.\nMagnificavit Dominus facere nobiscum: facti sumus laetantes.\nConverte, Domine, captivitatem nostram sicut torrens in austro.\nQui seminant in lacrimis, in exsultatione metent.\nEuntes ibant et flebant, mittentes semina sua.\nVenientes autem venient cum exsultatione, portantes manipulos suos.\nGloria Patri.",
+                "en-US": "When the Lord brought back the captives of Sion, then we became like men comforted.\nThen was our mouth filled with gladness, and our tongue with joy.\nThen shall they say among the heathen: The Lord hath done great things for them.\nYea, the Lord hath done great things for us; whereof we rejoice.\nTurn again our captivity, O Lord, as the rivers in the south.\nThey that sow in tears shall reap in joy.\nGoing they went and wept, casting their seed.\nBut coming they shall come again with joyfulness, carrying their sheaves.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 126",
+                "en-US": "Psalm 126"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Nisi Dominus aedificaverit domum, in vanum laboraverunt qui aedificant eam.\nNisi Dominus custodierit civitatem, frustra vigilat qui custodit eam.\nVanum est vobis ante lucem surgere: surgite postquam sederitis, qui manducatis panem doloris.\nCum dederit dilectis suis somnum: ecce hereditas Domini filii: merces, fructus ventris.\nSicut sagittae in manu potentis: ita filii excussorum.\nBeatus vir qui implevit desiderium suum ex ipsis: non confundetur cum loquetur inimicis suis in porta.\nGloria Patri.",
+                "en-US": "Except the Lord build the house, they labor in vain that build it.\nExcept the Lord keep the city, the watchman waketh but in vain.\nIt is vain for you to rise up before the light: rise ye after ye have taken your rest, ye that eat the bread of sorrow.\nWhen he giveth his beloved sleep: behold, children are the heritage of the Lord: the reward, and the fruit of the womb.\nLike as the arrows in the hand of the mighty, even so are the children of them that have been shaken.\nBlessed is the man that hath filled the desire with them: he shall not be confounded when he shall speak with his enemies in the gate.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 127",
+                "en-US": "Psalm 127"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Beati omnes qui timent Dominum, qui ambulant in viis ejus.\nLabores manuum tuarum quia manducabis: beatus es, et bene tibi erit.\nUxor tua sicut vitis abundans, in lateribus domus tuae.\nFilii tui sicut novellae olivarum, in circuitu mensae tuae.\nEcce sic benedicetur homo, qui timet Dominum.\nBenedicat tibi Dominus ex Sion: et videas bona Jerusalem omnibus diebus vitae tuae.\nEt videas filios filiorum tuorum, pacem super Israel.\nGloria Patri.",
+                "en-US": "Blessed are all they that fear the Lord, and walk in his ways.\nFor thou shalt eat the labors of thine hands: blessed art thou, and it shall be well with thee.\nThy wife shall be as the fruitful vine upon the walls of thine house.\nThy children like the olive-branches round about thy table.\nLo, thus shall the man be blessed, that feareth the Lord.\nThe Lord bless thee out of Sion, that thou shalt see Jerusalem in prosperity all the days of thy life.\nYea, that thou shalt see thy children's children, and peace upon Israel.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -606,7 +2877,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Chapter",
                 "en-US": "Chapter"
@@ -614,13 +2885,164 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Et radicavi in populo honorificato, et in parte Dei mei hereditas illius, et in plenitudine sanctorum detentio mea.\n℟. Deo gratias.\n℣. Ora pro nobis, Sancta Dei Genitrix.\n℟. Ut digni efficiamur promissionibus Christi.\n℣. Elegit eam Deus, et praelegit eam.\n℟. Et habitare eam facit in tabernaculo suo.\n℣. Dominus vobiscum. Vel ℣. Domine, exaudi, etc.",
-                "en-US": "And I took root in an honorable people, and in the portion of my God is his inheritance, and my abode is in the full assembly of the saints.\n℟. Thanks be to God.\n℟. Pray for us, O holy Mother of God.\n℟. Pray for us, O holy Mother of God.\n℣. That we may be made worthy of the promises of Christ: O holy Mother of God.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\n℟. Pray for us, O holy Mother of God.\n℟. God hath chosen her and preferred her.\n℣. And He maketh her to dwell in His tabernacle.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
+                "la": "Et radicavi in populo honorificato, et in parte Dei mei hereditas illius, et in plenitudine sanctorum detentio mea."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, Sancta Dei Genitrix."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Elegit eam Deus, et praelegit eam."
+                  },
+                  "r": {
+                    "la": "Et habitare eam facit in tabernaculo suo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Dominus vobiscum."
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Vel:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Domine, exaudi, etc."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "And I took root in an honorable people, and in the portion of my God is his inheritance, and my abode is in the full assembly of the saints."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Pray for us, O holy Mother of God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Pray for us, O holy Mother of God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "That we may be made worthy of the promises of Christ: O holy Mother of God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Pray for us, O holy Mother of God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "God hath chosen her and preferred her."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "God hath chosen her and preferred her."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "And He maketh her to dwell in His tabernacle."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -628,10 +3050,68 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Protege, Domine, famulos tuos subsidiis pacis: et, beatae Mariae semper Virginis patrociniis confidentes, a cunctis hostibus redde securos. Per Dominum.\n℣. Dominus vobiscum. Vel ℣. Domine, exaudi, etc.",
-                "en-US": "Protect Thy servants, O Lord, by granting them the gift of peace, and as they have confidence in the patronage of blessed Mary, ever virgin, so do Thou make them safe from all enemies. Through our Lord Jesus Christ, Thy Son, Who with Thee liveth and reigneth in the unity of the Holy Ghost, God world without end. Amen.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God."
+                "la": "Protege, Domine, famulos tuos subsidiis pacis: et, beatae Mariae semper Virginis patrociniis confidentes, a cunctis hostibus redde securos. Per Dominum."
               }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Dominus vobiscum."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Vel:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Domine, exaudi, etc."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Protect Thy servants, O Lord, by granting them the gift of peace, and as they have confidence in the patronage of blessed Mary, ever virgin, so do Thou make them safe from all enemies. Through our Lord Jesus Christ, Thy Son, Who with Thee liveth and reigneth in the unity of the Holy Ghost, God world without end. Amen."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -644,28 +3124,107 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave, Maria, gratia plena, Dominus tecum.",
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "la": "Benedicta tu.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende.",
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina.",
+                    "en-US": "As it was in the beginning, is now, and ever shall be, world without end, Amen. Alleluia."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "℣. Ave, Maria, gratia plena, Dominus tecum.\n℟. Benedicta tu.\n℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\nGloria Patri.",
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, world without end, Amen. Alleluia.\nFrom Septuagesima until Easter, instead of Alleluia is said: Praise be to Thee, O Lord, King of everlasting glory."
+                "la": "Gloria Patri."
               }
             },
             {
               "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "From Septuagesima until Easter, instead of Alleluia is said: Praise be to Thee, O Lord, King of everlasting glory."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento, salutis auctor.\nPsalmus 128\nSaepe expugnaverunt me a juventute mea, dicat nunc Israel:\nSaepe expugnaverunt me a juventute mea: etenim non potuerunt mihi.\nSupra dorsum meum fabricaverunt peccatores: prolongaverunt iniquitatem suam.\nDominus justus concidit cervices peccatorum: confundantur et convertantur retrorsum omnes, qui oderunt Sion.\nFiant sicut fenum tectorum: quod priusquam evellatur, exaruit.\nDe quo non implevit manum suam qui metit, et sinum suum qui manipulos colligit.\nEt non dixerunt qui praeteribant: Benedictio Domini super vos: benediximus vobis in nomine Domini.\nGloria Patri.\nPsalmus 129\nDe profundis clamavi ad te, Domine: Domine, exaudi vocem meam.\nFiant aures tuae intendentes, in vocem deprecationis meae.\nSi iniquitates observaveris, Domine: Domine, quis sustinebit?\nQuia apud te propitiatio est: et propter legem tuam sustinui te, Domine.\nSustinuit anima mea in verbo ejus: speravit anima mea in Domino.\nA custodia matutina usque ad noctem: speret Israel in Domino.\nQuia apud Dominum misericordia: et copiosa apud eum redemptio.\nEt ipse redimet Israel, ex omnibus iniquitatibus ejus.\nGloria Patri.\nPsalmus 130\nDomine, non est exaltatum cor meum: neque elati sunt oculi mei.\nNeque ambulavi in magnis: neque in mirabilibus super me.\nSi non humiliter sentiebam: sed exaltavi animam meam.\nSicut ablactatus est super matre sua, ita retributio in anima mea.\nSperet Israel in Domino, ex hoc nunc et usque in saeculum.\nGloria Patri.",
-                "en-US": "Author of grace.\nPsalm 128\nMany a time have they fought against me from my youth up, let Israel now say.\nYea, many a time have they fought against me from my youth up; but they have not prevailed against me.\nThe ungodly have wrought upon my back; they have lengthened their iniquity.\nThe righteous Lord hath hewn the necks of the ungodly: let them be confounded and turned backward, as many as hate Sion.\nLet them be even as the grass upon the housetops, which withereth afore it be grown up.\nWhereof the mower filleth not his hand, neither he that bindeth up the sheaves his bosom.\nAnd they who go by say not: The blessing of the Lord be upon you; we have blessed you in the Name of the Lord.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 129\nOut of the depths I have cried unto thee, O Lord: Lord, hear my voice.\nO let thine ears be attentive to the voice of my supplication.\nIf thou, O Lord, shalt observe our iniquities: Lord, who may endure it?\nFor with thee there is merciful forgiveness: and by reason of thy law, I have waited for thee, O Lord.\nMy soul hath relied on his word: my soul hath hoped in the Lord.\nFrom the morning watch even until night: let Israel hope in the Lord.\nBecause with the Lord there is mercy: and with him plentiful redemption.\nAnd he shall redeem Israel, from all his iniquities.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 130\nO Lord, mine heart is not exalted: nor are mine eyes raised up high.\nNeither have I walked in great matters, nor in wondrous things above me.\nIf I was not humbly minded, but exalted my soul.\nLike as a child that is weaned is towards his mother, even so is the reward in my soul.\nLet Israel hope in the Lord, from this time forth for evermore.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Memento, salutis auctor.",
+                "en-US": "Author of grace."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 128",
+                "en-US": "Psalm 128"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Saepe expugnaverunt me a juventute mea, dicat nunc Israel:\nSaepe expugnaverunt me a juventute mea: etenim non potuerunt mihi.\nSupra dorsum meum fabricaverunt peccatores: prolongaverunt iniquitatem suam.\nDominus justus concidit cervices peccatorum: confundantur et convertantur retrorsum omnes, qui oderunt Sion.\nFiant sicut fenum tectorum: quod priusquam evellatur, exaruit.\nDe quo non implevit manum suam qui metit, et sinum suum qui manipulos colligit.\nEt non dixerunt qui praeteribant: Benedictio Domini super vos: benediximus vobis in nomine Domini.\nGloria Patri.",
+                "en-US": "Many a time have they fought against me from my youth up, let Israel now say.\nYea, many a time have they fought against me from my youth up; but they have not prevailed against me.\nThe ungodly have wrought upon my back; they have lengthened their iniquity.\nThe righteous Lord hath hewn the necks of the ungodly: let them be confounded and turned backward, as many as hate Sion.\nLet them be even as the grass upon the housetops, which withereth afore it be grown up.\nWhereof the mower filleth not his hand, neither he that bindeth up the sheaves his bosom.\nAnd they who go by say not: The blessing of the Lord be upon you; we have blessed you in the Name of the Lord.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 129",
+                "en-US": "Psalm 129"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "De profundis clamavi ad te, Domine: Domine, exaudi vocem meam.\nFiant aures tuae intendentes, in vocem deprecationis meae.\nSi iniquitates observaveris, Domine: Domine, quis sustinebit?\nQuia apud te propitiatio est: et propter legem tuam sustinui te, Domine.\nSustinuit anima mea in verbo ejus: speravit anima mea in Domino.\nA custodia matutina usque ad noctem: speret Israel in Domino.\nQuia apud Dominum misericordia: et copiosa apud eum redemptio.\nEt ipse redimet Israel, ex omnibus iniquitatibus ejus.\nGloria Patri.",
+                "en-US": "Out of the depths I have cried unto thee, O Lord: Lord, hear my voice.\nO let thine ears be attentive to the voice of my supplication.\nIf thou, O Lord, shalt observe our iniquities: Lord, who may endure it?\nFor with thee there is merciful forgiveness: and by reason of thy law, I have waited for thee, O Lord.\nMy soul hath relied on his word: my soul hath hoped in the Lord.\nFrom the morning watch even until night: let Israel hope in the Lord.\nBecause with the Lord there is mercy: and with him plentiful redemption.\nAnd he shall redeem Israel, from all his iniquities.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 130",
+                "en-US": "Psalm 130"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Domine, non est exaltatum cor meum: neque elati sunt oculi mei.\nNeque ambulavi in magnis: neque in mirabilibus super me.\nSi non humiliter sentiebam: sed exaltavi animam meam.\nSicut ablactatus est super matre sua, ita retributio in anima mea.\nSperet Israel in Domino, ex hoc nunc et usque in saeculum.\nGloria Patri.",
+                "en-US": "O Lord, mine heart is not exalted: nor are mine eyes raised up high.\nNeither have I walked in great matters, nor in wondrous things above me.\nIf I was not humbly minded, but exalted my soul.\nLike as a child that is weaned is towards his mother, even so is the reward in my soul.\nLet Israel hope in the Lord, from this time forth for evermore.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -679,7 +3238,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Chapter",
                 "en-US": "Chapter"
@@ -687,13 +3246,146 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Quasi cedrus exaltata sum in Libano, et quasi cypressus in monte Sion: quasi palma exaltata sum in Cades, et quasi plantatio rosae in Jericho.\n℟. Deo gratias.\n℣. Elegit eam Deus, et praelegit eam.\n℟. Et habitare eam facit in tabernaculo suo.\n℣. Sancta Dei Genitrix, Virgo semper Maria.\n℟. Intercede pro nobis ad Dominum Deum nostrum.\n℣. Dominus vobiscum.\nVel ℣. Domine, exaudi, etc.",
-                "en-US": "I was exalted like the cedar in Libanus, and like a cypress on Mount Sion. Like a palm tree in Cades was I exalted, and like a rose plant in Jericho.\n℟. Thanks be to God.\n℟. God hath chosen her and preferred her.\n℟. God hath chosen her and preferred her.\n℣. And He maketh her to dwell in His tabernacle: and preferred her.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\n℟. God hath chosen her and preferred her.\n℣. O ever virgin, Mary, Holy Mother of God.\n℟. Intercede for us with Lord our God.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
+                "la": "Quasi cedrus exaltata sum in Libano, et quasi cypressus in monte Sion: quasi palma exaltata sum in Cades, et quasi plantatio rosae in Jericho."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Elegit eam Deus, et praelegit eam."
+                  },
+                  "r": {
+                    "la": "Et habitare eam facit in tabernaculo suo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sancta Dei Genitrix, Virgo semper Maria."
+                  },
+                  "r": {
+                    "la": "Intercede pro nobis ad Dominum Deum nostrum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Dominus vobiscum."
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Vel"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Domine, exaudi, etc."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "I was exalted like the cedar in Libanus, and like a cypress on Mount Sion. Like a palm tree in Cades was I exalted, and like a rose plant in Jericho."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "God hath chosen her and preferred her."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "And He maketh her to dwell in His tabernacle: and preferred her."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "God hath chosen her and preferred her."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O ever virgin, Mary, Holy Mother of God."
+                  },
+                  "r": {
+                    "en-US": "Intercede for us with Lord our God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -701,10 +3393,68 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Famulum tuorum, quaesumus, Domine, delictis ignosce: ut qui tibi placere de actibus nostris non valemus, Genitricis Filii tui Domini nostri intercessione salvemur. Per eundem Dominum.\n℣. Dominus vobiscum. Vel ℣. Domine, exaudi, etc.",
-                "en-US": "Forgive, we beseech Thee, O Lord, the sins of Thy servants, that we who cannot be pleasing to Thee by our deeds, may be saved by the intercession of the Mother of Thy Son, our Lord, Who with Thee liveth and reigneth in the unity of the Holy Ghost, God world without end. Amen.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God."
+                "la": "Famulum tuorum, quaesumus, Domine, delictis ignosce: ut qui tibi placere de actibus nostris non valemus, Genitricis Filii tui Domini nostri intercessione salvemur. Per eundem Dominum."
               }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Dominus vobiscum."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Vel:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Domine, exaudi, etc."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Forgive, we beseech Thee, O Lord, the sins of Thy servants, that we who cannot be pleasing to Thee by our deeds, may be saved by the intercession of the Mother of Thy Son, our Lord, Who with Thee liveth and reigneth in the unity of the Holy Ghost, God world without end. Amen."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -717,14 +3467,121 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave, Maria, gratia plena, Dominus tecum.",
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "la": "Benedicta tu.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende.",
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina.",
+                    "en-US": "As it was in the beginning, is now, and ever shall be, world without end, Amen. Alleluia."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "℣. Ave, Maria, gratia plena, Dominus tecum.\n℟. Benedicta tu.\n℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\nGloria Patri.\nPsalmus 109\nDixit Dominus Domino meo: Sede a dextris meis.\nDonec ponam inimicos tuos, scabellum pedum tuorum.\nVirgam virtutis tuae emittet Dominus ex Sion: dominare in medio inimicorum tuorum.\nTecum principium in die virtutis tuae in splendoribus sanctorum: ex utero ante luciferum genui te.\nJuravit Dominus, et non poenitebit eum: Tu es sacerdos in aeternum secundum ordinem Melchisedech.\nDominus a dextris tuis, confregit in die irae suae reges.\nJudicabit in nationibus, implebit ruinas: conquassabit capita in terra multorum.\nDe torrente in via bibet: propterea exaltabit caput.\nGloria Patri.\nPsalmus 112\nLaudate, pueri, Dominum: laudate nomen Domini.\nSit nomen Domini benedictum, ex hoc nunc, et usque in saeculum.\nA solis ortu usque ad occasum, laudabile nomen Domini.\nExcelsus super omnes gentes Dominus, et super caelos gloria ejus.\nQuis sicut Dominus Deus noster, qui in altis habitat, et humilia respicit in caelo et in terra?\nSuscitans a terra inopem, et de stercore erigens pauperem.\nUt collocet eum cum principibus, cum principibus populi sui.\nQui habitare facit sterilem in domo, matrem filiorum laetantem.\nGloria Patri.\nPsalmus 121\nLaetatus sum in his quae dicta sunt mihi: In domum Domini ibimus.\nStantes erant pedes nostri, in atriis tuis, Jerusalem.\nJerusalem, quae aedificatur ut civitas: cujus participatio ejus in idipsum.\nIlluc enim ascenderunt tribus, tribus Domini: testimonium Israel ad confitendum nomini Domini.\nQuia illic sederunt sedes in judicio, sedes super domum David.\nRogate quae ad pacem sunt Jerusalem: et abundantia diligentibus te.\nFiat pax in virtute tua: et abundantia in turribus tuis.\nPropter fratres meos, et proximos meos, loquebar pacem de te.\nPropter domum Domini Dei nostri, quaesivi bona tibi.\nGloria Patri.\nPsalmus 126\nNisi Dominus aedificaverit domum, in vanum laboraverunt qui aedificant eam.\nNisi Dominus custodierit civitatem, frustra vigilat qui custodit eam.\nVanum est vobis ante lucem surgere: surgite postquam sederitis, qui manducatis panem doloris.\nCum dederit dilectis suis somnum: ecce hereditas Domini filii: merces, fructus ventris.\nSicut sagittae in manu potentis: ita filii excussorum.\nBeatus vir qui implevit desiderium suum ex ipsis: non confundetur cum loquetur inimicis suis in porta.\nGloria Patri.\nPsalmus 147\nLauda, Jerusalem, Dominum: lauda Deum tuum, Sion.\nQuoniam confortavit seras portarum tuarum: benedixit filiis tuis in te.\nQui posuit fines tuos pacem: et adipe frumenti satiat te.\nQui emittit eloquium suum terrae: velociter currit sermo ejus.\nQui dat nivem sicut lanam: nebulam sicut cinerem spargit.\nMittit crystallum suam sicut buccellas: ante faciem frigoris ejus quis sustinebit?\nEmittet verbum suum: et liquefaciet ea: flabit spiritus ejus, et fluent aquae.\nQui annuntiat verbum suum Jacob: justitias, et judicia sua Israel.\nNon fecit taliter omni nationi: et judicia sua non manifestavit eis.\nGloria Patri.",
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, world without end, Amen. Alleluia.\nFrom Septuagesima until Easter, instead of Alleluia is said: Praise be to Thee, O Lord, King of everlasting glory.\nPsalm 109\nThe Lord said unto my Lord: Sit thou on my right hand, until I make thine enemies thy footstool.\nThe Lord shall send the rod of thy power out of Sion: be thou ruler, even in the midst among thine enemies.\nThine shall be the dominion in the day of thy power, amid the brightness of the saints: from the womb before the day star have I begotten thee.\nThe Lord sware, and will not repent: Thou art a priest for ever after the order of Melchisedech.\nThe Lord upon thy right hand shall wound even kings in the day of his wrath.\nHe shall judge among the heathen; he shall fill the places with the dead bodies: and smite in sunder the heads over divers countries.\nHe shall drink of the brook in the way; therefore shall he lift up his head.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 112\nPraise the Lord, O ye his servants: O praise the Name of the Lord.\nBlessed be the Name of the Lord, from this time forth for evermore.\nFrom the rising up of the sun unto the going down of the same, the Lord's Name be praised.\nThe Lord is high above all nations, and his glory above the heavens.\nWho is like unto the Lord our God, that hath his dwelling on high, and beholdeth what is lowly in heaven and in the earth?\nHe raiseth up the poor out of the dust, and lifteth the needy out of the dunghill.\nThat he may set him with the princes, even with the princes of his people.\nHe maketh the barren woman to keep house, and to be a joyful mother of children.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 121\nI rejoiced at the things that were said unto me: We will go into the house of the Lord.\nOur feet shall stand in thy gates, O Jerusalem.\nJerusalem is built as a city that is at unity in itself.\nFor thither did the tribes go up, even the tribes of the Lord, to testify unto Israel, to give thanks unto the Name of the Lord.\nFor their seats have sat in judgment, even the seats upon the house of David.\nO pray for the peace of Jerusalem; they shall prosper that love thee.\nPeace be within thy walls, and plenteousness within thy palaces.\nFor my brethren and companions' sakes, I spake peace of thee.\nYea, because of the house of the Lord our God, I have sought to do thee good.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 126\nExcept the Lord build the house, they labor in vain that build it.\nExcept the Lord keep the city, the watchman waketh but in vain.\nIt is vain for you to rise up before the light: rise ye after ye have taken your rest, ye that eat the bread of sorrow.\nWhen he giveth his beloved sleep: behold, children are the heritage of the Lord: the reward, and the fruit of the womb.\nLike as the arrows in the hand of the mighty, even so are the children of them that have been shaken.\nBlessed is the man that hath filled the desire with them: he shall not be confounded when he shall speak with his enemies in the gate.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 147\nPraise the Lord, O Jerusalem: praise thy God, O Sion.\nFor he hath made fast the bars of thy gates, and hath blessed thy children within thee.\nWho hath placed peace in thy borders, and filleth thee with the fat of the crops.\nWho sendeth forth his commandment upon earth, and his word runneth swiftly.\nWho giveth snow like wool, and scattereth the mist like ashes.\nHe sendeth his ice like morsels: who is able to abide before the face of his frost?\nHe shall send out his word, and shall melt them: his spirit shall breathe forth, and the waters shall flow.\nWho declareth his word unto Jacob, his statutes and judgments unto Israel.\nHe hath not dealt so with every nation: neither hath he given them knowledge of his judgments.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Gloria Patri."
               }
             },
             {
               "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "From Septuagesima until Easter, instead of Alleluia is said: Praise be to Thee, O Lord, King of everlasting glory."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 109",
+                "en-US": "Psalm 109"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Dixit Dominus Domino meo: Sede a dextris meis.\nDonec ponam inimicos tuos, scabellum pedum tuorum.\nVirgam virtutis tuae emittet Dominus ex Sion: dominare in medio inimicorum tuorum.\nTecum principium in die virtutis tuae in splendoribus sanctorum: ex utero ante luciferum genui te.\nJuravit Dominus, et non poenitebit eum: Tu es sacerdos in aeternum secundum ordinem Melchisedech.\nDominus a dextris tuis, confregit in die irae suae reges.\nJudicabit in nationibus, implebit ruinas: conquassabit capita in terra multorum.\nDe torrente in via bibet: propterea exaltabit caput.\nGloria Patri.",
+                "en-US": "The Lord said unto my Lord: Sit thou on my right hand, until I make thine enemies thy footstool.\nThe Lord shall send the rod of thy power out of Sion: be thou ruler, even in the midst among thine enemies.\nThine shall be the dominion in the day of thy power, amid the brightness of the saints: from the womb before the day star have I begotten thee.\nThe Lord sware, and will not repent: Thou art a priest for ever after the order of Melchisedech.\nThe Lord upon thy right hand shall wound even kings in the day of his wrath.\nHe shall judge among the heathen; he shall fill the places with the dead bodies: and smite in sunder the heads over divers countries.\nHe shall drink of the brook in the way; therefore shall he lift up his head.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 112",
+                "en-US": "Psalm 112"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Laudate, pueri, Dominum: laudate nomen Domini.\nSit nomen Domini benedictum, ex hoc nunc, et usque in saeculum.\nA solis ortu usque ad occasum, laudabile nomen Domini.\nExcelsus super omnes gentes Dominus, et super caelos gloria ejus.\nQuis sicut Dominus Deus noster, qui in altis habitat, et humilia respicit in caelo et in terra?\nSuscitans a terra inopem, et de stercore erigens pauperem.\nUt collocet eum cum principibus, cum principibus populi sui.\nQui habitare facit sterilem in domo, matrem filiorum laetantem.\nGloria Patri.",
+                "en-US": "Praise the Lord, O ye his servants: O praise the Name of the Lord.\nBlessed be the Name of the Lord, from this time forth for evermore.\nFrom the rising up of the sun unto the going down of the same, the Lord's Name be praised.\nThe Lord is high above all nations, and his glory above the heavens.\nWho is like unto the Lord our God, that hath his dwelling on high, and beholdeth what is lowly in heaven and in the earth?\nHe raiseth up the poor out of the dust, and lifteth the needy out of the dunghill.\nThat he may set him with the princes, even with the princes of his people.\nHe maketh the barren woman to keep house, and to be a joyful mother of children.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 121",
+                "en-US": "Psalm 121"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Laetatus sum in his quae dicta sunt mihi: In domum Domini ibimus.\nStantes erant pedes nostri, in atriis tuis, Jerusalem.\nJerusalem, quae aedificatur ut civitas: cujus participatio ejus in idipsum.\nIlluc enim ascenderunt tribus, tribus Domini: testimonium Israel ad confitendum nomini Domini.\nQuia illic sederunt sedes in judicio, sedes super domum David.\nRogate quae ad pacem sunt Jerusalem: et abundantia diligentibus te.\nFiat pax in virtute tua: et abundantia in turribus tuis.\nPropter fratres meos, et proximos meos, loquebar pacem de te.\nPropter domum Domini Dei nostri, quaesivi bona tibi.\nGloria Patri.",
+                "en-US": "I rejoiced at the things that were said unto me: We will go into the house of the Lord.\nOur feet shall stand in thy gates, O Jerusalem.\nJerusalem is built as a city that is at unity in itself.\nFor thither did the tribes go up, even the tribes of the Lord, to testify unto Israel, to give thanks unto the Name of the Lord.\nFor their seats have sat in judgment, even the seats upon the house of David.\nO pray for the peace of Jerusalem; they shall prosper that love thee.\nPeace be within thy walls, and plenteousness within thy palaces.\nFor my brethren and companions' sakes, I spake peace of thee.\nYea, because of the house of the Lord our God, I have sought to do thee good.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 126",
+                "en-US": "Psalm 126"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Nisi Dominus aedificaverit domum, in vanum laboraverunt qui aedificant eam.\nNisi Dominus custodierit civitatem, frustra vigilat qui custodit eam.\nVanum est vobis ante lucem surgere: surgite postquam sederitis, qui manducatis panem doloris.\nCum dederit dilectis suis somnum: ecce hereditas Domini filii: merces, fructus ventris.\nSicut sagittae in manu potentis: ita filii excussorum.\nBeatus vir qui implevit desiderium suum ex ipsis: non confundetur cum loquetur inimicis suis in porta.\nGloria Patri.",
+                "en-US": "Except the Lord build the house, they labor in vain that build it.\nExcept the Lord keep the city, the watchman waketh but in vain.\nIt is vain for you to rise up before the light: rise ye after ye have taken your rest, ye that eat the bread of sorrow.\nWhen he giveth his beloved sleep: behold, children are the heritage of the Lord: the reward, and the fruit of the womb.\nLike as the arrows in the hand of the mighty, even so are the children of them that have been shaken.\nBlessed is the man that hath filled the desire with them: he shall not be confounded when he shall speak with his enemies in the gate.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalmus 147",
+                "en-US": "Psalm 147"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Lauda, Jerusalem, Dominum: lauda Deum tuum, Sion.\nQuoniam confortavit seras portarum tuarum: benedixit filiis tuis in te.\nQui posuit fines tuos pacem: et adipe frumenti satiat te.\nQui emittit eloquium suum terrae: velociter currit sermo ejus.\nQui dat nivem sicut lanam: nebulam sicut cinerem spargit.\nMittit crystallum suam sicut buccellas: ante faciem frigoris ejus quis sustinebit?\nEmittet verbum suum: et liquefaciet ea: flabit spiritus ejus, et fluent aquae.\nQui annuntiat verbum suum Jacob: justitias, et judicia sua Israel.\nNon fecit taliter omni nationi: et judicia sua non manifestavit eis.\nGloria Patri.",
+                "en-US": "Praise the Lord, O Jerusalem: praise thy God, O Sion.\nFor he hath made fast the bars of thy gates, and hath blessed thy children within thee.\nWho hath placed peace in thy borders, and filleth thee with the fat of the crops.\nWho sendeth forth his commandment upon earth, and his word runneth swiftly.\nWho giveth snow like wool, and scattereth the mist like ashes.\nHe sendeth his ice like morsels: who is able to abide before the face of his frost?\nHe shall send out his word, and shall melt them: his spirit shall breathe forth, and the waters shall flow.\nWho declareth his word unto Jacob, his statutes and judgments unto Israel.\nHe hath not dealt so with every nation: neither hath he given them knowledge of his judgments.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -732,13 +3589,42 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Sancta Dei Genitrix, Virgo semper Maria, intercede pro nobis ad Dominum Deum nostrum.",
-                "en-US": "Holy Mother of God, Mary ever virgin, intercede for us with the Lord\nour God.\nLittle Chapter (Eccli. 24)\nLike a vine, I gave forth a sweet perfume like cinnamon and aromatical balm: I yielded an odor of sweetness,\nlike the choicest myrrh.\n℟. Thanks be to God."
+                "la": "Sancta Dei Genitrix, Virgo semper Maria, intercede pro nobis ad Dominum Deum nostrum."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Holy Mother of God, Mary ever virgin, intercede for us with the Lord\nour God."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Little Chapter (Eccli. 24)"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Like a vine, I gave forth a sweet perfume like cinnamon and aromatical balm: I yielded an odor of sweetness,\nlike the choicest myrrh."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Chapter",
                 "en-US": "Chapter"
@@ -747,26 +3633,68 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sicut cinnamomum, et balsamum aromatizans odorem dedi: quasi myrrha electa dedi suavitatem odoris.\n℟. Deo gratias.",
-                "en-US": "Like a vine, I gave forth a sweet perfume like cinnamon and aromatical balm: I yielded an odor of sweetness, like the choicest myrrh.\n℟. Thanks be to God."
+                "la": "Sicut cinnamomum, et balsamum aromatizans odorem dedi: quasi myrrha electa dedi suavitatem odoris.",
+                "en-US": "Like a vine, I gave forth a sweet perfume like cinnamon and aromatical balm: I yielded an odor of sweetness, like the choicest myrrh."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ave, maris stella,\nDei Mater alma,\nAtque semper virgo,\nFelix caeli porta.\nSumens illud Ave\nGabrielis ore,\nFunda nos in pace,\nMutans nomen Hevae.\nSolve vincula reis,\nProfer lumen caecis:\nMala nostra pelle,\nBona cuncta posce.\nMonstra te esse matrem:\nSumat per te preces,\nQui pro nobis natus\nTulit esse tuus.\nVirgo singularis,\nInter omnes mitis,\nNos culpis solutos,\nMites fac et castos.\nVitam praesta puram,\nIter para tutum,\nUt videntes Jesum\nSemper collaetemur.\nSit laus Deo Patri,\nSummo Christo decus,\nSpiritui Sancto,\nTribus honor unus. Amen.\n℣. Ora pro nobis, sancta Dei Genitrix.\n℟. Ut digni efficiamur promissionibus Christi.\nCanticum B. Mariae (Luc. 1)\nMagnificat anima mea Dominum;\nEt exsultavit spiritus meus in Deo salutari meo.\nQuia respexit humilitatem ancillae suae: ecce enim ex hoc beatam me dicent omnes generationes.\nQuia fecit mihi magna qui potens est: et sanctum nomen ejus,\nEt misericordia ejus a progenie in progenies timentibus eum.\nFecit potentiam in brachio suo: dispersit superbos mente cordis sui.\nDeposuit potentes de sede, et exaltavit humiles.\nEsurientes implevit bonis: et divites dimisit inanes.\nSuscepit Israel, puerum suum, recordatus misericordiae suae,\nSicut locutus est ad patres nostros, Abraham et semini ejus in saecula.\nGloria Patri.",
-                "en-US": "Hail, O star of ocean,\nGod's own Mother blest,\nEver sinless Virgin,\nGate of heaven's rest.\nTaking that sweet Ave,\nWhich from Gabriel came.\nPeace confirm within us,\nChanging Eva's name.\nBreak the sinners' fetters,\nTo the blind give day,\nWard all evils from us,\nFor all blessings pray.\nShow thyself a mother,\nMay the Word Divine,\nBorn for us thine infant,\nHear our pray'rs through thine.\nVirgin all excelling,\nMildest of the mild,\nFree from sin preserve us,\nMeek and undefil'd.\nKeep our lives all spotless,\nMake our way secure:\nTill we find in Jesus,\nJoys that shall endure.\nPraise to God the Father,\nHonor to the Son,\nTo the Holy Spirit,\nBe glory one. Amen.\n℣. Pray for us, O holy Mother of God.\n℟. That we may be made worthy of\nthe promises of Christ.\nCanticle of the Blessed Virgin Mary\nMy soul doth magnify the Lord;\nAnd my spirit hath rejoiced in God\nmy Saviour.\nFor he hath regarded the lowliness of his handmaiden: for behold, from\nhenceforth all generations shall call me blessed.\nFor he that is mighty hath magnified\nme, and holy is his Name.\nAnd his mercy is on them that fear\nhim throughout all generations.\nHe hath shewed strength with his arm, he hath scattered the proud in the\nimagination of their hearts.\nHe hath put down the mighty from their seat, and hath exalted the\nhumble and meek.\nHe hath filled the hungry with good things, and the rich he hath sent\nempty away.\nHe remembering his mercy hath\nholpen his servant Israel.\nAs he promised to our forefathers,\nAbraham and his seed for ever.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end.\nAmen."
+                "la": "Ave, maris stella,\nDei Mater alma,\nAtque semper virgo,\nFelix caeli porta.\nSumens illud Ave\nGabrielis ore,\nFunda nos in pace,\nMutans nomen Hevae.\nSolve vincula reis,\nProfer lumen caecis:\nMala nostra pelle,\nBona cuncta posce.\nMonstra te esse matrem:\nSumat per te preces,\nQui pro nobis natus\nTulit esse tuus.\nVirgo singularis,\nInter omnes mitis,\nNos culpis solutos,\nMites fac et castos.\nVitam praesta puram,\nIter para tutum,\nUt videntes Jesum\nSemper collaetemur.\nSit laus Deo Patri,\nSummo Christo decus,\nSpiritui Sancto,\nTribus honor unus. Amen.",
+                "en-US": "Hail, O star of ocean,\nGod's own Mother blest,\nEver sinless Virgin,\nGate of heaven's rest.\nTaking that sweet Ave,\nWhich from Gabriel came.\nPeace confirm within us,\nChanging Eva's name.\nBreak the sinners' fetters,\nTo the blind give day,\nWard all evils from us,\nFor all blessings pray.\nShow thyself a mother,\nMay the Word Divine,\nBorn for us thine infant,\nHear our pray'rs through thine.\nVirgin all excelling,\nMildest of the mild,\nFree from sin preserve us,\nMeek and undefil'd.\nKeep our lives all spotless,\nMake our way secure:\nTill we find in Jesus,\nJoys that shall endure.\nPraise to God the Father,\nHonor to the Son,\nTo the Holy Spirit,\nBe glory one. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Dei Genitrix.",
+                    "en-US": "Pray for us, O holy Mother of God."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi.",
+                    "en-US": "That we may be made worthy of"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "the promises of Christ."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Canticum B. Mariae (Luc. 1)",
+                "en-US": "Canticle of the Blessed Virgin Mary"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Magnificat anima mea Dominum;\nEt exsultavit spiritus meus in Deo salutari meo.\nQuia respexit humilitatem ancillae suae: ecce enim ex hoc beatam me dicent omnes generationes.\nQuia fecit mihi magna qui potens est: et sanctum nomen ejus,\nEt misericordia ejus a progenie in progenies timentibus eum.\nFecit potentiam in brachio suo: dispersit superbos mente cordis sui.\nDeposuit potentes de sede, et exaltavit humiles.\nEsurientes implevit bonis: et divites dimisit inanes.\nSuscepit Israel, puerum suum, recordatus misericordiae suae,\nSicut locutus est ad patres nostros, Abraham et semini ejus in saecula.\nGloria Patri.",
+                "en-US": "My soul doth magnify the Lord;\nAnd my spirit hath rejoiced in God\nmy Saviour.\nFor he hath regarded the lowliness of his handmaiden: for behold, from\nhenceforth all generations shall call me blessed.\nFor he that is mighty hath magnified\nme, and holy is his Name.\nAnd his mercy is on them that fear\nhim throughout all generations.\nHe hath shewed strength with his arm, he hath scattered the proud in the\nimagination of their hearts.\nHe hath put down the mighty from their seat, and hath exalted the\nhumble and meek.\nHe hath filled the hungry with good things, and the rich he hath sent\nempty away.\nHe remembering his mercy hath\nholpen his servant Israel.\nAs he promised to our forefathers,\nAbraham and his seed for ever.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -774,13 +3702,69 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Sancta Maria, succurre miseris, juva pusillanimes, refove flebiles, ora pro populo, intercede pro clero, intercede pro devoto femineo sexu.\n℣. Dominus vobiscum.\n℟. Et cum spiritu tuo.\nVel ℣. Domine, exaudi orationem meam. ℟. Et clamor meus ad te veniat.",
-                "en-US": "Holy Mary, succor the miserable, help the faint hearted, comfort the sorrowful, pray for the people, plead for the clergy, make intercession for the devout female sex.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
+                "la": "Sancta Maria, succurre miseris, juva pusillanimes, refove flebiles, ora pro populo, intercede pro clero, intercede pro devoto femineo sexu."
               }
             },
             {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
+            },
+            {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Vel"
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Holy Mary, succor the miserable, help the faint hearted, comfort the sorrowful, pray for the people, plead for the clergy, make intercession for the devout female sex."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -788,13 +3772,39 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Concede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis salute gaudere: et, gloriosa beatae Mariae semper Virginis intercessione, a praesenti liberari tristitia et aeterna perfrui laetitia. Per Christum Dominum nostrum.\n℟. Amen.\nMemoria B. P. N. Dominici",
-                "en-US": "Grant, we beseech Thee, O Lord God, that we, Thy servants, may enjoy continual health of mind and body; and that through the glorious intercession of blessed Mary, ever virgin, we may be delivered from present sorrow and enjoy eternal happiness. Through Christ our Lord.\nAmen.\nCommemoration of Our Holy Father, Saint Dominic"
+                "la": "Concede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis salute gaudere: et, gloriosa beatae Mariae semper Virginis intercessione, a praesenti liberari tristitia et aeterna perfrui laetitia. Per Christum Dominum nostrum."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Memoria B. P. N. Dominici"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Grant, we beseech Thee, O Lord God, that we, Thy servants, may enjoy continual health of mind and body; and that through the glorious intercession of blessed Mary, ever virgin, we may be delivered from present sorrow and enjoy eternal happiness. Through Christ our Lord.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Commemoration of Our Holy Father, Saint Dominic"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -802,13 +3812,60 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Magne Pater sancte Dominice, mortis hora nos tecum suscipe, et hic semper nos pie respice.\n℣. Os justi meditabitur sapientiam. ℟. Et lingua ejus loquetur judicium.",
-                "en-US": "O great and holy Father, Dominic, at the hour of death take us to thyself, and while here regard us always graciously.\n℣. The mouth of the just man shall speak wisdom.\n℟. And his tongue shall speak\njudgment.\nOration\nO God, Who didst vouchsafe to enlighten Thy Church by the merits and teachings of Thy blessed Confessor, Our Father Dominic, grant through his intercession that it may never be destitute of temporal help, and may always increase in spiritual growth.\nThrough Christ our Lord. Amen.\nCommemoration of all the Saints of the Dominican Order"
+                "la": "Magne Pater sancte Dominice, mortis hora nos tecum suscipe, et hic semper nos pie respice."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Os justi meditabitur sapientiam."
+                  },
+                  "r": {
+                    "la": "Et lingua ejus loquetur judicium."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O great and holy Father, Dominic, at the hour of death take us to thyself, and while here regard us always graciously."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "The mouth of the just man shall speak wisdom."
+                  },
+                  "r": {
+                    "en-US": "And his tongue shall speak"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "judgment.\nOration\nO God, Who didst vouchsafe to enlighten Thy Church by the merits and teachings of Thy blessed Confessor, Our Father Dominic, grant through his intercession that it may never be destitute of temporal help, and may always increase in spiritual growth.\nThrough Christ our Lord. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Commemoration of all the Saints of the Dominican Order"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -816,13 +3873,27 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Deus, qui Ecclesiam tuam beati Dominici Confessoris tui, Patris nostri, illustrare dignatus es meritis et doctrinis: concede, ut ejus intercessione temporalibus non destituatur auxiliis, et spiritualibus semper proficiat incrementis. Per Christum.\nMemoria SS. Ordinis",
-                "en-US": "O God, Who didst vouchsafe to enlighten Thy Church by the merits and teachings of Thy blessed Confessor, Our Father Dominic, grant through his intercession that it may never be destitute of temporal help, and may always increase in spiritual growth.\nThrough Christ our Lord. Amen.\nCommemoration of all the Saints of the Dominican Order"
+                "la": "Deus, qui Ecclesiam tuam beati Dominici Confessoris tui, Patris nostri, illustrare dignatus es meritis et doctrinis: concede, ut ejus intercessione temporalibus non destituatur auxiliis, et spiritualibus semper proficiat incrementis. Per Christum.\nMemoria SS. Ordinis"
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who didst vouchsafe to enlighten Thy Church by the merits and teachings of Thy blessed Confessor, Our Father Dominic, grant through his intercession that it may never be destitute of temporal help, and may always increase in spiritual growth.\nThrough Christ our Lord. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Commemoration of all the Saints of the Dominican Order"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -830,13 +3901,60 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Christi pia gratia Sanctos sublimavit, quos Patris Dominici Ordo propagavit: nos eorum meritis petimus juvari, atque suis precibus Deo commendari.\n℣. Sapientiam Sanctorum narrent populi. ℟. Et laudem eorum nuntiet ecclesia.",
-                "en-US": "The holy grace of Christ hath exalted the saints, whom the Order of Father Dominic has raised up. We beg to be helped by their merits and to be\ncommended to God by their prayers.\n℣. The wisdom of the holy the peoples shall speak.\n℟. And their praise the Church shall\nproclaim.\nOration\nGrant, we beseech Thee, almighty God, that the examples of the saints of our Order may incite us to a better life; that we may imitate the deeds of them whose memory we celebrate. Through Christ our Lord. Amen.\nCommemoration of all Saints"
+                "la": "Christi pia gratia Sanctos sublimavit, quos Patris Dominici Ordo propagavit: nos eorum meritis petimus juvari, atque suis precibus Deo commendari."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sapientiam Sanctorum narrent populi."
+                  },
+                  "r": {
+                    "la": "Et laudem eorum nuntiet ecclesia."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "The holy grace of Christ hath exalted the saints, whom the Order of Father Dominic has raised up. We beg to be helped by their merits and to be\ncommended to God by their prayers."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "The wisdom of the holy the peoples shall speak."
+                  },
+                  "r": {
+                    "en-US": "And their praise the Church shall"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "proclaim.\nOration\nGrant, we beseech Thee, almighty God, that the examples of the saints of our Order may incite us to a better life; that we may imitate the deeds of them whose memory we celebrate. Through Christ our Lord. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Commemoration of all Saints"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -844,13 +3962,27 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Concede, quaesumus, omnipotens Deus: ut ad meliorem vitam Sanctorum Ordinis nostri exempla nos provocent: quatenus, quorum memoriam agimus, etiam actus imitemur. Per Christum.\nMemoria Omnium Sanctorum",
-                "en-US": "Grant, we beseech Thee, almighty God, that the examples of the saints of our Order may incite us to a better life; that we may imitate the deeds of them whose memory we celebrate. Through Christ our Lord. Amen.\nCommemoration of all Saints"
+                "la": "Concede, quaesumus, omnipotens Deus: ut ad meliorem vitam Sanctorum Ordinis nostri exempla nos provocent: quatenus, quorum memoriam agimus, etiam actus imitemur. Per Christum.\nMemoria Omnium Sanctorum"
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Grant, we beseech Thee, almighty God, that the examples of the saints of our Order may incite us to a better life; that we may imitate the deeds of them whose memory we celebrate. Through Christ our Lord. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Commemoration of all Saints"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -858,13 +3990,60 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Sancti Dei omnes intercedere dignemini pro nostra omniumque salute.\n℣. Orate pro nobis, omnes Sancti Dei. ℟. Ut digni efficiamur promissionibus Christi.",
-                "en-US": "All ye saints of God vouchsafe to make intercession for our salvation,\nand for that of all.\n℣. Pray for us, all ye saints of God.\n℟. That we may be made worthy of the promises of Christ.\nOration\nGrant, we beseech Thee, O Lord: that all Thy saints may pray for us unceasingly, and vouchsafe in Thy clemency to hear them. Through Christ our Lord. Amen.\nCommemoration for Peace"
+                "la": "Sancti Dei omnes intercedere dignemini pro nostra omniumque salute."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Orate pro nobis, omnes Sancti Dei."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "All ye saints of God vouchsafe to make intercession for our salvation,\nand for that of all."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Pray for us, all ye saints of God."
+                  },
+                  "r": {
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Oration\nGrant, we beseech Thee, O Lord: that all Thy saints may pray for us unceasingly, and vouchsafe in Thy clemency to hear them. Through Christ our Lord. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Commemoration for Peace"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -872,13 +4051,27 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Tribue, quaesumus, Domine, omnes Sanctos tuos jugiter pro nobis orare; et eos clementer exaudire digneris. Per Christum.\nMemoria de Pace",
-                "en-US": "Grant, we beseech Thee, O Lord: that all Thy saints may pray for us unceasingly, and vouchsafe in Thy clemency to hear them. Through Christ our Lord. Amen.\nCommemoration for Peace"
+                "la": "Tribue, quaesumus, Domine, omnes Sanctos tuos jugiter pro nobis orare; et eos clementer exaudire digneris. Per Christum.\nMemoria de Pace"
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Grant, we beseech Thee, O Lord: that all Thy saints may pray for us unceasingly, and vouchsafe in Thy clemency to hear them. Through Christ our Lord. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Commemoration for Peace"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -886,13 +4079,111 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Da pacem, Domine, in diebus nostris: quia non est alius, qui pugnet pro nobis, nisi tu Deus noster.\n℣. Fiat pax in virtute tua.\n℟. Et abundantia in turribus tuis.",
-                "en-US": "Give peace, O Lord, in our days, because there is no other who will\nfight for us, except Thee, our God.\n℣. Let peace be in thy strength.\n℟. And abundance in thy towers.\nOration\nO God, from Whom are holy desires, right counsels, and just works, grant to Thy servants that peace which the world cannot give; that our hearts being devoted to Thy commandments, and the fear of enemies being taken away, the times may, by Thy protection, be peaceful. Through our Lord Jesus Christ, Thy Son, Who with Thee liveth and reigneth in the unity of the Holy Ghost, God, world without end.\nAmen.\nDuring Advent\nMagnificat Antiphon:\nO Virgin of virgins, how will this be done? For thou art seen to have none like thee either before or after. Ye daughters of Jerusalem, why look ye at me in wonder? This mystery\nwhich ye see is all divine.\nOration\nO God, Who wast pleased that, at the message of an angel, Thy Word should take flesh from the womb of the Blessed Virgin Mary, grant that we, Thy suppliants, who believe her to be truly the Mother of God, may be helped through her intercession with Thee. Through the same Christ our Lord. Amen.\nFrom Christmas to Purification\nMagnificat Antiphon:\nO wonderful intercourse! The Creator of human kind, taking unto Himself a living body, vouchsafed to be born of a virgin; and coming forth amongst us, a man without human generation bestowed upon us His\ndivinity.\nOration\nO God, Who through the fruitful virginity of blessed Mary, hast given to mankind the reward of eternal salvation, grant, we beseech Thee, that we may feel the intercession she makes for us, through whom we have been made worthy to receive the Author of life, Christ our\nLord. Amen.\nDuring Paschaltide\n: O Queen of heaven, rejoice, alleluia; for He Whom thou didst merit to bear, alleluia, hath risen as He said\nalleluia; pray to God for us, alleluia.\nDuring Ascensiontide\n:O Queen of heaven, rejoice, alleluia; for He Whom thou didst merit to bear, alleluia, hath ascended as He said alleluia; pray to God for us,\nalleluia."
+                "la": "Da pacem, Domine, in diebus nostris: quia non est alius, qui pugnet pro nobis, nisi tu Deus noster."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fiat pax in virtute tua."
+                  },
+                  "r": {
+                    "la": "Et abundantia in turribus tuis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Give peace, O Lord, in our days, because there is no other who will\nfight for us, except Thee, our God."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let peace be in thy strength."
+                  },
+                  "r": {
+                    "en-US": "And abundance in thy towers."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Oration\nO God, from Whom are holy desires, right counsels, and just works, grant to Thy servants that peace which the world cannot give; that our hearts being devoted to Thy commandments, and the fear of enemies being taken away, the times may, by Thy protection, be peaceful. Through our Lord Jesus Christ, Thy Son, Who with Thee liveth and reigneth in the unity of the Holy Ghost, God, world without end.\nAmen."
               }
             },
             {
               "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Advent"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Magnificat Antiphon:\nO Virgin of virgins, how will this be done? For thou art seen to have none like thee either before or after. Ye daughters of Jerusalem, why look ye at me in wonder? This mystery\nwhich ye see is all divine.\nOration\nO God, Who wast pleased that, at the message of an angel, Thy Word should take flesh from the womb of the Blessed Virgin Mary, grant that we, Thy suppliants, who believe her to be truly the Mother of God, may be helped through her intercession with Thee. Through the same Christ our Lord. Amen."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "From Christmas to Purification"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Magnificat Antiphon:\nO wonderful intercourse! The Creator of human kind, taking unto Himself a living body, vouchsafed to be born of a virgin; and coming forth amongst us, a man without human generation bestowed upon us His\ndivinity.\nOration\nO God, Who through the fruitful virginity of blessed Mary, hast given to mankind the reward of eternal salvation, grant, we beseech Thee, that we may feel the intercession she makes for us, through whom we have been made worthy to receive the Author of life, Christ our\nLord. Amen."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Paschaltide"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O Queen of heaven, rejoice, alleluia; for He Whom thou didst merit to bear, alleluia, hath risen as He said\nalleluia; pray to God for us, alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Ascensiontide"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O Queen of heaven, rejoice, alleluia; for He Whom thou didst merit to bear, alleluia, hath ascended as He said alleluia; pray to God for us,\nalleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -900,13 +4191,154 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Deus, a quo sancta desideria, recta consilia, et justa sunt opera: da servis tuis illam, quam mundus dare non potest, pacem; ut et corda nostra mandatis tuis dedita, et, hostium sublata formidine, tempora sint tua protectione tranquilla. Per Dominum.\n℟. Amen.\n℣. Dominus vobiscum.\n℟. Et cum spiritu tuo.\nVel ℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\nBenedicamus Domino. ℟. Deo gratias.\n℣. Ave, Maria, gratia plena, Dominus tecum. ℟. Benedicta tu in mulieribus et benedictus fructus ventris tui, Jesus.\nPer totum Adventum:\nAd Magnif. Ant.\nO Virgo virginum, quomodo fiet istud? quia nec primam similem visa es, nec habere sequentem. Filiae Jerusalem, quid me admiramini? Divinum est mysterium hoc, quod cernitis.",
-                "en-US": "O God, from Whom are holy desires, right counsels, and just works, grant to Thy servants that peace which the world cannot give; that our hearts being devoted to Thy commandments, and the fear of enemies being taken away, the times may, by Thy protection, be peaceful. Through our Lord Jesus Christ, Thy Son, Who with Thee liveth and reigneth in the unity of the Holy Ghost, God, world without end.\nAmen.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. Hail Mary, full of grace, the Lord is with thee.\n℟. Blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus.\nDuring Advent\nMagnificat Antiphon:\nO Virgin of virgins, how will this be done? For thou art seen to have none like thee either before or after. Ye daughters of Jerusalem, why look ye at me in wonder? This mystery which ye see is all divine."
+                "la": "Deus, a quo sancta desideria, recta consilia, et justa sunt opera: da servis tuis illam, quam mundus dare non potest, pacem; ut et corda nostra mandatis tuis dedita, et, hostium sublata formidine, tempora sint tua protectione tranquilla. Per Dominum."
               }
             },
             {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
+            },
+            {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Vel"
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave, Maria, gratia plena, Dominus tecum."
+                  },
+                  "r": {
+                    "la": "Benedicta tu in mulieribus et benedictus fructus ventris tui, Jesus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Per totum Adventum:\nAd Magnif. Ant.\nO Virgo virginum, quomodo fiet istud? quia nec primam similem visa es, nec habere sequentem. Filiae Jerusalem, quid me admiramini? Divinum est mysterium hoc, quod cernitis."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, from Whom are holy desires, right counsels, and just works, grant to Thy servants that peace which the world cannot give; that our hearts being devoted to Thy commandments, and the fear of enemies being taken away, the times may, by Thy protection, be peaceful. Through our Lord Jesus Christ, Thy Son, Who with Thee liveth and reigneth in the unity of the Holy Ghost, God, world without end.\nAmen."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Hail Mary, full of grace, the Lord is with thee."
+                  },
+                  "r": {
+                    "en-US": "Blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Advent"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Magnificat Antiphon:\nO Virgin of virgins, how will this be done? For thou art seen to have none like thee either before or after. Ye daughters of Jerusalem, why look ye at me in wonder? This mystery which ye see is all divine."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -914,13 +4346,49 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Deus, qui de beatae Mariae Virginis utero Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis, ut qui vere eam Genitricem Dei credimus, ejus apud te intercessionibus adjuvemur. Per eundem Christum.\n℟. Amen.\nA Nativitate Domini usque ad Purificationem inclusive:\nAd Magnif. Ant.\nO admirabile commercium! Creator generis humani animatum corpus sumens, de Virgine nasci dignatus est: et procedens homo sine semine, largitus est nobis suam Deitatem.",
-                "en-US": "O God, Who wast pleased that, at the message of an angel, Thy Word should take flesh from the womb of the Blessed Virgin Mary, grant that we, Thy suppliants, who believe her to be truly the Mother of God, may be helped through her intercession with Thee. Through the same Christ our Lord. Amen.\nFrom Christmas to Purification\nMagnificat Antiphon:\nO wonderful intercourse! The Creator of human kind, taking unto Himself a living body, vouchsafed to be born of a virgin; and coming forth amongst us, a man without human generation bestowed upon us His divinity."
+                "la": "Deus, qui de beatae Mariae Virginis utero Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis, ut qui vere eam Genitricem Dei credimus, ejus apud te intercessionibus adjuvemur. Per eundem Christum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "A Nativitate Domini usque ad Purificationem inclusive:\nAd Magnif. Ant.\nO admirabile commercium! Creator generis humani animatum corpus sumens, de Virgine nasci dignatus est: et procedens homo sine semine, largitus est nobis suam Deitatem."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who wast pleased that, at the message of an angel, Thy Word should take flesh from the womb of the Blessed Virgin Mary, grant that we, Thy suppliants, who believe her to be truly the Mother of God, may be helped through her intercession with Thee. Through the same Christ our Lord. Amen."
               }
             },
             {
               "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "From Christmas to Purification"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Magnificat Antiphon:\nO wonderful intercourse! The Creator of human kind, taking unto Himself a living body, vouchsafed to be born of a virgin; and coming forth amongst us, a man without human generation bestowed upon us His divinity."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -928,13 +4396,70 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Deus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus, ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Christum Dominum nostrum.\n℟. Amen.\nTempore Paschali:\nAd Magnif. Ant.\nRegina caeli, laetare, alleluia: quia quem meruisti portare, alleluia: resurrexit, sicut dixit, alleluia: ora pro nobis Deum, alleluia.",
-                "en-US": "O God, Who through the fruitful virginity of blessed Mary, hast given to mankind the reward of eternal salvation, grant, we beseech Thee, that we may feel the intercession she makes for us, through whom we have been made worthy to receive the Author of life, Christ our Lord. Amen.\nDuring Paschaltide:\nO Queen of heaven, rejoice, alleluia; for He Whom thou didst merit to bear, alleluia, hath risen as He said alleluia; pray to God for us, alleluia.\nDuring Ascensiontide:\nO Queen of heaven, rejoice, alleluia; for He Whom thou didst merit to bear, alleluia, hath ascended as He said alleluia; pray to God for us, alleluia."
+                "la": "Deus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus, ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Christum Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Tempore Paschali:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Ad Magnif. Ant.\nRegina caeli, laetare, alleluia: quia quem meruisti portare, alleluia: resurrexit, sicut dixit, alleluia: ora pro nobis Deum, alleluia."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who through the fruitful virginity of blessed Mary, hast given to mankind the reward of eternal salvation, grant, we beseech Thee, that we may feel the intercession she makes for us, through whom we have been made worthy to receive the Author of life, Christ our Lord. Amen."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Paschaltide:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O Queen of heaven, rejoice, alleluia; for He Whom thou didst merit to bear, alleluia, hath risen as He said alleluia; pray to God for us, alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Ascensiontide:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O Queen of heaven, rejoice, alleluia; for He Whom thou didst merit to bear, alleluia, hath ascended as He said alleluia; pray to God for us, alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -942,8 +4467,23 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Concede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis salute gaudere: et, gloriosa beatae Mariae semper Virginis intercessione, a praesenti liberari tristitia et aeterna perfrui laetitia. Per Christum.\n℟. Amen.",
+                "la": "Concede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis salute gaudere: et, gloriosa beatae Mariae semper Virginis intercessione, a praesenti liberari tristitia et aeterna perfrui laetitia. Per Christum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
                 "en-US": "Grant, we beseech Thee, O Lord God, that we, Thy servants, may enjoy continual health of mind and body; and that through the glorious intercession of blessed Mary, ever virgin, we may be delivered from present sorrow and enjoy eternal happiness. Through Christ our Lord.\nAmen."
               }
             }
@@ -959,13 +4499,196 @@
           "sections": [
             {
               "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
               "inline": {
-                "la": "℣. Ave, Maria, etc.\n℣. Converte nos, Deus, salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\nGloria Patri.\nPsalmus 131\nMemento, Domine, David, et omnis mansuetudinis ejus:\nSicut juravit Domino, votum vovit Deo Jacob:\nSi introiero in tabernaculum domus meae, si ascendero in lectum strati mei:\nSi dedero somnum oculis meis, et palpebris meis dormitationem:\nEt requiem temporibus meis, donec inveniam locum Domino, tabernaculum Deo Jacob.\nEcce, audivimus eam in Ephrata: invenimus eam in campis silvae.\nIntroibimus in tabernaculum ejus: adorabimus in loco ubi steterunt pedes ejus.\nSurge, Domine, in requiem tuam, tu et arca sanctificationis tuae.\nSacerdotes tui induantur justitiam: et sancti tui exsultent.\nPropter David servum tuum, non avertas faciem Christi tui.\nJuravit Dominus David veritatem, et non frustrabitur eam: de fructu ventris tui ponam super sedem tuam.\nSi custodierint filii tui testamentum meum, et testimonia mea haec, quae docebo eos:\nEt filii eorum usque in saeculum, sedebunt super sedem tuam.\nQuoniam elegit Dominus Sion; elegit eam in habitationem sibi.\nHaec requies mea in saeculum saeculi: hic habitabo quoniam elegi eam.\nViduam ejus benedicens benedicam: pauperes ejus saturabo panibus.\nSacerdotes ejus induam salutari: et sancti ejus exsultatione exsultabunt.\nIlluc producam cornu David, paravi lucernam Christo meo.\nInimicos ejus induam confusione: super ipsum autem efflorebit sanctificatio mea.\nGloria Patri.\nPsalmus 132\nEcce quam bonum, et quam jucundum habitare fratres in unum:\nSicut unguentum in capite, quod descendit in barbam, barbam Aaron.\nQuod descendit in oram vestimenti ejus: sicut ros Hermon, qui descendit in montem Sion.\nQuoniam illic mandavit Dominus benedictionem, et vitam usque in saeculum.\nGloria Patri.\nPsalmus 133\nEcce nunc benedicite Dominum, omnes servi Domini:\nQui statis in domo Domini, in atriis domus Dei nostri.\nIn noctibus extollite manus vestras in sancta, et benedicite Dominum.\nBenedicat te Dominus ex Sion, qui fecit caelum et terram.\nGloria Patri.",
-                "en-US": "℣. Convert us, O God, our Saviour.\n℟. And turn away Thy wrath from us.\n℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, world without end,\nAmen. Alleluia.\nPsalm 131\nO Lord, remember David, and all his meekness.\nHow he sware unto the Lord, and vowed a vow unto the God of Jacob.\nI will not come within the tabernacle of mine house, nor go up into the bed wherein I lie.\nI will not suffer mine eyes to sleep, nor mine eyelids to slumber.\nNeither the temples of my head to take any rest: until I find out a place for the Lord, a tabernacle for the God of Jacob.\nLo, we heard of it at Ephratah, and found it in the fields of the wood.\nWe will go into his tabernacle, and worship in the place where his feet stood.\nArise, O Lord, into thy resting-place; thou, and the ark which thou hast sanctified.\nLet thy priests be clothed with righteousness; and let thy saints rejoice.\nFor the sake of thy servant David, turn not away the face of thine anointed.\nThe Lord hath made a faithful oath unto David, and he shall not make it void: of the fruit of thy womb shall I set upon thy throne.\nIf thy children will keep my covenant, and my testimonies that I shall teach them.\nTheir children also for evermore shall sit upon thy throne.\nFor the Lord hath chosen Sion: he hath chosen it to be a habitation for himself.\nThis shall be my rest for ever and ever: here will I dwell, for I have chosen it.\nBlessing I will bless her widow: and will satisfy her poor with bread.\nI will clothe her priests with salvation, and her saints shall rejoice with exceeding great joy.\nThere will I bring forth a horn unto David: I have prepared a lantern for mine anointed.\nHis enemies will I clothe with confusion: but upon him shall my sanctification flourish.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 132\nBehold, how good and joyful a thing it is, for brethren to dwell together in unity.\nIt is like the precious oil upon the head, that ran down upon the beard, even upon the beard of Aaron.\nThat went down to the skirts of his clothing: like as the dew of Hermon, which fell upon mount Sion.\nFor there the Lord hath commanded blessing, and life for evermore.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 133\nBehold now, bless the Lord, all ye servants of the Lord.\nYe that stand in the house of the Lord, even in the courts of the house of our God.\nLift up your hands by night in the sanctuary, and bless ye the Lord.\nThe Lord that made heaven and earth give thee blessing out of Sion.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Ave, Maria, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos, Deus, salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Gloria Patri."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Psalmus 131"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Memento, Domine, David, et omnis mansuetudinis ejus:\nSicut juravit Domino, votum vovit Deo Jacob:\nSi introiero in tabernaculum domus meae, si ascendero in lectum strati mei:\nSi dedero somnum oculis meis, et palpebris meis dormitationem:\nEt requiem temporibus meis, donec inveniam locum Domino, tabernaculum Deo Jacob.\nEcce, audivimus eam in Ephrata: invenimus eam in campis silvae.\nIntroibimus in tabernaculum ejus: adorabimus in loco ubi steterunt pedes ejus.\nSurge, Domine, in requiem tuam, tu et arca sanctificationis tuae.\nSacerdotes tui induantur justitiam: et sancti tui exsultent.\nPropter David servum tuum, non avertas faciem Christi tui.\nJuravit Dominus David veritatem, et non frustrabitur eam: de fructu ventris tui ponam super sedem tuam.\nSi custodierint filii tui testamentum meum, et testimonia mea haec, quae docebo eos:\nEt filii eorum usque in saeculum, sedebunt super sedem tuam.\nQuoniam elegit Dominus Sion; elegit eam in habitationem sibi.\nHaec requies mea in saeculum saeculi: hic habitabo quoniam elegi eam.\nViduam ejus benedicens benedicam: pauperes ejus saturabo panibus.\nSacerdotes ejus induam salutari: et sancti ejus exsultatione exsultabunt.\nIlluc producam cornu David, paravi lucernam Christo meo.\nInimicos ejus induam confusione: super ipsum autem efflorebit sanctificatio mea.\nGloria Patri."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Psalmus 132"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Ecce quam bonum, et quam jucundum habitare fratres in unum:\nSicut unguentum in capite, quod descendit in barbam, barbam Aaron.\nQuod descendit in oram vestimenti ejus: sicut ros Hermon, qui descendit in montem Sion.\nQuoniam illic mandavit Dominus benedictionem, et vitam usque in saeculum.\nGloria Patri."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Psalmus 133"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Ecce nunc benedicite Dominum, omnes servi Domini:\nQui statis in domo Domini, in atriis domus Dei nostri.\nIn noctibus extollite manus vestras in sancta, et benedicite Dominum.\nBenedicat te Dominus ex Sion, qui fecit caelum et terram.\nGloria Patri."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Convert us, O God, our Saviour."
+                  },
+                  "r": {
+                    "en-US": "And turn away Thy wrath from us."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now, and ever shall be, world without end,"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Amen. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Psalm 131"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O Lord, remember David, and all his meekness.\nHow he sware unto the Lord, and vowed a vow unto the God of Jacob.\nI will not come within the tabernacle of mine house, nor go up into the bed wherein I lie.\nI will not suffer mine eyes to sleep, nor mine eyelids to slumber.\nNeither the temples of my head to take any rest: until I find out a place for the Lord, a tabernacle for the God of Jacob.\nLo, we heard of it at Ephratah, and found it in the fields of the wood.\nWe will go into his tabernacle, and worship in the place where his feet stood.\nArise, O Lord, into thy resting-place; thou, and the ark which thou hast sanctified.\nLet thy priests be clothed with righteousness; and let thy saints rejoice.\nFor the sake of thy servant David, turn not away the face of thine anointed.\nThe Lord hath made a faithful oath unto David, and he shall not make it void: of the fruit of thy womb shall I set upon thy throne.\nIf thy children will keep my covenant, and my testimonies that I shall teach them.\nTheir children also for evermore shall sit upon thy throne.\nFor the Lord hath chosen Sion: he hath chosen it to be a habitation for himself.\nThis shall be my rest for ever and ever: here will I dwell, for I have chosen it."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Blessing I will bless her widow: and will satisfy her poor with bread."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "I will clothe her priests with salvation, and her saints shall rejoice with exceeding great joy.\nThere will I bring forth a horn unto David: I have prepared a lantern for mine anointed.\nHis enemies will I clothe with confusion: but upon him shall my sanctification flourish.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Psalm 132"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Behold, how good and joyful a thing it is, for brethren to dwell together in unity.\nIt is like the precious oil upon the head, that ran down upon the beard, even upon the beard of Aaron.\nThat went down to the skirts of his clothing: like as the dew of Hermon, which fell upon mount Sion.\nFor there the Lord hath commanded blessing, and life for evermore.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Psalm 133"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Behold now, bless the Lord, all ye servants of the Lord.\nYe that stand in the house of the Lord, even in the courts of the house of our God.\nLift up your hands by night in the sanctuary, and bless ye the Lord.\nThe Lord that made heaven and earth give thee blessing out of Sion.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -973,13 +4696,95 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Virgo Maria, non est tibi similis nata in mundo inter mulieres, florens ut rosa, fragrans sicut lilium: ora pro nobis, sancta Dei Genitrix.",
-                "en-US": "O Virgin Mary, there is no one in the world born of woman like to thee; flourishing like the rose, fragrant as the lily: pray for us, O holy Mother of\nGod.\nLittle Chapter (Eccli. 24)\nI am the mother of fair love, and of fear, and of knowledge, and of holy\nhope.\n℟. Thanks be to God.\n℟. Intercede for us, O holy Virgin of virgins, * Mary, Mother of God.\n℟. Intercede for us, O holy Virgin of\nvirgins, Mary, Mother of God.\n℣. That we may be made worthy of the promises of Christ: Mary, Mother of God.\nGlory be to the Father, and to the Son,\nand to the Holy Ghost.\n℟. Intercede for us, O holy Virgin of\nvirgins, * Mary, Mother of God."
+                "la": "Virgo Maria, non est tibi similis nata in mundo inter mulieres, florens ut rosa, fragrans sicut lilium: ora pro nobis, sancta Dei Genitrix."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O Virgin Mary, there is no one in the world born of woman like to thee; flourishing like the rose, fragrant as the lily: pray for us, O holy Mother of\nGod."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Little Chapter (Eccli. 24)"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "I am the mother of fair love, and of fear, and of knowledge, and of holy\nhope."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Intercede for us, O holy Virgin of virgins, * Mary, Mother of God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Intercede for us, O holy Virgin of"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "virgins, Mary, Mother of God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "That we may be made worthy of the promises of Christ: Mary, Mother of God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Glory be to the Father, and to the Son,\nand to the Holy Ghost."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Intercede for us, O holy Virgin of"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "virgins, * Mary, Mother of God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Chapter",
                 "en-US": "Chapter"
@@ -987,27 +4792,134 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Ego mater pulchrae dilectionis et timoris et agnitionis et sanctae spei.\n℟. Deo gratias.\n℟. Intercede pro nobis, sancta Virgo Virginum, Mater Dei, Maria.\n℣. Ut digni efficiamur promissionibus Christi.",
-                "en-US": "I am the mother of fair love, and of fear, and of knowledge, and of holy hope.\n℟. Thanks be to God.\n℟. Intercede for us, O holy Virgin of virgins, * Mary, Mother of God.\n℟. Intercede for us, O holy Virgin of virgins, Mary, Mother of God.\n℣. That we may be made worthy of the promises of Christ: Mary, Mother of God.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\n℟. Intercede for us, O holy Virgin of virgins, * Mary, Mother of God."
+                "la": "Ego mater pulchrae dilectionis et timoris et agnitionis et sanctae spei."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Intercede pro nobis, sancta Virgo Virginum, Mater Dei, Maria."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Ut digni efficiamur promissionibus Christi."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "I am the mother of fair love, and of fear, and of knowledge, and of holy hope."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Intercede for us, O holy Virgin of virgins, * Mary, Mother of God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Intercede for us, O holy Virgin of virgins, Mary, Mother of God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "That we may be made worthy of the promises of Christ: Mary, Mother of God."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Intercede for us, O holy Virgin of virgins, * Mary, Mother of God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Virgo singularis,\nInter omnes mitis,\nNos culpis solutos,\nMites fac et castos.\nVitam praesta puram,\nIter para tutum:\nUt videntes Jesum\nSemper collaetemur.\nSit laus Deo Patri,\nSummo Christo decus,\nSpiritui Sancto,\nTribus honor unus. Amen.\n℣. Post partum, Virgo, inviolata permansisti.\n℟. Dei Genitrix, intercede pro nobis.\nCanticum Simeonis (Luc. 2)\nNunc dimittis servum tuum, Domine, secundum verbum tuum in pace:\nQuia viderunt oculi mei salutare tuum,\nQuod parasti ante faciem omnium populorum:\nLumen ad revelationem gentium, et gloriam plebis tuae Israel.\nGloria Patri.",
-                "en-US": "Virgin all excelling,\nMildest of the mild,\nFree from sin preserve us,\nMeek and undefiled.\nKeep our lives all spotless,\nMake our way secure:\nTill we find in Jesus,\nJoys that shall endure.\nPraise to God the Father,\nHonour to the Son,\nTo the Holy Spirit,\nBe glory one. Amen.\n℣. After childbirth thou didst still remain a virgin undefiled:\n℟. Mother of God, intercede for us.\nCanticle of Simeon\nNow Thou dost dismiss Thy\nservant, O Lord according to Thy word.\nBecause mine eyes have seen Thy\nsalvation,\nWhich thou hast prepared before the\nface of all people;\nA light for the revelation of the gentiles, and to be the glory of Thy\npeople Israel.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end.\nAmen."
+                "la": "Virgo singularis,\nInter omnes mitis,\nNos culpis solutos,\nMites fac et castos.\nVitam praesta puram,\nIter para tutum:\nUt videntes Jesum\nSemper collaetemur.\nSit laus Deo Patri,\nSummo Christo decus,\nSpiritui Sancto,\nTribus honor unus. Amen.",
+                "en-US": "Virgin all excelling,\nMildest of the mild,\nFree from sin preserve us,\nMeek and undefiled.\nKeep our lives all spotless,\nMake our way secure:\nTill we find in Jesus,\nJoys that shall endure.\nPraise to God the Father,\nHonour to the Son,\nTo the Holy Spirit,\nBe glory one. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Post partum, Virgo, inviolata permansisti.",
+                    "en-US": "After childbirth thou didst still remain a virgin undefiled:"
+                  },
+                  "r": {
+                    "la": "Dei Genitrix, intercede pro nobis.",
+                    "en-US": "Mother of God, intercede for us."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Canticum Simeonis (Luc. 2)",
+                "en-US": "Canticle of Simeon"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Nunc dimittis servum tuum, Domine, secundum verbum tuum in pace:\nQuia viderunt oculi mei salutare tuum,\nQuod parasti ante faciem omnium populorum:\nLumen ad revelationem gentium, et gloriam plebis tuae Israel.\nGloria Patri.",
+                "en-US": "Now Thou dost dismiss Thy\nservant, O Lord according to Thy word.\nBecause mine eyes have seen Thy\nsalvation,\nWhich thou hast prepared before the\nface of all people;\nA light for the revelation of the gentiles, and to be the glory of Thy\npeople Israel.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1015,13 +4927,215 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Sub tuum praesidium confugimus, sancta Dei Genitrix: nostras deprecationes ne despicias in necessitatibus, sed a periculis cunctis libera nos semper Virgo benedicta.\nDominus vobiscum.\n℟. Et cum spiritu tuo.\nVel ℣. Domine, exaudi orationem meam. ℟. Et clamor meus ad te veniat.",
-                "en-US": "We fly to thy patronage, O holy Mother of God; despise not our petitions in our necessities, but deliver us from all dangers, O ever blessed Virgin.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\nOration\nGrant, O merciful God, protection for our frailty: that we who celebrate the memory of the holy Mother of God may, by the help of her intercession, arise from our sins. Through the same Jesus Christ, our Lord, Thy Son, Who with Thee liveth and reigneth in the unity of the Holy Ghost, God, world without end. Amen.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\nBlessing\nMay the blessing of Almighty God, Father, Son, and Holy Ghost descend upon and remain with us\nforever.\n℟. Amen.\n℣. Hail Mary, full of grace, the Lord is with thee.\n℟. Blessed art thou amongst women, and blessed is the fruit of thy womb,\nJesus.\nSalve Regina\nHail, holy Queen, Mother of mercy, hail, our life, our sweetness, and our hope! To thee do we cry, poor\nbanished children of Eve, to thee do we send up our sighs, mourning and weeping in this vale of tears. Turn then, most gracious advocate, thine eyes of mercy towards us; and after this our exile, show unto us the blessed fruit of thy womb, Jesus. O clement, O loving, O sweet Virgin Mary.\n℣. Make me worthy to praise thee, holy Virgin.\n℟. Give me strength against thine\nenemies.\nLet us pray,\nGrant, we beseech Thee, O Lord God, that we, Thy servants, may enjoy continual health of mind and body; and that, through the intercession of blessed Mary, ever virgin, we may be delivered from present sorrow, and enjoy eternal happiness. Through Christ our Lord.\nAmen.\nO Lumen\nO Light of the Church, doctor of truth, Rose of patience, ivory of chastity, freely hast thou dispensed the\nwater of wisdom: Preacher of grace, unite us to the blessed.\n℣. Pray for us, blessed Father Dominic.\n℟. That we may be made worthy of the promises of Christ.\nLet us pray,\nGrant, we beseech Thee, almighty God, that we who are oppressed with the weight of our sins may be relieved by the intercession of Thy Confessor and our Father, the Blessed Dominic. Through Christ our\nLord. Amen.\nTermination\nMay the souls of the faithful departed, through the mercy of God, rest in peace. Amen.\nOur Father and I believe."
+                "la": "Sub tuum praesidium confugimus, sancta Dei Genitrix: nostras deprecationes ne despicias in necessitatibus, sed a periculis cunctis libera nos semper Virgo benedicta.\nDominus vobiscum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Et cum spiritu tuo."
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Vel"
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "We fly to thy patronage, O holy Mother of God; despise not our petitions in our necessities, but deliver us from all dangers, O ever blessed Virgin."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Oration\nGrant, O merciful God, protection for our frailty: that we who celebrate the memory of the holy Mother of God may, by the help of her intercession, arise from our sins. Through the same Jesus Christ, our Lord, Thy Son, Who with Thee liveth and reigneth in the unity of the Holy Ghost, God, world without end. Amen."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Blessing"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "May the blessing of Almighty God, Father, Son, and Holy Ghost descend upon and remain with us\nforever."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Hail Mary, full of grace, the Lord is with thee."
+                  },
+                  "r": {
+                    "en-US": "Blessed art thou amongst women, and blessed is the fruit of thy womb,"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Jesus.\nSalve Regina\nHail, holy Queen, Mother of mercy, hail, our life, our sweetness, and our hope! To thee do we cry, poor\nbanished children of Eve, to thee do we send up our sighs, mourning and weeping in this vale of tears. Turn then, most gracious advocate, thine eyes of mercy towards us; and after this our exile, show unto us the blessed fruit of thy womb, Jesus. O clement, O loving, O sweet Virgin Mary."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Make me worthy to praise thee, holy Virgin."
+                  },
+                  "r": {
+                    "en-US": "Give me strength against thine"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "enemies."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Let us pray,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Grant, we beseech Thee, O Lord God, that we, Thy servants, may enjoy continual health of mind and body; and that, through the intercession of blessed Mary, ever virgin, we may be delivered from present sorrow, and enjoy eternal happiness. Through Christ our Lord.\nAmen.\nO Lumen\nO Light of the Church, doctor of truth, Rose of patience, ivory of chastity, freely hast thou dispensed the\nwater of wisdom: Preacher of grace, unite us to the blessed."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Pray for us, blessed Father Dominic."
+                  },
+                  "r": {
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Let us pray,"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Grant, we beseech Thee, almighty God, that we who are oppressed with the weight of our sins may be relieved by the intercession of Thy Confessor and our Father, the Blessed Dominic. Through Christ our\nLord. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Termination"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "May the souls of the faithful departed, through the mercy of God, rest in peace. Amen.\nOur Father and I believe."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
@@ -1029,9 +5143,280 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Concede, misericors Deus, fragilitati nostrae praesidium: ut qui sanctae Dei Genitricis memoriam agimus, intercessionis ejus auxilio, a nostris iniquitatibus resurgamus. Per eumdem Dominum nostrum.\n℣. Dominus vobiscum.\n℟. Et cum spiritu tuo.\nVel ℣. Domine, exaudi orationem meam. ℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Ave, Maria, gratia plena, Dominus tecum.\n℟. Benedicta tu in mulieribus et benedictus fructus ventris tui, Jesus.\nSalve Regina\nSalve, Regina, mater misericordiae; vita, dulcedo et spes nostra, salve. Ad te clamamus exsules filii Hevae. Ad te\nsuspiramus gementes et flentes in hac lacrimarum valle. Eja ergo, advocata nostra, illos tuos misericordes oculos ad nos converte. Et Jesum, benedictum fructum ventris tui nobis post hoc exsilium ostende. O clemens, o pia, o dulcis Virgo Maria.\n℣. Dignare me laudare te, Virgo sacrata.\n℟. Da mihi virtutem contra hostes tuos.\nOremus,\nConcede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis sanitate gaudere:\nUt, gloriosa beatae Mariae semper Virginis intercessione, a praesenti liberari tristitia,\nEt aeterna perfrui laetitia. Per Christum Dominum nostrum. Amen.\nO Lumen\nO lumen Ecclesiae, Doctor veritatis, Rosa patientiae, Ebur castitatis, aquam sapientiae propinasti gratis:\nPraedicator gratiae nos junge beatis.\n℣. Ora pro nobis, beate Pater Dominice.\n℟. Ut digni efficiamur promissionibus Christi.\nOremus,\nConcede, quaesumus, omnipotens Deus, ut qui peccatorum nostrorum pondere premimur,\nbeati Dominici Confessoris tui, Patris nostri, patrocinio sublevemur.\nPer Christum Dominum nostrum. Amen.\nFine\nFidelium animae per misericordiam Dei requiescant in pace. Amen.\nPater et Credo.",
-                "en-US": "Grant, O merciful God, protection for our frailty: that we who celebrate the memory of the holy Mother of God may, by the help of her intercession, arise from our sins. Through the same Jesus Christ, our Lord, Thy Son, Who with Thee liveth and reigneth in the unity of the Holy Ghost, God, world without end. Amen.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\nBlessing\nMay the blessing of Almighty God, Father, Son, and Holy Ghost descend upon and remain with us forever.\n℟. Amen.\n℣. Hail Mary, full of grace, the Lord is with thee.\n℟. Blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus.\nSalve Regina\nHail, holy Queen, Mother of mercy, hail, our life, our sweetness, and our hope! To thee do we cry, poor banished children of Eve, to thee do we send up our sighs, mourning and weeping in this vale of tears. Turn then, most gracious advocate, thine eyes of mercy towards us; and after this our exile, show unto us the blessed fruit of thy womb, Jesus. O clement, O loving, O sweet Virgin Mary.\n℣. Make me worthy to praise thee, holy Virgin.\n℟. Give me strength against thine enemies.\nLet us pray,\nGrant, we beseech Thee, O Lord God, that we, Thy servants, may enjoy continual health of mind and body; and that, through the intercession of blessed Mary, ever virgin, we may be delivered from present sorrow, and enjoy eternal happiness. Through Christ our Lord.\nAmen.\nO Lumen\nO Light of the Church, doctor of truth, Rose of patience, ivory of chastity, freely hast thou dispensed the water of wisdom: Preacher of grace, unite us to the blessed.\n℣. Pray for us, blessed Father Dominic.\n℟. That we may be made worthy of the promises of Christ.\nLet us pray,\nGrant, we beseech Thee, almighty God, that we who are oppressed with the weight of our sins may be relieved by the intercession of Thy Confessor and our Father, the Blessed Dominic. Through Christ our Lord. Amen.\nTermination\nMay the souls of the faithful departed, through the mercy of God, rest in peace. Amen.\nOur Father and I believe."
+                "la": "Concede, misericors Deus, fragilitati nostrae praesidium: ut qui sanctae Dei Genitricis memoriam agimus, intercessionis ejus auxilio, a nostris iniquitatibus resurgamus. Per eumdem Dominum nostrum."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Vel"
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave, Maria, gratia plena, Dominus tecum."
+                  },
+                  "r": {
+                    "la": "Benedicta tu in mulieribus et benedictus fructus ventris tui, Jesus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Salve Regina\nSalve, Regina, mater misericordiae; vita, dulcedo et spes nostra, salve. Ad te clamamus exsules filii Hevae. Ad te\nsuspiramus gementes et flentes in hac lacrimarum valle. Eja ergo, advocata nostra, illos tuos misericordes oculos ad nos converte. Et Jesum, benedictum fructum ventris tui nobis post hoc exsilium ostende. O clemens, o pia, o dulcis Virgo Maria."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dignare me laudare te, Virgo sacrata."
+                  },
+                  "r": {
+                    "la": "Da mihi virtutem contra hostes tuos."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Oremus,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Concede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis sanitate gaudere:\nUt, gloriosa beatae Mariae semper Virginis intercessione, a praesenti liberari tristitia,\nEt aeterna perfrui laetitia. Per Christum Dominum nostrum. Amen.\nO Lumen\nO lumen Ecclesiae, Doctor veritatis, Rosa patientiae, Ebur castitatis, aquam sapientiae propinasti gratis:\nPraedicator gratiae nos junge beatis."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, beate Pater Dominice."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Oremus,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Concede, quaesumus, omnipotens Deus, ut qui peccatorum nostrorum pondere premimur,\nbeati Dominici Confessoris tui, Patris nostri, patrocinio sublevemur.\nPer Christum Dominum nostrum. Amen.\nFine\nFidelium animae per misericordiam Dei requiescant in pace. Amen.\nPater et Credo."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Grant, O merciful God, protection for our frailty: that we who celebrate the memory of the holy Mother of God may, by the help of her intercession, arise from our sins. Through the same Jesus Christ, our Lord, Thy Son, Who with Thee liveth and reigneth in the unity of the Holy Ghost, God, world without end. Amen."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Blessing"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "May the blessing of Almighty God, Father, Son, and Holy Ghost descend upon and remain with us forever."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Hail Mary, full of grace, the Lord is with thee."
+                  },
+                  "r": {
+                    "en-US": "Blessed art thou amongst women, and blessed is the fruit of thy womb, Jesus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Salve Regina\nHail, holy Queen, Mother of mercy, hail, our life, our sweetness, and our hope! To thee do we cry, poor banished children of Eve, to thee do we send up our sighs, mourning and weeping in this vale of tears. Turn then, most gracious advocate, thine eyes of mercy towards us; and after this our exile, show unto us the blessed fruit of thy womb, Jesus. O clement, O loving, O sweet Virgin Mary."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Make me worthy to praise thee, holy Virgin."
+                  },
+                  "r": {
+                    "en-US": "Give me strength against thine enemies."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Let us pray,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Grant, we beseech Thee, O Lord God, that we, Thy servants, may enjoy continual health of mind and body; and that, through the intercession of blessed Mary, ever virgin, we may be delivered from present sorrow, and enjoy eternal happiness. Through Christ our Lord.\nAmen.\nO Lumen\nO Light of the Church, doctor of truth, Rose of patience, ivory of chastity, freely hast thou dispensed the water of wisdom: Preacher of grace, unite us to the blessed."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Pray for us, blessed Father Dominic."
+                  },
+                  "r": {
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Let us pray,"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Grant, we beseech Thee, almighty God, that we who are oppressed with the weight of our sins may be relieved by the intercession of Thy Confessor and our Father, the Blessed Dominic. Through Christ our Lord. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Termination"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "May the souls of the faithful departed, through the mercy of God, rest in peace. Amen.\nOur Father and I believe."
               }
             }
           ]

--- a/content/practices/little-office-bvm-lyon/flow.json
+++ b/content/practices/little-office-bvm-lyon/flow.json
@@ -27,7 +27,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Invit."
               }
@@ -39,7 +39,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 94"
               }
@@ -51,7 +51,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -63,7 +63,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -75,13 +75,13 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "O Quam glorifica luce coruscas,\nStirpis Davidicae regia proles;\nSublimis residens, virgo Maria,\nSupra Coeligenas aetheris omnes!\n\nTu cum virgineo mater honore\nCoelorum Domino pectoris aulam\nSacris visceribus casta dedisti:\nHumanos Deus hinc induit artus.\n\nQuem cunctus venerans orbis adorat,\nCui nunc rite genu flectitur omne;\nA quo, te precibus subveniente,\nAeterni petimus gaudia regni.\n\nDivinae Soboli, qui dare matrem\nIn terris voluit, gloria Patri:\nCujus Virgo parens, gloria Nato:\nQuo fecunda, tibi gloria, Flamen.\nAmen."
               }
@@ -99,7 +99,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -111,7 +111,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 8"
               }
@@ -123,7 +123,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 18"
               }
@@ -135,7 +135,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 44"
               }
@@ -147,7 +147,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -159,10 +159,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Audi, filia, et vide, et inclina aurem tuam.\n℟. Et concupiscet rex decorem tuum. Ps. 44"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Audi, filia, et vide, et inclina aurem tuam."
+                  },
+                  "r": {
+                    "la": "Et concupiscet rex decorem tuum. Ps. 44"
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -171,7 +178,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Lectiones infra, post III. Nocturnum."
               }
@@ -189,7 +196,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -201,7 +208,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 45"
               }
@@ -213,7 +220,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 71"
               }
@@ -225,7 +232,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 84"
               }
@@ -237,7 +244,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -249,10 +256,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Sanctificavit tabernaculum suum Altissimus.\n℟. Deus in medio ejus. Ps. 45"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sanctificavit tabernaculum suum Altissimus."
+                  },
+                  "r": {
+                    "la": "Deus in medio ejus. Ps. 45"
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -261,7 +275,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Lectiones infra."
               }
@@ -279,7 +293,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -291,7 +305,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 86"
               }
@@ -303,7 +317,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 96"
               }
@@ -315,7 +329,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 97"
               }
@@ -327,7 +341,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -339,9 +353,22 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sanctificavit tabernaculum suum Altissimus."
+                  },
+                  "r": {
+                    "la": "Deus in medio ejus."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Sanctificavit tabernaculum suum Altissimus.\n℟. Deus in medio ejus.\nPs. 45."
+                "la": "Ps. 45."
               }
             },
             {
@@ -351,7 +378,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Absolutio."
               }
@@ -359,11 +386,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Deus meminerit testamenti sui quod locutus est; et exaudiat orationes nostras.\n℟. Amen."
+                "la": "Deus meminerit testamenti sui quod locutus est; et exaudiat orationes nostras."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio i. Isaiae, 7."
               }
@@ -371,11 +404,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Adjecit Dominus loqui ad Achaz, dicens: Pete tibi signum a Domino Deo tuo in profundum inferni, sive in excelsum supra. Et dixit Achaz: Non petam, et non tentabo Dominum. Et dixit: Audite ergo, domus David; Numquid parum vobis est molestos esse hominibus; quia molesti estis et Deo meo? Propter hoc dabit Dominus ipse vobis signum: Ecce Virgo concipiet, et pariet filium, et vocabitur nomen ejus Emmanuel. Tu autem.\n℟. Benedicam. ut supra."
+                "la": "Adjecit Dominus loqui ad Achaz, dicens: Pete tibi signum a Domino Deo tuo in profundum inferni, sive in excelsum supra. Et dixit Achaz: Non petam, et non tentabo Dominum. Et dixit: Audite ergo, domus David; Numquid parum vobis est molestos esse hominibus; quia molesti estis et Deo meo? Propter hoc dabit Dominus ipse vobis signum: Ecce Virgo concipiet, et pariet filium, et vocabitur nomen ejus Emmanuel. Tu autem."
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Benedicam. ut supra."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio ii. Gal. 4."
               }
@@ -383,11 +422,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quanto tempore heres parvulus est, nihil differt a servo; cum sit dominus omnium; sed sub tutoribus et actoribus est usque ad praefinitum tempus a patre: ita et nos, cum essemus parvuli, sub elementis mundi eramus servientes. At ubi venit plenitudo temporis, misit Deus Filium suum, factum ex muliere, factum sub lege; ut eos qui sub lege erant redimeret; ut adoptionem filiorum reciperemus. Tu autem.\n℟. Quod in ea. ut supra."
+                "la": "Quanto tempore heres parvulus est, nihil differt a servo; cum sit dominus omnium; sed sub tutoribus et actoribus est usque ad praefinitum tempus a patre: ita et nos, cum essemus parvuli, sub elementis mundi eramus servientes. At ubi venit plenitudo temporis, misit Deus Filium suum, factum ex muliere, factum sub lege; ut eos qui sub lege erant redimeret; ut adoptionem filiorum reciperemus. Tu autem."
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Quod in ea. ut supra."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio iii. Apoc. 11. et 12."
               }
@@ -395,7 +440,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Apertum est templum Dei in caelo, et visa est arca testamenti ejus in templo ejus: et facta sunt fulgura, et voces, et terrae motus, et grando magna. Et signum magnum apparuit in caelo: Mulier amicta sole, et luna sub pedibus ejus: et in capite ejus corona stellarum duodecim. Tu autem.\n℟. Deus ex femine. ut supra."
+                "la": "Apertum est templum Dei in caelo, et visa est arca testamenti ejus in templo ejus: et facta sunt fulgura, et voces, et terrae motus, et grando magna. Et signum magnum apparuit in caelo: Mulier amicta sole, et luna sub pedibus ejus: et in capite ejus corona stellarum duodecim. Tu autem."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Deus ex femine. ut supra."
               }
             },
             {
@@ -423,11 +474,11 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adjutorium etc."
+                "la": "Deus, in adjutorium etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -439,7 +490,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 66"
               }
@@ -451,7 +502,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 92"
               }
@@ -463,7 +514,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 99"
               }
@@ -475,7 +526,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Zachariae"
               }
@@ -487,7 +538,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 150"
               }
@@ -499,7 +550,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -511,7 +562,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum."
               }
@@ -523,22 +574,29 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus,"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Nunc aurora. ut supra."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Recordatus est Dominus misericordiae suae.\n℟. Et veritatis suae domui Israel. Ps. 97."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Recordatus est Dominus misericordiae suae."
+                  },
+                  "r": {
+                    "la": "Et veritatis suae domui Israel. Ps. 97."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -559,7 +617,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -577,7 +635,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -589,21 +647,40 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. In aeternum exsultabunt: et habitabitis in eis.\n℟. Et gloriabuntur in te, Domine. Ps. 5."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In aeternum exsultabunt: et habitabitis in eis."
+                  },
+                  "r": {
+                    "la": "Et gloriabuntur in te, Domine. Ps. 5."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede, quaesumus, omnipotens Deus: ut sancti tui Apostoli, Martyres, Pontifices, Virgines, atque omnes sancti, quorum memoriam celebramus, nos ubique adjuvent: ut, quatenus illorum suffragio tranquilla pace in tua laude laetemur. Per Dominum nostrum Jesum Christum Filium tuum: qui tecum vivit.\n℟. Amen."
+                "la": "Concede, quaesumus, omnipotens Deus: ut sancti tui Apostoli, Martyres, Pontifices, Virgines, atque omnes sancti, quorum memoriam celebramus, nos ubique adjuvent: ut, quatenus illorum suffragio tranquilla pace in tua laude laetemur. Per Dominum nostrum Jesum Christum Filium tuum: qui tecum vivit."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Dominus vobiscum."
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Dominus vobiscum."
               }
             },
             {
@@ -615,7 +692,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Domine, exaudi. ℣. Benedicamus Domino."
+                "la": "Domine, exaudi."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Benedicamus Domino."
               }
             }
           ]
@@ -629,19 +712,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus."
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Memento, de Deo Deus,\nQuod matre natus Virgine,\nNostri misertus, perditi\nMundi redemptor veneris.\n\nEt nos, Dei Virgo parens,\nVultu benigno respice:\nPlacabilem tua prece\nFac esse nobis Filium.\n\nQui natus es de Virgine,\nJesu, tibi sit gloria,\nCum patre, cumque Spiritu,\nIn sempiterna saecula. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 53"
               }
@@ -653,7 +736,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 95"
               }
@@ -665,7 +748,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 116"
               }
@@ -677,7 +760,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -689,7 +772,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum."
               }
@@ -703,11 +786,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. br. Semen ejus * In aeternum manebit. Semen.\n℣. Et thronus ejus sicut sol * in conspectu meo, * In aeternum. Gloria Patri. Semen. Ps. 88.\n℣. Dominabitur a mari usque ad mare,\n℟. Et usque ad terminos orbis terrarum. Ps. 71."
+                "la": "br. Semen ejus * In aeternum manebit. Semen."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Et thronus ejus sicut sol * in conspectu meo, * In aeternum. Gloria Patri. Semen. Ps. 88."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominabitur a mari usque ad mare,"
+                  },
+                  "r": {
+                    "la": "Et usque ad terminos orbis terrarum. Ps. 71."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -735,7 +837,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 24"
               }
@@ -747,7 +849,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 53"
               }
@@ -759,7 +861,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 121"
               }
@@ -771,7 +873,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -783,7 +885,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum."
               }
@@ -797,17 +899,29 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. br. Deus in medio ejus; * Non commovebitur. Deus.\n℣. Adjuvabit eam * mane diluculo: * Non commovebitur. Gloria. Deus. Ps. 45."
+                "la": "br. Deus in medio ejus; * Non commovebitur. Deus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Elegit eam Dominus ℟. In habitationem sibi. Ps. 131."
+                "la": "Adjuvabit eam * mane diluculo: * Non commovebitur. Gloria. Deus. Ps. 45."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Elegit eam Dominus"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "In habitationem sibi. Ps. 131."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -835,7 +949,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 122"
               }
@@ -847,7 +961,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 123"
               }
@@ -859,7 +973,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 124"
               }
@@ -871,7 +985,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -883,7 +997,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum."
               }
@@ -897,11 +1011,37 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. br. Homo * Natus est in ea. Homo.\n℣. Et ipse fundavit eam * Altissimus.\n℟. Natus est. Gloria. Homo. Ps. 86.\n℣. Ipse tanquam sponsus.\n℟. Procedens de thalamo suo. Ps. 18."
+                "la": "br. Homo * Natus est in ea. Homo."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ipse fundavit eam * Altissimus."
+                  },
+                  "r": {
+                    "la": "Natus est. Gloria. Homo. Ps. 86."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ipse tanquam sponsus."
+                  },
+                  "r": {
+                    "la": "Procedens de thalamo suo. Ps. 18."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -929,7 +1069,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 125"
               }
@@ -941,7 +1081,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 126"
               }
@@ -953,7 +1093,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 127"
               }
@@ -965,7 +1105,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -977,7 +1117,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum."
               }
@@ -991,11 +1131,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. br. Misericordia et veritas Obviaverunt sibi. Misericordia. ℣. Iustitia et pax osculatae sunt; Obviaverunt sibi. Gloria Patri. Misericordia.\n℣. Veritas de terra orta est,\n℟. Et iustitia de caelo prospexit. Ps. 84."
+                "la": "br. Misericordia et veritas Obviaverunt sibi. Misericordia."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Iustitia et pax osculatae sunt; Obviaverunt sibi. Gloria Patri. Misericordia."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Veritas de terra orta est,"
+                  },
+                  "r": {
+                    "la": "Et iustitia de caelo prospexit. Ps. 84."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -1019,11 +1178,11 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adjutorium etc."
+                "la": "Deus, in adjutorium etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -1035,7 +1194,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 109"
               }
@@ -1047,7 +1206,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 112"
               }
@@ -1059,7 +1218,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 121"
               }
@@ -1071,7 +1230,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 126"
               }
@@ -1083,7 +1242,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 147"
               }
@@ -1095,7 +1254,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -1107,7 +1266,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum."
               }
@@ -1119,22 +1278,29 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus."
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Ave, maris stella,\nDei mater alma,\nAtque semper virgo,\nFelix coeli porta.\n\nSumens illud Ave\nGabrielis ore,\nFunda nos in pace,\nMutans Evae nomen.\n\nSolve vincula reis,\nProfer lumen caecis,\nMala nostra pelle,\nBona cuncta posce.\n\nMonstra te esse matrem;\nSumat per te preces,\nQui pro nobis natus,\nTulit esse tuus.\n\nVirgo singularis,\nInter omnes mitis,\nNos culpis solutos,\nMites fac et castos.\n\nVitam praesta puram,\nIter para tutum;\nUt videntes Jesum,\nSemper collaetemur.\n\nSit laus Deo Patri,\nSummo Christo decus,\nSpiritui Sancto;\nTribus honor unus.\nr\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Anima mea exultabit in Domino,\n℟. Et delectabitur super salutari suo. Ps. 34."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Anima mea exultabit in Domino,"
+                  },
+                  "r": {
+                    "la": "Et delectabitur super salutari suo. Ps. 34."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1155,7 +1321,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -1185,11 +1351,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos etc.\n℣. Deus, in adjutorium."
+                "la": "Converte nos etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 128"
               }
@@ -1201,7 +1373,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 129"
               }
@@ -1213,7 +1385,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 130"
               }
@@ -1225,7 +1397,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -1237,19 +1409,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus."
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Virgo, Dei genitrix, quem totus non capit orbis,\nIn tua se clausit viscera factus homo.\nHinc merito dicent te saecula cuncta beatam :\nHinc populi matrem te dominamque colunt.\nSuscipe, quos pia plebs tibi pendere certat honores :\nAnnue, sollicitam quam prece poscit, opem.\nGloria magna Patri: compar sit gloria Nato ;\nAmborum tibi par, Spiritus alme, decus. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum."
               }
@@ -1261,10 +1433,30 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Vultum tuum Deprecabuntur. Vultum.\n℟. Omnes divites plebis Deprecabuntur. Gloria Patri. Vultum.\n℣. Memores erunt nominis tui\n℟. In omni generatione et generationem. Ps. 44."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Vultum tuum Deprecabuntur. Vultum."
+                  },
+                  "r": {
+                    "la": "Omnes divites plebis Deprecabuntur. Gloria Patri. Vultum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Memores erunt nominis tui"
+                  },
+                  "r": {
+                    "la": "In omni generatione et generationem. Ps. 44."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1285,7 +1477,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -1297,7 +1489,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prosa de Beata, ad eandem"
               }
@@ -1309,13 +1501,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Veritas de terra orta est,\n℟. Et justitia de coelo prospexit."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Veritas de terra orta est,"
+                  },
+                  "r": {
+                    "la": "Et justitia de coelo prospexit."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }

--- a/content/practices/little-office-bvm-monastic/flow.json
+++ b/content/practices/little-office-bvm-monastic/flow.json
@@ -45,19 +45,52 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, labia ✠ ea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia ✠ ea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Invitatory"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -69,7 +102,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -81,7 +114,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 94"
               }
@@ -93,7 +126,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -105,7 +138,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -117,49 +150,25 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Quem terra, pontus, aethera\nColunt, adorant, praedicant,\nTrinam regentem machinam,\nClaustrum Mariae bajulat."
+                "la": "Quem terra, pontus, aethera\nColunt, adorant, praedicant,\nTrinam regentem machinam,\nClaustrum Mariae bajulat.\n\nCui luna, sol, et omnia\nDeserviunt per tempora,\nPerfusa caeli gratia,\nGestant puellae viscera.\n\nBeata Mater munere,\nCujus supernus artifex\nMundum pugillo continens,\nVentris sub arca clausus est.\n\nBeata caeli nuntio,\nFoecunda sancto Spiritu,\nDesideratus gentibus,\nCujus per alvum fusus est.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Cui luna, sol, et omnia\nDeserviunt per tempora,\nPerfusa caeli gratia,\nGestant puellae viscera."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Beata Mater munere,\nCujus supernus artifex\nMundum pugillo continens,\nVentris sub arca clausus est."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Beata caeli nuntio,\nFoecunda sancto Spiritu,\nDesideratus gentibus,\nCujus per alvum fusus est."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalms for Sunday, Monday and Thursday"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -171,7 +180,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 8"
               }
@@ -183,7 +192,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -195,7 +204,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -207,7 +216,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 18"
               }
@@ -219,7 +228,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -231,7 +240,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -243,7 +252,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 23"
               }
@@ -255,7 +264,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -267,10 +276,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Diffusa est gratia in labiis tuis.\n℟. Propterea benedixit te Deus in aeternum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Diffusa est gratia in labiis tuis."
+                  },
+                  "r": {
+                    "la": "Propterea benedixit te Deus in aeternum."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -279,19 +295,26 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Et ne nos inducas in tentationem:\n℟. Sed libera nos a malo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem:"
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalms for Tuesday and Friday"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -303,7 +326,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 44"
               }
@@ -315,7 +338,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -327,7 +350,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -339,7 +362,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 45"
               }
@@ -351,7 +374,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -363,7 +386,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -375,7 +398,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 86"
               }
@@ -387,7 +410,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -399,10 +422,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Diffusa est gratia in labiis tuis.\n℟. Propterea benedixit te Deus in aeternum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Diffusa est gratia in labiis tuis."
+                  },
+                  "r": {
+                    "la": "Propterea benedixit te Deus in aeternum."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -411,19 +441,26 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Et ne nos inducas in tentationem:\n℟. Sed libera nos a malo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem:"
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalms for Wednesday and Saturday"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -435,7 +472,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 95"
               }
@@ -447,7 +484,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -459,7 +496,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -471,7 +508,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 96"
               }
@@ -483,7 +520,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -495,7 +532,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -507,7 +544,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Adventu)"
               }
@@ -519,7 +556,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 97"
               }
@@ -531,7 +568,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -543,7 +580,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Adventu)"
               }
@@ -555,10 +592,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Diffusa est gratia in labiis tuis.\n℟. Propterea benedixit te Deus in aeternum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Diffusa est gratia in labiis tuis."
+                  },
+                  "r": {
+                    "la": "Propterea benedixit te Deus in aeternum."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -567,13 +611,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Et ne nos inducas in tentationem:\n℟. Sed libera nos a malo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem:"
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "The Absolution Outside Advent"
               }
@@ -581,11 +632,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Precibus et meritis beatae Mariae semper Virginis et omnium Sanctorum, perducat nos Dominus ad regna caelorum.\n℟. Amen."
+                "la": "Precibus et meritis beatae Mariae semper Virginis et omnium Sanctorum, perducat nos Dominus ad regna caelorum."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "The Blessing"
               }
@@ -593,17 +650,29 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Jube, domne, benedicere.\nNos cum prole pia benedicat Virgo Maria.\n℟. Amen."
+                "la": "Jube, domne, benedicere."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Nos cum prole pia benedicat Virgo Maria."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Lessons and Responsories Outside Advent"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Lesson I - Ecclesiasticus xxiv"
               }
@@ -611,11 +680,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "In omnibus requiem quaesivi, et in hereditate Domini morabor. Tunc praecepit, et dixit mihi Creator omnium: et qui creavit me, requievit in tabernaculo meo. Et dixit mihi: In Jacob inhabita, et in Israel hereditare, et in electis meis mitte radices. Tu autem, Domine, miserere nobis.\n℟. Deo gratias."
+                "la": "In omnibus requiem quaesivi, et in hereditate Domini morabor. Tunc praecepit, et dixit mihi Creator omnium: et qui creavit me, requievit in tabernaculo meo. Et dixit mihi: In Jacob inhabita, et in Israel hereditare, et in electis meis mitte radices. Tu autem, Domine, miserere nobis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsory"
               }
@@ -623,11 +698,24 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Sancta et immaculata virginitas, quibus te laudibus efferam, nescio: Quia quem caeli capere non poterant, tuo gremio contulisti.\n℣. Benedicta tu in mulieribus, et benedictus fructus ventris tui.\n℟. Quia quem caeli capere non poterant, tuo gremio contulisti."
+                "la": "Sancta et immaculata virginitas, quibus te laudibus efferam, nescio: Quia quem caeli capere non poterant, tuo gremio contulisti."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui."
+                  },
+                  "r": {
+                    "la": "Quia quem caeli capere non poterant, tuo gremio contulisti."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "The Blessing"
               }
@@ -635,11 +723,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Jube, domne, benedicere.\nIpsa Virgo Virginum intercedat pro nobis ad Dominum\n℟. Amen."
+                "la": "Jube, domne, benedicere."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Ipsa Virgo Virginum intercedat pro nobis ad Dominum"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Lesson II - Sirach 24:15-16"
               }
@@ -647,11 +747,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Et sic in Sion firmata sum, et in civitate sanctificata similiter requievi, et in Ierusalem potestas mea. Et radicavi in populo honorificato, et in parte Dei mei hereditas illius, et in plenitudine sanctorum detentio mea. Tu autem, Domine, miserere nobis.\n℟. Deo gratias."
+                "la": "Et sic in Sion firmata sum, et in civitate sanctificata similiter requievi, et in Ierusalem potestas mea. Et radicavi in populo honorificato, et in parte Dei mei hereditas illius, et in plenitudine sanctorum detentio mea. Tu autem, Domine, miserere nobis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsory"
               }
@@ -659,8 +765,21 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Beata es, Virgo Maria, quae Dominum portasti, Creatorem mundi: Genuisti qui te fecit, et in aeternum permanes Virgo.\n℣. Ave Maria, gratia plena, Dominus tecum.\n℟. Genuisti qui te fecit, et in aeternum permanes Virgo."
+                "la": "Beata es, Virgo Maria, quae Dominum portasti, Creatorem mundi: Genuisti qui te fecit, et in aeternum permanes Virgo."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria, gratia plena, Dominus tecum."
+                  },
+                  "r": {
+                    "la": "Genuisti qui te fecit, et in aeternum permanes Virgo."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -669,13 +788,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Genuisti qui te fecit, et in aeternum permanes Virgo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Genuisti qui te fecit, et in aeternum permanes Virgo."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "The Blessing"
               }
@@ -683,11 +809,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Jube, domne, benedicere.\nPer Virginem matrem concedat nobis Dominus salutem et pacem.\n℟. Amen."
+                "la": "Jube, domne, benedicere."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Per Virginem matrem concedat nobis Dominus salutem et pacem."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Lesson III - Sirach 24:17-20"
               }
@@ -695,11 +833,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quasi cedrus exaltata sum in Libano, et quasi cypressus in monte Sion: Quasi palma exaltata sum in Cades, et quasi plantatio rosae in Iericho: Quasi oliva speciosa in campis, et quasi platanus exaltata sum iuxta aquam in plateis. Sicut cinnamomum et balsamum aromatizans odorem dedi: quasi myrrha electa dedi suavitatem odoris: Tu autem, Domine, miserere nobis.\n℟. Deo gratias."
+                "la": "Quasi cedrus exaltata sum in Libano, et quasi cypressus in monte Sion: Quasi palma exaltata sum in Cades, et quasi plantatio rosae in Iericho: Quasi oliva speciosa in campis, et quasi platanus exaltata sum iuxta aquam in plateis. Sicut cinnamomum et balsamum aromatizans odorem dedi: quasi myrrha electa dedi suavitatem odoris: Tu autem, Domine, miserere nobis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsory"
               }
@@ -713,11 +857,37 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Felix namque es, sacra Virgo Maria, et omni laude dignissima: Quia ex te ortus est sol justitiae, Christus, Deus noster.\n℣. Ora pro populo, interveni pro clero, intercede pro devoto femineo sexu: sentiant omnes tuum juvamen, quicumque celebrant tuam sanctam Commemorationem.\n℟. Quia ex te ortus est sol justitiae, Christus, Deus noster.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Christus, Deus noster."
+                "la": "Felix namque es, sacra Virgo Maria, et omni laude dignissima: Quia ex te ortus est sol justitiae, Christus, Deus noster."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro populo, interveni pro clero, intercede pro devoto femineo sexu: sentiant omnes tuum juvamen, quicumque celebrant tuam sanctam Commemorationem."
+                  },
+                  "r": {
+                    "la": "Quia ex te ortus est sol justitiae, Christus, Deus noster."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Christus, Deus noster."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "The Absolution during Advent"
               }
@@ -725,11 +895,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Precibus et meritis beatae Mariae semper Virginis et omnium Sanctorum, perducat nos Dominus ad regna caelorum.\n℟. Amen."
+                "la": "Precibus et meritis beatae Mariae semper Virginis et omnium Sanctorum, perducat nos Dominus ad regna caelorum."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "The Blessing"
               }
@@ -737,17 +913,29 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Jube, domne, benedicere.\nNos cum prole pia benedicat Virgo Maria.\n℟. Amen."
+                "la": "Jube, domne, benedicere."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Nos cum prole pia benedicat Virgo Maria."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Lessons and Responsories for Advent"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Lesson I - Luke 1:26-28"
               }
@@ -755,11 +943,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Missus est Angelus Gabriel a Deo in civitatem Galilaeae, cui nomen Nazareth, Ad virginem desponsatam viro, cui nomen erat Ioseph, de domo David: et nomen virginis Maria. Et ingressus Angelus ad eam dixit: Ave gratia plena: Dominus tecum: benedicta tu in mulieribus. Tu autem, Domine, miserere nobis.\n℟. Deo gratias."
+                "la": "Missus est Angelus Gabriel a Deo in civitatem Galilaeae, cui nomen Nazareth, Ad virginem desponsatam viro, cui nomen erat Ioseph, de domo David: et nomen virginis Maria. Et ingressus Angelus ad eam dixit: Ave gratia plena: Dominus tecum: benedicta tu in mulieribus. Tu autem, Domine, miserere nobis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsory"
               }
@@ -767,11 +961,24 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Missus est Gabriel Angelus ad Mariam Virginem desponsatam Ioseph, nuntians ei verbum; et expavescit Virgo de lumine: ne timeas, Maria, invenisti gratiam apud Dominum: Ecce concipies et paries, et vocabitur Altissimi Filius.\n℣. Dabit ei Dominus Deus sedem David, patris eius, et regnabit in domo Jacob in aeternum.\n℟. Ecce concipies et paries, et vocabitur Altissimi Filius."
+                "la": "Missus est Gabriel Angelus ad Mariam Virginem desponsatam Ioseph, nuntians ei verbum; et expavescit Virgo de lumine: ne timeas, Maria, invenisti gratiam apud Dominum: Ecce concipies et paries, et vocabitur Altissimi Filius."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dabit ei Dominus Deus sedem David, patris eius, et regnabit in domo Jacob in aeternum."
+                  },
+                  "r": {
+                    "la": "Ecce concipies et paries, et vocabitur Altissimi Filius."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "The Blessing"
               }
@@ -779,11 +986,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Jube, domne, benedicere.\nIpsa Virgo Virginum intercedat pro nobis ad Dominum.\n℟. Amen."
+                "la": "Jube, domne, benedicere."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Ipsa Virgo Virginum intercedat pro nobis ad Dominum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Lesson II - Luke 1: 26-28"
               }
@@ -791,11 +1010,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quae cum audisset, turbata est in sermone eius, et cogitabat qualis esset ista salutatio. Et ait Angelus ei: Ne timeas, Maria: invenisti enim gratiam apud Deum: Ecce concipies in utero, et paries filium, et vocabis nomen eius Iesum: Hic erit magnus, et Filius Altissimi vocabitur, et dabit illi Dominus Deus sedem David patris eius: et regnabit in domo Iacob in aeternum, Et regni eius non erit finis. Tu autem, Domine, miserere nobis.\n℟. Deo gratias."
+                "la": "Quae cum audisset, turbata est in sermone eius, et cogitabat qualis esset ista salutatio. Et ait Angelus ei: Ne timeas, Maria: invenisti enim gratiam apud Deum: Ecce concipies in utero, et paries filium, et vocabis nomen eius Iesum: Hic erit magnus, et Filius Altissimi vocabitur, et dabit illi Dominus Deus sedem David patris eius: et regnabit in domo Iacob in aeternum, Et regni eius non erit finis. Tu autem, Domine, miserere nobis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsory"
               }
@@ -803,7 +1028,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Ave, Maria, gratia plena; Dominus tecum: Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi: quod enim ex te nascetur Sanctum, vocabitur Filius Dei.\n℣. Quomodo fiet istud, quoniam virum non cognosco? Et respondens Angelus, dixit ei."
+                "la": "Ave, Maria, gratia plena; Dominus tecum: Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi: quod enim ex te nascetur Sanctum, vocabitur Filius Dei."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Quomodo fiet istud, quoniam virum non cognosco? Et respondens Angelus, dixit ei."
               }
             },
             {
@@ -813,13 +1044,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi: quod enim ex te nascetur Sanctum, vocabitur Filius Dei."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi: quod enim ex te nascetur Sanctum, vocabitur Filius Dei."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "The Blessing"
               }
@@ -827,11 +1065,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Jube, domne, benedicere.\nPer Virginem matrem concedat nobis Dominus salutem et pacem.\n℟. Amen."
+                "la": "Jube, domne, benedicere."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Per Virginem matrem concedat nobis Dominus salutem et pacem."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Lesson III - Luke 1: 34-38"
               }
@@ -839,11 +1089,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Dixit autem Maria ad Angelum: Quomodo fiet istud, quoniam virum non cognosco? Et respondens Angelus dixit ei: Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi. Ideoque et quod nascetur ex te Sanctum, vocabitur Filius Dei. Et ecce Elisabeth cognata tua, et ipsa concepit filium in senectute sua: et hic mensis sextus est illi, quae vocatur sterilis: Quia non erit impossibile apud Deum omne verbum. Dixit autem Maria: Ecce ancilla Domini: fiat mihi secundum verbum tuum. Tu autem, Domine, miserere nobis.\n℟. Deo gratias."
+                "la": "Dixit autem Maria ad Angelum: Quomodo fiet istud, quoniam virum non cognosco? Et respondens Angelus dixit ei: Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi. Ideoque et quod nascetur ex te Sanctum, vocabitur Filius Dei. Et ecce Elisabeth cognata tua, et ipsa concepit filium in senectute sua: et hic mensis sextus est illi, quae vocatur sterilis: Quia non erit impossibile apud Deum omne verbum. Dixit autem Maria: Ecce ancilla Domini: fiat mihi secundum verbum tuum. Tu autem, Domine, miserere nobis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsory"
               }
@@ -851,8 +1107,34 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Suscipe verbum, Virgo Maria, quod tibi a Domino per Angelum transmissum est: concipies et paries Deum pariter et hominem, Ut benedicta dicaris inter omnes mulieres.\n℣. Paries quidem filium, et virginitatis non patieris detrimentum: efficieris gravida, et eris mater semper intacta.\n℟. Ut benedicta dicaris inter omnes mulieres.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Ut benedicta dicaris inter omnes mulieres."
+                "la": "Suscipe verbum, Virgo Maria, quod tibi a Domino per Angelum transmissum est: concipies et paries Deum pariter et hominem, Ut benedicta dicaris inter omnes mulieres."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Paries quidem filium, et virginitatis non patieris detrimentum: efficieris gravida, et eris mater semper intacta."
+                  },
+                  "r": {
+                    "la": "Ut benedicta dicaris inter omnes mulieres."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Ut benedicta dicaris inter omnes mulieres."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -861,7 +1143,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Collect"
               }
@@ -879,34 +1161,93 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Et ne nos inducas in tentationem:\n℟. Sed liber nos a malo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem:"
+                  },
+                  "r": {
+                    "la": "Sed liber nos a malo."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui de beatae Mariae Virginis utero Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis; ut, qui vere eam Genitricem Dei credimus, eius apud te intercessionibus adjuvemur. Per eundem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui de beatae Mariae Virginis utero Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis; ut, qui vere eam Genitricem Dei credimus, eius apud te intercessionibus adjuvemur. Per eundem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Conclusion"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -937,19 +1278,39 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (Outside Lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (Outside Lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Psalms"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -961,7 +1322,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -973,7 +1334,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -985,7 +1346,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 92"
               }
@@ -997,7 +1358,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -1009,7 +1370,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -1021,7 +1382,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -1033,7 +1394,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -1045,7 +1406,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -1057,7 +1418,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -1069,7 +1430,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 99"
               }
@@ -1081,7 +1442,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -1093,7 +1454,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -1105,7 +1466,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -1117,7 +1478,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -1129,7 +1490,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -1141,7 +1502,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -1153,7 +1514,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 62"
               }
@@ -1165,7 +1526,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 66"
               }
@@ -1177,7 +1538,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -1189,7 +1550,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -1201,7 +1562,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -1213,7 +1574,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -1225,7 +1586,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -1237,7 +1598,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -1249,7 +1610,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Trium Puerorum"
               }
@@ -1261,7 +1622,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -1273,7 +1634,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -1285,7 +1646,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -1297,7 +1658,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -1309,7 +1670,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -1321,7 +1682,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -1333,7 +1694,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 148"
               }
@@ -1341,11 +1702,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudate Dominum de caelis: laudate eum in excelsis.\nLaudate eum, omnes angeli ejus: laudate eum, omnes virtutes ejus.\nLaudate eum, sol et luna: laudate eum, omnes stellae et lumen.\nLaudate eum, caeli caelorum: et aquae omnes, quae super caelos sunt, laudent nomen Domini.\nQuia ipse dixit, et facta sunt: ipse mandavit, et creata sunt.\nStatuit ea in aeternum, et in saeculum saeculi: praeceptum posuit, et non praeteribit.\nLaudate Dominum de terra, dracones, et omnes abyssi.\nIgnis, grando, nix, glacies, spiritus procellarum: quae faciunt verbum ejus:\nMontes, et omnes colles: ligna fructifera, et omnes cedri.\nBestiae, et universa pecora: serpentes, et volucres pennatae:\nReges terrae, et omnes populi: principes, et omnes judices terrae.\nJuvenes, et virgines: senes cum junioribus laudent nomen Domini: quia exaltatum est nomen ejus solius.\nConfessio ejus super caelum et terram: et exaltavit cornu populi sui.\nHymnus omnibus sanctis ejus: filiis Israel, populo appropinquanti sibi.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Laudate Dominum de caelis: laudate eum in excelsis.\nLaudate eum, omnes angeli ejus: laudate eum, omnes virtutes ejus.\nLaudate eum, sol et luna: laudate eum, omnes stellae et lumen.\nLaudate eum, caeli caelorum: et aquae omnes, quae super caelos sunt, laudent nomen Domini.\nQuia ipse dixit, et facta sunt: ipse mandavit, et creata sunt.\nStatuit ea in aeternum, et in saeculum saeculi: praeceptum posuit, et non praeteribit.\nLaudate Dominum de terra, dracones, et omnes abyssi.\nIgnis, grando, nix, glacies, spiritus procellarum: quae faciunt verbum ejus:\nMontes, et omnes colles: ligna fructifera, et omnes cedri.\nBestiae, et universa pecora: serpentes, et volucres pennatae:\nReges terrae, et omnes populi: principes, et omnes judices terrae.\nJuvenes, et virgines: senes cum junioribus laudent nomen Domini: quia exaltatum est nomen ejus solius.\nConfessio ejus super caelum et terram: et exaltavit cornu populi sui."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus omnibus sanctis ejus: filiis Israel, populo appropinquanti sibi."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -1357,7 +1730,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -1369,7 +1742,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -1381,7 +1754,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter From Christmas to Advent - Cant vi"
               }
@@ -1389,11 +1762,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Viderunt eam filiae Sion, et beatissimam praedicaverunt et reginae laudaverunt eam.\n℟. Deo gratias."
+                "la": "Viderunt eam filiae Sion, et beatissimam praedicaverunt et reginae laudaverunt eam."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter in Advent - Is 11:1-2"
               }
@@ -1401,11 +1780,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Egredietur virga de radice Iesse, et flos de radice eius ascendet. Et requiescet super eum Spiritus Domini.\n℟. Deo gratias."
+                "la": "Egredietur virga de radice Iesse, et flos de radice eius ascendet. Et requiescet super eum Spiritus Domini."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
@@ -1441,19 +1826,26 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedicta tu in mulieribus.\n℟. Et benedictus fructus ventris tui."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicta tu in mulieribus."
+                  },
+                  "r": {
+                    "la": "Et benedictus fructus ventris tui."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Canticle of the Zachary - Lk 1"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -1465,7 +1857,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -1477,7 +1869,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -1507,7 +1899,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -1519,7 +1911,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -1531,7 +1923,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -1561,17 +1953,25 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Collect"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1580,9 +1980,21 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui de beatae Mariae Virginis utero Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis; ut, qui vere eam Genitricem Dei credimus, eius apud te intercessionibus adjuvemur. Per eundem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\n℟. Amen."
+                "la": "Deus, qui de beatae Mariae Virginis utero Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis; ut, qui vere eam Genitricem Dei credimus, eius apud te intercessionibus adjuvemur. Per eundem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
@@ -1592,19 +2004,31 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\n℟. Amen."
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Commemoration of the Saints Outside Advent"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1612,23 +2036,48 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancti Dei omnes, intercedere dignemini pro nostra omniumque salute.\n℣. Laetamini in Domino et exsultate, justi.\n℟. Et gloriamini, omnes recti corde."
+                "la": "Sancti Dei omnes, intercedere dignemini pro nostra omniumque salute."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Laetamini in Domino et exsultate, justi."
+                  },
+                  "r": {
+                    "la": "Et gloriamini, omnes recti corde."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nProtege, Domine, populum tuum, et, Apostolorum tuorum Petri et Pauli et aliorum Apostolorum patrocinio confidentem, perpetua defensione conserva.\nOmnes Sancti tui, quaesumus, Domine, nos ubique adjuvent: ut, dum eorum merita recolimus, patrocinia sentiamus: et pacem tuam nostris concede temporibus, et ab Ecclesia tua cunctam repelle nequitiam; iter, actus et voluntates nostras et omnium famulorum tuorum, in salutis tuae prosperitate dispone, benefactoribus nostris sempiterna bona retribue, et omnibus fidelibus defunctis requiem aeternam concede.\n℟. Amen."
+                "la": "Protege, Domine, populum tuum, et, Apostolorum tuorum Petri et Pauli et aliorum Apostolorum patrocinio confidentem, perpetua defensione conserva.\nOmnes Sancti tui, quaesumus, Domine, nos ubique adjuvent: ut, dum eorum merita recolimus, patrocinia sentiamus: et pacem tuam nostris concede temporibus, et ab Ecclesia tua cunctam repelle nequitiam; iter, actus et voluntates nostras et omnium famulorum tuorum, in salutis tuae prosperitate dispone, benefactoribus nostris sempiterna bona retribue, et omnibus fidelibus defunctis requiem aeternam concede."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Commemoration of the Saints in Advent"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1636,26 +2085,84 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce Dominus veniet, et omnes Sancti ejus cum eo: et erit in die illa lux magna, Alleluia.\n℣. Ecce apparebit Dominus super nubem candidam.\n℟. Et cum eo Sanctorum millia."
+                "la": "Ecce Dominus veniet, et omnes Sancti ejus cum eo: et erit in die illa lux magna, Alleluia."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ecce apparebit Dominus super nubem candidam."
+                  },
+                  "r": {
+                    "la": "Et cum eo Sanctorum millia."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConscientias nostras, quaesumus, Domine, visitando purifica: ut, veniens Jesus Christus, Filius tuus, Dominus noster, cum omnibus Sanctis, paratam sibi in nobis inveniat mansionem: qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\n℟. Amen."
+                "la": "Conscientias nostras, quaesumus, Domine, visitando purifica: ut, veniens Jesus Christus, Filius tuus, Dominus noster, cum omnibus Sanctis, paratam sibi in nobis inveniat mansionem: qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Conclusion"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1666,11 +2173,24 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater noster, qui es in caelis, sanctificetur nomen tuum: adveniat regnum tuum: fiat voluntas tua, sicut in caelo et in terra. Panem nostrum quotidianum da nobis hodie: et dimitte nobis debita nostra, sicut et nos dimittimus debitoribus nostris: et ne nos inducas in tentationem: sed libera nos a malo. Amen.\n℣. Dominus det nobis suam pacem.\n℟. Et vitam aeternam. Amen."
+                "la": "Pater noster, qui es in caelis, sanctificetur nomen tuum: adveniat regnum tuum: fiat voluntas tua, sicut in caelo et in terra. Panem nostrum quotidianum da nobis hodie: et dimitte nobis debita nostra, sicut et nos dimittimus debitoribus nostris: et ne nos inducas in tentationem: sed libera nos a malo. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus det nobis suam pacem."
+                  },
+                  "r": {
+                    "la": "Et vitam aeternam. Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Anthem"
               }
@@ -1694,15 +2214,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Dignare me laudare te, Virgo sacrata.\n℟. Da mihi virtutem contra hostes tuos."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dignare me laudare te, Virgo sacrata."
+                  },
+                  "r": {
+                    "la": "Da mihi virtutem contra hostes tuos."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede, misericors Deus, fragilitati nostrae praesidium: ut, qui sanctae Dei Genitricis memoriam agimus; intercessionis eius auxilio, a nostris iniquitatibus resurgamus. Per eumdem Christum Dominum nostrum.\n℟. Amen."
+                "la": "Concede, misericors Deus, fragilitati nostrae praesidium: ut, qui sanctae Dei Genitricis memoriam agimus; intercessionis eius auxilio, a nostris iniquitatibus resurgamus. Per eumdem Christum Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
@@ -1718,15 +2257,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Gaude et laetare, Virgo Maria, Alleluia.\n℟. Quia surrexit Dominus vere, Alleluia."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gaude et laetare, Virgo Maria, Alleluia."
+                  },
+                  "r": {
+                    "la": "Quia surrexit Dominus vere, Alleluia."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui per resurrectionem Filii tui, Domini nostri Iesu Christi mundum laetificare dignatus es: praesta, quaesumus; ut per eius Genitricem Virginem Mariam, perpetuae capiamus gaudia vitae. Per eumdem Christum Dominum nostrum.\n℟. Amen."
+                "la": "Deus, qui per resurrectionem Filii tui, Domini nostri Iesu Christi mundum laetificare dignatus es: praesta, quaesumus; ut per eius Genitricem Virginem Mariam, perpetuae capiamus gaudia vitae. Per eumdem Christum Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
@@ -1742,28 +2300,54 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, sancta Dei Genitrix.\n℟. Ut digni efficiamur promissionibus Christi."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nOmnipotens sempiterne Deus, qui gloriosae Virginis Matris Mariae corpus et animam, ut dignum Filii tui habitaculum effici mereretur, Spiritu Sancto cooperante praeparasti: da, ut cuius commemoratione laetamur; eius pia intercessione, ab instantibus malis, et a morte perpetua liberemur. Per eumdem Christum Dominum nostrum.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Dei Genitrix."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Omnipotens sempiterne Deus, qui gloriosae Virginis Matris Mariae corpus et animam, ut dignum Filii tui habitaculum effici mereretur, Spiritu Sancto cooperante praeparasti: da, ut cuius commemoratione laetamur; eius pia intercessione, ab instantibus malis, et a morte perpetua liberemur. Per eumdem Christum Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Final blessing"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Divinum auxilium ✠ maneat semper nobiscum.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Divinum auxilium ✠ maneat semper nobiscum."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -1776,7 +2360,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Introduction"
               }
@@ -1788,31 +2372,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris."
+                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris.\n\nMaria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -1824,7 +2396,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -1836,7 +2408,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -1848,7 +2420,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 53"
               }
@@ -1860,7 +2432,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 84"
               }
@@ -1872,7 +2444,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 116"
               }
@@ -1884,7 +2456,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -1896,7 +2468,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -1908,7 +2480,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -1920,7 +2492,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter Outside Advent - Song of Songs 6:9"
               }
@@ -1928,11 +2500,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quae est ista, quae progreditur quasi aurora consurgens, pulchra ut luna, electa ut sol, terribilis ut castrorum acies ordinata?\n℟. Deo gratias."
+                "la": "Quae est ista, quae progreditur quasi aurora consurgens, pulchra ut luna, electa ut sol, terribilis ut castrorum acies ordinata?"
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter During Advent - Isaiah 7:14-15"
               }
@@ -1940,14 +2518,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce virgo concipiet, et pariet filium, et vocabitur nomen eius Emmanuel. Butýrum et mel comedet, ut sciat reprobare malum, et eligere bonum.\n℟. Deo gratias."
+                "la": "Ecce virgo concipiet, et pariet filium, et vocabitur nomen eius Emmanuel. Butýrum et mel comedet, ut sciat reprobare malum, et eligere bonum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Dignare me laudare te, Virgo sacrata.\n℟. Da mihi virtutem contra hostes tuos."
+                "la": "Deo gratias."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dignare me laudare te, Virgo sacrata."
+                  },
+                  "r": {
+                    "la": "Da mihi virtutem contra hostes tuos."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -1956,16 +2547,23 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1974,9 +2572,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui virginalem aulam beatae Mariae, in qua habitares, eligere dignatus es: da, quaesumus; ut, sua nos defensione munitos, jucundos facias suae interesse commemorationi. Qui vivis et regnas cum Deo Patre, in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+                "la": "Deus, qui virginalem aulam beatae Mariae, in qua habitares, eligere dignatus es: da, quaesumus; ut, sua nos defensione munitos, jucundos facias suae interesse commemorationi. Qui vivis et regnas cum Deo Patre, in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
               }
             },
             {
@@ -1986,22 +2590,61 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui virginalem aulam beatae Mariae, in qua habitares, eligere dignatus es: da, quaesumus; ut, sua nos defensione munitos, jucundos facias suae interesse commemorationi. Qui vivis et regnas cum Deo Patre, in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui virginalem aulam beatae Mariae, in qua habitares, eligere dignatus es: da, quaesumus; ut, sua nos defensione munitos, jucundos facias suae interesse commemorationi. Qui vivis et regnas cum Deo Patre, in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Conclusion"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -2014,7 +2657,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Introduction"
               }
@@ -2026,31 +2669,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris."
+                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris.\n\nMaria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -2062,7 +2693,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -2074,7 +2705,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -2086,7 +2717,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 119"
               }
@@ -2098,7 +2729,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 120"
               }
@@ -2110,7 +2741,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 121"
               }
@@ -2122,7 +2753,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -2134,7 +2765,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -2146,7 +2777,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -2158,7 +2789,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter Outside Advent - Sirach 24:15"
               }
@@ -2166,11 +2797,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Et sic in Sion firmata sum, et in civitate sanctificata similiter requievi, et in Ierusalem potestas mea.\n℟. Deo gratias."
+                "la": "Et sic in Sion firmata sum, et in civitate sanctificata similiter requievi, et in Ierusalem potestas mea."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter During Advent - Isaiah 11:1-2"
               }
@@ -2178,14 +2815,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Egredietur virga de radice Iesse, et flos de radice eius ascendet. Et requiescet super eum Spiritus Domini.\n℟. Deo gratias."
+                "la": "Egredietur virga de radice Iesse, et flos de radice eius ascendet. Et requiescet super eum Spiritus Domini."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Diffusa est gratia in labiis tuis.\n℟Propterea benedixit te Deus in aeternum."
+                "la": "Deo gratias."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Diffusa est gratia in labiis tuis."
+                  },
+                  "r": {
+                    "la": "Propterea benedixit te Deus in aeternum."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -2194,16 +2844,23 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -2212,9 +2869,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui de beatae Mariae Virginis utero, Verbum tuum, angelo nuntiante, carnem suscipere voluisti; praesta supplicibus tuis, ut qui vere eam Genetricem Dei credimus, ejus apud te intercessionibus adjuvemur. Per eundem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+                "la": "Deus, qui de beatae Mariae Virginis utero, Verbum tuum, angelo nuntiante, carnem suscipere voluisti; praesta supplicibus tuis, ut qui vere eam Genetricem Dei credimus, ejus apud te intercessionibus adjuvemur. Per eundem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
               }
             },
             {
@@ -2224,13 +2887,19 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Conclusion"
               }
@@ -2252,7 +2921,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Introduction"
               }
@@ -2264,31 +2933,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris."
+                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris.\n\nMaria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -2300,7 +2957,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -2312,7 +2969,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -2324,7 +2981,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 122"
               }
@@ -2336,7 +2993,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 123"
               }
@@ -2348,7 +3005,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 124"
               }
@@ -2360,7 +3017,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -2372,7 +3029,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -2384,7 +3041,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -2396,7 +3053,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter Outside Advent - Sirach 24:16"
               }
@@ -2404,11 +3061,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Et radicavi in populo honorificato, et in parte Dei mei hereditas illius, et in plenitudine sanctorum detentio mea.\n℟. Deo gratias."
+                "la": "Et radicavi in populo honorificato, et in parte Dei mei hereditas illius, et in plenitudine sanctorum detentio mea."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter During Advent - Luke 1:32-33"
               }
@@ -2416,26 +3079,46 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Dabit illi Dominus Deus sedem David, patris ejus, et regnabit in domo Jacob in aeternum, et regni ejus non erit finis.\n℟. Deo gratias."
+                "la": "Dabit illi Dominus Deus sedem David, patris ejus, et regnabit in domo Jacob in aeternum, et regni ejus non erit finis."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Benedicta tu in mulieribus.\n℟. Et benedictus fructus ventris tui."
+                "la": "Deo gratias."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicta tu in mulieribus."
+                  },
+                  "r": {
+                    "la": "Et benedictus fructus ventris tui."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -2444,9 +3127,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede, misericors Deus, fragilitati nostrae praesidium; ut, qui sanctae Dei Genetricis memoriam agimus; intercessionis eius auxilio, a nostris iniquitatibus resurgamus. Per eumdem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+                "la": "Concede, misericors Deus, fragilitati nostrae praesidium; ut, qui sanctae Dei Genetricis memoriam agimus; intercessionis eius auxilio, a nostris iniquitatibus resurgamus. Per eumdem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
               }
             },
             {
@@ -2456,13 +3145,19 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Conclusion"
               }
@@ -2484,7 +3179,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Introduction"
               }
@@ -2496,31 +3191,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris."
+                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris.\n\nMaria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -2532,7 +3215,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -2544,7 +3227,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -2556,7 +3239,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 125"
               }
@@ -2568,7 +3251,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 126"
               }
@@ -2580,7 +3263,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 127"
               }
@@ -2592,7 +3275,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -2604,7 +3287,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -2616,7 +3299,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -2628,7 +3311,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter Outside Advent - Sirach 24:19-20"
               }
@@ -2636,17 +3319,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "In plateis sicut cinnamomum et balsamum aromatizans odorem dedi: quasi myrrha electa, dedi suavitatem odoris.\n℟. Deo gratias."
+                "la": "In plateis sicut cinnamomum et balsamum aromatizans odorem dedi: quasi myrrha electa, dedi suavitatem odoris."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Post partum, Virgo, inviolata permansisti.\n℟. Dei Genitrix, intercede pro nobis."
+                "la": "Deo gratias."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Post partum, Virgo, inviolata permansisti."
+                  },
+                  "r": {
+                    "la": "Dei Genitrix, intercede pro nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter During Advent - Isaiah 7:14-15"
               }
@@ -2654,14 +3350,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce virgo concipiet, et pariet filium, et vocabitur nomen ejus Emmanuel. Butýrum et mel comedet, ut sciat reprobare malum, et eligere bonum.\n℟. Deo gratias."
+                "la": "Ecce virgo concipiet, et pariet filium, et vocabitur nomen ejus Emmanuel. Butýrum et mel comedet, ut sciat reprobare malum, et eligere bonum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Angelus Domini nuntiavit Mariae.\n℟. Et concepit de Spiritu Sancto."
+                "la": "Deo gratias."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Angelus Domini nuntiavit Mariae."
+                  },
+                  "r": {
+                    "la": "Et concepit de Spiritu Sancto."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -2670,16 +3379,23 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -2688,9 +3404,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nFamulorum tuorum, quaesumus, Domine, delictis ignosce: ut qui tibi placere de actibus nostris non valemus: Genitricis Filii tui Domini nostri intercessione salvemur: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+                "la": "Famulorum tuorum, quaesumus, Domine, delictis ignosce: ut qui tibi placere de actibus nostris non valemus: Genitricis Filii tui Domini nostri intercessione salvemur: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
               }
             },
             {
@@ -2700,13 +3422,19 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Conclusion"
               }
@@ -2728,7 +3456,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Introduction"
               }
@@ -2740,13 +3468,13 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalms"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -2758,7 +3486,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -2770,7 +3498,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -2782,7 +3510,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 109"
               }
@@ -2794,7 +3522,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -2806,7 +3534,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -2818,7 +3546,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -2830,7 +3558,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -2842,7 +3570,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -2854,7 +3582,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -2866,7 +3594,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 112"
               }
@@ -2878,7 +3606,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -2890,7 +3618,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -2902,7 +3630,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -2914,7 +3642,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -2926,7 +3654,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -2938,7 +3666,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -2950,7 +3678,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 121"
               }
@@ -2962,7 +3690,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -2974,7 +3702,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -2986,7 +3714,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -2998,7 +3726,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -3010,7 +3738,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -3022,7 +3750,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -3034,7 +3762,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 126"
               }
@@ -3046,7 +3774,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -3058,7 +3786,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -3070,7 +3798,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -3082,7 +3810,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -3094,7 +3822,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -3106,7 +3834,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -3118,7 +3846,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 147"
               }
@@ -3130,7 +3858,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -3142,7 +3870,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -3154,7 +3882,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -3166,7 +3894,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter Outside Advent - Sir 24:24"
               }
@@ -3174,11 +3902,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ab initio et ante saecula creata sum, et usque ad futurum saeculum non desinam, et in habitatione sancta coram ipso ministravi.\n℟. Deo gratias."
+                "la": "Ab initio et ante saecula creata sum, et usque ad futurum saeculum non desinam, et in habitatione sancta coram ipso ministravi."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter During Advent. - Is 11:1-2"
               }
@@ -3186,11 +3920,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Egredietur virga de radice Jesse, et flos de radice ejus ascendet. Et requiescet super eum Spiritus Domini.\n℟. Deo gratias."
+                "la": "Egredietur virga de radice Jesse, et flos de radice ejus ascendet. Et requiescet super eum Spiritus Domini."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
@@ -3250,19 +3990,26 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Diffusa est gratia in labiis tuis.\n℟. Propterea benedixit te Deus in aeternum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Diffusa est gratia in labiis tuis."
+                  },
+                  "r": {
+                    "la": "Propterea benedixit te Deus in aeternum."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Canticle of the Blessed Virgin Mary - Lk 1"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -3274,7 +4021,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -3298,7 +4045,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -3316,7 +4063,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -3328,7 +4075,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -3352,7 +4099,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -3370,16 +4117,23 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Collect"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -3388,9 +4142,21 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis sanitate gaudere: et, gloriosa beatae Mariae semper Virginis intercessione, a praesenti liberari tristitia, et aeterna perfrui laetitia. Per Dominum nostrum Jesum Christum, Filium tuum: qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\n℟. Amen."
+                "la": "Concede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis sanitate gaudere: et, gloriosa beatae Mariae semper Virginis intercessione, a praesenti liberari tristitia, et aeterna perfrui laetitia. Per Dominum nostrum Jesum Christum, Filium tuum: qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
@@ -3400,19 +4166,31 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\n℟. Amen."
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Commemoration of the Saints Outside Advent"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -3420,17 +4198,48 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancti Dei omnes, intercedere dignemini pro nostra omniumque salute.\n℣. Laetamini in Domino et exsultate, justi.\n℟. Et gloriamini, omnes recti corde.\nOremus,\nProtege, Domine, populum tuum, et, Apostolorum tuorum Petri et Pauli et aliorum Apostolorum patrocinio confidentem, perpetua defensione conserva.\nOmnes Sancti tui, quaesumus, Domine, nos ubique adjuvent: ut, dum eorum merita recolimus, patrocinia sentiamus: et pacem tuam nostris concede temporibus, et ab Ecclesia tua cunctam repelle nequitiam; iter, actus et voluntates nostras et omnium famulorum tuorum, in salutis tuae prosperitate dispone, benefactoribus nostris sempiterna bona retribue, et omnibus fidelibus defunctis requiem aeternam concede.\n℟ Amen."
+                "la": "Sancti Dei omnes, intercedere dignemini pro nostra omniumque salute."
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Laetamini in Domino et exsultate, justi."
+                  },
+                  "r": {
+                    "la": "Et gloriamini, omnes recti corde."
+                  }
+                }
+              ]
+            },
+            {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Protege, Domine, populum tuum, et, Apostolorum tuorum Petri et Pauli et aliorum Apostolorum patrocinio confidentem, perpetua defensione conserva.\nOmnes Sancti tui, quaesumus, Domine, nos ubique adjuvent: ut, dum eorum merita recolimus, patrocinia sentiamus: et pacem tuam nostris concede temporibus, et ab Ecclesia tua cunctam repelle nequitiam; iter, actus et voluntates nostras et omnium famulorum tuorum, in salutis tuae prosperitate dispone, benefactoribus nostris sempiterna bona retribue, et omnibus fidelibus defunctis requiem aeternam concede."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Commemoration of the Saints During Advent"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -3438,11 +4247,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce Dominus veniet, et omnes Sancti ejus cum eo: et erit in die illa lux magna, Alleluia.\n℣. Ecce apparebit Dominus super nubem candidam.\n℟. Et cum eo Sanctorum millia.\nOremus,\nConscientias nostras, quaesumus, Domine, visitando purifica: ut, veniens Jesus Christus, Filius tuus, Dominus noster, cum omnibus Sanctis, paratam sibi in nobis inveniat mansionem: qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\n℟ Amen."
+                "la": "Ecce Dominus veniet, et omnes Sancti ejus cum eo: et erit in die illa lux magna, Alleluia."
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ecce apparebit Dominus super nubem candidam."
+                  },
+                  "r": {
+                    "la": "Et cum eo Sanctorum millia."
+                  }
+                }
+              ]
+            },
+            {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Conscientias nostras, quaesumus, Domine, visitando purifica: ut, veniens Jesus Christus, Filius tuus, Dominus noster, cum omnibus Sanctis, paratam sibi in nobis inveniat mansionem: qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Conclusion"
               }
@@ -3478,17 +4318,50 @@
             {
               "type": "rubric",
               "text": {
-                "en-US": "In the first ℣, the sign of the cross is made with the thumb over the heart, instead of the usual manner."
+                "en-US": "In the first versicle, the sign of the cross is made with the thumb over the heart, instead of the usual manner."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Converte nos ✠ Deus, salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos ✠ Deus, salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Psalm 128"
               }
@@ -3500,7 +4373,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 129"
               }
@@ -3512,7 +4385,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 130"
               }
@@ -3524,31 +4397,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris."
+                "la": "Memento salutis Auctor,\nQuod nostri quondam corporis,\nEx illibata Virgine\nNascendo, formam sumpseris.\n\nMaria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria Mater gratiae,\nMater misericordiae:\nTu nos ab hoste protege,\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter Outside Advent - Sir 24:24"
               }
@@ -3556,17 +4417,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ego mater pulchrae dilectionis, et timoris, et agnitionis, et sanctae spei.\n℟. Deo gratias."
+                "la": "Ego mater pulchrae dilectionis, et timoris, et agnitionis, et sanctae spei."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Ora pro nobis, sancta Dei Genitrix.\n℟. Ut digni efficiamur promissionibus Christi."
+                "la": "Deo gratias."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Dei Genitrix."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter During Advent - Is 7:14-15"
               }
@@ -3574,14 +4448,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce virgo concipiet, et pariet Filium, et vocabitur nomen ejus Emmanuel. Butyrum et mel comedet, ut sciat reprobare malum, et eligere bonum.\n℟. Deo gratias."
+                "la": "Ecce virgo concipiet, et pariet Filium, et vocabitur nomen ejus Emmanuel. Butyrum et mel comedet, ut sciat reprobare malum, et eligere bonum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Angelus Domini nuntiavit Mariae.\n℟. Et concepit de Spiritu sancto."
+                "la": "Deo gratias."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Angelus Domini nuntiavit Mariae."
+                  },
+                  "r": {
+                    "la": "Et concepit de Spiritu sancto."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -3590,7 +4477,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -3602,7 +4489,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -3626,7 +4513,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -3644,7 +4531,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Candlemas until Advent)"
               }
@@ -3656,7 +4543,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Advent)"
               }
@@ -3680,7 +4567,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon (from Christmas to Candlemas)"
               }
@@ -3698,16 +4585,23 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -3716,9 +4610,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nBeatae et gloriosae semper Virginis Mariae, quaesumus, Domine, intercessio gloriosa nos protegat, et ad vitam perducat aeternam. Per Dominum nostrum Jesum Christum, Filium tuum: qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+                "la": "Beatae et gloriosae semper Virginis Mariae, quaesumus, Domine, intercessio gloriosa nos protegat, et ad vitam perducat aeternam. Per Dominum nostrum Jesum Christum, Filium tuum: qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
               }
             },
             {
@@ -3728,9 +4628,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui de beatae Mariae Virginis utero Verbum tuum, angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis, ut qui vere eam Genitricem Dei credimus, ejus apud te intercessionibus adjuvemur.\nPer eumdem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+                "la": "Deus, qui de beatae Mariae Virginis utero Verbum tuum, angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis, ut qui vere eam Genitricem Dei credimus, ejus apud te intercessionibus adjuvemur.\nPer eumdem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
               }
             },
             {
@@ -3740,25 +4646,51 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui salutis aeternae beatae Mariae virginitate fecunda, humano generi praemia praestitisti; tribue, quaesumus, ut ipsam pro nobis intercedere sentiamus, pre quam meruimus Auctorem vitae suscipere, Dominum nostrum Jesum Christum, Filium tuum: qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum."
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui salutis aeternae beatae Mariae virginitate fecunda, humano generi praemia praestitisti; tribue, quaesumus, ut ipsam pro nobis intercedere sentiamus, pre quam meruimus Auctorem vitae suscipere, Dominum nostrum Jesum Christum, Filium tuum: qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Conclusion"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "The Blessing"
               }

--- a/content/practices/little-office-bvm-mount-carmel/flow.json
+++ b/content/practices/little-office-bvm-mount-carmel/flow.json
@@ -32,25 +32,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In omni tribulatione nostra per sacratissimum scapulare,"
+                  },
+                  "r": {
+                    "la": "Succurrere nobis o virgo Maria, dignare."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina ad adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domina ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. In omni tribulatione nostra per sacratissimum scapulare,\n℟. Succurrere nobis o virgo Maria, dignare.\n℣. Domina ad adjutorium meum intende.\n℟. Domina ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Styx dum instat, et minantur\nMundus, Caro praelia,\nVigilantes nunc conantur\nAgere per devia,\nNunc et tentant dormientes;\nNos Maria protege\nTurbas contra tam potentes\nScapularis agide!\nEt, o vere res miranda\nHostis jam repellitur,\nPicta clypeo dum tanta\nHeroina cernitur."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -58,11 +84,24 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Non timebis a timore nocturno, a sagitta volante in die, a negotio perambulante in tenebris.\n℣. Scapulis suis obumbrabit tibi,\n℟. Et sub pennis ejus sperabis."
+                "la": "Non timebis a timore nocturno, a sagitta volante in die, a negotio perambulante in tenebris."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Scapulis suis obumbrabit tibi,"
+                  },
+                  "r": {
+                    "la": "Et sub pennis ejus sperabis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -84,25 +123,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In omni tribulatione nostra per sacratissimum scapulare,"
+                  },
+                  "r": {
+                    "la": "Succurrere nobis o virgo Maria dignare."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina ad adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domina ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. In omni tribulatione nostra per sacratissimum scapulare,\n℟. Succurrere nobis o virgo Maria dignare.\n℣. Domina ad adjutorium meum intende.\n℟. Domina ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Coquit ira, pectus fodit\nRancor et ambitio,\nMetus, Moeror, Cura rodit,\nUrit et Suspicio,\nSed, Maria! hos ardores\nDic quis ferre poterit,\nFibras per interiores\nMens quos usque percipit,\nScapularis nisi scuto\nHis a tortoribus\nGrate colloces in tuto\nUmbras nos favoribus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -130,25 +195,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In omni tribulatione nostra per sacratissimum scapulare,"
+                  },
+                  "r": {
+                    "la": "Succurrere nobis o virgo Maria dignare."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina ad adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domina ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. In omni tribulatione nostra per sacratissimum scapulare,\n℟. Succurrere nobis o virgo Maria dignare.\n℣. Domina ad adjutorium meum intende.\n℟. Domina ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Taeda Martis innocenti\nTincta flagrat sanguine,\nCuncta ferox praeponenti\nMiles turbat chalybe;\nAt, ut milvus quando venit,\nPulli simul properant,\nMatris, quae pericula gemit,\nAlis ut deliteant,\nSic Maria! te precamur,\nScapularis explicas\nAlas nobis, quibus tegamur\nMartis a ferocia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -176,25 +267,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In omni tribulatione nostra per sacratissimum scapulare,"
+                  },
+                  "r": {
+                    "la": "Succurrere nobis o virgo Maria dignare."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina ad adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domina ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. In omni tribulatione nostra per sacratissimum scapulare,\n℟. Succurrere nobis o virgo Maria dignare.\n℣. Domina ad adjutorium meum intende.\n℟. Domina ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Si injuria nos rodit,\nNigrat aut infamia,\nVera quoque si explodit\nPlebs in nos dictoria;\nQuis haec tela venenata\nO Maria! abiget?\nScapularis nisi sacrata\nVirtus id efficiet,\nIgnis, Saga, Latro, Mare\nFurant sive Fulmina,\nSacrum nos per Scapulare\nPia Mater adjuva!"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -222,25 +339,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In omni tribulatione nostra per sacratissimum scapulare,"
+                  },
+                  "r": {
+                    "la": "Succurrere nobis o virgo Maria dignare."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina ad adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domina ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. In omni tribulatione nostra per sacratissimum scapulare,\n℟. Succurrere nobis o virgo Maria dignare.\n℣. Domina ad adjutorium meum intende.\n℟. Domina ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Morbi quando, et dolores\nTotum corpus cruciant,\nIpsam fere per languores\nMentem ut excruciant,\nSudor mortis quando premit\nGelu mixtus rigido,\nEn! Maria praesto venit\nScapularis pharmaco;\nCedunt febres, cessant morbi,\nReviviscit animus,\nNovos, spiritu jam orbi,\nAegri spirant Spiritus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -268,25 +411,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In omni tribulatione nostra per sacratissimum scapulare,"
+                  },
+                  "r": {
+                    "la": "Succurrere nobis o virgo Maria dignare."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina ad adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domina ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. In omni tribulatione nostra per sacratissimum scapulare,\n℟. Succurrere nobis o virgo Maria dignare.\n℣. Domina ad adjutorium meum intende.\n℟. Domina ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Jamque tandem diu inanis\nVitae fluit clepsydra,\nProh! quam furiis insanis\nMonstra frement Stygia!\nLongo mala jam commissa\nAccusabunt ordine,\nBona pandent nunc omissa;\nVirgo, sed benvole\nHaec tu debita cassabis\nScapularis spongia,\nSpectra pelles, et fugabis\nVana Stygis somnia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -314,25 +483,64 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In omni tribulatione nostra per sacratissimum scapulare,"
+                  },
+                  "r": {
+                    "la": "Succurrere nobis o virgo Maria dignare."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Convertat nos Domina, tuis precibus placatus Jesus Christus Filius tuus."
+                  },
+                  "r": {
+                    "la": "Et avertat iram suam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina ad adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domina ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. In omni tribulatione nostra per sacratissimum scapulare,\n℟. Succurrere nobis o virgo Maria dignare.\n℣. Convertat nos Domina, tuis precibus placatus Jesus Christus Filius tuus.\n℟. Et avertat iram suam a nobis.\n℣. Domina ad adjutorium meum intende.\n℟. Domina ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Mens mortali si excedat\nSuo quondam corpore,\nFac secura coelum petat\nTe, Maria, praeduce,\nNec deflectat ad purgantium\nAntra flammis horrida,\nUbi stridor est clamantium,\nFletus et miseria;\nSed nos, ac fideles cunctos\nScapulari vinculo\nTibi, Virgo, serva junctos\nTristii hoc ergastulo."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -360,21 +568,15 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Hymnus"
       }
     },
     {
-      "type": "prayer",
+      "type": "hymn",
       "inline": {
-        "la": "Scapularis o Regina!\nHoc sacrato tegmine\nQuae sub alis, ut Gallina\nTuos scis protegere;\nPreces tibi has dicamus\nFausta per et aspera,\nFac, ut pie hic degamus,\nDonec post haec tempora\nInsigniti nuptialis\nScapularis vestibus,\nAgni perpetim Pascualis\nRecreemur dapibus."
-      }
-    },
-    {
-      "type": "prayer",
-      "inline": {
-        "la": "Amen."
+        "la": "Scapularis o Regina!\nHoc sacrato tegmine\nQuae sub alis, ut Gallina\nTuos scis protegere;\nPreces tibi has dicamus\nFausta per et aspera,\nFac, ut pie hic degamus,\nDonec post haec tempora\nInsigniti nuptialis\nScapularis vestibus,\nAgni perpetim Pascualis\nRecreemur dapibus.\n\nAmen."
       }
     }
   ]

--- a/content/practices/little-office-bvm-norbertine/flow.json
+++ b/content/practices/little-office-bvm-norbertine/flow.json
@@ -33,13 +33,59 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣.Ave Maria, gratia plena; Dominus tecum.\n℟.Benedicta tu in mulieribus, et benedictus fructus ventris tui.\n℣. Domine, labia ✠ ea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (vel:) Laus tibi, Domine, Rex aeternae gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria, gratia plena; Dominus tecum."
+                  },
+                  "r": {
+                    "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia ✠ ea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (vel:) Laus tibi, Domine, Rex aeternae gloriae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -51,7 +97,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 94"
               }
@@ -63,7 +109,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -75,7 +121,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -87,39 +133,15 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Quem terra, pontus, aethera\nColunt, adorant, praedicant,\nTrinam regentem machinam,\nClaustrum Mariae bajulat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Cui luna, sol et omnia\nDeserviunt per tempora,\nPerfusa caeli gratia,\nGestant puellae viscera."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Beata Mater munere,\nCujus, supernus Artifex\nMundum pugillo continens,\nVentris sub arca clausus est."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Beata caeli nuntio,\nFecunda Sancto Spiritu,\nDesideratus gentibus\nCujus per alvum fusus est."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
+                "la": "Quem terra, pontus, aethera\nColunt, adorant, praedicant,\nTrinam regentem machinam,\nClaustrum Mariae bajulat.\n\nCui luna, sol et omnia\nDeserviunt per tempora,\nPerfusa caeli gratia,\nGestant puellae viscera.\n\nBeata Mater munere,\nCujus, supernus Artifex\nMundum pugillo continens,\nVentris sub arca clausus est.\n\nBeata caeli nuntio,\nFecunda Sancto Spiritu,\nDesideratus gentibus\nCujus per alvum fusus est.\n\nGloria tibi, Domine,\nQui natus es de Virgine,\nCum Patre, et Sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
@@ -129,7 +151,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -141,7 +163,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 8"
               }
@@ -153,7 +175,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -165,7 +187,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 18"
               }
@@ -177,7 +199,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -189,7 +211,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 23"
               }
@@ -201,15 +223,40 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria gratia plena."
+                  },
+                  "r": {
+                    "la": "Dominus tecum, benedicta tu in mulieribus."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Ave Maria gratia plena.\n℟. Dominus tecum, benedicta tu in mulieribus."
+                "la": "Pater noster, secreto et secreto ad"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater noster, secreto et secreto ad ℣. Et ne nos.\nSegnuntur secunda Lectiones cum ℟. ij, et correlatique ut infra."
+                "la": "Et ne nos."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Segnuntur secunda Lectiones cum"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "ij, et correlatique ut infra."
               }
             },
             {
@@ -219,7 +266,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -231,7 +278,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 44"
               }
@@ -243,7 +290,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -255,7 +302,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 45"
               }
@@ -267,7 +314,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -279,7 +326,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 86"
               }
@@ -293,7 +340,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Speciosa facta es et fulgoris in delicias tuas.\n℣. Sancta Dei genitrix\nPater noster."
+                "la": "Speciosa facta es et fulgoris in delicias tuas."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Sancta Dei genitrix"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Pater noster."
               }
             },
             {
@@ -309,7 +368,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -321,7 +380,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 95"
               }
@@ -333,7 +392,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -345,7 +404,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 96"
               }
@@ -357,7 +416,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -369,7 +428,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 97"
               }
@@ -387,28 +446,48 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona: Diffusa est gracia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona: post partum Virgo inviolata permansit, Dei genitrix intercede pro nobis."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Dignare me laudare te, Virgo sacrata.\n℟. Da mihi virtutem contra hostes tuos."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dignare me laudare te, Virgo sacrata."
+                  },
+                  "r": {
+                    "la": "Da mihi virtutem contra hostes tuos."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Pater noster.\n℣. Et ne nos inducas.\n℟. Sed libera nos a malo."
+                "la": "Pater noster."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas."
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -417,7 +496,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Benedicta:"
               }
@@ -425,17 +504,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Precibus suis Matris Benedictat nos Filius Dei Patris.\n℟. Amen."
+                "la": "Precibus suis Matris Benedictat nos Filius Dei Patris."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectiones in Adventu."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Reading (j. Luc. 1. 26)"
               }
@@ -449,17 +534,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Missus est Gabriel Angelus ad Mariam virginem desponsatam Joseph, nuntians ei verbum, et expavescit virgo de lumine. Ne timeas Maria: invenisti gratiam apud Dominum, Ecce concipies et paries, et vocabitur Altissimi Filius."
+                "la": "Missus est Gabriel Angelus ad Mariam virginem desponsatam Joseph, nuntians ei verbum, et expavescit virgo de lumine. Ne timeas Maria: invenisti gratiam apud Dominum, Ecce concipies et paries, et vocabitur Altissimi Filius."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Dabit ei Dominus Deus sedem David patris ejus, et regnabit in domo Jacob in aeternum. cEcce concipies."
+                "la": "Dabit ei Dominus Deus sedem David patris ejus, et regnabit in domo Jacob in aeternum. cEcce concipies."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Reading (ii)"
               }
@@ -473,17 +558,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Ave Maria gratia plena Dominus tecum: Spiritus sanctus superveniet in te, et virtus Altissimi obumbrabit tibi: quod enim ex te nascetur sanctum, vocabitur filius Dei."
+                "la": "Ave Maria gratia plena Dominus tecum: Spiritus sanctus superveniet in te, et virtus Altissimi obumbrabit tibi: quod enim ex te nascetur sanctum, vocabitur filius Dei."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Quomodo fiet istud, quoniam virum non cognosco? Et respondit Angelus, dicens ei: Spiritus sanctus"
+                "la": "Quomodo fiet istud, quoniam virum non cognosco? Et respondit Angelus, dicens ei: Spiritus sanctus"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Reading (iiij)"
               }
@@ -497,13 +582,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Suscipe verbum virgo Maria, quod tibi a Domino per Angelum transmissum est, concipies et paries Deum pariter et hominem: Ut benedicta dicaris inter omnes mulieres.\n℣. Paries quidem filium et virginitas non patieris detrimentum: efficieris gravida, et eris mater semper intacta. Ut benedicta. Gloria Patri. Ut Benedicta."
+                "la": "Suscipe verbum virgo Maria, quod tibi a Domino per Angelum transmissum est, concipies et paries Deum pariter et hominem: Ut benedicta dicaris inter omnes mulieres."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Hymn Te Deum, per totum Adventum et Septuagesimum usque ad Pascha non dicitur, nec semper repetitur in Adventu. ℟. a principio usque ad Nativitatem Domini, et usque ad Septuagesimum, et Pascha, dicitur ad Adventum."
+                "la": "Paries quidem filium et virginitas non patieris detrimentum: efficieris gravida, et eris mater semper intacta. Ut benedicta. Gloria Patri. Ut Benedicta."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Hymn Te Deum, per totum Adventum et Septuagesimum usque ad Pascha non dicitur, nec semper repetitur in Adventu. responsum a principio usque ad Nativitatem Domini, et usque ad Septuagesimum, et Pascha, dicitur ad Adventum."
               }
             },
             {
@@ -513,7 +604,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Reading (j. Eccl. 24. 6. ii)"
               }
@@ -525,7 +616,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Reading (ii)"
               }
@@ -539,11 +630,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Beata es Virgo Maria, quae Dominum portasti Creatorem mundi: Genuit qui te fecit et in aeternum permanes Virgo.\n℣. Ave Maria, gratia plena, Dominus tecum: Genuit."
+                "la": "Beata es Virgo Maria, quae Dominum portasti Creatorem mundi: Genuit qui te fecit et in aeternum permanes Virgo."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Ave Maria, gratia plena, Dominus tecum: Genuit."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Reading (iii)"
               }
@@ -557,7 +654,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Felix namque es sacra Virgo Maria, et omni laude dignissima.\n℣. Quia ex te ortus est sol justitiae Christus Deus noster."
+                "la": "Felix namque es sacra Virgo Maria, et omni laude dignissima."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Quia ex te ortus est sol justitiae Christus Deus noster."
               }
             },
             {
@@ -569,7 +672,7 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Sacerdotalis, Ave Maria gratia plena etc."
+                "la": "Sacerdotalis, Ave Maria gratia plena etc."
               }
             },
             {
@@ -579,10 +682,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Sacerdos. Elegit eam Deus, et praelegit eam\n℟. Et habitare eam facit in tabernaculo suo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sacerdos. Elegit eam Deus, et praelegit eam"
+                  },
+                  "r": {
+                    "la": "Et habitare eam facit in tabernaculo suo."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -597,7 +707,7 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium etc."
+                "la": "Deus in adjutorium etc."
               }
             },
             {
@@ -625,7 +735,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 92"
               }
@@ -637,7 +747,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 99"
               }
@@ -649,7 +759,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 62"
               }
@@ -661,7 +771,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 66"
               }
@@ -673,7 +783,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Trium Puerorum"
               }
@@ -685,7 +795,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 148"
               }
@@ -693,11 +803,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudate Dominum de caelis: laudate eum in excelsis.\nLaudate eum, omnes angeli ejus: laudate eum, omnes virtutes ejus.\nLaudate eum, sol et luna: laudate eum, omnes stellae et lumen.\nLaudate eum, caeli caelorum: et aquae omnes, quae super caelos sunt, laudent nomen Domini.\nQuia ipse dixit, et facta sunt: ipse mandavit, et creata sunt.\nStatuit ea in aeternum, et in saeculum saeculi: praeceptum posuit, et non praeteribit.\nLaudate Dominum de terra, dracones, et omnes abyssi.\nIgnis, grando, nix, glacies, spiritus procellarum: quae faciunt verbum ejus:\nMontes, et omnes colles: ligna fructifera, et omnes cedri.\nBestiae, et universa pecora: serpentes, et volucres pennatae:\nReges terrae, et omnes populi: principes, et omnes judices terrae.\nJuvenes, et virgines: senes cum junioribus laudent nomen Domini: quia exaltatum est nomen ejus solius.\nConfessio ejus super caelum et terram: et exaltavit cornu populi sui.\nHymnus omnibus sanctis ejus: filiis Israel, populo appropinquanti sibi."
+                "la": "Laudate Dominum de caelis: laudate eum in excelsis.\nLaudate eum, omnes angeli ejus: laudate eum, omnes virtutes ejus.\nLaudate eum, sol et luna: laudate eum, omnes stellae et lumen.\nLaudate eum, caeli caelorum: et aquae omnes, quae super caelos sunt, laudent nomen Domini.\nQuia ipse dixit, et facta sunt: ipse mandavit, et creata sunt.\nStatuit ea in aeternum, et in saeculum saeculi: praeceptum posuit, et non praeteribit.\nLaudate Dominum de terra, dracones, et omnes abyssi.\nIgnis, grando, nix, glacies, spiritus procellarum: quae faciunt verbum ejus:\nMontes, et omnes colles: ligna fructifera, et omnes cedri.\nBestiae, et universa pecora: serpentes, et volucres pennatae:\nReges terrae, et omnes populi: principes, et omnes judices terrae.\nJuvenes, et virgines: senes cum junioribus laudent nomen Domini: quia exaltatum est nomen ejus solius.\nConfessio ejus super caelum et terram: et exaltavit cornu populi sui."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus omnibus sanctis ejus: filiis Israel, populo appropinquanti sibi."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Psalm 149"
               }
@@ -709,7 +825,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 150"
               }
@@ -727,9 +843,15 @@
               }
             },
             {
+              "type": "subheading",
+              "text": {
+                "la": "Capitulum. - Isaiæ. 11."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Capitulum. - Isaiæ. 11.\nEgreditur virga de radice Jesse, et flos de radice ejus ascendet, et requiescet super eum Spiritus Domini."
+                "la": "Egreditur virga de radice Jesse, et flos de radice ejus ascendet, et requiescet super eum Spiritus Domini."
               }
             },
             {
@@ -739,46 +861,47 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Capitulum. Eccli. 24.\nEgo mater pulchra dilectionis et timoris et agnitionis et sanctae spei.\n℟. Deo gratias."
+              "type": "subheading",
+              "text": {
+                "la": "Capitulum. Eccli. 24."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Ego mater pulchra dilectionis et timoris et agnitionis et sanctae spei."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O Gloriosa Domina,\nExcellsa supra sidera,\nQui te creavit pro vide,\nLactasti sacro ubere."
+                "la": "O Gloriosa Domina,\nExcellsa supra sidera,\nQui te creavit pro vide,\nLactasti sacro ubere.\n\nQuod Eva tristis abstulit,\nTu reddis almo germini.\nIntente astra serbiles.\nCaeli fenestra facta es.\n\nTu Regis alti janua,\nEt porta lucis fulgida,\nVitam datam per virginem,\nGentes redemptae plaudite.\n\nGloria tibi Domine,\nQui natus es de Virgine,\nCum Patre et sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Quod Eva tristis abstulit,\nTu reddis almo germini.\nIntente astra serbiles.\nCaeli fenestra facta es."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Tu Regis alti janua,\nEt porta lucis fulgida,\nVitam datam per virginem,\nGentes redemptae plaudite."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi Domine,\nQui natus es de Virgine,\nCum Patre et sancto Spiritu,\nIn sempiterna saecula.\nAmen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Elegit eam Deus, et praelegit eam.\n℟. Et habitare eam facit in tabernaculo suo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Elegit eam Deus, et praelegit eam."
+                  },
+                  "r": {
+                    "la": "Et habitare eam facit in tabernaculo suo."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -793,7 +916,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Zachariae (Benedictus)"
               }
@@ -805,7 +928,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -817,7 +940,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -829,7 +952,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -853,7 +976,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -907,17 +1030,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Ave Maria gratia plena, etc.\n℣. Deus in adjutorium."
+                "la": "Ave Maria gratia plena, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus in adjutorium."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Memento salutis, usque supra ad Completorium."
               }
@@ -947,7 +1076,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 1"
               }
@@ -959,7 +1088,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 2"
               }
@@ -971,7 +1100,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 3"
               }
@@ -983,7 +1112,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum. - Eccli. 24."
               }
@@ -997,17 +1126,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. breve.\nAve Maria, gratia plena. Ave Maria.\n℣. Dominus tecum.\nGratia. Gloria Patri. Ave Maria."
+                "la": "breve."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Benedicta tu in mulieribus.\n℟. Et benedictus fructus ventris tui."
+                "la": "Ave Maria, gratia plena. Ave Maria."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Dominus tecum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gratia. Gloria Patri. Ave Maria."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicta tu in mulieribus."
+                  },
+                  "r": {
+                    "la": "Et benedictus fructus ventris tui."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -1031,17 +1185,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Ave Maria gratia plena, etc.\n℣. Deus in adjutorium."
+                "la": "Ave Maria gratia plena, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus in adjutorium."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Memento salutis auctor ut supra."
               }
@@ -1071,7 +1231,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 119"
               }
@@ -1083,7 +1243,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 120"
               }
@@ -1095,7 +1255,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 121"
               }
@@ -1107,7 +1267,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum. - Eccl. 24. 11."
               }
@@ -1121,14 +1281,40 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. breve. Speciosa facta es et suavis, in deliciis tuis.\n℣. Speciosa facta es.\n℟. Santa Dei genitrix.\nIn deliciis tuis. Gloria Patri. Speciosa facta."
+                "la": "breve. Speciosa facta es et suavis, in deliciis tuis."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Speciosa facta es."
+                  },
+                  "r": {
+                    "la": "Santa Dei genitrix."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Dignare me laudare te, Virgo sacra.\n℟. Da mihi virtutem contra hostes tuos."
+                "la": "In deliciis tuis. Gloria Patri. Speciosa facta."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dignare me laudare te, Virgo sacra."
+                  },
+                  "r": {
+                    "la": "Da mihi virtutem contra hostes tuos."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -1149,23 +1335,29 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Ave Maria gratia plena, etc.\n℣. Deus in adjutorium."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymn"
+                "la": "Ave Maria gratia plena, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Deus in adjutorium."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymn"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Memento salutis auctor ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon (in Adventu)"
               }
@@ -1189,7 +1381,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 121"
               }
@@ -1201,7 +1393,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 123"
               }
@@ -1213,7 +1405,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 124"
               }
@@ -1225,7 +1417,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Chapter (- Eccl. 24. 15)"
               }
@@ -1239,7 +1431,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. breve.\nDignare me laudare te. Virgo sacra. Dignare.\n℣. Da mihi virtutem contra hostes tuos. Virgo. Gloria Patri. Dignare."
+                "la": "breve."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Dignare me laudare te. Virgo sacra. Dignare."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Da mihi virtutem contra hostes tuos. Virgo. Gloria Patri. Dignare."
               }
             },
             {
@@ -1249,10 +1453,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Diffusa est gratia in labiis tuis.\n℟. Propterea benedixit te Deus in aeternum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Diffusa est gratia in labiis tuis."
+                  },
+                  "r": {
+                    "la": "Propterea benedixit te Deus in aeternum."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1261,9 +1472,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Diffusa est gratia. dicitur Post partum Virgo inviolata permanstit."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Diffusa est gratia. dicitur Post partum Virgo inviolata permanstit.\n℟. Dei genitrix intercede pro nobis."
+                "la": "Dei genitrix intercede pro nobis."
               }
             },
             {
@@ -1285,17 +1502,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Ave Maria gratia plena, etc.\n℣. Deus in adjutorium."
+                "la": "Ave Maria gratia plena, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus in adjutorium."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Memento salutis auctor ut supra."
               }
@@ -1325,7 +1548,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 125"
               }
@@ -1337,7 +1560,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 126"
               }
@@ -1349,7 +1572,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 127"
               }
@@ -1361,7 +1584,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum. - Eccl. 24. 16."
               }
@@ -1381,17 +1604,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. breve. Diffusa est gratia.\nIn labiis tuis.\nDiffusa est.\n℣. Propterea benedixit te Deus in aeternum.\nIn labiis. Gloria Patri.\nDiffusa."
+                "la": "breve. Diffusa est gratia."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Elegit eam Deus, et praelegit eam\n℟. Et habitare eam facit in tabernaculo suo."
+                "la": "In labiis tuis.\nDiffusa est."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Propterea benedixit te Deus in aeternum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "In labiis. Gloria Patri.\nDiffusa."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Elegit eam Deus, et praelegit eam"
+                  },
+                  "r": {
+                    "la": "Et habitare eam facit in tabernaculo suo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -1411,14 +1659,39 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. breve.\nPost partum Virgo. Inviolata permanstit.\nPost partum.\n℣. Dei genitrix intercede pro nobis.\nInviolata. Gloria Patri. Post partum."
+                "la": "breve."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Diffusa est gratia in labiis tuis.\n℟. Propterea benedixit te Deus in aeternum."
+                "la": "Post partum Virgo. Inviolata permanstit.\nPost partum."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Dei genitrix intercede pro nobis."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Inviolata. Gloria Patri. Post partum."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Diffusa est gratia in labiis tuis."
+                  },
+                  "r": {
+                    "la": "Propterea benedixit te Deus in aeternum."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -1437,10 +1710,17 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣.Ave Maria, gratia plena; Dominus tecum.\n℟.Benedicta tu in mulieribus, et benedictus fructus ventris tui."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria, gratia plena; Dominus tecum."
+                  },
+                  "r": {
+                    "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1449,10 +1729,30 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (vel:) Laus tibi, Domine, Rex aeternae gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (vel:) Laus tibi, Domine, Rex aeternae gloriae."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1461,7 +1761,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1479,7 +1779,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1491,7 +1791,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 109"
               }
@@ -1503,7 +1803,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 121"
               }
@@ -1515,7 +1815,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 126"
               }
@@ -1527,7 +1827,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 147"
               }
@@ -1563,19 +1863,32 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℟. Sequens est prosa, Inviolata dicitur singulis diebus Sabbati tantum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℟. Gaude Maria Virgo cunctas haereses sola interemisti quae Gabrielis Archangeli dictis credidit, Dum virgo Deum et hominem genuit Et post partum Virgo inviolata permanstit.\n℣. Gabrielem Archangelum scimus divinitus te esse affatum, uterum tuum de Spiritu Sancto credimus impregnatum; erubescat Judas infelix, qui dicit Christum ex Joseph femine esse natum Dum Virgo Deum.\nGloria Patri. Et post partum Virgo."
-              }
-            },
-            {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Sequens est prosa, Inviolata dicitur singulis diebus Sabbati tantum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gaude Maria Virgo cunctas haereses sola interemisti quae Gabrielis Archangeli dictis credidit, Dum virgo Deum et hominem genuit Et post partum Virgo inviolata permanstit."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gabrielem Archangelum scimus divinitus te esse affatum, uterum tuum de Spiritu Sancto credimus impregnatum; erubescat Judas infelix, qui dicit Christum ex Joseph femine esse natum Dum Virgo Deum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Et post partum Virgo."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prosa."
               }
@@ -1587,57 +1900,15 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ave maris stella,\nDei Mater alma,\nAtque semper Virgo,\nFelix caeli porta."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sumens illud Ave\nGabrielis ore,\nFunda nos in pace,\nMutans Hevae nomen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Solve vincla reis,\nProfer lumen caecis,\nMala nostra pelle,\nBona cuncta posce."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Monstra te esse matrem,\nSumat per te preces,\nQui pro nobis natus,\nTulit esse tuus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Virgo singularis,\nInter omnes mitis,\nNos culpis solutos\nMites fac et castos."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Vitam praesta puram,\nIter para tutum,\nUt videntes Jesum,\nSemper collaetemur."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit laus Deo Patri,\nSummo Christo decus,\nSpiritui Sancto,\nTribus honor unus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Amen."
+                "la": "Ave maris stella,\nDei Mater alma,\nAtque semper Virgo,\nFelix caeli porta.\n\nSumens illud Ave\nGabrielis ore,\nFunda nos in pace,\nMutans Hevae nomen.\n\nSolve vincla reis,\nProfer lumen caecis,\nMala nostra pelle,\nBona cuncta posce.\n\nMonstra te esse matrem,\nSumat per te preces,\nQui pro nobis natus,\nTulit esse tuus.\n\nVirgo singularis,\nInter omnes mitis,\nNos culpis solutos\nMites fac et castos.\n\nVitam praesta puram,\nIter para tutum,\nUt videntes Jesum,\nSemper collaetemur.\n\nSit laus Deo Patri,\nSummo Christo decus,\nSpiritui Sancto,\nTribus honor unus.\n\nAmen."
               }
             },
             {
@@ -1647,7 +1918,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1659,7 +1930,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -1677,13 +1948,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ave Maria gratia plena.\n℟. Dominus tecum, benedicta tu in mulieribus."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria gratia plena."
+                  },
+                  "r": {
+                    "la": "Dominus tecum, benedicta tu in mulieribus."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1695,7 +1973,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -1713,13 +1991,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Post partum Virgo inviolata permanstit.\n℟. Dei genitrix intercedet pro nobis."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Post partum Virgo inviolata permanstit."
+                  },
+                  "r": {
+                    "la": "Dei genitrix intercedet pro nobis."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1731,7 +2016,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -1749,10 +2034,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Post partum Virgo inviolata permanstit.\n℟. Dei genitrix intercedet pro nobis."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Post partum Virgo inviolata permanstit."
+                  },
+                  "r": {
+                    "la": "Dei genitrix intercedet pro nobis."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1761,7 +2053,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1769,11 +2061,24 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce Dominus veniet et omnes Sancti ejus cum eo, et erit in die illa lux magna, allelúia.\n℣. Laetamini in Domino, et exultate justi.\n℟. Et gloriamini omnes recti corde."
+                "la": "Ecce Dominus veniet et omnes Sancti ejus cum eo, et erit in die illa lux magna, allelúia."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Laetamini in Domino, et exultate justi."
+                  },
+                  "r": {
+                    "la": "Et gloriamini omnes recti corde."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -1791,7 +2096,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1799,23 +2104,36 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancti tui Domine florebunt sicut lilium, * allelúia, et sicut odor balsami erunt ante te, allelúia.\n℣. Gaudete justi in Domino, allelúia.\n℟. Rectos delect colludatio, allelúia."
+                "la": "Sancti tui Domine florebunt sicut lilium, * allelúia, et sicut odor balsami erunt ante te, allelúia."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gaudete justi in Domino, allelúia."
+                  },
+                  "r": {
+                    "la": "Rectos delect colludatio, allelúia."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Laetetur Ecclesia, ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Commemorationes"
               }
@@ -1833,7 +2151,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1845,13 +2163,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. In conspectu Angelorum psallam tibi Domine.\n℟. Adorabo ad templum sanctum tuum, et confitebor nomini tuo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In conspectu Angelorum psallam tibi Domine."
+                  },
+                  "r": {
+                    "la": "Adorabo ad templum sanctum tuum, et confitebor nomini tuo."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -1869,13 +2194,13 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Commemoratio de Apostolis."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -1883,11 +2208,24 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Gloriosi principes terrae, quomodo in vita sua dilexerunt se, ita et in morte non sunt separati.\n℣. In omnem terram exivit sonus eorum.\n℟. Et in fines orbis terrae verba eorum."
+                "la": "Gloriosi principes terrae, quomodo in vita sua dilexerunt se, ita et in morte non sunt separati."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In omnem terram exivit sonus eorum."
+                  },
+                  "r": {
+                    "la": "Et in fines orbis terrae verba eorum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -1911,7 +2249,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -1923,7 +2261,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -1941,7 +2279,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "OCommemoratio de S. Nicolao Episcopo et Confessore."
               }
@@ -1959,13 +2297,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis beate Nicolai.\n℟. Ut digni efficiamur promissionibus Christi."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis beate Nicolai."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -1983,13 +2328,13 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Commemoratio de SS. Ursula et sociis Virginibus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2001,13 +2346,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Gloriosus Deus in Sanctis suis.\n℟. Mirabilis in majestate sua."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloriosus Deus in Sanctis suis."
+                  },
+                  "r": {
+                    "la": "Mirabilis in majestate sua."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -2031,25 +2383,32 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Commemoratio de omnibus Sanctis."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "subheading",
+              "text": {
                 "la": "Antiphona. Sancti Dei omnes intercedite pro nostra omniumque salute."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Laetamini in Domino, et exsultate justi.\n℟. Et gloriamini omnes recti corde."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Laetamini in Domino, et exsultate justi."
+                  },
+                  "r": {
+                    "la": "Et gloriamini omnes recti corde."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -2061,10 +2420,30 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Dominus vobiscum.\n℟. Et cum spiritu tuo.\n℣. Benedicamus Domino.\n℟. Deo gratias."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -2073,7 +2452,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 66"
               }
@@ -2085,13 +2464,33 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Salvos fac servos tuos, et ancillas tuas.\n℟. Deus meus sperantes in te.\n℣. Dominus vobiscum.\n℟. Et cum spiritu tuo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Salvos fac servos tuos, et ancillas tuas."
+                  },
+                  "r": {
+                    "la": "Deus meus sperantes in te."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -2111,14 +2510,21 @@
             {
               "type": "rubric",
               "text": {
-                "la": "Supadditae commemorationes, cum Psalm. Deus misereatur, omissus fuerit singulis Festis Dupl. et supra, et quibusdam aliis diebus in Officio Canonico notatis. In Festis tamen Dupl. et Majoribus Dupl. per annum. Oratio Concede nos. et Laetetur, sub uno Per Dominum. dicuntur, praesertim in Adventu et ab Off. Epiph. usque ad Purificationem; in Adventu enim dicitur Oratio Deus qui de Beatae et Conscientias, et ab Off. Epiph. usque ad Purificat. Oratio. Deus qui salutis et Laetetur, ut supra. deinde ℣. Dominus vobiscum. ℟. Benedicamus Domino. Postea subjungitur."
+                "la": "Supadditae commemorationes, cum Psalm. Deus misereatur, omissus fuerit singulis Festis Dupl. et supra, et quibusdam aliis diebus in Officio Canonico notatis. In Festis tamen Dupl. et Majoribus Dupl. per annum. Oratio Concede nos. et Laetetur, sub uno Per Dominum. dicuntur, praesertim in Adventu et ab Off. Epiph. usque ad Purificationem; in Adventu enim dicitur Oratio Deus qui de Beatae et Conscientias, et ab Off. Epiph. usque ad Purificat. Oratio. Deus qui salutis et Laetetur, ut supra. deinde versus Dominus vobiscum. responsum Benedicamus Domino. Postea subjungitur."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Fidelium animae defunctorum per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae defunctorum per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -2133,11 +2539,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Ave Maria gratia plena, etc.\n℣. Converte nos Deus etc.\n℣. Deus in adjutorium etc."
+                "la": "Ave Maria gratia plena, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Converte nos Deus etc."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus in adjutorium etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -2149,7 +2567,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 12"
               }
@@ -2161,7 +2579,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 42"
               }
@@ -2173,7 +2591,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 128"
               }
@@ -2185,7 +2603,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalm 130"
               }
@@ -2197,7 +2615,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum. - Eccl. 24. 20."
               }
@@ -2209,27 +2627,15 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Memento salutis auctor,\nQuod nostri quondam corporis,\nEx illibata virgine\nNascendo formam sumpseris,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Maria mater gratiae,\nMater misericordiae;\nTu nos ab hoste protege,\nEt hora mortis suscipe."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Gloria tibi Domine,\nQui natus es de Virgine,\nCum Patre et sancto Spiritu,\nIn sempiterna saecula.\nAmen."
+                "la": "Memento salutis auctor,\nQuod nostri quondam corporis,\nEx illibata virgine\nNascendo formam sumpseris,\n\nMaria mater gratiae,\nMater misericordiae;\nTu nos ab hoste protege,\nEt hora mortis suscipe.\n\nGloria tibi Domine,\nQui natus es de Virgine,\nCum Patre et sancto Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
@@ -2239,10 +2645,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ave Maria, gratia plena.\n℟. Dominus tecum, benedicta tu in mulieribus."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria, gratia plena."
+                  },
+                  "r": {
+                    "la": "Dominus tecum, benedicta tu in mulieribus."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -2251,10 +2664,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Post partum Virgo inviolata permanstit.\n℟. Dei genitrix intercede pro nobis."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Post partum Virgo inviolata permanstit."
+                  },
+                  "r": {
+                    "la": "Dei genitrix intercede pro nobis."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -2287,7 +2707,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -2299,7 +2719,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -2323,7 +2743,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -2335,7 +2755,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
@@ -2347,9 +2767,22 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus Vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Dominus Vobiscum.\n℟. Et cum spiritu tuo.\n℣. Benedicamus Domino."
+                "la": "Benedicamus Domino."
               }
             },
             {

--- a/content/practices/little-office-bvm-roman/flow.json
+++ b/content/practices/little-office-bvm-roman/flow.json
@@ -27,14 +27,78 @@
           },
           "sections": [
             {
+              "type": "rubric",
+              "text": {
+                "en-US": "The Hail Mary is prayed silently."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "The Hail Mary is prayed silently.\nAve Maria, gratia plena; Dominus tecum: benedicta tu in mulieribus, et benedictus fructus ventris tui Jesus.\nSancta Maria, Mater Dei, ora pro nobis peccatoribus, nunc et in hora mortis nostrae. Amen.\nAll trace the sign of the cross on their lips.\n℣. Domine, labia ✠ ea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae.\nInvitatory",
-                "en-US": "The Hail Mary is prayed silently.\nHail Mary, full of grace; The Lord is with thee; Blessed art thou amongst women, And blessed is the fruit of thy womb, Jesus.\nHoly Mary, Mother of God, Pray for us sinners, now and at the hour of our death. Amen.\nAll trace the sign of the cross on their lips.\n℣. Lord, ✠ Thou shalt open my lips.\n℟. And my mouth shall declare Thy praise.\n℣. O God, ✠ hasten to mine aid\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, world without end. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Praise be to Thee, O Lord, King of glory everlasting.\nInvitatory"
+                "la": "Ave Maria, gratia plena; Dominus tecum: benedicta tu in mulieribus, et benedictus fructus ventris tui Jesus.\nSancta Maria, Mater Dei, ora pro nobis peccatoribus, nunc et in hora mortis nostrae. Amen.",
+                "en-US": "Hail Mary, full of grace; The Lord is with thee; Blessed art thou amongst women, And blessed is the fruit of thy womb, Jesus.\nHoly Mary, Mother of God, Pray for us sinners, now and at the hour of our death. Amen."
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "en-US": "All trace the sign of the cross on their lips."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia ✠ ea aperies.",
+                    "en-US": "Lord, ✠ Thou shalt open my lips."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam.",
+                    "en-US": "And my mouth shall declare Thy praise."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende.",
+                    "en-US": "O God, ✠ hasten to mine aid"
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto.",
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae.",
+                    "en-US": "As it was in the beginning, is now, and ever shall be, world without end. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Praise be to Thee, O Lord, King of glory everlasting."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Invitatory",
+                "en-US": "Invitatory"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -48,7 +112,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -57,12 +121,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ave Maria, gratia plena, Dominus tecum.\nPsalm 94\nVenite, exsultemus Domino, jubilemus Deo, salutari nostro: praeoccupemus faciem ejus in confessione, et in psalmis jubilemus ei.\nAve Maria, gratia plena, Dominus tecum.\nQuoniam Deus magnus Dominus, et Rex magnus super omnes deos, quoniam non repellet Dominus plebem suam: quia in manu ejus sunt omnes fines terrae, et altitudines montium ipse conspicit.\nDominus tecum.\nQuoniam ipsius est mare, et ipse fecit illud, et aridam fundaverunt manus ejus (genuflectitur) venite, adoremus, et procidamus ante Deum: ploremus coram Domino, qui fecit nos, quia ipse est Dominus, Deus noster; nos autem populus ejus, et oves pascuae ejus.\nAve Maria, gratia plena, Dominus tecum.\nHodie, si vocem ejus audieritis, nolite obdurare corda vestra, sicut in exacerbatione secundum diem tentationis in deserto: ubi tentaverunt me patres vestri, probaverunt et viderunt opera mea.\nDominus tecum.\nQuadraginta annis proximus fui generationi huic, et dixi; Semper hi errant corde, ipsi vero non cognoverunt vias meas: quibus juravi in ira mea; Si introibunt in requiem meam.\nAve Maria, gratia plena, Dominus tecum.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "Hail, Mary, full of grace, the Lord is with thee.\nPsalm 94\nO come, let us exult in the Lord; let us rejoice before God our Saviour. Let us come into His presence with thanksgiving; and rejoice before Him with psalms.\nHail, Mary, full of grace, the Lord is with thee.\nFor the Lord is a great God, and a great King above all gods; for the Lord will not cast off His people, for in His hand are all the ends of the earth; and the heights of the mountains He beholdeth.\nThe Lord is with thee.\nFor the sea is His, and He made it; and His hands formed the dry land. (genuflect) Come, let us worship and fall down before God; let us weep before the Lord that made us; for He is the Lord our God; and we are His people, and the sheep of His pasture.\nHail, Mary, full of grace, the Lord is with thee.\nToday if ye shall hear His voice, harden not your hearts; as in the provocation, according to the day of temptation in the wilderness: where your fathers tempted Me, proved and saw My works.\nThe Lord is with thee.\nForty years long was I nigh unto that generation, and said: They do always err in their heart; and they have not known My ways, to whom I swore in My wrath that they should not enter into My rest.\nHail, Mary, full of grace, the Lord is with thee.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Ave Maria, gratia plena, Dominus tecum.",
+                "en-US": "Hail, Mary, full of grace, the Lord is with thee."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 94",
+                "en-US": "Psalm 94"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Venite, exsultemus Domino, jubilemus Deo, salutari nostro: praeoccupemus faciem ejus in confessione, et in psalmis jubilemus ei.\nAve Maria, gratia plena, Dominus tecum.\nQuoniam Deus magnus Dominus, et Rex magnus super omnes deos, quoniam non repellet Dominus plebem suam: quia in manu ejus sunt omnes fines terrae, et altitudines montium ipse conspicit.\nDominus tecum.\nQuoniam ipsius est mare, et ipse fecit illud, et aridam fundaverunt manus ejus (genuflectitur) venite, adoremus, et procidamus ante Deum: ploremus coram Domino, qui fecit nos, quia ipse est Dominus, Deus noster; nos autem populus ejus, et oves pascuae ejus.\nAve Maria, gratia plena, Dominus tecum.\nHodie, si vocem ejus audieritis, nolite obdurare corda vestra, sicut in exacerbatione secundum diem tentationis in deserto: ubi tentaverunt me patres vestri, probaverunt et viderunt opera mea.\nDominus tecum.\nQuadraginta annis proximus fui generationi huic, et dixi; Semper hi errant corde, ipsi vero non cognoverunt vias meas: quibus juravi in ira mea; Si introibunt in requiem meam.\nAve Maria, gratia plena, Dominus tecum.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "O come, let us exult in the Lord; let us rejoice before God our Saviour. Let us come into His presence with thanksgiving; and rejoice before Him with psalms.\nHail, Mary, full of grace, the Lord is with thee.\nFor the Lord is a great God, and a great King above all gods; for the Lord will not cast off His people, for in His hand are all the ends of the earth; and the heights of the mountains He beholdeth.\nThe Lord is with thee.\nFor the sea is His, and He made it; and His hands formed the dry land. (genuflect) Come, let us worship and fall down before God; let us weep before the Lord that made us; for He is the Lord our God; and we are His people, and the sheep of His pasture.\nHail, Mary, full of grace, the Lord is with thee.\nToday if ye shall hear His voice, harden not your hearts; as in the provocation, according to the day of temptation in the wilderness: where your fathers tempted Me, proved and saw My works.\nThe Lord is with thee.\nForty years long was I nigh unto that generation, and said: They do always err in their heart; and they have not known My ways, to whom I swore in My wrath that they should not enter into My rest.\nHail, Mary, full of grace, the Lord is with thee.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -76,7 +154,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -90,21 +168,28 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Quem terra, pontus, sidera\nColunt, adorant, praedicant,\nTrinam regentem machinam,\nClaustrum Mariae bajulat.\nCui luna, sol, et omnia\nDeserviunt per tempora,\nPerfusa caeli gratia,\nGestant puellae viscera.\nBeata Mater munere,\nCujus supernus artifex\nMundum pugillo continens,\nVentris sub arca clausus est.\nBeata caeli nuntio,\nFœcunda sancto Spiritu,\nDesideratus gentibus,\nCujus per alvum fusus est.\nJesu, tibi sit gloria,\nQui natus es de Virgine,\nCum Patre et almo Spiritu,\nIn sempiterna saecula.\nAmen.\nPsalms for Sunday, Monday and Thursday",
-                "en-US": "The Lord, Whom earth, and air, and sea\nWith one adoring voice resound;\nWho rules them all in majesty;\nIn Mary's heart a cloister found.\nLo! in a humble virgin's womb\nOvershadowed by almighty power,\nHe Whom the stars, and sun, and moon,\nEach serve in their appointed hour.\nO Mother blest, to whom was given\nWithin thy compass to contain\nThe Architect of earth and heaven,\nWhose hands the universe sustain!\nTo thee was sent an angel down;\nIn thee the Spirit was enshrined;\nFrom thee came forth that mighty One,\nThe long-desired of all mankind.\nO Jesu! born of virgin bright,\nImmortal glory be to Thee;\nPraise to the Father infinite,\nAnd Holy Ghost eternally.\nAmen.\nPsalms for Sunday, Monday and Thursday"
+                "la": "Quem terra, pontus, sidera\nColunt, adorant, praedicant,\nTrinam regentem machinam,\nClaustrum Mariae bajulat.\nCui luna, sol, et omnia\nDeserviunt per tempora,\nPerfusa caeli gratia,\nGestant puellae viscera.\nBeata Mater munere,\nCujus supernus artifex\nMundum pugillo continens,\nVentris sub arca clausus est.\nBeata caeli nuntio,\nFœcunda sancto Spiritu,\nDesideratus gentibus,\nCujus per alvum fusus est.\nJesu, tibi sit gloria,\nQui natus es de Virgine,\nCum Patre et almo Spiritu,\nIn sempiterna saecula.\nAmen.",
+                "en-US": "The Lord, Whom earth, and air, and sea\nWith one adoring voice resound;\nWho rules them all in majesty;\nIn Mary's heart a cloister found.\nLo! in a humble virgin's womb\nOvershadowed by almighty power,\nHe Whom the stars, and sun, and moon,\nEach serve in their appointed hour.\nO Mother blest, to whom was given\nWithin thy compass to contain\nThe Architect of earth and heaven,\nWhose hands the universe sustain!\nTo thee was sent an angel down;\nIn thee the Spirit was enshrined;\nFrom thee came forth that mighty One,\nThe long-desired of all mankind.\nO Jesu! born of virgin bright,\nImmortal glory be to Thee;\nPraise to the Father infinite,\nAnd Holy Ghost eternally.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalms for Sunday, Monday and Thursday",
+                "en-US": "Psalms for Sunday, Monday and Thursday"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -113,12 +198,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Benedicta tu.\nPsalm 8\nDomine, Dominus noster, quam admirabile est nomen tuum in universa terra!\nQuoniam elevata est magnificentia tua, super caelos.\nEx ore infantium et lactentium perfecisti laudem propter inimicos tuos, ut destruas inimicum et ultorem.\nQuoniam videbo caelos tuos, opera digitorum tuorum: lunam et stellas, quae tu fundasti.\nQuid est homo quod memor es ejus? aut filius hominis, quoniam visitas eum?\nMinuisti eum paulo minus ab angelis, gloria et honore coronasti eum: et constituisti eum super opera manuum tuarum.\nomnia subjecisti sub pedibus ejus, oves et boves universas: insuper et pecora campi.\nVolucres caeli, et pisces maris, qui perambulant semitas maris.\nDomine, Dominus noster, quam admirabile est nomen tuum in universa terra!\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "Blessed art thou amongst women.\nPsalm 8\nO Lord, our Lord, how admirable is Thy name in the whole earth!\nFor Thy magnificence is exalted above the heavens.\nOut of the mouth of babes and sucklings Thou hast perfected praise because of Thine enemies, that Thou mayest destroy the enemy and the avenger.\nFor I will behold Thy heavens, the works of Thy fingers: the moon and the stars which Thou hast set.\nWhat is man that Thou art mindful of him? or the son of man that Thou visitest him?\nThou hast made him a little less than the angels, Thou hast crowned him with glory and honor; and hast set him over the works of Thy hands.\nAll things Thou hast put under his feet: sheep and all oxen, yea, also the beasts of the field.\nThe birds of the air and the fishes of the sea, that pass through the paths of the sea.\nO Lord, our Lord, how admirable is Thy name in all the earth!\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Benedicta tu.",
+                "en-US": "Blessed art thou amongst women."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 8",
+                "en-US": "Psalm 8"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Domine, Dominus noster, quam admirabile est nomen tuum in universa terra!\nQuoniam elevata est magnificentia tua, super caelos.\nEx ore infantium et lactentium perfecisti laudem propter inimicos tuos, ut destruas inimicum et ultorem.\nQuoniam videbo caelos tuos, opera digitorum tuorum: lunam et stellas, quae tu fundasti.\nQuid est homo quod memor es ejus? aut filius hominis, quoniam visitas eum?\nMinuisti eum paulo minus ab angelis, gloria et honore coronasti eum: et constituisti eum super opera manuum tuarum.\nomnia subjecisti sub pedibus ejus, oves et boves universas: insuper et pecora campi.\nVolucres caeli, et pisces maris, qui perambulant semitas maris.\nDomine, Dominus noster, quam admirabile est nomen tuum in universa terra!\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "O Lord, our Lord, how admirable is Thy name in the whole earth!\nFor Thy magnificence is exalted above the heavens.\nOut of the mouth of babes and sucklings Thou hast perfected praise because of Thine enemies, that Thou mayest destroy the enemy and the avenger.\nFor I will behold Thy heavens, the works of Thy fingers: the moon and the stars which Thou hast set.\nWhat is man that Thou art mindful of him? or the son of man that Thou visitest him?\nThou hast made him a little less than the angels, Thou hast crowned him with glory and honor; and hast set him over the works of Thy hands.\nAll things Thou hast put under his feet: sheep and all oxen, yea, also the beasts of the field.\nThe birds of the air and the fishes of the sea, that pass through the paths of the sea.\nO Lord, our Lord, how admirable is Thy name in all the earth!\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -132,7 +231,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -141,12 +240,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sicut myrrha.\nPsalm 18\nCaeli enarrant gloriam Dei: et opera manuum ejus annuntiat firmamentum.\nDies diei eructat verbum, et nox nocti indicat scientiam.\nNon sunt loquelae, neque sermones, quorum non audiantur voces eorum.\nIn omnem terram exivit sonus eorum: et in fines orbis terrae verba eorum.\nIn sole posuit tabernaculum suum: et ipse tamquam sponsus procedens de thalamo suo:\nExsultavit ut gigas ad currendam viam, a summo caelo egressio ejus:\nEt occursus ejus usque ad summum ejus: nec est qui se abscondat a calore ejus.\nLex Domini immaculata, convertens animas: testimonium Domini fidele, sapientiam praestans parvulis.\nJustitiae Domini rectae, laetificantes corda: praeceptum Domini lucidum, illuminans oculos.\nTimor Domini sanctus, permanens in saeculum saeculi: judicia Domini vera, justificata in semetipsa.\nDesiderabilia super aurum et lapidem pretiosum multum: et dulciora super mel et favum.\netenim servus tuus custodit ea, in custodiendis illis retributio multa.\nDelicta quis intellegit? ab occultis meis munda me: et ab alienis parce servo tuo.\nSi mei non fuerint dominati, tunc immaculatus ero: et emundabor a delicto maximo.\nEt erunt ut complaceant eloquia oris mei: et meditatio cordis mei in conspectu tuo semper.\nDomine, adjutor meus, et redemptor meus.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "Like unto choice myrrh.\nPsalm 18\nThe heavens are telling the glory of God; and the firmament declareth the works of His hands.\nDay unto day uttereth speech; and night unto night showeth knowledge.\nThey are not speeches nor words, whose voices are not heard.\nUnto all the earth their sound hath gone forth, and their words unto the ends of the world.\nIn the sun hath He set His tabernacle; and as a bridegroom cometh out His bride-chamber.\nHe hath rejoiced as a giant to run His course. His going forth is from the end of heaven;\nAnd His course even unto the end thereof: and there is none that is hid from His heat.\nThe law of the Lord is without spot, converting souls: the testimony of the Lord is faithful, giving wisdom to little ones.\nThe precepts of the Lord are right, rejoicing hearts: the commandment of the Lord is lightsome, enlightening the eyes.\nThe fear of the Lord is holy, enduring for ever and ever: the judgments of the Lord are true, justified in themselves.\nMore to be desired are they than gold and many precious stones; and sweeter than honey and the honey-comb.\nFor Thy servant keepeth them; and in keeping them there is great reward.\nWho understandeth his sins? From my secret ones cleanse me, and from strangers spare Thy servant.\nIf they shall have no dominion over me, then shall I be without spot: and I shall be cleansed from grievous sin.\nAnd the sayings of my mouth and the meditation of my heart in Thy sight shall be ever pleasing.\nO Lord, my helper and my redeemer.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Sicut myrrha.",
+                "en-US": "Like unto choice myrrh."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 18",
+                "en-US": "Psalm 18"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Caeli enarrant gloriam Dei: et opera manuum ejus annuntiat firmamentum.\nDies diei eructat verbum, et nox nocti indicat scientiam.\nNon sunt loquelae, neque sermones, quorum non audiantur voces eorum.\nIn omnem terram exivit sonus eorum: et in fines orbis terrae verba eorum.\nIn sole posuit tabernaculum suum: et ipse tamquam sponsus procedens de thalamo suo:\nExsultavit ut gigas ad currendam viam, a summo caelo egressio ejus:\nEt occursus ejus usque ad summum ejus: nec est qui se abscondat a calore ejus.\nLex Domini immaculata, convertens animas: testimonium Domini fidele, sapientiam praestans parvulis.\nJustitiae Domini rectae, laetificantes corda: praeceptum Domini lucidum, illuminans oculos.\nTimor Domini sanctus, permanens in saeculum saeculi: judicia Domini vera, justificata in semetipsa.\nDesiderabilia super aurum et lapidem pretiosum multum: et dulciora super mel et favum.\netenim servus tuus custodit ea, in custodiendis illis retributio multa.\nDelicta quis intellegit? ab occultis meis munda me: et ab alienis parce servo tuo.\nSi mei non fuerint dominati, tunc immaculatus ero: et emundabor a delicto maximo.\nEt erunt ut complaceant eloquia oris mei: et meditatio cordis mei in conspectu tuo semper.\nDomine, adjutor meus, et redemptor meus.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "The heavens are telling the glory of God; and the firmament declareth the works of His hands.\nDay unto day uttereth speech; and night unto night showeth knowledge.\nThey are not speeches nor words, whose voices are not heard.\nUnto all the earth their sound hath gone forth, and their words unto the ends of the world.\nIn the sun hath He set His tabernacle; and as a bridegroom cometh out His bride-chamber.\nHe hath rejoiced as a giant to run His course. His going forth is from the end of heaven;\nAnd His course even unto the end thereof: and there is none that is hid from His heat.\nThe law of the Lord is without spot, converting souls: the testimony of the Lord is faithful, giving wisdom to little ones.\nThe precepts of the Lord are right, rejoicing hearts: the commandment of the Lord is lightsome, enlightening the eyes.\nThe fear of the Lord is holy, enduring for ever and ever: the judgments of the Lord are true, justified in themselves.\nMore to be desired are they than gold and many precious stones; and sweeter than honey and the honey-comb.\nFor Thy servant keepeth them; and in keeping them there is great reward.\nWho understandeth his sins? From my secret ones cleanse me, and from strangers spare Thy servant.\nIf they shall have no dominion over me, then shall I be without spot: and I shall be cleansed from grievous sin.\nAnd the sayings of my mouth and the meditation of my heart in Thy sight shall be ever pleasing.\nO Lord, my helper and my redeemer.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -160,7 +273,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -169,12 +282,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ante torum.\nPsalm 23\nDomini est terra, et plenitudo ejus: orbis terrarum, et universi qui habitant in eo.\nQuia ipse super maria fundavit eum: et super flumina praeparavit eum.\nQuis ascendet in montem Domini? aut quis stabit in loco sancto ejus?\ninnocens manibus et mundo corde, qui non accepit in vano animam suam, nec juravit in dolo proximo suo.\nHic accipiet benedictionem a Domino: et misericordiam a Deo, salutari suo.\nHaec est generatio quaerentium eum, quaerentium faciem Dei Jacob.\nAttollite portas, principes, vestras, et elevamini, portae aeternales: et introibit Rex gloriae.\nQuis est iste Rex gloriae? Dominus fortis et potens: Dominus potens in praelio.\nAttollite portas, principes, vestras, et elevamini, portae aeternales: et introibit Rex gloriae.\nQuis est iste Rex gloriae? Dominus virtutum ipse est Rex gloriae.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "Before this Virgin's couch.\nPsalm 23\nThe earth is the Lord's, and the fullness thereof: the world and all they that dwell therein.\nFor He hath founded it upon the seas; and hath prepared it upon the rivers.\nWho shall go up to the mountain of the Lord? or who shall stand in His holy place?\nHe that hath clean hands and a pure heart: who hath not taken his soul in vain, nor sworn deceitfully to his neighbour.\nHe shall receive a blessing from the Lord, and mercy from God his Saviour.\nThis is the generation of them that seek Him: of them that seek the face of the God of Jacob.\nLift up your gates, O ye princes, and be ye lifted up, O eternal gates: and the King of glory shall enter in.\nWho is this King of glory? The Lord strong and mighty: the Lord mighty in battle.\nLift up your gates, O ye princes, and be ye lifted up, O eternal gates; and the King of glory shall enter in.\nWho is this King of glory? The Lord of hosts, He is the King of glory.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Ante torum.",
+                "en-US": "Before this Virgin's couch."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 23",
+                "en-US": "Psalm 23"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Domini est terra, et plenitudo ejus: orbis terrarum, et universi qui habitant in eo.\nQuia ipse super maria fundavit eum: et super flumina praeparavit eum.\nQuis ascendet in montem Domini? aut quis stabit in loco sancto ejus?\ninnocens manibus et mundo corde, qui non accepit in vano animam suam, nec juravit in dolo proximo suo.\nHic accipiet benedictionem a Domino: et misericordiam a Deo, salutari suo.\nHaec est generatio quaerentium eum, quaerentium faciem Dei Jacob.\nAttollite portas, principes, vestras, et elevamini, portae aeternales: et introibit Rex gloriae.\nQuis est iste Rex gloriae? Dominus fortis et potens: Dominus potens in praelio.\nAttollite portas, principes, vestras, et elevamini, portae aeternales: et introibit Rex gloriae.\nQuis est iste Rex gloriae? Dominus virtutum ipse est Rex gloriae.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "The earth is the Lord's, and the fullness thereof: the world and all they that dwell therein.\nFor He hath founded it upon the seas; and hath prepared it upon the rivers.\nWho shall go up to the mountain of the Lord? or who shall stand in His holy place?\nHe that hath clean hands and a pure heart: who hath not taken his soul in vain, nor sworn deceitfully to his neighbour.\nHe shall receive a blessing from the Lord, and mercy from God his Saviour.\nThis is the generation of them that seek Him: of them that seek the face of the God of Jacob.\nLift up your gates, O ye princes, and be ye lifted up, O eternal gates: and the King of glory shall enter in.\nWho is this King of glory? The Lord strong and mighty: the Lord mighty in battle.\nLift up your gates, O ye princes, and be ye lifted up, O eternal gates; and the King of glory shall enter in.\nWho is this King of glory? The Lord of hosts, He is the King of glory.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -183,12 +310,56 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ante torum hujus Virginis frequentate nobis dulcia cantica dramatis.\n℣. Diffusa est gratia in labiis tuis.\n℟. Propterea benedixit te Deus in aeternum.\nPater noster... [continue silently]\n℣. Et ne nos inducas in tentationem:\n℟. Sed libera nos a malo.\nPsalms for Tuesday and Friday",
-                "en-US": "Before this Virgin's couch sing us again and again the sweet songs of the play.\n℣. Grace is poured forth on thy lips.\n℟. Therefore hath God blessed thee for ever.\nOur Father... [continue silently]\n℣. And lead us not into temptation:\n℟. But deliver us from evil.\nPsalms for Tuesday and Friday"
+                "la": "Ante torum hujus Virginis frequentate nobis dulcia cantica dramatis.",
+                "en-US": "Before this Virgin's couch sing us again and again the sweet songs of the play."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Diffusa est gratia in labiis tuis.",
+                    "en-US": "Grace is poured forth on thy lips."
+                  },
+                  "r": {
+                    "la": "Propterea benedixit te Deus in aeternum.",
+                    "en-US": "Therefore hath God blessed thee for ever."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Pater noster... [continue silently]",
+                "en-US": "Our Father... [continue silently]"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem:",
+                    "en-US": "And lead us not into temptation:"
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo.",
+                    "en-US": "But deliver us from evil."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Psalms for Tuesday and Friday",
+                "en-US": "Psalms for Tuesday and Friday"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -197,12 +368,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Specie tua.\nPsalm 44\nEructavit cor meum verbum bonum: dico ego opera mea Regi.\nLingua mea calamus scribae: velociter scribentis.\nSpeciosus forma prae filiis hominum, diffusa est gratia in labiis tuis: propterea benedixit te Deus in aeternum.\nAccingere gladio tuo super femur tuum, potentissime.\nSpecie tua et pulchritudine tua: intende, prospere procede, et regna.\nPropter veritatem, et mansuetudinem, et justitiam: et deducet te mirabiliter dextera tua.\nSagittae tuae acutae, populi sub te cadent: in corda inimicorum Regis.\nSedes tua, Deus, in saeculum saeculi: virga directionis virga regni tui.\nDilexisti justitiam, et odisti iniquitatem: propterea unxit te Deus, Deus tuus, oleo laetitiae prae consortibus tuis.\nMyrrha, et gutta, et casia a vestimentis tuis, a domibus eburneis: ex quibus delectaverunt te filiae regum in honore tuo.\nastitit regina a dextris tuis in vestitu deaurato: circumdata varietate.\nAudi filia, et vide, et inclina aurem tuam: et obliviscere populum tuum et domum patris tui.\nEt concupiscet Rex decorem tuum: quoniam ipse est Dominus Deus tuus, et adorabunt eum.\nEt filiae Tyri in muneribus vultum tuum deprecabuntur: omnes divites plebis.\nOmnis gloria ejus filiae Regis ab intus, in fimbriis aureis circumamicta varietatibus.\nAdducentur Regi virgines post eam: proximae ejus afferentur tibi.\nAfferentur in laetitia et exsultatione: adducentur in templum Regis.\nPro patribus tuis nati sunt tibi filii: constitues eos principes super omnem terram.\nMemores erunt nominis tui: in omni generatione et generationem.\nPropterea populi confitebuntur tibi in aeternum: et in saeculum saeculi.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "In thy comeliness.\nPsalm 44\nMy heart hath uttered a good word: I address my works to the King.\nMy tongue is the pen of a writer that writeth swiftly.\nThou art beautiful above the sons of men, grace is poured forth on Thy lips; therefore God hath blessed Thee for ever.\nGird Thy sword upon Thy thigh, O Thou most mighty.\nWith Thy comeliness and Thy beauty, bend [Thy bow], advance prosperously, and reign.\nIn behalf of truth and meekness and justice; and Thy right hand shall guide Thee wondrously.\nThine arrows are sharp; under Thee shall the peoples fall, into the hearts of the King's enemies.\nThy throne, O God, is for ever and ever: the scepter of Thy kingdom is a scepter of uprightness.\nThou lovest justice and hatest iniquity: therefore God, Thy God, hath anointed Thee with the oil of gladness above Thy fellows.\nMyrrh and aloes and cassia perfume Thy garments, from out of ivory palaces: from which kings' daughters gladden Thee in Thine honor.\nOn Thy right hand standeth the Queen, in golden raiment wrought about with variety.\nHearken, O daughter, and consider, and incline thine ear; forget also thine own people and thy father's house.\nAnd the King shall greatly desire thy beauty; for He is the Lord thy God, and Him they shall adore.\nAnd the daughters of Tyre, all the rich ones of the people, with gifts shall entreat thy face.\nAll her glory [is that] of the King's daughter from within, with fringes of gold, arrayed in divers colors.\nAfter her shall virgins be brought unto the King: her neighbors shall be brought unto thee.\nWith joy and gladness shall they be brought: they shall be brought into the temple of the King.\nInstead of thy fathers, sons are born to thee: thou shalt make them princes over all the earth.\nThey shall be mindful of thy name from generation to generation.\nTherefore shall the people praise thee for ever: yea for ever and ever.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Specie tua.",
+                "en-US": "In thy comeliness."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 44",
+                "en-US": "Psalm 44"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Eructavit cor meum verbum bonum: dico ego opera mea Regi.\nLingua mea calamus scribae: velociter scribentis.\nSpeciosus forma prae filiis hominum, diffusa est gratia in labiis tuis: propterea benedixit te Deus in aeternum.\nAccingere gladio tuo super femur tuum, potentissime.\nSpecie tua et pulchritudine tua: intende, prospere procede, et regna.\nPropter veritatem, et mansuetudinem, et justitiam: et deducet te mirabiliter dextera tua.\nSagittae tuae acutae, populi sub te cadent: in corda inimicorum Regis.\nSedes tua, Deus, in saeculum saeculi: virga directionis virga regni tui.\nDilexisti justitiam, et odisti iniquitatem: propterea unxit te Deus, Deus tuus, oleo laetitiae prae consortibus tuis.\nMyrrha, et gutta, et casia a vestimentis tuis, a domibus eburneis: ex quibus delectaverunt te filiae regum in honore tuo.\nastitit regina a dextris tuis in vestitu deaurato: circumdata varietate.\nAudi filia, et vide, et inclina aurem tuam: et obliviscere populum tuum et domum patris tui.\nEt concupiscet Rex decorem tuum: quoniam ipse est Dominus Deus tuus, et adorabunt eum.\nEt filiae Tyri in muneribus vultum tuum deprecabuntur: omnes divites plebis.\nOmnis gloria ejus filiae Regis ab intus, in fimbriis aureis circumamicta varietatibus.\nAdducentur Regi virgines post eam: proximae ejus afferentur tibi.\nAfferentur in laetitia et exsultatione: adducentur in templum Regis.\nPro patribus tuis nati sunt tibi filii: constitues eos principes super omnem terram.\nMemores erunt nominis tui: in omni generatione et generationem.\nPropterea populi confitebuntur tibi in aeternum: et in saeculum saeculi.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "My heart hath uttered a good word: I address my works to the King.\nMy tongue is the pen of a writer that writeth swiftly.\nThou art beautiful above the sons of men, grace is poured forth on Thy lips; therefore God hath blessed Thee for ever.\nGird Thy sword upon Thy thigh, O Thou most mighty.\nWith Thy comeliness and Thy beauty, bend [Thy bow], advance prosperously, and reign.\nIn behalf of truth and meekness and justice; and Thy right hand shall guide Thee wondrously.\nThine arrows are sharp; under Thee shall the peoples fall, into the hearts of the King's enemies.\nThy throne, O God, is for ever and ever: the scepter of Thy kingdom is a scepter of uprightness.\nThou lovest justice and hatest iniquity: therefore God, Thy God, hath anointed Thee with the oil of gladness above Thy fellows.\nMyrrh and aloes and cassia perfume Thy garments, from out of ivory palaces: from which kings' daughters gladden Thee in Thine honor.\nOn Thy right hand standeth the Queen, in golden raiment wrought about with variety.\nHearken, O daughter, and consider, and incline thine ear; forget also thine own people and thy father's house.\nAnd the King shall greatly desire thy beauty; for He is the Lord thy God, and Him they shall adore.\nAnd the daughters of Tyre, all the rich ones of the people, with gifts shall entreat thy face.\nAll her glory [is that] of the King's daughter from within, with fringes of gold, arrayed in divers colors.\nAfter her shall virgins be brought unto the King: her neighbors shall be brought unto thee.\nWith joy and gladness shall they be brought: they shall be brought into the temple of the King.\nInstead of thy fathers, sons are born to thee: thou shalt make them princes over all the earth.\nThey shall be mindful of thy name from generation to generation.\nTherefore shall the people praise thee for ever: yea for ever and ever.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -216,7 +401,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -225,12 +410,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Adjuvabit eam.\nPsalm 45\nDeus noster refugium, et virtus: adjutor in tribulationibus, quae invenerunt nos nimis.\nPropterea non timebimus dum turbabitur terra: et transferentur montes in cor maris.\nSonuerunt, et turbatae sunt aquae eorum: conturbati sunt montes in fortitudine ejus.\nFluminis impetus laetificat civitatem Dei: sanctificavit tabernaculum suum Altissimus.\nDeus in medio ejus, non commovebitur: adjuvabit eam Deus mane diluculo.\nConturbatae sunt gentes, et inclinata sunt regna: dedit vocem suam, mota est terra.\nDominus virtutum nobiscum: susceptor noster Deus Jacob.\nVenite, et videte opera Domini, quae posuit prodigia super terram: auferens bella usque ad finem terrae.\nArcum conteret, et confringet arma: et scuta comburet igni.\nVacate, et videte quoniam ego sum Deus: exaltabor in gentibus, et exaltabor in terra.\nDominus virtutum nobiscum: susceptor noster Deus Jacob.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "God shall help her.\nPsalm 45\nOur God is a refuge and strength; a helper in troubles, which have come upon us heavily.\nTherefore shall we not fear when the earth shall be troubled; and the mountains shall be removed into the heart of the sea.\nTheir waters roar and are troubled: the mountains are troubled at the violence thereof.\nThe stream of the river maketh glad the city of God: the Most High hath hallowed His tabernacle.\nGod is in the midst of her, she shall not be moved: God shall help her in the morning early.\nNations were troubled, and kingdoms bowed down: He gave forth His voice: the earth quaked.\nThe Lord of hosts is with us: the God of Jacob is our helper.\nCome ye and behold the works of the Lord: what wonders He hath wrought upon earth, making wars to cease even to the ends of the earth.\nHe shall break the bow and snap the weapons in sunder; and the shields shall He burn with fire.\nBe still, and see that I am God: I will be exalted among the nations, and I will be exalted in the earth.\nThe Lord of hosts is with us: the God of Jacob is our helper.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Adjuvabit eam.",
+                "en-US": "God shall help her."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 45",
+                "en-US": "Psalm 45"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus noster refugium, et virtus: adjutor in tribulationibus, quae invenerunt nos nimis.\nPropterea non timebimus dum turbabitur terra: et transferentur montes in cor maris.\nSonuerunt, et turbatae sunt aquae eorum: conturbati sunt montes in fortitudine ejus.\nFluminis impetus laetificat civitatem Dei: sanctificavit tabernaculum suum Altissimus.\nDeus in medio ejus, non commovebitur: adjuvabit eam Deus mane diluculo.\nConturbatae sunt gentes, et inclinata sunt regna: dedit vocem suam, mota est terra.\nDominus virtutum nobiscum: susceptor noster Deus Jacob.\nVenite, et videte opera Domini, quae posuit prodigia super terram: auferens bella usque ad finem terrae.\nArcum conteret, et confringet arma: et scuta comburet igni.\nVacate, et videte quoniam ego sum Deus: exaltabor in gentibus, et exaltabor in terra.\nDominus virtutum nobiscum: susceptor noster Deus Jacob.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "Our God is a refuge and strength; a helper in troubles, which have come upon us heavily.\nTherefore shall we not fear when the earth shall be troubled; and the mountains shall be removed into the heart of the sea.\nTheir waters roar and are troubled: the mountains are troubled at the violence thereof.\nThe stream of the river maketh glad the city of God: the Most High hath hallowed His tabernacle.\nGod is in the midst of her, she shall not be moved: God shall help her in the morning early.\nNations were troubled, and kingdoms bowed down: He gave forth His voice: the earth quaked.\nThe Lord of hosts is with us: the God of Jacob is our helper.\nCome ye and behold the works of the Lord: what wonders He hath wrought upon earth, making wars to cease even to the ends of the earth.\nHe shall break the bow and snap the weapons in sunder; and the shields shall He burn with fire.\nBe still, and see that I am God: I will be exalted among the nations, and I will be exalted in the earth.\nThe Lord of hosts is with us: the God of Jacob is our helper.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -244,7 +443,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -253,12 +452,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sicut laetantium.\nPsalm 86\nFundamenta ejus in montibus sanctis: diligit Dominus portas Sion super omnia tabernacula Jacob.\nGloriosa dicta sunt de te, civitas Dei.\nMemor ero Rahab, et Babylonis scientium me.\nEcce, alienigenae, et Tyrus, et populus aethiopum, hi fuerunt illic.\nNumquid Sion dicet: Homo, et homo natus est in ea: et ipse fundavit eam Altissimus?\nDominus narrabit in scripturis populorum, et principum: horum, qui fuerunt in ea.\nSicut laetantium omnium habitatio est in te.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "As of people all rejoicing.\nPsalm 86\nHis foundations are in the holy mountains; the Lord loveth the gates of Sion above all the dwellings of Jacob.\nGlorious things are spoken of thee, O city of God.\nI will be mindful of Rahab and of Babylon, that know me.\nBehold strangers, and Tyre, and the people of the Ethiopians, these were there.\nShall it not be said of Sion: This one, and that one, is born in her: and the Most High Himself hath founded her?\nThe Lord shall tell it in His writings of peoples and of princes, of them that have been in her.\nAs of people all rejoicing, so is our dwelling in thee.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Sicut laetantium.",
+                "en-US": "As of people all rejoicing."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 86",
+                "en-US": "Psalm 86"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Fundamenta ejus in montibus sanctis: diligit Dominus portas Sion super omnia tabernacula Jacob.\nGloriosa dicta sunt de te, civitas Dei.\nMemor ero Rahab, et Babylonis scientium me.\nEcce, alienigenae, et Tyrus, et populus aethiopum, hi fuerunt illic.\nNumquid Sion dicet: Homo, et homo natus est in ea: et ipse fundavit eam Altissimus?\nDominus narrabit in scripturis populorum, et principum: horum, qui fuerunt in ea.\nSicut laetantium omnium habitatio est in te.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "His foundations are in the holy mountains; the Lord loveth the gates of Sion above all the dwellings of Jacob.\nGlorious things are spoken of thee, O city of God.\nI will be mindful of Rahab and of Babylon, that know me.\nBehold strangers, and Tyre, and the people of the Ethiopians, these were there.\nShall it not be said of Sion: This one, and that one, is born in her: and the Most High Himself hath founded her?\nThe Lord shall tell it in His writings of peoples and of princes, of them that have been in her.\nAs of people all rejoicing, so is our dwelling in thee.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -267,12 +480,56 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sicut laetantium omnium nostrum habitatio est in te, sancta Dei Genitrix.\n℣. Diffusa est gratia in labiis tuis.\n℟. Propterea benedixit te Deus in aeternum.\nPater noster... [continue silently]\n℣. Et ne nos inducas in tentationem:\n℟. Sed libera nos a malo.\nPsalms for Wednesday and Saturday",
-                "en-US": "As of people all rejoicing, so is our dwelling in thee, O holy Mother of God.\n℣. Grace is poured forth on thy lips.\n℟. Therefore hath God blessed thee for ever.\nOur Father... [continue silently]\n℣. And lead us not into temptation:\n℟. But deliver us from evil.\nPsalms for Wednesday and Saturday"
+                "la": "Sicut laetantium omnium nostrum habitatio est in te, sancta Dei Genitrix.",
+                "en-US": "As of people all rejoicing, so is our dwelling in thee, O holy Mother of God."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Diffusa est gratia in labiis tuis.",
+                    "en-US": "Grace is poured forth on thy lips."
+                  },
+                  "r": {
+                    "la": "Propterea benedixit te Deus in aeternum.",
+                    "en-US": "Therefore hath God blessed thee for ever."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Pater noster... [continue silently]",
+                "en-US": "Our Father... [continue silently]"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem:",
+                    "en-US": "And lead us not into temptation:"
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo.",
+                    "en-US": "But deliver us from evil."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Psalms for Wednesday and Saturday",
+                "en-US": "Psalms for Wednesday and Saturday"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -281,12 +538,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Gaude, Maria Virgo.\nPsalm 95\nCantate Domino canticum novum: cantate Domino, omnis terra.\nCantate Domino, et benedicite nomini ejus: annuntiate de die in diem salutare ejus.\nAnnuntiate inter gentes gloriam ejus, in omnibus populis mirabilia ejus.\nQuoniam magnus Dominus, et laudabilis nimis: terribilis est super omnes deos.\nQuoniam omnes dii gentium daemonia: Dominus autem caelos fecit.\nConfessio, et pulchritudo in conspectu ejus: sanctimonia et magnificentia in sanctificatione ejus.\nAfferte Domino, patriae gentium, afferte Domino gloriam et honorem: afferte Domino gloriam nomini ejus.\nTollite hostias, et introite in atria ejus: adorate Dominum in atrio sancto ejus.\nCommoveatur a facie ejus universa terra: dicite in gentibus quia Dominus regnavit.\netenim correxit orbem terrae qui non commovebitur: judicabit populos in aequitate.\nLaetentur caeli, et exsultet terra: commoveatur mare, et plenitudo ejus: gaudebunt campi, et omnia quae in eis sunt.\nTunc exsultabunt omnia ligna silvarum a facie Domini, quia venit: quoniam venit judicare terram.\nJudicabit orbem terrae in aequitate, et populos in veritate sua.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "Rejoice, O Virgin Mary.\nPsalm 95\nO sing unto the Lord a new song: sing unto the Lord, all the earth.\nSing unto the Lord, and bless His name: tell forth His salvation from day to day.\nTell forth His glory among the gentiles: His wonders amongst all peoples.\nFor the Lord is great, and highly to be praised: He is to be feared above all gods.\nFor all the gods of the Gentiles are devils; but the Lord made the heavens.\nPraise and beauty are before Him; holiness and majesty are in His sanctuary.\nBring unto the Lord, O ye kindred of the Gentiles, bring unto the Lord glory and honor: bring unto the Lord glory unto His name.\nBring sacrifices, and come into His courts: adore ye the Lord in His holy court.\nLet all the earth be moved at His presence: tell ye among the Gentiles that the Lord hath reigned.\nFor He hath established the world, and it shall not be moved: He will judge the peoples with equity.\nLet the heavens rejoice and let the earth be glad: let the sea be moved, and the fuless thereof; the fields shall be joyful, and all things that are therein.\nThen shall all the trees of the woods rejoice before the face of the Lord, for He cometh: for He cometh to judge the earth.\nHe shall judge the world with equity, and the peoples in His truth.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Gaude, Maria Virgo.",
+                "en-US": "Rejoice, O Virgin Mary."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 95",
+                "en-US": "Psalm 95"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Cantate Domino canticum novum: cantate Domino, omnis terra.\nCantate Domino, et benedicite nomini ejus: annuntiate de die in diem salutare ejus.\nAnnuntiate inter gentes gloriam ejus, in omnibus populis mirabilia ejus.\nQuoniam magnus Dominus, et laudabilis nimis: terribilis est super omnes deos.\nQuoniam omnes dii gentium daemonia: Dominus autem caelos fecit.\nConfessio, et pulchritudo in conspectu ejus: sanctimonia et magnificentia in sanctificatione ejus.\nAfferte Domino, patriae gentium, afferte Domino gloriam et honorem: afferte Domino gloriam nomini ejus.\nTollite hostias, et introite in atria ejus: adorate Dominum in atrio sancto ejus.\nCommoveatur a facie ejus universa terra: dicite in gentibus quia Dominus regnavit.\netenim correxit orbem terrae qui non commovebitur: judicabit populos in aequitate.\nLaetentur caeli, et exsultet terra: commoveatur mare, et plenitudo ejus: gaudebunt campi, et omnia quae in eis sunt.\nTunc exsultabunt omnia ligna silvarum a facie Domini, quia venit: quoniam venit judicare terram.\nJudicabit orbem terrae in aequitate, et populos in veritate sua.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "O sing unto the Lord a new song: sing unto the Lord, all the earth.\nSing unto the Lord, and bless His name: tell forth His salvation from day to day.\nTell forth His glory among the gentiles: His wonders amongst all peoples.\nFor the Lord is great, and highly to be praised: He is to be feared above all gods.\nFor all the gods of the Gentiles are devils; but the Lord made the heavens.\nPraise and beauty are before Him; holiness and majesty are in His sanctuary.\nBring unto the Lord, O ye kindred of the Gentiles, bring unto the Lord glory and honor: bring unto the Lord glory unto His name.\nBring sacrifices, and come into His courts: adore ye the Lord in His holy court.\nLet all the earth be moved at His presence: tell ye among the Gentiles that the Lord hath reigned.\nFor He hath established the world, and it shall not be moved: He will judge the peoples with equity.\nLet the heavens rejoice and let the earth be glad: let the sea be moved, and the fuless thereof; the fields shall be joyful, and all things that are therein.\nThen shall all the trees of the woods rejoice before the face of the Lord, for He cometh: for He cometh to judge the earth.\nHe shall judge the world with equity, and the peoples in His truth.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -300,7 +571,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -309,12 +580,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Dignare me.\nPsalm 96\nDominus regnavit, exsultet terra: laetentur insulae multae.\nNubes, et caligo in circuitu ejus: justitia, et judicium correctio sedis ejus.\nIgnis ante ipsum praecedet, et inflammabit in circuitu inimicos ejus.\nIlluxerunt fulgura ejus orbi terrae: vidit, et commota est terra.\nMontes, sicut cera fluxerunt a facie Domini: a facie Domini omnis terra.\nAnnuntiaverunt caeli justitiam ejus: et viderunt omnes populi gloriam ejus.\nConfundantur omnes, qui adorant sculptilia: et qui gloriantur in simulacris suis.\nAdorate eum, omnes angeli ejus: audivit, et laetata est Sion.\nEt exsultaverunt filiae Judae, propter judicia tua, Domine:\nQuoniam tu Dominus Altissimus super omnem terram: nimis exaltatus es super omnes deos.\nQui diligitis Dominum, odite malum: custodit Dominus animas sanctorum suorum, de manu peccatoris liberabit eos.\nLux orta est justo, et rectis corde laetitia.\nLaetamini, justi, in Domino: et confitemini memoriae sanctificationis ejus.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "Vouchsafe that I.\nPsalm 96\nThe Lord doth reign; let the earth rejoice: let the multitude of the isles be glad.\nClouds and darkness are round about Him: justice and judgment are the foundation of His throne.\nFire shall go forth before Him, and shall burn up His enemies on every side.\nHis lightnings shone upon the world: the earth saw, and was moved.\nThe mountains melted like wax before the face of the Lord; yea, all the earth, at the presence of the Lord.\nThe heavens declared His justice; and all the peoples saw His glory.\nLet them all be confounded that adore graven things; and that glory in their idols.\nAdore Him, all ye His angels; Sion heard, and was glad.\nAnd the daughters of Juda rejoiced, because of Thy judgments, O Lord.\nFor Thou art Lord most high over all the earth: Thou art exalted exceedingly above all gods.\nYe that love the Lord, hate evil: the Lord keepeth the souls of His saints; He will deliver them out of the hand of the sinner.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Dignare me.",
+                "en-US": "Vouchsafe that I."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 96",
+                "en-US": "Psalm 96"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Dominus regnavit, exsultet terra: laetentur insulae multae.\nNubes, et caligo in circuitu ejus: justitia, et judicium correctio sedis ejus.\nIgnis ante ipsum praecedet, et inflammabit in circuitu inimicos ejus.\nIlluxerunt fulgura ejus orbi terrae: vidit, et commota est terra.\nMontes, sicut cera fluxerunt a facie Domini: a facie Domini omnis terra.\nAnnuntiaverunt caeli justitiam ejus: et viderunt omnes populi gloriam ejus.\nConfundantur omnes, qui adorant sculptilia: et qui gloriantur in simulacris suis.\nAdorate eum, omnes angeli ejus: audivit, et laetata est Sion.\nEt exsultaverunt filiae Judae, propter judicia tua, Domine:\nQuoniam tu Dominus Altissimus super omnem terram: nimis exaltatus es super omnes deos.\nQui diligitis Dominum, odite malum: custodit Dominus animas sanctorum suorum, de manu peccatoris liberabit eos.\nLux orta est justo, et rectis corde laetitia.\nLaetamini, justi, in Domino: et confitemini memoriae sanctificationis ejus.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "The Lord doth reign; let the earth rejoice: let the multitude of the isles be glad.\nClouds and darkness are round about Him: justice and judgment are the foundation of His throne.\nFire shall go forth before Him, and shall burn up His enemies on every side.\nHis lightnings shone upon the world: the earth saw, and was moved.\nThe mountains melted like wax before the face of the Lord; yea, all the earth, at the presence of the Lord.\nThe heavens declared His justice; and all the peoples saw His glory.\nLet them all be confounded that adore graven things; and that glory in their idols.\nAdore Him, all ye His angels; Sion heard, and was glad.\nAnd the daughters of Juda rejoiced, because of Thy judgments, O Lord.\nFor Thou art Lord most high over all the earth: Thou art exalted exceedingly above all gods.\nYe that love the Lord, hate evil: the Lord keepeth the souls of His saints; He will deliver them out of the hand of the sinner.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -328,7 +613,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -342,7 +627,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -351,12 +636,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Angelus Domini.\nPsalm 97\nCantate Domino canticum novum: quia mirabilia fecit.\nSalvavit sibi dextera ejus: et bracchium sanctum ejus.\nNotum fecit Dominus salutare suum: in conspectu gentium revelavit justitiam suam.\nRecordatus est misericordiae suae, et veritatis suae domui Israel.\nViderunt omnes termini terrae salutare Dei nostri.\nJubilate Deo, omnis terra: cantate, et exsultate, et psallite.\nPsallite Domino in cithara, in cithara et voce psalmi: in tubis ductilibus, et voce tubae corneae.\nJubilate in conspectu regis Domini: moveatur mare, et plenitudo ejus: orbis terrarum, et qui habitant in eo.\nFlumina plaudent manu, simul montes exsultabunt a conspectu Domini: quoniam venit judicare terram.\nJudicabit orbem terrarum in justitia, et populos in aequitate.tionis ejus\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "The Angel of the Lord.\nPsalm 97\nSing unto the Lord a new song: for He hath done wonderful things.\nHis right hand and His holy arm hath wrought salvation for Him.\nThe Lord hath made known His salvation: He hath revealed His justice in the sight of the Gentiles.\nHe hath remembered His mercy and His truth toward the house of Israel.\nAll the ends of the earth have seen the salvation of our God.\nSing joyfully unto God, all the earth; sing, rejoice, and give praise.\nGive praise unto the Lord upon the harp, upon the harp and with voice of psalms: with the long trumpets and sound of the horn.\nSing joyfully before the Lord our King; let the sea be moved, and the fulness thereof; the compass of the earth, and they that dwell therein.\nThe rivers shall clap their hands, the mountains shall rejoice together at the presence of the Lord, for He cometh to judge the earth.\nHe shall judge the world with justice, and the peoples with equity.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Angelus Domini.",
+                "en-US": "The Angel of the Lord."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 97",
+                "en-US": "Psalm 97"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Cantate Domino canticum novum: quia mirabilia fecit.\nSalvavit sibi dextera ejus: et bracchium sanctum ejus.\nNotum fecit Dominus salutare suum: in conspectu gentium revelavit justitiam suam.\nRecordatus est misericordiae suae, et veritatis suae domui Israel.\nViderunt omnes termini terrae salutare Dei nostri.\nJubilate Deo, omnis terra: cantate, et exsultate, et psallite.\nPsallite Domino in cithara, in cithara et voce psalmi: in tubis ductilibus, et voce tubae corneae.\nJubilate in conspectu regis Domini: moveatur mare, et plenitudo ejus: orbis terrarum, et qui habitant in eo.\nFlumina plaudent manu, simul montes exsultabunt a conspectu Domini: quoniam venit judicare terram.\nJudicabit orbem terrarum in justitia, et populos in aequitate.tionis ejus\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "Sing unto the Lord a new song: for He hath done wonderful things.\nHis right hand and His holy arm hath wrought salvation for Him.\nThe Lord hath made known His salvation: He hath revealed His justice in the sight of the Gentiles.\nHe hath remembered His mercy and His truth toward the house of Israel.\nAll the ends of the earth have seen the salvation of our God.\nSing joyfully unto God, all the earth; sing, rejoice, and give praise.\nGive praise unto the Lord upon the harp, upon the harp and with voice of psalms: with the long trumpets and sound of the horn.\nSing joyfully before the Lord our King; let the sea be moved, and the fulness thereof; the compass of the earth, and they that dwell therein.\nThe rivers shall clap their hands, the mountains shall rejoice together at the presence of the Lord, for He cometh to judge the earth.\nHe shall judge the world with justice, and the peoples with equity.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -370,7 +669,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -379,12 +678,119 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Angelus Domini nuntiavit Mariae; et concepit de Spiritu Sancto.\n℣. Diffusa est gratia in labiis tuis.\n℟. Propterea benedixit te Deus in aeternum.\nPater noster... [continue silently]\n℣. Et ne nos inducas in tentationem:\n℟. Sed libera nos a malo.\nThe Absolution Outside Advent\nPrecibus et meritis beatae Mariae semper Virginis et omnium Sanctorum, perducat nos Dominus ad regna caelorum.\n℟. Amen.\nThe Blessing\n℣. Jube, domne, benedicere.\nNos cum prole pia benedicat Virgo Maria.\n℟. Amen.\nLessons and Responsories Outside Advent\nLesson I - Ecclesiasticus xxiv\nIn omnibus requiem quaesivi, et in hereditate Domini morabor. Tunc praecepit, et dixit mihi Creator omnium: et qui creavit me, requievit in tabernaculo meo. Et dixit mihi: In Jacob inhabita, et in Israel hereditare, et in electis meis mitte radices. Tu autem, Domine, miserere nobis.\n℟. Deo gratias.",
-                "en-US": "The angel of the Lord declared unto Mary, and she conceived by the Holy Ghost.\n℣. Grace is poured forth on thy lips.\n℟. Therefore hath God blessed thee for ever.\nOur Father... [continue silently]\n℣. And lead us not into temptation:\n℟. But deliver us from evil.\nThe Absolution\nThrough the prayers and merits of Blessed Mary, ever a virgin, and of all the saints, may the Lord bring us to the kingdom of heaven.\n℟. Amen.\nThe Blessing\n℣. Pray, a blessing.\nMay the Virgin Mary with her loving Child bless us.\n℟. Amen.\nLessons and Responsories Outside Advent\nLesson I - Ecclesiasticus xxiv\nIn all these I sought rest, and I shall abide in the inheritance of the Lord. Then the Creator of all things commanded and said to me; and He that made me rested in my tabernacle, and He said to me: Let thy dwelling be in Jacob, and thine inheritance in Israel, and take root in My chosen people. Do Thou, Lord, have mercy on us.\n℟. Thanks be to God."
+                "la": "Angelus Domini nuntiavit Mariae; et concepit de Spiritu Sancto.",
+                "en-US": "The angel of the Lord declared unto Mary, and she conceived by the Holy Ghost."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Diffusa est gratia in labiis tuis.",
+                    "en-US": "Grace is poured forth on thy lips."
+                  },
+                  "r": {
+                    "la": "Propterea benedixit te Deus in aeternum.",
+                    "en-US": "Therefore hath God blessed thee for ever."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Pater noster... [continue silently]",
+                "en-US": "Our Father... [continue silently]"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem:",
+                    "en-US": "And lead us not into temptation:"
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo.",
+                    "en-US": "But deliver us from evil."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "The Absolution Outside Advent\nPrecibus et meritis beatae Mariae semper Virginis et omnium Sanctorum, perducat nos Dominus ad regna caelorum.",
+                "en-US": "The Absolution\nThrough the prayers and merits of Blessed Mary, ever a virgin, and of all the saints, may the Lord bring us to the kingdom of heaven."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "The Blessing",
+                "en-US": "The Blessing"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Jube, domne, benedicere.",
+                "en-US": "Pray, a blessing."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Nos cum prole pia benedicat Virgo Maria.",
+                "en-US": "May the Virgin Mary with her loving Child bless us."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Lessons and Responsories Outside Advent",
+                "en-US": "Lessons and Responsories Outside Advent"
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Lesson I - Ecclesiasticus xxiv",
+                "en-US": "Lesson I - Ecclesiasticus xxiv"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "In omnibus requiem quaesivi, et in hereditate Domini morabor. Tunc praecepit, et dixit mihi Creator omnium: et qui creavit me, requievit in tabernaculo meo. Et dixit mihi: In Jacob inhabita, et in Israel hereditare, et in electis meis mitte radices. Tu autem, Domine, miserere nobis.",
+                "en-US": "In all these I sought rest, and I shall abide in the inheritance of the Lord. Then the Creator of all things commanded and said to me; and He that made me rested in my tabernacle, and He said to me: Let thy dwelling be in Jacob, and thine inheritance in Israel, and take root in My chosen people. Do Thou, Lord, have mercy on us."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsory",
                 "en-US": "Responsory"
@@ -393,12 +799,76 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Sancta et immaculata virginitas, quibus te laudibus efferam, nescio: Quia quem caeli capere non poterant, tuo gremio contulisti.\n℣. Benedicta tu in mulieribus, et benedictus fructus ventris tui.\n℟. Quia quem caeli capere non poterant, tuo gremio contulisti.\nThe Blessing\n℣. Jube, domne, benedicere.\nIpsa Virgo Virginum intercedat pro nobis ad Dominum\n℟. Amen.\nLesson II - Sirach 24:15-16\nEt sic in Sion firmata sum, et in civitate sanctificata similiter requievi, et in Ierusalem potestas mea. Et radicavi in populo honorificato, et in parte Dei mei hereditas illius, et in plenitudine sanctorum detentio mea. Tu autem, Domine, miserere nobis.\n℟. Deo gratias.",
-                "en-US": "℟. O holy and immaculate virginity, I know not with what praises to extol thee. For Him Whom heaven could not hold thou didst carry at thy bosom.\n℣. Blessed art thou amongst women, and blessed is the fruit of thy womb.\n℟. For Him Whom heaven could not hold thou didst carry at thy bosom.\nThe Blessing\n℣. Pray, a blessing.\nMay the Virgin of virgins herself plead for us before the Lord.\n℟. Amen.\nLesson II - Sirach 24:15-16\nAnd so was I established in Sion, and in the holy city likewise I rested; and my power was in Jerusalem. And I took root in an honorable people, and in the portion of my God is His inheritance, and my abode is in the full assembly of saints. Do Thou, Lord, have mercy on us.\n℟. Thanks be to God."
+                "la": "Sancta et immaculata virginitas, quibus te laudibus efferam, nescio: Quia quem caeli capere non poterant, tuo gremio contulisti.",
+                "en-US": "O holy and immaculate virginity, I know not with what praises to extol thee. For Him Whom heaven could not hold thou didst carry at thy bosom."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicta tu in mulieribus, et benedictus fructus ventris tui.",
+                    "en-US": "Blessed art thou amongst women, and blessed is the fruit of thy womb."
+                  },
+                  "r": {
+                    "la": "Quia quem caeli capere non poterant, tuo gremio contulisti.",
+                    "en-US": "For Him Whom heaven could not hold thou didst carry at thy bosom."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "The Blessing",
+                "en-US": "The Blessing"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Jube, domne, benedicere.",
+                "en-US": "Pray, a blessing."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Ipsa Virgo Virginum intercedat pro nobis ad Dominum",
+                "en-US": "May the Virgin of virgins herself plead for us before the Lord."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Lesson II - Sirach 24:15-16",
+                "en-US": "Lesson II - Sirach 24:15-16"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Et sic in Sion firmata sum, et in civitate sanctificata similiter requievi, et in Ierusalem potestas mea. Et radicavi in populo honorificato, et in parte Dei mei hereditas illius, et in plenitudine sanctorum detentio mea. Tu autem, Domine, miserere nobis.",
+                "en-US": "And so was I established in Sion, and in the holy city likewise I rested; and my power was in Jerusalem. And I took root in an honorable people, and in the portion of my God is His inheritance, and my abode is in the full assembly of saints. Do Thou, Lord, have mercy on us."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsory",
                 "en-US": "Responsory"
@@ -407,12 +877,300 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Beata es, Virgo Maria, quae Dominum portasti, Creatorem mundi: Genuisti qui te fecit, et in aeternum permanes Virgo.\n℣. Ave Maria, gratia plena, Dominus tecum.\n℟. Genuisti qui te fecit, et in aeternum permanes Virgo.\nThe following verses are added to the responsory on days when the Te Deum is said:\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Genuisti qui te fecit, et in aeternum permanes Virgo.\nThe Blessing\n℣. Jube, domne, benedicere.\nPer Virginem matrem concedat nobis Dominus salutem et pacem.\n℟. Amen.\nLesson III - Sirach 24:17-20\nQuasi cedrus exaltata sum in Libano, et quasi cypressus in monte Sion: Quasi palma exaltata sum in Cades, et quasi plantatio rosae in Iericho: Quasi oliva speciosa in campis, et quasi platanus exaltata sum iuxta aquam in plateis. Sicut cinnamomum et balsamum aromatizans odorem dedi: quasi myrrha electa dedi suavitatem odoris: Tu autem, Domine, miserere nobis.\n℟. Deo gratias.",
-                "en-US": "℟. Blessed art thou, O Virgin Mary, who didst bear the Lord, the Creator of the world. Thou didst bring forth Him that made thee and remainest a virgin for ever.\n℣. Hail, Mary, full of grace, the Lord is with thee.\n℟. Thou didst bring forth Him that made thee, and remainest a virgin for ever.\nThe following verses are added to the responsory on days when the Te Deum is said:\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. Thou didst bring forth Him that made thee, and remainest a virgin for ever.\nThe Blessing\n℣. Pray, a blessing.\nThrough the Virgin Mother may the Lord grant us salvation and peace.\n℟. Amen.\nLesson III - Sirach 24:17-20\nI was exalted like a cedar in Lebanon, and as a cypress-tree on Mount Sion. I was exalted like a palm-tree in Cades, and as a rose-plant in Jericho. As a fair olive-tree in the plains, and as a plane-tree by the water in the streets, was I exalted. I gave forth a sweet fragrance like cinnamon and aromatic balm. I yielded a sweet smell like choicest myrrh. Do Thou, Lord, have mercy on us.\n℟. Thanks be to God."
+                "la": "Beata es, Virgo Maria, quae Dominum portasti, Creatorem mundi: Genuisti qui te fecit, et in aeternum permanes Virgo.",
+                "en-US": "Blessed art thou, O Virgin Mary, who didst bear the Lord, the Creator of the world. Thou didst bring forth Him that made thee and remainest a virgin for ever."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ave Maria, gratia plena, Dominus tecum.",
+                    "en-US": "Hail, Mary, full of grace, the Lord is with thee."
+                  },
+                  "r": {
+                    "la": "Genuisti qui te fecit, et in aeternum permanes Virgo.",
+                    "en-US": "Thou didst bring forth Him that made thee, and remainest a virgin for ever."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "The following verses are added to the responsory on days when the Te Deum is said:"
               }
             },
             {
               "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "The following verses are added to the responsory on days when the Te Deum is said:"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto.",
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "la": "Genuisti qui te fecit, et in aeternum permanes Virgo.",
+                    "en-US": "Thou didst bring forth Him that made thee, and remainest a virgin for ever."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "The Blessing",
+                "en-US": "The Blessing"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Jube, domne, benedicere.",
+                "en-US": "Pray, a blessing."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Per Virginem matrem concedat nobis Dominus salutem et pacem.",
+                "en-US": "Through the Virgin Mother may the Lord grant us salvation and peace."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Lesson III - Sirach 24:17-20",
+                "en-US": "Lesson III - Sirach 24:17-20"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Quasi cedrus exaltata sum in Libano, et quasi cypressus in monte Sion: Quasi palma exaltata sum in Cades, et quasi plantatio rosae in Iericho: Quasi oliva speciosa in campis, et quasi platanus exaltata sum iuxta aquam in plateis. Sicut cinnamomum et balsamum aromatizans odorem dedi: quasi myrrha electa dedi suavitatem odoris: Tu autem, Domine, miserere nobis.",
+                "en-US": "I was exalted like a cedar in Lebanon, and as a cypress-tree on Mount Sion. I was exalted like a palm-tree in Cades, and as a rose-plant in Jericho. As a fair olive-tree in the plains, and as a plane-tree by the water in the streets, was I exalted. I gave forth a sweet fragrance like cinnamon and aromatic balm. I yielded a sweet smell like choicest myrrh. Do Thou, Lord, have mercy on us."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Responsory",
+                "en-US": "Responsory"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "The following responsory is said only on days when the Te Deum is not said:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Felix namque es, sacra Virgo Maria, et omni laude dignissima: Quia ex te ortus est sol justitiae, Christus, Deus noster."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro populo, interveni pro clero, intercede pro devoto femineo sexu: sentiant omnes tuum juvamen, quicumque celebrant tuam sanctam Commemorationem."
+                  },
+                  "r": {
+                    "la": "Quia ex te ortus est sol justitiae, Christus, Deus noster."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Christus, Deus noster."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "The Absolution during Advent\nPrecibus et meritis beatae Mariae semper Virginis et omnium Sanctorum, perducat nos Dominus ad regna caelorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "The Blessing"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "priest",
+              "inline": {
+                "la": "Jube, domne, benedicere."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Nos cum prole pia benedicat Virgo Maria."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Lessons and Responsories for Advent"
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Lesson I - Luke 1:26-28"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Missus est Angelus Gabriel a Deo in civitatem Galilaeae, cui nomen Nazareth, Ad virginem desponsatam viro, cui nomen erat Ioseph, de domo David: et nomen virginis Maria. Et ingressus Angelus ad eam dixit: Ave gratia plena: Dominus tecum: benedicta tu in mulieribus. Tu autem, Domine, miserere nobis."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "The following responsory is said only on days when the Te Deum is not said:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Happy indeed art thou, O holy Virgin Mary, and most worthy of all praise: For out of thee arose the Sun of righteousness, Christ our God."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Pray for the people, intercede for the clergy, plead for religious women. Let all enjoy thine aid who keep holy commemoration of thee."
+                  },
+                  "r": {
+                    "en-US": "For out of thee arose the Sun of righteousness, Christ our God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "Christ our God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Lessons and Responsories for Advent"
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Lesson I - Luke 1: 26-28"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "The angel Gabriel was sent from God into a city of Galilee called Nazareth, to a virgin espoused to a man whose name was Joseph, of the house of David; and the Virgin's name was Mary. And the angel being come in, said unto her: Hail, full of grace, the Lord is with thee: blessed art thou amongst women. Do thou, Lord, have mercy on us."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsory",
                 "en-US": "Responsory"
@@ -421,12 +1179,76 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "The following responsory is said only on days when the Te Deum is not said:\n℟. Felix namque es, sacra Virgo Maria, et omni laude dignissima: Quia ex te ortus est sol justitiae, Christus, Deus noster.\n℣. Ora pro populo, interveni pro clero, intercede pro devoto femineo sexu: sentiant omnes tuum juvamen, quicumque celebrant tuam sanctam Commemorationem.\n℟. Quia ex te ortus est sol justitiae, Christus, Deus noster.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Christus, Deus noster.\nThe Absolution during Advent\nPrecibus et meritis beatae Mariae semper Virginis et omnium Sanctorum, perducat nos Dominus ad regna caelorum.\n℟. Amen.\nThe Blessing\n℣. Jube, domne, benedicere.\nNos cum prole pia benedicat Virgo Maria.\n℟. Amen.\nLessons and Responsories for Advent\nLesson I - Luke 1:26-28\nMissus est Angelus Gabriel a Deo in civitatem Galilaeae, cui nomen Nazareth, Ad virginem desponsatam viro, cui nomen erat Ioseph, de domo David: et nomen virginis Maria. Et ingressus Angelus ad eam dixit: Ave gratia plena: Dominus tecum: benedicta tu in mulieribus. Tu autem, Domine, miserere nobis.\n℟. Deo gratias.",
-                "en-US": "The following responsory is said only on days when the Te Deum is not said:\n℟. Happy indeed art thou, O holy Virgin Mary, and most worthy of all praise: For out of thee arose the Sun of righteousness, Christ our God.\n℣. Pray for the people, intercede for the clergy, plead for religious women. Let all enjoy thine aid who keep holy commemoration of thee.\n℟. For out of thee arose the Sun of righteousness, Christ our God.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. Christ our God.\nLessons and Responsories for Advent\nLesson I - Luke 1: 26-28\nThe angel Gabriel was sent from God into a city of Galilee called Nazareth, to a virgin espoused to a man whose name was Joseph, of the house of David; and the Virgin's name was Mary. And the angel being come in, said unto her: Hail, full of grace, the Lord is with thee: blessed art thou amongst women. Do thou, Lord, have mercy on us.\n℟. Thanks be to God."
+                "la": "Missus est Gabriel Angelus ad Mariam Virginem desponsatam Ioseph, nuntians ei verbum; et expavescit Virgo de lumine: ne timeas, Maria, invenisti gratiam apud Dominum: Ecce concipies et paries, et vocabitur Altissimi Filius.",
+                "en-US": "The angel Gabriel was sent to Mary, the Virgin, who was espoused to Joseph, declaring to her the word, and the Virgin trembles at the light. Fear not, Mary, thou hast found grace with the Lord: Behold, thou shalt conceive, and shalt bring forth, and He shall be called the Son of the Most High."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dabit ei Dominus Deus sedem David, patris eius, et regnabit in domo Jacob in aeternum.",
+                    "en-US": "The Lord shall give unto Him the throne of David His father, and He shall reign in the house of Jacob for ever."
+                  },
+                  "r": {
+                    "la": "Ecce concipies et paries, et vocabitur Altissimi Filius.",
+                    "en-US": "Behold, thou shalt conceive, and shalt bring forth, and He shall be called the Son of the Most High."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "The Blessing",
+                "en-US": "The Blessing"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Jube, domne, benedicere.",
+                "en-US": "Pray, a blessing."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Ipsa Virgo Virginum intercedat pro nobis ad Dominum.",
+                "en-US": "May the Virgin of virgins herself plead for us before the Lord."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Lesson II - Luke 1: 26-28",
+                "en-US": "Lesson II - Luke 1:26-28"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Quae cum audisset, turbata est in sermone eius, et cogitabat qualis esset ista salutatio. Et ait Angelus ei: Ne timeas, Maria: invenisti enim gratiam apud Deum: Ecce concipies in utero, et paries filium, et vocabis nomen eius Iesum: Hic erit magnus, et Filius Altissimi vocabitur, et dabit illi Dominus Deus sedem David patris eius: et regnabit in domo Iacob in aeternum, Et regni eius non erit finis. Tu autem, Domine, miserere nobis.",
+                "en-US": "And when she had heard these things, she was troubled at his saying, and thought within herself what manner of salutation this should be. And the angel said unto her: Fear not, Mary, for thou hast found grace with God. Behold, thou shalt conceive in the womb, and shalt bring forth a Son, and thou shalt call His name Jesus. He shall be great, and shall be called the Son of the Most High. And the Lord God will give unto Him the throne of David His father, and He shall reign in the house of Jacob for ever; and of His kingdom there shall be no end. Do thou, Lord, have mercy on us."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsory",
                 "en-US": "Responsory"
@@ -435,36 +1257,440 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Missus est Gabriel Angelus ad Mariam Virginem desponsatam Ioseph, nuntians ei verbum; et expavescit Virgo de lumine: ne timeas, Maria, invenisti gratiam apud Dominum: Ecce concipies et paries, et vocabitur Altissimi Filius.\n℣. Dabit ei Dominus Deus sedem David, patris eius, et regnabit in domo Jacob in aeternum.\n℟. Ecce concipies et paries, et vocabitur Altissimi Filius.\nThe Blessing\n℣. Jube, domne, benedicere.\nIpsa Virgo Virginum intercedat pro nobis ad Dominum.\n℟. Amen.\nLesson II - Luke 1: 26-28\nQuae cum audisset, turbata est in sermone eius, et cogitabat qualis esset ista salutatio. Et ait Angelus ei: Ne timeas, Maria: invenisti enim gratiam apud Deum: Ecce concipies in utero, et paries filium, et vocabis nomen eius Iesum: Hic erit magnus, et Filius Altissimi vocabitur, et dabit illi Dominus Deus sedem David patris eius: et regnabit in domo Iacob in aeternum, Et regni eius non erit finis. Tu autem, Domine, miserere nobis.\n℟. Deo gratias.",
-                "en-US": "℟. The angel Gabriel was sent to Mary, the Virgin, who was espoused to Joseph, declaring to her the word, and the Virgin trembles at the light. Fear not, Mary, thou hast found grace with the Lord: Behold, thou shalt conceive, and shalt bring forth, and He shall be called the Son of the Most High.\n℣. The Lord shall give unto Him the throne of David His father, and He shall reign in the house of Jacob for ever.\n℟. Behold, thou shalt conceive, and shalt bring forth, and He shall be called the Son of the Most High.\nThe Blessing\n℣. Pray, a blessing.\nMay the Virgin of virgins herself plead for us before the Lord.\n℟. Amen.\nLesson II - Luke 1:26-28\nAnd when she had heard these things, she was troubled at his saying, and thought within herself what manner of salutation this should be. And the angel said unto her: Fear not, Mary, for thou hast found grace with God. Behold, thou shalt conceive in the womb, and shalt bring forth a Son, and thou shalt call His name Jesus. He shall be great, and shall be called the Son of the Most High. And the Lord God will give unto Him the throne of David His father, and He shall reign in the house of Jacob for ever; and of His kingdom there shall be no end. Do thou, Lord, have mercy on us.\n℟. Thanks be to God."
+                "la": "Ave, Maria, gratia plena; Dominus tecum: Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi: quod enim ex te nascetur Sanctum, vocabitur Filius Dei.",
+                "en-US": "Hail, Mary, full of grace, the Lord is with thee. The Holy Ghost shall come upon thee, and the power of the Most High shall overshadow thee; for the Holy which shall be born of thee shall be called the Son of God."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Quomodo fiet istud, quoniam virum non cognosco? Et respondens Angelus, dixit ei.",
+                "en-US": "How shall this be done, seeing I know not man? And the angel answering said unto her: The Holy Ghost shall come upon thee, and the power of the Most High shall over-shadow thee; for the Holy which shall be born of thee shall be called the Son of God."
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "The following verses are added to the responsory on days when the Te Deum is said:"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "The following verses are added to the responsory on days when the Te Deum is said:"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto.",
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "la": "Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi: quod enim ex te nascetur Sanctum, vocabitur Filius Dei.",
+                    "en-US": "The Holy Ghost shall come upon thee, and the power of the Most High shall overshadow thee; for the Holy which shall be born of thee shall be called the Son of God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "The Blessing",
+                "en-US": "The Blessing"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Jube, domne, benedicere.",
+                "en-US": "Pray, a blessing."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Per Virginem matrem concedat nobis Dominus salutem et pacem.",
+                "en-US": "Through the Virgin Mother may the Lord grant us salvation and peace."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Lesson III - Luke 1: 34-38",
+                "en-US": "Lesson III - Luke 1: 34-38"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Dixit autem Maria ad Angelum: Quomodo fiet istud, quoniam virum non cognosco? Et respondens Angelus dixit ei: Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi. Ideoque et quod nascetur ex te Sanctum, vocabitur Filius Dei. Et ecce Elisabeth cognata tua, et ipsa concepit filium in senectute sua: et hic mensis sextus est illi, quae vocatur sterilis: Quia non erit impossibile apud Deum omne verbum. Dixit autem Maria: Ecce ancilla Domini: fiat mihi secundum verbum tuum. Tu autem, Domine, miserere nobis.",
+                "en-US": "And Mary said to the angel: How shall this be done, seeing I know not man? And the angel answering said unto her: The Holy Ghost shall come upon thee, and the power of the Most High shall overshadow thee. And therefore also the Holy which shall be born of thee shall be called the Son of God. And behold, thy cousin Elizabeth, she also hath conceived a son in her old age, and this is the sixth month with her who is called barren; for no word shall be impossible with God. And Mary said: Behold the handmaid of the Lord, be it done to me according to Thy word. Do Thou, Lord, have mercy on us."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsory",
                 "en-US": "Responsory"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℟. Ave, Maria, gratia plena; Dominus tecum: Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi: quod enim ex te nascetur Sanctum, vocabitur Filius Dei.\n℣. Quomodo fiet istud, quoniam virum non cognosco? Et respondens Angelus, dixit ei.\nThe following verses are added to the responsory on days when the Te Deum is said:\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi: quod enim ex te nascetur Sanctum, vocabitur Filius Dei.\nThe Blessing\n℣. Jube, domne, benedicere.\nPer Virginem matrem concedat nobis Dominus salutem et pacem.\n℟. Amen.\nLesson III - Luke 1: 34-38\nDixit autem Maria ad Angelum: Quomodo fiet istud, quoniam virum non cognosco? Et respondens Angelus dixit ei: Spiritus Sanctus superveniet in te, et virtus Altissimi obumbrabit tibi. Ideoque et quod nascetur ex te Sanctum, vocabitur Filius Dei. Et ecce Elisabeth cognata tua, et ipsa concepit filium in senectute sua: et hic mensis sextus est illi, quae vocatur sterilis: Quia non erit impossibile apud Deum omne verbum. Dixit autem Maria: Ecce ancilla Domini: fiat mihi secundum verbum tuum. Tu autem, Domine, miserere nobis.\n℟. Deo gratias.",
-                "en-US": "℟. Hail, Mary, full of grace, the Lord is with thee. The Holy Ghost shall come upon thee, and the power of the Most High shall overshadow thee; for the Holy which shall be born of thee shall be called the Son of God.\n℣. How shall this be done, seeing I know not man? And the angel answering said unto her: The Holy Ghost shall come upon thee, and the power of the Most High shall over-shadow thee; for the Holy which shall be born of thee shall be called the Son of God.\nThe following verses are added to the responsory on days when the Te Deum is said:\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. The Holy Ghost shall come upon thee, and the power of the Most High shall overshadow thee; for the Holy which shall be born of thee shall be called the Son of God.\nThe Blessing\n℣. Pray, a blessing.\nThrough the Virgin Mother may the Lord grant us salvation and peace.\n℟. Amen.\nLesson III - Luke 1: 34-38\nAnd Mary said to the angel: How shall this be done, seeing I know not man? And the angel answering said unto her: The Holy Ghost shall come upon thee, and the power of the Most High shall overshadow thee. And therefore also the Holy which shall be born of thee shall be called the Son of God. And behold, thy cousin Elizabeth, she also hath conceived a son in her old age, and this is the sixth month with her who is called barren; for no word shall be impossible with God. And Mary said: Behold the handmaid of the Lord, be it done to me according to Thy word. Do Thou, Lord, have mercy on us.\n℟. Thanks be to God."
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "The following responsory is said only on days when the Te Deum is not said:"
               }
             },
             {
               "type": "rubric",
+              "lang": "en-US",
               "text": {
-                "la": "Responsory",
-                "en-US": "Responsory"
+                "en-US": "The following responsory is said only on days when the Te Deum is not said:"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "The following responsory is said only on days when the Te Deum is not said:\n℟. Suscipe verbum, Virgo Maria, quod tibi a Domino per Angelum transmissum est: concipies et paries Deum pariter et hominem, Ut benedicta dicaris inter omnes mulieres.\n℣. Paries quidem filium, et virginitatis non patieris detrimentum: efficieris gravida, et eris mater semper intacta.\n℟. Ut benedicta dicaris inter omnes mulieres.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Ut benedicta dicaris inter omnes mulieres.\nTe Deum\nThe following Hymn, Te Deum, is said from Christmas until Septuagesima, and from Easter Sunday until Advent.\nFrom Septuagesima until Easter, it is said only on festivals of the Blessed Virgin.\nWhen the Te Deum is said, the third Responsory is omitted, and Gloria Patri is said in the second Responsory, as was noted above.\nTe Deum laudamus: te Dominum confitemur.\nTe aeternum Patrem omnis terra veneratur.\nTibi omnes angeli, tibi Caeli, et universae Potestates:\nTibi Cherubim et Seraphim incessabili voce proclamant:\nDuring the following verse, all make a profound bow.\nSanctus, Sanctus, Sanctus Dominus Deus Sabaoth.\nPleni sunt caeli et terra maiestatis gloriae tuae.\nTe gloriosus Apostolorum chorus,\nTe Prophetarum laudabilis numerus,\nTe Martyrum candidatus laudat exercitus.\nTe per orbem terrarum sancta confitetur Ecclesia,\nPatrem immensae maiestatis;\nVenerandum tuum verum et unicum Filium;\nSanctum quoque Paraclitum Spiritum.\nTu Rex gloriae, Christe.\nTu Patris sempiternus es Filius.\nDuring the following verse, all make a profound bow.\nTu, ad liberandum suscepturus hominem: non horruisti Virginis uterum.\nTu, devicto mortis aculeo, aperuisti credentibus regna caelorum.\nTu ad dexteram Dei sedes, in gloria Patris.\nJudex crederis esse venturus.\nDuring the following verse, all kneel.\nTe ergo quaesumus, tuis famulis subveni, quos pretioso sanguine redemisti.\naeterna fac cum Sanctis tuis in gloria numerari.\nSalvum fac populum tuum, Domine, et benedic hereditati tuae.\nEt rege eos, et extolle illos usque in aeternum.\nPer singulos dies benedicimus te.\nDuring the following verse, all make a profound bow.\nEt laudamus nomen tuum in saeculum, et in saeculum saeculi.\nDignare, Domine, die isto sine peccato nos custodire.\nMiserere nostri, Domine, miserere nostri.\nFiat misericordia tua, Domine, super nos, quemadmodum speravimus in te.\nIn te, Domine, speravi: non confundar in aeternum.\nIf Lauds is to be prayed immediately, the rest is omitted.\nCollect\nOremus,\nDeus, qui de beatae Mariae Virginis utero Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis; ut, qui vere eam Genitricem Dei credimus, eius apud te intercessionibus adjuvemur. Per eundem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\n℟. Amen.\nConclusion\n℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.\nThe Our Father is prayed silently.",
-                "en-US": "The following responsory is said only on days when the Te Deum is not said:\n℟. Receive, O Virgin Mary, the word which the Lord hath sent thee through an angel: Thou shalt conceive, and shalt bring forth both God and man, that thou mayest be called blessed amongst all women.\n℣. Yea, thou shalt bring forth a Son, and shalt suffer no loss of virginity: thou shalt be with child, and shalt be a mother ever undefiled.\n℟. That thou mayest be called blessed amongst all women.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. That thou mayest be called blessed amongst all women.\nTe Deum\nThe following Hymn, Te Deum, is said from Christmas until Septuagesima, and from Easter Sunday until Advent.\nFrom Septuagesima until Easter, it is said only on festivals of the Blessed Virgin.\nWhen the Te Deum is said, the third Responsory is omitted, and Gloria Patri is said in the second Responsory, as was noted above.\nWe praise Thee, O God; we acknowledge Thee to be the Lord.\nThee, the Father everlasting, all the earth doth worship.\nTo Thee all the angels, to Thee the heavens, and all the powers,\nTo Thee the cherubim and seraphim cry out without ceasing:\nDuring the following verse, all make a profound bow.\nHoly, Holy, Holy, Lord God of hosts.\nFull are the heavens and the earth of the majesty of Thy glory.\nThee the glorious choir of the apostles.\nThee the admirable company of the prophets.\nThee the white-robed army of martyrs doth praise.\nThee the holy Church throughout the world doth confess.\nThe Father of incomprehensible Majesty.\nThine adorable, true, and only Son.\nAnd the Holy Ghost the Paraclete.\nThou, O Christ, art the King of glory.\nThou art the everlasting Son of the Father.\nDuring the following verse, all make a profound bow.\nThou, having taken upon Thee to deliver man, didst not disdain the Virgin's womb.\nThou, having overcome the sting of death, hast opened to believers the kingdom of heaven.\nThou sittest at the right hand of God, in the glory of the Father.\nThou, we believe, art the Judge to come.\nDuring the following verse, all kneel.\nWe beseech Thee, therefore, to help Thy servants, whom Thou hast redeemed with Thy precious blood.\nMake them to be numbered with Thy saints in glory everlasting.\nO Lord, save Thy people, and bless Thine inheritance.\nAnd govern them, and exalt them for ever.\nDay by day we bless Thee.\nDuring the following verse, all make a profound bow.\nAnd we praise Thy name for ever; yea, for ever and ever.\nVouchsafe, O Lord, this day, to keep us without sin.\nHave mercy on us, O Lord; have mercy on us.\nLet Thy mercy, O Lord, be upon us; as we have trusted in Thee.\nIn Thee, O Lord, have I trusted: let me not be confounded for ever.\nIf Lauds is to be prayed immediately, the rest is omitted.\nCollect\nLet us pray,\nO God, Who didst will that Thine eternal Word should take flesh in the womb of the Blessed Virgin Mary, when the angel delivered his message: grant that Thy petitioners, who verily believe her to be the Mother of God, may be assisted by her intercession. Through the same Christ our Lord.\n℟. Amen.\nConclusion\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed, through the mercy of God, rest in peace.\n℟. Amen.\nThe Our Father is prayed silently."
+                "la": "Suscipe verbum, Virgo Maria, quod tibi a Domino per Angelum transmissum est: concipies et paries Deum pariter et hominem, Ut benedicta dicaris inter omnes mulieres.",
+                "en-US": "Receive, O Virgin Mary, the word which the Lord hath sent thee through an angel: Thou shalt conceive, and shalt bring forth both God and man, that thou mayest be called blessed amongst all women."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Paries quidem filium, et virginitatis non patieris detrimentum: efficieris gravida, et eris mater semper intacta.",
+                    "en-US": "Yea, thou shalt bring forth a Son, and shalt suffer no loss of virginity: thou shalt be with child, and shalt be a mother ever undefiled."
+                  },
+                  "r": {
+                    "la": "Ut benedicta dicaris inter omnes mulieres.",
+                    "en-US": "That thou mayest be called blessed amongst all women."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto.",
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "la": "Ut benedicta dicaris inter omnes mulieres.",
+                    "en-US": "That thou mayest be called blessed amongst all women."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Te Deum"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "The following Hymn, Te Deum, is said from Christmas until Septuagesima, and from Easter Sunday until Advent.\nFrom Septuagesima until Easter, it is said only on festivals of the Blessed Virgin."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "When the Te Deum is said, the third Responsory is omitted, and Gloria Patri is said in the second Responsory, as was noted above."
+              }
+            },
+            {
+              "type": "hymn",
+              "lang": "la",
+              "inline": {
+                "la": "Te Deum laudamus: te Dominum confitemur.\nTe aeternum Patrem omnis terra veneratur.\nTibi omnes angeli, tibi Caeli, et universae Potestates:\nTibi Cherubim et Seraphim incessabili voce proclamant:"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "During the following verse, all make a profound bow."
+              }
+            },
+            {
+              "type": "hymn",
+              "lang": "la",
+              "inline": {
+                "la": "Sanctus, Sanctus, Sanctus Dominus Deus Sabaoth.\nPleni sunt caeli et terra maiestatis gloriae tuae.\nTe gloriosus Apostolorum chorus,\nTe Prophetarum laudabilis numerus,\nTe Martyrum candidatus laudat exercitus.\nTe per orbem terrarum sancta confitetur Ecclesia,\nPatrem immensae maiestatis;\nVenerandum tuum verum et unicum Filium;\nSanctum quoque Paraclitum Spiritum.\nTu Rex gloriae, Christe.\nTu Patris sempiternus es Filius."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "During the following verse, all make a profound bow."
+              }
+            },
+            {
+              "type": "hymn",
+              "lang": "la",
+              "inline": {
+                "la": "Tu, ad liberandum suscepturus hominem: non horruisti Virginis uterum.\nTu, devicto mortis aculeo, aperuisti credentibus regna caelorum.\nTu ad dexteram Dei sedes, in gloria Patris.\nJudex crederis esse venturus."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "During the following verse, all kneel."
+              }
+            },
+            {
+              "type": "hymn",
+              "lang": "la",
+              "inline": {
+                "la": "Te ergo quaesumus, tuis famulis subveni, quos pretioso sanguine redemisti.\naeterna fac cum Sanctis tuis in gloria numerari.\nSalvum fac populum tuum, Domine, et benedic hereditati tuae.\nEt rege eos, et extolle illos usque in aeternum.\nPer singulos dies benedicimus te."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "During the following verse, all make a profound bow."
+              }
+            },
+            {
+              "type": "hymn",
+              "lang": "la",
+              "inline": {
+                "la": "Et laudamus nomen tuum in saeculum, et in saeculum saeculi.\nDignare, Domine, die isto sine peccato nos custodire.\nMiserere nostri, Domine, miserere nostri.\nFiat misericordia tua, Domine, super nos, quemadmodum speravimus in te.\nIn te, Domine, speravi: non confundar in aeternum."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "If Lauds is to be prayed immediately, the rest is omitted."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Collect"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Deus, qui de beatae Mariae Virginis utero Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis; ut, qui vere eam Genitricem Dei credimus, eius apud te intercessionibus adjuvemur. Per eundem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Te Deum"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "The following Hymn, Te Deum, is said from Christmas until Septuagesima, and from Easter Sunday until Advent.\nFrom Septuagesima until Easter, it is said only on festivals of the Blessed Virgin."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "When the Te Deum is said, the third Responsory is omitted, and Gloria Patri is said in the second Responsory, as was noted above."
+              }
+            },
+            {
+              "type": "hymn",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "We praise Thee, O God; we acknowledge Thee to be the Lord.\nThee, the Father everlasting, all the earth doth worship.\nTo Thee all the angels, to Thee the heavens, and all the powers,\nTo Thee the cherubim and seraphim cry out without ceasing:"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During the following verse, all make a profound bow."
+              }
+            },
+            {
+              "type": "hymn",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Holy, Holy, Holy, Lord God of hosts.\nFull are the heavens and the earth of the majesty of Thy glory.\nThee the glorious choir of the apostles.\nThee the admirable company of the prophets.\nThee the white-robed army of martyrs doth praise.\nThee the holy Church throughout the world doth confess.\nThe Father of incomprehensible Majesty.\nThine adorable, true, and only Son.\nAnd the Holy Ghost the Paraclete.\nThou, O Christ, art the King of glory.\nThou art the everlasting Son of the Father."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During the following verse, all make a profound bow."
+              }
+            },
+            {
+              "type": "hymn",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Thou, having taken upon Thee to deliver man, didst not disdain the Virgin's womb.\nThou, having overcome the sting of death, hast opened to believers the kingdom of heaven.\nThou sittest at the right hand of God, in the glory of the Father.\nThou, we believe, art the Judge to come."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During the following verse, all kneel."
+              }
+            },
+            {
+              "type": "hymn",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "We beseech Thee, therefore, to help Thy servants, whom Thou hast redeemed with Thy precious blood.\nMake them to be numbered with Thy saints in glory everlasting.\nO Lord, save Thy people, and bless Thine inheritance.\nAnd govern them, and exalt them for ever.\nDay by day we bless Thee."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During the following verse, all make a profound bow."
+              }
+            },
+            {
+              "type": "hymn",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "And we praise Thy name for ever; yea, for ever and ever.\nVouchsafe, O Lord, this day, to keep us without sin.\nHave mercy on us, O Lord; have mercy on us.\nLet Thy mercy, O Lord, be upon us; as we have trusted in Thee.\nIn Thee, O Lord, have I trusted: let me not be confounded for ever."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "If Lauds is to be prayed immediately, the rest is omitted."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Collect"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who didst will that Thine eternal Word should take flesh in the womb of the Blessed Virgin Mary, when the angel delivered his message: grant that Thy petitioners, who verily believe her to be the Mother of God, may be assisted by her intercession. Through the same Christ our Lord."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Conclusion",
+                "en-US": "Conclusion"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+                    "en-US": "May the souls of the faithful departed, through the mercy of God, rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "The Our Father is prayed silently."
               }
             }
           ]
@@ -478,14 +1704,57 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "The Hail Mary is prayed silently.\nAve Maria, gratia plena; Dominus tecum: benedicta tu in mulieribus, et benedictus fructus ventris tui Jesus. Sancta Maria, Mater Dei, ora pro nobis peccatoribus, nunc et in hora mortis nostrae. Amen.\n℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (Outside Lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae.\nPsalms",
-                "en-US": "The Hail Mary is prayed silently.\nHail Mary, full of grace; The Lord is with thee; Blessed art thou amongst women, And blessed is the fruit of thy womb, Jesus. Holy Mary, Mother of God, Pray for us sinners, now and at the hour of our death. Amen.\n℣. O God, ✠ come to my assistance;\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, world without end. Amen. (Outside Lent:) Alleluia. (from Septuagesima to Holy Saturday:) Praise be to Thee, O Lord, King of glory everlasting.\nPsalms"
+              "type": "rubric",
+              "text": {
+                "en-US": "The Hail Mary is prayed silently."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Ave Maria, gratia plena; Dominus tecum: benedicta tu in mulieribus, et benedictus fructus ventris tui Jesus. Sancta Maria, Mater Dei, ora pro nobis peccatoribus, nunc et in hora mortis nostrae. Amen.",
+                "en-US": "Hail Mary, full of grace; The Lord is with thee; Blessed art thou amongst women, And blessed is the fruit of thy womb, Jesus. Holy Mary, Mother of God, Pray for us sinners, now and at the hour of our death. Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende.",
+                    "en-US": "O God, ✠ come to my assistance;"
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto.",
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (Outside Lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae.",
+                    "en-US": "As it was in the beginning, is now, and ever shall be, world without end. Amen. (Outside Lent:) Alleluia. (from Septuagesima to Holy Saturday:) Praise be to Thee, O Lord, King of glory everlasting."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalms",
+                "en-US": "Psalms"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -499,7 +1768,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -513,7 +1782,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -522,12 +1791,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "O admirabile commercium!\nPsalm 92\nDominus regnavit, decorem indutus est: indutus est Dominus fortitudinem, et praecinxit se.\netenim firmavit orbem terrae, qui non commovebitur.\nParata sedes tua ex tunc: a saeculo tu es.\nElevaverunt flumina, Domine: elevaverunt flumina vocem suam.\nElevaverunt flumina fluctus suos, a vocibus aquarum multarum.\nMirabiles elationes maris: mirabilis in altis Dominus.\nTestimonia tua credibilia facta sunt nimis: domum tuam decet sanctitudo, Domine, in longitudinem dierum.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "O wondrous union!\nPsalm 92\nThe Lord reigneth: He is clothed with beauty: the Lord is clothed with strength, and hath girded Himself.\nFor He hath established the world, which shall not be moved.\nThy throne is prepared of old: Thou art from everlasting.\nThe floods have lifted up, O Lord: the floods have lifted up their voice.\nThe floods have lifted up their waves, with the noise of many waters.\nWonderful are the surges of the sea: wonderful is the Lord on high.\nThy testimonies are made exceedingly trustworthy: holiness becometh Thy house, O Lord, unto length of days.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "O admirabile commercium!",
+                "en-US": "O wondrous union!"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 92",
+                "en-US": "Psalm 92"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Dominus regnavit, decorem indutus est: indutus est Dominus fortitudinem, et praecinxit se.\netenim firmavit orbem terrae, qui non commovebitur.\nParata sedes tua ex tunc: a saeculo tu es.\nElevaverunt flumina, Domine: elevaverunt flumina vocem suam.\nElevaverunt flumina fluctus suos, a vocibus aquarum multarum.\nMirabiles elationes maris: mirabilis in altis Dominus.\nTestimonia tua credibilia facta sunt nimis: domum tuam decet sanctitudo, Domine, in longitudinem dierum.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "The Lord reigneth: He is clothed with beauty: the Lord is clothed with strength, and hath girded Himself.\nFor He hath established the world, which shall not be moved.\nThy throne is prepared of old: Thou art from everlasting.\nThe floods have lifted up, O Lord: the floods have lifted up their voice.\nThe floods have lifted up their waves, with the noise of many waters.\nWonderful are the surges of the sea: wonderful is the Lord on high.\nThy testimonies are made exceedingly trustworthy: holiness becometh Thy house, O Lord, unto length of days.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -541,7 +1824,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -555,7 +1838,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -569,7 +1852,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -583,7 +1866,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -597,7 +1880,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -606,12 +1889,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quando natus es.\nPsalm 99\nJubilate Deo, omnis terra: servite Domino in laetitia.\nIntroite in conspectu ejus, in exsultatione.\nScitote quoniam Dominus ipse est Deus: ipse fecit nos, et non ipsi nos.\nPopulus ejus, et oves pascuae ejus: introite portas ejus in confessione, atria ejus in hymnis: confitemini illi.\nLaudate nomen ejus: quoniam suavis est Dominus, in aeternum misericordia ejus, et usque in generationem et generationem veritas ejus.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "When thou wert wondrously born.\nPsalm 99\nSing joyfully unto God all the earth: serve ye the Lord with gladness.\nCome in before His presence with exceeding joy.\nKnow ye that the Lord He is God: He hath made us, and not we ourselves.\nWe are His people and the sheep of His pasture: go ye into His gates with thanksgiving, and into His courts with hymns; and give thanks unto Him.\nPraise ye His name; for the Lord is gracious, His mercy is for ever, and His truth endureth from generation to generation.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Quando natus es.",
+                "en-US": "When thou wert wondrously born."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 99",
+                "en-US": "Psalm 99"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Jubilate Deo, omnis terra: servite Domino in laetitia.\nIntroite in conspectu ejus, in exsultatione.\nScitote quoniam Dominus ipse est Deus: ipse fecit nos, et non ipsi nos.\nPopulus ejus, et oves pascuae ejus: introite portas ejus in confessione, atria ejus in hymnis: confitemini illi.\nLaudate nomen ejus: quoniam suavis est Dominus, in aeternum misericordia ejus, et usque in generationem et generationem veritas ejus.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "Sing joyfully unto God all the earth: serve ye the Lord with gladness.\nCome in before His presence with exceeding joy.\nKnow ye that the Lord He is God: He hath made us, and not we ourselves.\nWe are His people and the sheep of His pasture: go ye into His gates with thanksgiving, and into His courts with hymns; and give thanks unto Him.\nPraise ye His name; for the Lord is gracious, His mercy is for ever, and His truth endureth from generation to generation.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -625,7 +1922,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -639,7 +1936,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -653,7 +1950,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -667,7 +1964,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -681,7 +1978,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -690,12 +1987,40 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Rubum, quem viderat Moyses.\nPsalm 62\nDeus, Deus meus, ad te de luce vigilo.\nSitivit in te anima mea, quam multipliciter tibi caro mea.\nIn terra deserta, et invia, et inaquosa: sic in sancto apparui tibi, ut viderem virtutem tuam, et gloriam tuam.\nQuoniam melior est misericordia tua super vitas: labia mea laudabunt te.\nSic benedicam te in vita mea: et in nomine tuo levabo manus meas.\nSicut adipe et pinguedine repleatur anima mea: et labiis exsultationis laudabit os meum.\nSi memor fui tui super stratum meum, in matutinis meditabor in te: quia fuisti adjutor meus.\nEt in velamento alarum tuarum exsultabo, adhaesit anima mea post te: me suscepit dextera tua.\nIpsi vero in vanum quaesierunt animam meam, introibunt in inferiora terrae: tradentur in manus gladii, partes vulpium erunt.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nPsalm 66\nDeus misereatur nostri, et benedicat nobis: illuminet vultum suum super nos, et misereatur nostri.\nUt cognoscamus in terra viam tuam, in omnibus gentibus salutare tuum.\nConfiteantur tibi populi, Deus: confiteantur tibi populi omnes.\nLaetentur et exsultent gentes: quoniam judicas populos in aequitate, et gentes in terra dirigis.\nConfiteantur tibi populi, Deus, confiteantur tibi populi omnes: terra dedit fructum suum.\nBenedicat nos Deus, Deus noster, benedicat nos Deus: et metuant eum omnes fines terrae.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "The bush which Moses saw.\nPsalm 62\nO God, my God, to Thee do I wake at break of day.\nFor Thee my soul thirsteth; for Thee my flesh longeth, O how exceedingly!\nIn a desert, pathless, and waterless land: so have I come before Thee in the holy place, that I might see Thy power and Thy glory.\nFor Thy mercy is better than life: my lips shall praise Thee.\nThus will I bless Thee all my life long; and in Thy name will I lift up my hands.\nLet my soul be filled as with marrow and fatness; and my mouth shall praise Thee with joyful lips.\nIf I have remembered Thee upon my bed, on Thee will I meditate in the morning; because Thou hast been my helper.\nAnd I will rejoice under the covert of Thy wings: my soul cleaveth unto Thee; Thy right hand upholdeth me.\nBut they seek my soul in vain: they shall go into the lower parts of the earth: they shall be delivered into the power of the sword: they shall be portions for foxes.\nBut the king shall rejoice in God, all they that swear by Him shall be praised: because the mouth of them that speak wicked things is stopped.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 66\nGod be merciful unto us, and bless us: cause His countenance to shine upon us, and be merciful unto us.\nThat we may know Thy way upon earth: Thy salvation in all nations.\nLet the peoples give thanks to Thee, O God: let all the peoples give Thee thanks.\nO let the nations be glad and rejoice; for Thou judgest the peoples with justice, and governest the nations upon earth.\nLet the peoples give thanks to Thee, O God: let all the peoples give Thee thanks.\nMay God, even our own God, bless us, may God bless us; and may all the ends of the earth fear Him.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Rubum, quem viderat Moyses.",
+                "en-US": "The bush which Moses saw."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 62",
+                "en-US": "Psalm 62"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, Deus meus, ad te de luce vigilo.\nSitivit in te anima mea, quam multipliciter tibi caro mea.\nIn terra deserta, et invia, et inaquosa: sic in sancto apparui tibi, ut viderem virtutem tuam, et gloriam tuam.\nQuoniam melior est misericordia tua super vitas: labia mea laudabunt te.\nSic benedicam te in vita mea: et in nomine tuo levabo manus meas.\nSicut adipe et pinguedine repleatur anima mea: et labiis exsultationis laudabit os meum.\nSi memor fui tui super stratum meum, in matutinis meditabor in te: quia fuisti adjutor meus.\nEt in velamento alarum tuarum exsultabo, adhaesit anima mea post te: me suscepit dextera tua.\nIpsi vero in vanum quaesierunt animam meam, introibunt in inferiora terrae: tradentur in manus gladii, partes vulpium erunt.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "O God, my God, to Thee do I wake at break of day.\nFor Thee my soul thirsteth; for Thee my flesh longeth, O how exceedingly!\nIn a desert, pathless, and waterless land: so have I come before Thee in the holy place, that I might see Thy power and Thy glory.\nFor Thy mercy is better than life: my lips shall praise Thee.\nThus will I bless Thee all my life long; and in Thy name will I lift up my hands.\nLet my soul be filled as with marrow and fatness; and my mouth shall praise Thee with joyful lips.\nIf I have remembered Thee upon my bed, on Thee will I meditate in the morning; because Thou hast been my helper.\nAnd I will rejoice under the covert of Thy wings: my soul cleaveth unto Thee; Thy right hand upholdeth me.\nBut they seek my soul in vain: they shall go into the lower parts of the earth: they shall be delivered into the power of the sword: they shall be portions for foxes.\nBut the king shall rejoice in God, all they that swear by Him shall be praised: because the mouth of them that speak wicked things is stopped.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 66",
+                "en-US": "Psalm 66"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus misereatur nostri, et benedicat nobis: illuminet vultum suum super nos, et misereatur nostri.\nUt cognoscamus in terra viam tuam, in omnibus gentibus salutare tuum.\nConfiteantur tibi populi, Deus: confiteantur tibi populi omnes.\nLaetentur et exsultent gentes: quoniam judicas populos in aequitate, et gentes in terra dirigis.\nConfiteantur tibi populi, Deus, confiteantur tibi populi omnes: terra dedit fructum suum.\nBenedicat nos Deus, Deus noster, benedicat nos Deus: et metuant eum omnes fines terrae.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "God be merciful unto us, and bless us: cause His countenance to shine upon us, and be merciful unto us.\nThat we may know Thy way upon earth: Thy salvation in all nations.\nLet the peoples give thanks to Thee, O God: let all the peoples give Thee thanks.\nO let the nations be glad and rejoice; for Thou judgest the peoples with justice, and governest the nations upon earth.\nLet the peoples give thanks to Thee, O God: let all the peoples give Thee thanks.\nMay God, even our own God, bless us, may God bless us; and may all the ends of the earth fear Him.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -709,7 +2034,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -723,7 +2048,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -737,7 +2062,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -751,7 +2076,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -765,7 +2090,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -774,12 +2099,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Germinavit radix Iesse.\nCanticum Trium Puerorum\nBenedicite, omnia opera Domini, Domino: laudate et superexaltate eum in saecula.\nBenedicite, angeli Domini, Domino: benedicite, caeli, Domino.\nBenedicite, aquae omnes, quae super caelos sunt, Domino: benedicite, omnes virtutes Domini, Domino.\nBenedicite, sol et luna, Domino: benedicite, stellae caeli, Domino.\nBenedicite, omnis imber et ros, Domino: benedicite, omnes spiritus Dei, Domino.\nBenedicite, ignis et aestus, Domino: benedicite, frigus et aestus, Domino.\nBenedicite, rores et pruina, Domino: benedicite, gelu et frigus, Domino.\nBenedicite, glacies et nives, Domino: benedicite, noctes et dies, Domino.\nBenedicite, lux et tenebrae, Domino: benedicite, fulgura et nubes, Domino.\nBenedicat terra Dominum: laudet et superexaltet eum in saecula.\nBenedicite, montes et colles, Domino: benedicite, universa germinantia in terra, Domino.\nBenedicite, fontes, Domino: benedicite, maria et flumina, Domino.\nBenedicite, cete, et omnia, quae moventur in aquis, Domino: benedicite, omnes volucres caeli, Domino.\nBenedicite, omnes bestiae et pecora, Domino: benedicite, filii hominum, Domino.\nBenedicat Israel Dominum: laudet et superexaltet eum in saecula.\nBenedicite, sacerdotes Domini, Domino: benedicite, servi Domini, Domino.\nBenedicite, Anania, Azaria, Misael, Domino: laudate et superexaltate eum in saecula.\nBenedicamus Patrem et Filium cum Sancto Spiritu: laudemus et superexaltemus eum in saecula.\nBenedictus es, Domine, in firmamento caeli: et laudabilis, et gloriosus, et superexaltatus in saecula.",
-                "en-US": "The root of Jesse hath budded.\nCanticum Trium Puerorum\nAll ye works of the Lord, bless the Lord, praise and exalt Him above all for ever.\nO ye angels of the Lord, bless the Lord: O ye heavens, bless the Lord.\nO all ye waters that are above the heavens, bless the Lord: O all ye powers of the Lord, bless the Lord.\nO ye sun and moon, bless the Lord; O ye stars of heaven, bless the Lord.\nO every shower and dew, bless ye the Lord; O all ye spirits of God, bless the Lord.\nO ye fire and heat, bless the Lord; O ye cold and heat, bless the Lord.\nO ye dews and hoar-frosts, bless the Lord; O ye frost and cold, bless the Lord.\nO ye ice and snow, bless the Lord; O ye nights and days, bless the Lord.\nO ye light and darkness, bless the Lord; O ye lightnings and clouds, bless the Lord.\nO let the earth bless the Lord; let it praise and exalt Him above all for ever.\nO ye mountains and hills, bless the Lord; O all ye things that spring up in the earth, bless the Lord.\nO ye fountains, bless the Lord; O ye seas and rivers, bless the Lord.\nO ye whales, and all that move in the waters, bless the Lord; O all ye fowls of the air, bless the Lord.\nO all ye beasts and cattle, bless the Lord; O ye sons of men, bless the Lord.\nO let Israel bless the Lord; let him praise and exalt Him above all for ever.\nO ye priests of the Lord, bless the Lord; O ye servants of the Lord, bless the Lord.\nO ye spirits and souls of the just, bless the Lord; O ye holy and humble of heart, bless the Lord.\nO Ananias, Azarias, and Misael, bless ye the Lord; praise and exalt Him above all for ever.\nLet us bless the Father, and the Son, with the Holy Ghost; let us praise and magnify Him for ever.\nBlessed art Thou, O Lord, in the firmament of heaven; and worthy of praise, and glorious, and magnified for ever."
+                "la": "Germinavit radix Iesse.",
+                "en-US": "The root of Jesse hath budded."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Canticum Trium Puerorum",
+                "en-US": "Canticum Trium Puerorum"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Benedicite, omnia opera Domini, Domino: laudate et superexaltate eum in saecula.\nBenedicite, angeli Domini, Domino: benedicite, caeli, Domino.\nBenedicite, aquae omnes, quae super caelos sunt, Domino: benedicite, omnes virtutes Domini, Domino.\nBenedicite, sol et luna, Domino: benedicite, stellae caeli, Domino.\nBenedicite, omnis imber et ros, Domino: benedicite, omnes spiritus Dei, Domino.\nBenedicite, ignis et aestus, Domino: benedicite, frigus et aestus, Domino.\nBenedicite, rores et pruina, Domino: benedicite, gelu et frigus, Domino.\nBenedicite, glacies et nives, Domino: benedicite, noctes et dies, Domino.\nBenedicite, lux et tenebrae, Domino: benedicite, fulgura et nubes, Domino.\nBenedicat terra Dominum: laudet et superexaltet eum in saecula.\nBenedicite, montes et colles, Domino: benedicite, universa germinantia in terra, Domino.\nBenedicite, fontes, Domino: benedicite, maria et flumina, Domino.\nBenedicite, cete, et omnia, quae moventur in aquis, Domino: benedicite, omnes volucres caeli, Domino.\nBenedicite, omnes bestiae et pecora, Domino: benedicite, filii hominum, Domino.\nBenedicat Israel Dominum: laudet et superexaltet eum in saecula.\nBenedicite, sacerdotes Domini, Domino: benedicite, servi Domini, Domino.\nBenedicite, Anania, Azaria, Misael, Domino: laudate et superexaltate eum in saecula.\nBenedicamus Patrem et Filium cum Sancto Spiritu: laudemus et superexaltemus eum in saecula.\nBenedictus es, Domine, in firmamento caeli: et laudabilis, et gloriosus, et superexaltatus in saecula.",
+                "en-US": "All ye works of the Lord, bless the Lord, praise and exalt Him above all for ever.\nO ye angels of the Lord, bless the Lord: O ye heavens, bless the Lord.\nO all ye waters that are above the heavens, bless the Lord: O all ye powers of the Lord, bless the Lord.\nO ye sun and moon, bless the Lord; O ye stars of heaven, bless the Lord.\nO every shower and dew, bless ye the Lord; O all ye spirits of God, bless the Lord.\nO ye fire and heat, bless the Lord; O ye cold and heat, bless the Lord.\nO ye dews and hoar-frosts, bless the Lord; O ye frost and cold, bless the Lord.\nO ye ice and snow, bless the Lord; O ye nights and days, bless the Lord.\nO ye light and darkness, bless the Lord; O ye lightnings and clouds, bless the Lord.\nO let the earth bless the Lord; let it praise and exalt Him above all for ever.\nO ye mountains and hills, bless the Lord; O all ye things that spring up in the earth, bless the Lord.\nO ye fountains, bless the Lord; O ye seas and rivers, bless the Lord.\nO ye whales, and all that move in the waters, bless the Lord; O all ye fowls of the air, bless the Lord.\nO all ye beasts and cattle, bless the Lord; O ye sons of men, bless the Lord.\nO let Israel bless the Lord; let him praise and exalt Him above all for ever.\nO ye priests of the Lord, bless the Lord; O ye servants of the Lord, bless the Lord.\nO ye spirits and souls of the just, bless the Lord; O ye holy and humble of heart, bless the Lord.\nO Ananias, Azarias, and Misael, bless ye the Lord; praise and exalt Him above all for ever.\nLet us bless the Father, and the Son, with the Holy Ghost; let us praise and magnify Him for ever.\nBlessed art Thou, O Lord, in the firmament of heaven; and worthy of praise, and glorious, and magnified for ever."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -793,7 +2132,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -807,7 +2146,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -821,7 +2160,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -835,7 +2174,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -849,7 +2188,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -858,12 +2197,54 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce Maria.\nPsalm 148\nLaudate Dominum de caelis: laudate eum in excelsis.\nLaudate eum, omnes angeli ejus: laudate eum, omnes virtutes ejus.\nLaudate eum, sol et luna: laudate eum, omnes stellae et lumen.\nLaudate eum, caeli caelorum: et aquae omnes, quae super caelos sunt, laudent nomen Domini.\nQuia ipse dixit, et facta sunt: ipse mandavit, et creata sunt.\nStatuit ea in aeternum, et in saeculum saeculi: praeceptum posuit, et non praeteribit.\nLaudate Dominum de terra, dracones, et omnes abyssi.\nIgnis, grando, nix, glacies, spiritus procellarum: quae faciunt verbum ejus:\nMontes, et omnes colles: ligna fructifera, et omnes cedri.\nBestiae, et universa pecora: serpentes, et volucres pennatae:\nReges terrae, et omnes populi: principes, et omnes judices terrae.\nJuvenes, et virgines: senes cum junioribus laudent nomen Domini: quia exaltatum est nomen ejus solius.\nConfessio ejus super caelum et terram: et exaltavit cornu populi sui.\nHymnus omnibus sanctis ejus: filiis Israel, populo appropinquanti sibi.\nPsalm 149\nCantate Domino canticum novum: laus ejus in ecclesia sanctorum.\nLaetetur Israel in eo, qui fecit eum: et filii Sion exsultent in rege suo.\nLaudent nomen ejus in choro: in tympano, et psalterio psallant ei:\nQuia beneplacitum est Domino in populo suo: et exaltabit mansuetos in salutem.\nExsultabunt sancti in gloria: laetabuntur in cubilibus suis.\nExaltationes Dei in gutture eorum: et gladii ancipites in manibus eorum.\nAd faciendam vindictam in nationibus: increpationes in populis.\nAd alligandos reges eorum in compedibus: et nobiles eorum in manicis ferreis.\nUt faciant in eis judicium conscriptum: gloria haec est omnibus sanctis ejus.\nPsalm 150\nLaudate Dominum in sanctis ejus: laudate eum in firmamento virtutis ejus.\nLaudate eum in virtutibus ejus: laudate eum secundum multitudinem magnitudinis ejus.\nLaudate eum in sono tubae: laudate eum in psalterio, et cithara.\nLaudate eum in tympano, et choro: laudate eum in chordis, et organo.\nLaudate eum in cymbalis benesonantibus: laudate eum in cymbalis jubilationis: omnis spiritus laudet Dominum.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "Behold, Mary.\nPsalm 148\nPraise the Lord from the heavens; praise Him in the heights.\nPraise Him, all ye His angels; praise Him, all His hosts.\nPraise Him, sun and moon; praise Him, all ye stars and light.\nPraise Him, ye heavens of heavens; and let all the waters that are above the heavens, praise the name of the Lord.\nFor He spake, and they were made: He commanded, and they were created.\nHe hath established them for ever, and for evermore; He hath made a decree, and it shall not pass away.\nPraise the Lord from the earth; ye dragons and all deeps.\nFire, hail, snow, ice, and stormy winds, which fulfil His word.\nMountains and all hills; fruitful trees and all cedars.\nBeasts and all cattle; creeping things, and feathered fowls.\nKings of the earth and all peoples; princes and all judges of the earth.\nYoung men and maidens, old men and children, let them praise the name of the Lord; for His name alone is exalted.\nHis praise is above heaven and earth; and He hath exalted the horn of His people.\nA song of praise to all His saints; to the children of Israel, a people drawing nigh unto Him.\nPsalm 149\nSing unto the Lord a new song; let His praise be in the Church of the saints.\nLet Israel rejoice in Him that made him; and let the children of Sion be joyful in their King.\nLet them praise Him name in the choir; let them sing unto Him with timbrel and psaltery.\nFor the Lord is well pleased with His people; and He will exalt the meek unto salvation.\nThe saints shall rejoice in glory: they shall be joyful in their beds.\nThe high praises of God shall be in their mouth; and two-edged swords in their hands:\nTo execute vengeance upon the nations; and chastisements among the peoples:\nTo bind their kings with fetters; and their nobles with chains of iron.\nTo execute upon them the judgement that is written: Such glory have all his saints.\nPsalm 150\nPraise ye the Lord in his holy places: praise Him in the firmament of his power.\nPraise Him in His might acts: praise Him according to the multitude of His greatness.\nPraise Him with sound of trumpet: praise Him with psaltery and harp.\nPriase him with timbrel and choir: praise Him with strings and organs.\nPraise Him upon the high-sounding cymbals; praise Him upon cymbals of joy: let every spirit praise the Lord.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Ecce Maria.",
+                "en-US": "Behold, Mary."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 148",
+                "en-US": "Psalm 148"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Laudate Dominum de caelis: laudate eum in excelsis.\nLaudate eum, omnes angeli ejus: laudate eum, omnes virtutes ejus.\nLaudate eum, sol et luna: laudate eum, omnes stellae et lumen.\nLaudate eum, caeli caelorum: et aquae omnes, quae super caelos sunt, laudent nomen Domini.\nQuia ipse dixit, et facta sunt: ipse mandavit, et creata sunt.\nStatuit ea in aeternum, et in saeculum saeculi: praeceptum posuit, et non praeteribit.\nLaudate Dominum de terra, dracones, et omnes abyssi.\nIgnis, grando, nix, glacies, spiritus procellarum: quae faciunt verbum ejus:\nMontes, et omnes colles: ligna fructifera, et omnes cedri.\nBestiae, et universa pecora: serpentes, et volucres pennatae:\nReges terrae, et omnes populi: principes, et omnes judices terrae.\nJuvenes, et virgines: senes cum junioribus laudent nomen Domini: quia exaltatum est nomen ejus solius.\nConfessio ejus super caelum et terram: et exaltavit cornu populi sui.\nHymnus omnibus sanctis ejus: filiis Israel, populo appropinquanti sibi.",
+                "en-US": "Praise the Lord from the heavens; praise Him in the heights.\nPraise Him, all ye His angels; praise Him, all His hosts.\nPraise Him, sun and moon; praise Him, all ye stars and light.\nPraise Him, ye heavens of heavens; and let all the waters that are above the heavens, praise the name of the Lord.\nFor He spake, and they were made: He commanded, and they were created.\nHe hath established them for ever, and for evermore; He hath made a decree, and it shall not pass away.\nPraise the Lord from the earth; ye dragons and all deeps.\nFire, hail, snow, ice, and stormy winds, which fulfil His word.\nMountains and all hills; fruitful trees and all cedars.\nBeasts and all cattle; creeping things, and feathered fowls.\nKings of the earth and all peoples; princes and all judges of the earth.\nYoung men and maidens, old men and children, let them praise the name of the Lord; for His name alone is exalted.\nHis praise is above heaven and earth; and He hath exalted the horn of His people.\nA song of praise to all His saints; to the children of Israel, a people drawing nigh unto Him."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 149",
+                "en-US": "Psalm 149"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Cantate Domino canticum novum: laus ejus in ecclesia sanctorum.\nLaetetur Israel in eo, qui fecit eum: et filii Sion exsultent in rege suo.\nLaudent nomen ejus in choro: in tympano, et psalterio psallant ei:\nQuia beneplacitum est Domino in populo suo: et exaltabit mansuetos in salutem.\nExsultabunt sancti in gloria: laetabuntur in cubilibus suis.\nExaltationes Dei in gutture eorum: et gladii ancipites in manibus eorum.\nAd faciendam vindictam in nationibus: increpationes in populis.\nAd alligandos reges eorum in compedibus: et nobiles eorum in manicis ferreis.\nUt faciant in eis judicium conscriptum: gloria haec est omnibus sanctis ejus.",
+                "en-US": "Sing unto the Lord a new song; let His praise be in the Church of the saints.\nLet Israel rejoice in Him that made him; and let the children of Sion be joyful in their King.\nLet them praise Him name in the choir; let them sing unto Him with timbrel and psaltery.\nFor the Lord is well pleased with His people; and He will exalt the meek unto salvation.\nThe saints shall rejoice in glory: they shall be joyful in their beds.\nThe high praises of God shall be in their mouth; and two-edged swords in their hands:\nTo execute vengeance upon the nations; and chastisements among the peoples:\nTo bind their kings with fetters; and their nobles with chains of iron.\nTo execute upon them the judgement that is written: Such glory have all his saints."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 150",
+                "en-US": "Psalm 150"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Laudate Dominum in sanctis ejus: laudate eum in firmamento virtutis ejus.\nLaudate eum in virtutibus ejus: laudate eum secundum multitudinem magnitudinis ejus.\nLaudate eum in sono tubae: laudate eum in psalterio, et cithara.\nLaudate eum in tympano, et choro: laudate eum in chordis, et organo.\nLaudate eum in cymbalis benesonantibus: laudate eum in cymbalis jubilationis: omnis spiritus laudet Dominum.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "Praise ye the Lord in his holy places: praise Him in the firmament of his power.\nPraise Him in His might acts: praise Him according to the multitude of His greatness.\nPraise Him with sound of trumpet: praise Him with psaltery and harp.\nPriase him with timbrel and choir: praise Him with strings and organs.\nPraise Him upon the high-sounding cymbals; praise Him upon cymbals of joy: let every spirit praise the Lord.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -877,7 +2258,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -891,7 +2272,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -900,26 +2281,90 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce Maria genuit nobis Salvatorem, quem Ioannes videns, exclamavit, dicens: Ecce Agnus Dei, ecce qui tollit peccata mundi, alleluia.\nLittle Chapter From Christmas to Advent - Cant vi\nViderunt eam filiae Sion, et beatissimam praedicaverunt et reginae laudaverunt eam.\n℟. Deo gratias.\nLittle Chapter in Advent - Is 11:1-2\nEgredietur virga de radice Iesse, et flos de radice eius ascendet. Et requiescet super eum Spiritus Domini.\n℟. Deo gratias.",
-                "en-US": "Behold, Mary, hath brought us forth a Saviour, Whom when John saw, he cried aloud, saying: Behold the Lamb of God! Behold Him Who taketh away the sins of the world, Alleluia.\nLittle Chapter from Christmas until Advent - Cant vi\nThe daughters of Sion saw her, and declared her most blessed; and queens praised her.\n℟. Thanks be to God.\nLittle Chapter in Advent - Is 11:1-2\nThere shall come forth a rod out of the root of Jesse, and a flower shall rise up out of his root, and the Spirit of the Lord shall rest upon Him.\n℟. Thanks be to God."
+                "la": "Ecce Maria genuit nobis Salvatorem, quem Ioannes videns, exclamavit, dicens: Ecce Agnus Dei, ecce qui tollit peccata mundi, alleluia.\nLittle Chapter From Christmas to Advent - Cant vi\nViderunt eam filiae Sion, et beatissimam praedicaverunt et reginae laudaverunt eam.",
+                "en-US": "Behold, Mary, hath brought us forth a Saviour, Whom when John saw, he cried aloud, saying: Behold the Lamb of God! Behold Him Who taketh away the sins of the world, Alleluia.\nLittle Chapter from Christmas until Advent - Cant vi\nThe daughters of Sion saw her, and declared her most blessed; and queens praised her."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Little Chapter in Advent - Is 11:1-2\nEgredietur virga de radice Iesse, et flos de radice eius ascendet. Et requiescet super eum Spiritus Domini.",
+                "en-US": "Little Chapter in Advent - Is 11:1-2\nThere shall come forth a rod out of the root of Jesse, and a flower shall rise up out of his root, and the Spirit of the Lord shall rest upon Him."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "The first verse of the hymn is said kneeling."
+              }
+            },
+            {
+              "type": "hymn",
+              "lang": "la",
               "inline": {
-                "la": "The first verse of the hymn is said kneeling.\nO gloriosa virginum,\nSublimis inter sidera,\nQui te creavit, parvulum\nLactente nutris ubere.\nQuod Heva tristis abstulit,\nTu reddis almo germine:\nIntrent ut astra flebiles,\nCaeli recludis cardines.\nTu Regis alti janua\nEt aula lucis fulgida:\nVitam datam per Virginem,\nGentes redemptae, plaudite.\nJesu, tibi sit gloria,\nQui natus es de Virgine,\nCum Patre et almo Spiritu,\nIn sempiterna saecula.\nAmen.\n℣. Benedicta tu in mulieribus.\n℟. Et benedictus fructus ventris tui.\nCanticle of the Zachary - Lk 1",
-                "en-US": "The first verse of the hymn is said kneeling.\nO Queen of all the virgin choir,\nEnthroned above the starry sky,\nWho with thy bosom's milk didst feed\nThine own Creator, Lord most high.\nWhat man had lost in hapless Eve,\nThy sacred womb to man restores;\nThou to the wretched here beneath\nHast open'd heaven's eternal doors.\nHail, O refulgent Hall of light!\nHail, Gate august of heaven's high King!\nThrough thee redeemed to endless life,\nThy praise let all the nations sing.\nO Jesu! born of Virgin bright,\nImmortal glory be to Thee;\nPraise to the Father infinite\nAnd Holy Ghost eternally.\nAmen.\n℣. Blessed art thou amongst women.\n℟. And blessed is the fruit of thy womb.\nCanticle of the Zachary - Lk 1"
+                "la": "O gloriosa virginum,\nSublimis inter sidera,\nQui te creavit, parvulum\nLactente nutris ubere.\nQuod Heva tristis abstulit,\nTu reddis almo germine:\nIntrent ut astra flebiles,\nCaeli recludis cardines.\nTu Regis alti janua\nEt aula lucis fulgida:\nVitam datam per Virginem,\nGentes redemptae, plaudite.\nJesu, tibi sit gloria,\nQui natus es de Virgine,\nCum Patre et almo Spiritu,\nIn sempiterna saecula.\nAmen."
               }
             },
             {
               "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "The first verse of the hymn is said kneeling."
+              }
+            },
+            {
+              "type": "hymn",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O Queen of all the virgin choir,\nEnthroned above the starry sky,\nWho with thy bosom's milk didst feed\nThine own Creator, Lord most high.\nWhat man had lost in hapless Eve,\nThy sacred womb to man restores;\nThou to the wretched here beneath\nHast open'd heaven's eternal doors.\nHail, O refulgent Hall of light!\nHail, Gate august of heaven's high King!\nThrough thee redeemed to endless life,\nThy praise let all the nations sing.\nO Jesu! born of Virgin bright,\nImmortal glory be to Thee;\nPraise to the Father infinite\nAnd Holy Ghost eternally.\nAmen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicta tu in mulieribus.",
+                    "en-US": "Blessed art thou amongst women."
+                  },
+                  "r": {
+                    "la": "Et benedictus fructus ventris tui.",
+                    "en-US": "And blessed is the fruit of thy womb."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Canticle of the Zachary - Lk 1",
+                "en-US": "Canticle of the Zachary - Lk 1"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -933,7 +2378,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -947,7 +2392,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -955,13 +2400,48 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Mirabile mysterium.\nDuring Eastertide, instead of the above, the following antiphon is said:\nAnt. Regina caeli.\nBenedictus ✠ Dominus, Deus Israel: quia visitavit, et fecit redemptionem plebis suae:\nEt erexit cornu salutis nobis: in domo David, pueri sui.\nSicut locutus est per os sanctorum, qui a saeculo sunt, prophetarum ejus:\nSalutem ex inimicis nostris, et de manu omnium, qui oderunt nos.\nAd faciendam misericordiam cum patribus nostris: et memorari testamenti sui sancti.\nJusjurandum, quod juravit ad abraham patrem nostrum, daturum se nobis:\nUt sine timore, de manu inimicorum nostrorum liberati, serviamus illi.\nIn sanctitate, et justitia coram ipso, omnibus diebus nostris.\nEt tu, puer, Propheta Altissimi vocaberis: praeibis enim ante faciem Domini, parare vias ejus:\nAd dandam scientiam salutis plebi ejus: in remissionem peccatorum eorum:\nPer viscera misericordiae Dei nostri: in quibus visitavit nos, oriens ex alto:\nIlluminare his, qui in tenebris, et in umbra mortis sedent: ad dirigendos pedes nostros in viam pacis.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "A wondrous mystery.\nDuring Eastertide, instead of the above, the following antiphon is said:\nAnt. O Queen of heaven.\nBlessed be the Lord ✠ God of Israel, because He hath visited and wrought the redemption of His people.\nAnd hath raised up a horn of salvation to us in the house of David His servant;\nAs He spoke by the mouth of His holy prophets, who are from the beginning:\nSalvation from our enemies, and from the hand of all that hate us.\nTo perform mercy to our fathers, and to remember His holy testament.\nThe oath which He swore to Abraham our father, that He would grant to us,\nThat being delivered from the hand of our enemies, we may serve Him without fear,\nIn holiness and justice before Him all our days.\nAnd thou, child, shalt be called the prophet of the Highest;\nfor thou shalt go before the face of the Lord to prepare His ways:\nTo give knowledge of salvation to His people, unto the remission of their sins;\nThrough the bowels of the mercy of our God, in which the Orient from on high hath visited us.\nTo enlighten them that sit in darkness and in the shadow of death; to direct our feet into the way of peace.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Mirabile mysterium."
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "During Eastertide, instead of the above, the following antiphon is said:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "A wondrous mystery."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Eastertide, instead of the above, the following antiphon is said:"
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Ant. Regina caeli.",
+                "en-US": "Ant. O Queen of heaven."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Benedictus ✠ Dominus, Deus Israel: quia visitavit, et fecit redemptionem plebis suae:\nEt erexit cornu salutis nobis: in domo David, pueri sui.\nSicut locutus est per os sanctorum, qui a saeculo sunt, prophetarum ejus:\nSalutem ex inimicis nostris, et de manu omnium, qui oderunt nos.\nAd faciendam misericordiam cum patribus nostris: et memorari testamenti sui sancti.\nJusjurandum, quod juravit ad abraham patrem nostrum, daturum se nobis:\nUt sine timore, de manu inimicorum nostrorum liberati, serviamus illi.\nIn sanctitate, et justitia coram ipso, omnibus diebus nostris.\nEt tu, puer, Propheta Altissimi vocaberis: praeibis enim ante faciem Domini, parare vias ejus:\nAd dandam scientiam salutis plebi ejus: in remissionem peccatorum eorum:\nPer viscera misericordiae Dei nostri: in quibus visitavit nos, oriens ex alto:\nIlluminare his, qui in tenebris, et in umbra mortis sedent: ad dirigendos pedes nostros in viam pacis.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "Blessed be the Lord ✠ God of Israel, because He hath visited and wrought the redemption of His people.\nAnd hath raised up a horn of salvation to us in the house of David His servant;\nAs He spoke by the mouth of His holy prophets, who are from the beginning:\nSalvation from our enemies, and from the hand of all that hate us.\nTo perform mercy to our fathers, and to remember His holy testament.\nThe oath which He swore to Abraham our father, that He would grant to us,\nThat being delivered from the hand of our enemies, we may serve Him without fear,\nIn holiness and justice before Him all our days.\nAnd thou, child, shalt be called the prophet of the Highest;\nfor thou shalt go before the face of the Lord to prepare His ways:\nTo give knowledge of salvation to His people, unto the remission of their sins;\nThrough the bowels of the mercy of our God, in which the Orient from on high hath visited us.\nTo enlighten them that sit in darkness and in the shadow of death; to direct our feet into the way of peace.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -975,7 +2455,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -989,7 +2469,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -997,13 +2477,240 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Mirabile mysterium declaratur hodie: innovantur naturae, Deus homo factus est: id quod fuit permansit, et quod non erat assumpsit; non commixtionem passus, neque divisionem.\nDuring Eastertide, instead of the above, the following antiphon is said:\nAnt. Regina caeli,laetare, alleluia; quia quem meruisti portare, alleluia; resurrexit, sicut dixit, alleluia: ora pro nobis Deum, alleluia.\nKyrie Eleison\nChriste Eleision\nKyrie Eleison\nCollect\n℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\nFrom Candlemas until Christmas\nOremus,\nDeus, qui de beatae Mariae Virginis utero Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis; ut, qui vere eam Genitricem Dei credimus, eius apud te intercessionibus adjuvemur. Per eundem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\n℟. Amen.\nFrom Christmas until Candlemas\nOremus,\nDeus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\n℟. Amen.\nCommemoration of the Saints Outside Advent",
-                "en-US": "A wondrous mystery is revealed today: marvels are wrought. God is made man; He still remaineth what He was, and hath taken upon Him what He was not, suffering neither confusion nor division.\nDuring Eastertide, instead of the above, the following antiphon is said:\nAnt. O Queen of heaven rejoice! alleluia: for He whom thou didst merit to bear, alleluia, hath arisen as he said, alleluia; pray for us to God, alleluia.\nLord, have mercy on us.\nChrist, have mercy on us.\nLord, have mercy on us.\nCollect\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\nFrom Candlemas until Christmas\nLet us pray,\nO God, Who didst will that Thine eternal Word should take flesh in the womb of the Blessed Virgin Mary, when the angel delivered his message: grant that Thy petitioners, who verily believe her to be the Mother of God, may be assisted by her intercession. Through the same Christ our Lord.\n℟. Amen.\nFrom Christmas until Candlemas\nLet us pray,\nO God, Who, by the fruitful virginity of blessed Mary, hast given to mankind the rewards of eternal salvation; grant, we beseech Thee, that we may experience her intercession for us, by whom we deserved to receive the Author of life, Our Lord Jesus Christ, Thy Son, Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\n℟. Amen.\nCommemoration of the Saints outside Advent"
+                "la": "Mirabile mysterium declaratur hodie: innovantur naturae, Deus homo factus est: id quod fuit permansit, et quod non erat assumpsit; non commixtionem passus, neque divisionem."
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "During Eastertide, instead of the above, the following antiphon is said:"
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Ant. Regina caeli,laetare, alleluia; quia quem meruisti portare, alleluia; resurrexit, sicut dixit, alleluia: ora pro nobis Deum, alleluia."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Kyrie Eleison\nChriste Eleision\nKyrie Eleison"
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Collect"
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "From Candlemas until Christmas"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Oremus,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Deus, qui de beatae Mariae Virginis utero Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis; ut, qui vere eam Genitricem Dei credimus, eius apud te intercessionibus adjuvemur. Per eundem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "From Christmas until Candlemas"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Oremus,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Deus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Commemoration of the Saints Outside Advent"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "A wondrous mystery is revealed today: marvels are wrought. God is made man; He still remaineth what He was, and hath taken upon Him what He was not, suffering neither confusion nor division."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Eastertide, instead of the above, the following antiphon is said:"
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Ant. O Queen of heaven rejoice! alleluia: for He whom thou didst merit to bear, alleluia, hath arisen as he said, alleluia; pray for us to God, alleluia."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Lord, have mercy on us.\nChrist, have mercy on us.\nLord, have mercy on us."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Collect"
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "From Candlemas until Christmas"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Let us pray,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who didst will that Thine eternal Word should take flesh in the womb of the Blessed Virgin Mary, when the angel delivered his message: grant that Thy petitioners, who verily believe her to be the Mother of God, may be assisted by her intercession. Through the same Christ our Lord."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "From Christmas until Candlemas"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Let us pray,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who, by the fruitful virginity of blessed Mary, hast given to mankind the rewards of eternal salvation; grant, we beseech Thee, that we may experience her intercession for us, by whom we deserved to receive the Author of life, Our Lord Jesus Christ, Thy Son, Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Commemoration of the Saints outside Advent"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1011,13 +2718,97 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Sancti Dei omnes, intercedere dignemini pro nostra omniumque salute.\n℣. Laetamini in Domino et exsultate, justi.\n℟. Et gloriamini, omnes recti corde.\nOremus,\nProtege, Domine, populum tuum, et, Apostolorum tuorum Petri et Pauli et aliorum Apostolorum patrocinio confidentem, perpetua defensione conserva.\nOmnes Sancti tui, quaesumus, Domine, nos ubique adjuvent: ut, dum eorum merita recolimus, patrocinia sentiamus: et pacem tuam nostris concede temporibus, et ab Ecclesia tua cunctam repelle nequitiam; iter, actus et voluntates nostras et omnium famulorum tuorum, in salutis tuae prosperitate dispone, benefactoribus nostris sempiterna bona retribue, et omnibus fidelibus defunctis requiem aeternam concede.\n℟. Amen.\nCommemoration of the Saints in Advent",
-                "en-US": "All ye saints of God, vouchsafe to plead for our salvation and for that of all mankind.\n℣. Be glad in the Lord, and rejoice, ye just.\n℣. And be joyful, all ye that are of right heart.\nLet us pray,\nShield, O Lord, Thy people, and ever keep them in Thy care, who put their trust in the pleading of Thine apostles Peter and Paul, and of the other apostles.\nMay all Thy saints, we beseech Thee, O Lord, everywhere come to our help, that while we do honor to their merits, we may also enjoy their intercession: grant Thine own peace unto our times, and drive away all wickedness from Thy Church; direct our way, our actions, and our wishes and those of all Thy servants in the way of salvation; to our benefactors render everlasting blessings, and to all the faithful departed grant eternal rest. Through Our Lord Jesus Christ, Thy Son, Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\nAmen.\nCommemoration of the Saints During Advent"
+                "la": "Sancti Dei omnes, intercedere dignemini pro nostra omniumque salute."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Laetamini in Domino et exsultate, justi."
+                  },
+                  "r": {
+                    "la": "Et gloriamini, omnes recti corde."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Oremus,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Protege, Domine, populum tuum, et, Apostolorum tuorum Petri et Pauli et aliorum Apostolorum patrocinio confidentem, perpetua defensione conserva.\nOmnes Sancti tui, quaesumus, Domine, nos ubique adjuvent: ut, dum eorum merita recolimus, patrocinia sentiamus: et pacem tuam nostris concede temporibus, et ab Ecclesia tua cunctam repelle nequitiam; iter, actus et voluntates nostras et omnium famulorum tuorum, in salutis tuae prosperitate dispone, benefactoribus nostris sempiterna bona retribue, et omnibus fidelibus defunctis requiem aeternam concede."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Commemoration of the Saints in Advent"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "All ye saints of God, vouchsafe to plead for our salvation and for that of all mankind."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "Be glad in the Lord, and rejoice, ye just."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "And be joyful, all ye that are of right heart."
               }
             },
             {
               "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Let us pray,"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Shield, O Lord, Thy people, and ever keep them in Thy care, who put their trust in the pleading of Thine apostles Peter and Paul, and of the other apostles.\nMay all Thy saints, we beseech Thee, O Lord, everywhere come to our help, that while we do honor to their merits, we may also enjoy their intercession: grant Thine own peace unto our times, and drive away all wickedness from Thy Church; direct our way, our actions, and our wishes and those of all Thy servants in the way of salvation; to our benefactors render everlasting blessings, and to all the faithful departed grant eternal rest. Through Our Lord Jesus Christ, Thy Son, Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Commemoration of the Saints During Advent"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1025,10 +2816,604 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Ecce Dominus veniet, et omnes Sancti ejus cum eo: et erit in die illa lux magna, Alleluia.\n℣. Ecce apparebit Dominus super nubem candidam.\n℟. Et cum eo Sanctorum millia.\nOremus,\nConscientias nostras, quaesumus, Domine, visitando purifica: ut, veniens Jesus Christus, Filius tuus, Dominus noster, cum omnibus Sanctis, paratam sibi in nobis inveniat mansionem: qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\n℟. Amen.\nConclusion\n℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.\nThe Our Father is prayed silently.\nPater noster, qui es in caelis, sanctificetur nomen tuum: adveniat regnum tuum: fiat voluntas tua, sicut in caelo et in terra. Panem nostrum quotidianum da nobis hodie: et dimitte nobis debita nostra, sicut et nos dimittimus debitoribus nostris: et ne nos inducas in tentationem: sed libera nos a malo. Amen.\n℣. Dominus det nobis suam pacem.\n℟. Et vitam aeternam. Amen.\nAnthem\nThen is said one of the following Anthems of the Blessed Virgin Mary according to the season.\nFrom Candlemas until Compline on Holy Saturday exclusively\nAve, Regina caelorum,\nAve Domina Angelorum:\nSalve, radix, salve, porta\nEx qua mundo lux est orta:\nGaude Virgo gloriosa,\nSuper omnes speciosa,\nVale, o valde decora,\nEt pro nobis Christum exora.\n℣. Dignare me laudare te, Virgo sacrata.\n℟. Da mihi virtutem contra hostes tuos.\nOremus,\nConcede, misericors Deus, fragilitati nostrae praesidium: ut, qui sanctae Dei Genitricis memoriam agimus; intercessionis eius auxilio, a nostris iniquitatibus resurgamus. Per eumdem Christum Dominum nostrum.\n℟. Amen.\nFrom Compline of Holy Saturday until None on the Saturday after Pentecost inclusively\nRegina caeli laetare, alleluia;\nQuia quem meruisti portare, alleluia,\nResurrexit, sicut dixit, alleluia:\nOra pro nobis Deum, alleluia.\n℣. Gaude et laetare, Virgo Maria, Alleluia.\n℟. Quia surrexit Dominus vere, Alleluia.\nOremus,\nDeus, qui per resurrectionem Filii tui, Domini nostri Iesu Christi mundum laetificare dignatus es: praesta, quaesumus; ut per eius Genitricem Virginem Mariam, perpetuae capiamus gaudia vitae. Per eumdem Christum Dominum nostrum.\n℟. Amen.\nFrom Compline of the Saturday after Pentecost until Advent\nSalve, Regina, mater misericordiae;\nVita, dulcedo, et spes nostra, salve.\nAd te clamamus exules filii Hevae.\nAd te suspiramus gementes et flentes in hac lacrimarum valle.\nEia ergo, Advocata nostra, illos tuos misericordes oculos ad nos converte.\nEt Iesum, benedictum fructum ventris tui, nobis post hoc exsilium ostende.\nO clemens, O pia, O dulcis Virgo Maria.\n℣. Ora pro nobis, sancta Dei Genitrix.\n℟. Ut digni efficiamur promissionibus Christi.\nOremus,\nOmnipotens sempiterne Deus, qui gloriosae Virginis Matris Mariae corpus et animam, ut dignum Filii tui habitaculum effici mereretur, Spiritu Sancto cooperante praeparasti: da, ut cuius commemoratione laetamur; eius pia intercessione, ab instantibus malis, et a morte perpetua liberemur. Per eumdem Christum Dominum nostrum.\n℟. Amen.\nFinal blessing\n℣. Divinum auxilium ✠ maneat semper nobiscum.\n℟. Amen.",
-                "en-US": "Behold, the Lord shall come, and all His saints with Him, and in that day there shall be great light, Alleluia.\n℣. Behold, the Lord shall appear upon a shining cloud.\n℣. And with Him thousands of saints.\nLet us pray,\nCleanse our consciences, we beseech Thee, O Lord, by Thy visitation, that when Jesus Christ, Thy Son, Our Lord, shall come with all the saints, He may find within us a resting-place made ready for Him. Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\nAmen.\nConclusion\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed, through the mercy of God, rest in peace.\n℟. Amen.\nThe Our Father is prayed silently.\nOur Father, who art in heaven, Hallowed be thy name. Thy kingdom come. Thy will be done on earth as it is in heaven. Give us this day our daily bread. And forgive us our trespasses, as we forgive those who trespass against us. And lead us not into temptation: But deliver us from evil. Amen.\n℣. May the Lord grant us His peace.\n℟. And life everlasting. Amen.\nAnthem\nThen is said one of the following Anthems of the Blessed Virgin Mary according to the season.\nFrom Candlemas until Compline on Holy Saturday exclusively\nHail, O Queen of heav'n enthroned!\nHail, by angels Mistress owned!\nRoot of Jesse! Gate of morn,\nWhen the world's true Light was born:\nGlorious Virgin, joy to thee,\nBeautiful surpassingly!\nFairest thou where all are fair!\nPlead for us a pitying prayer.\n℣. Vouchsafe that I may praise thee, O Blessed Virgin.\n℟. Grant me strength agains thine enemies.\nLet us pray,\nO most merciful God, grant succor unto our frailty; that as we celebrate the memory of the holy Mother of God, so by the help of her intercession we may rise again from our sins. Through the same Christ our Lord.\n℟. Amen.\nFrom Compline of Holy Saturday until None on the Saturday after Pentecost inclusively\nO Queen of heaven rejoice, Alleluia,\nFor He Whom thou wast to bear, Alleluia,\nHath risen, as He said, Alleluia.\nPray for us to God, Alleluia.\n℣. Rejoice and be glad, O Virgin Mary, Alleluia.\n℟. For the Lord hath risen indeed, Alleluia.\nLet us pray,\nO God, Who didst vouchsafe to give joy to the world through the Resurrection of Thy Son, Our Lord Jesus Christ; grant, we beseech Thee, that, through His Mother, the Virgin Mary, we may obtain the joys of everlasting life. Through the same Christ our Lord.\n℟. Amen.\nFrom Compline of the Saturday after Pentecost until Advent\nHail, holy Queen, Mother of mercy.\nHail, our life, our sweetness, and our hope!\nTo thee do we cry, poor banished children of Eve.\nTo thee do we send up our sighs, mourning, and weeping in this vale of tears.\nTurn then, most gracious advocate, thine eyes of mercy toward us.\nAnd after this our exile show unto us the blessed fruit of thy womb, Jesus.\nO clement, O loving, O sweet Virgin Mary.\n℣. Pray for us, O holy Mother of God.\n℟. That we may be made worthy of the promises of Christ.\nLet us pray,\nAlmighty, everlasting God, Who, by the co-operation of the Holy Ghost, didst so make ready the body and soul of the glorious Virgin Mother Mary that she deserved to become a meet dwelling for Thy Son; grant that we, who rejoice in her memory, may through her loving intercession be delivered the evils that hang over us, and from everlasting death. Through the same Christ our Lord.\n℟. Amen.\nFinal Blessing\n℣. May the divine assistance ✠ remain always with us.\n℟. Amen."
+                "la": "Ecce Dominus veniet, et omnes Sancti ejus cum eo: et erit in die illa lux magna, Alleluia."
               }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ecce apparebit Dominus super nubem candidam."
+                  },
+                  "r": {
+                    "la": "Et cum eo Sanctorum millia."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Oremus,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Conscientias nostras, quaesumus, Domine, visitando purifica: ut, veniens Jesus Christus, Filius tuus, Dominus noster, cum omnibus Sanctis, paratam sibi in nobis inveniat mansionem: qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Conclusion"
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "The Our Father is prayed silently."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Pater noster, qui es in caelis, sanctificetur nomen tuum: adveniat regnum tuum: fiat voluntas tua, sicut in caelo et in terra. Panem nostrum quotidianum da nobis hodie: et dimitte nobis debita nostra, sicut et nos dimittimus debitoribus nostris: et ne nos inducas in tentationem: sed libera nos a malo. Amen."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus det nobis suam pacem."
+                  },
+                  "r": {
+                    "la": "Et vitam aeternam. Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Anthem"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Then is said one of the following Anthems of the Blessed Virgin Mary according to the season."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "From Candlemas until Compline on Holy Saturday exclusively"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Ave, Regina caelorum,\nAve Domina Angelorum:\nSalve, radix, salve, porta\nEx qua mundo lux est orta:\nGaude Virgo gloriosa,\nSuper omnes speciosa,\nVale, o valde decora,\nEt pro nobis Christum exora."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dignare me laudare te, Virgo sacrata."
+                  },
+                  "r": {
+                    "la": "Da mihi virtutem contra hostes tuos."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Oremus,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Concede, misericors Deus, fragilitati nostrae praesidium: ut, qui sanctae Dei Genitricis memoriam agimus; intercessionis eius auxilio, a nostris iniquitatibus resurgamus. Per eumdem Christum Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "From Compline of Holy Saturday until None on the Saturday after Pentecost inclusively"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Regina caeli laetare, alleluia;\nQuia quem meruisti portare, alleluia,\nResurrexit, sicut dixit, alleluia:\nOra pro nobis Deum, alleluia."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gaude et laetare, Virgo Maria, Alleluia."
+                  },
+                  "r": {
+                    "la": "Quia surrexit Dominus vere, Alleluia."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Oremus,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Deus, qui per resurrectionem Filii tui, Domini nostri Iesu Christi mundum laetificare dignatus es: praesta, quaesumus; ut per eius Genitricem Virginem Mariam, perpetuae capiamus gaudia vitae. Per eumdem Christum Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "From Compline of the Saturday after Pentecost until Advent"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Salve, Regina, mater misericordiae;\nVita, dulcedo, et spes nostra, salve.\nAd te clamamus exules filii Hevae.\nAd te suspiramus gementes et flentes in hac lacrimarum valle.\nEia ergo, Advocata nostra, illos tuos misericordes oculos ad nos converte.\nEt Iesum, benedictum fructum ventris tui, nobis post hoc exsilium ostende.\nO clemens, O pia, O dulcis Virgo Maria."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Dei Genitrix."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Oremus,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Omnipotens sempiterne Deus, qui gloriosae Virginis Matris Mariae corpus et animam, ut dignum Filii tui habitaculum effici mereretur, Spiritu Sancto cooperante praeparasti: da, ut cuius commemoratione laetamur; eius pia intercessione, ab instantibus malis, et a morte perpetua liberemur. Per eumdem Christum Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Final blessing"
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Divinum auxilium ✠ maneat semper nobiscum."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Behold, the Lord shall come, and all His saints with Him, and in that day there shall be great light, Alleluia."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "Behold, the Lord shall appear upon a shining cloud."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "priest",
+              "inline": {
+                "en-US": "And with Him thousands of saints."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Let us pray,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Cleanse our consciences, we beseech Thee, O Lord, by Thy visitation, that when Jesus Christ, Thy Son, Our Lord, shall come with all the saints, He may find within us a resting-place made ready for Him. Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Conclusion"
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "May the souls of the faithful departed, through the mercy of God, rest in peace."
+                  },
+                  "r": {
+                    "en-US": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "The Our Father is prayed silently."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Our Father, who art in heaven, Hallowed be thy name. Thy kingdom come. Thy will be done on earth as it is in heaven. Give us this day our daily bread. And forgive us our trespasses, as we forgive those who trespass against us. And lead us not into temptation: But deliver us from evil. Amen."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "May the Lord grant us His peace."
+                  },
+                  "r": {
+                    "en-US": "And life everlasting. Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Anthem"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Then is said one of the following Anthems of the Blessed Virgin Mary according to the season."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "From Candlemas until Compline on Holy Saturday exclusively"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Hail, O Queen of heav'n enthroned!\nHail, by angels Mistress owned!\nRoot of Jesse! Gate of morn,\nWhen the world's true Light was born:\nGlorious Virgin, joy to thee,\nBeautiful surpassingly!\nFairest thou where all are fair!\nPlead for us a pitying prayer."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Vouchsafe that I may praise thee, O Blessed Virgin."
+                  },
+                  "r": {
+                    "en-US": "Grant me strength agains thine enemies."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Let us pray,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O most merciful God, grant succor unto our frailty; that as we celebrate the memory of the holy Mother of God, so by the help of her intercession we may rise again from our sins. Through the same Christ our Lord."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "From Compline of Holy Saturday until None on the Saturday after Pentecost inclusively"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O Queen of heaven rejoice, Alleluia,\nFor He Whom thou wast to bear, Alleluia,\nHath risen, as He said, Alleluia.\nPray for us to God, Alleluia."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Rejoice and be glad, O Virgin Mary, Alleluia."
+                  },
+                  "r": {
+                    "en-US": "For the Lord hath risen indeed, Alleluia."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Let us pray,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who didst vouchsafe to give joy to the world through the Resurrection of Thy Son, Our Lord Jesus Christ; grant, we beseech Thee, that, through His Mother, the Virgin Mary, we may obtain the joys of everlasting life. Through the same Christ our Lord."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "From Compline of the Saturday after Pentecost until Advent"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Hail, holy Queen, Mother of mercy.\nHail, our life, our sweetness, and our hope!\nTo thee do we cry, poor banished children of Eve.\nTo thee do we send up our sighs, mourning, and weeping in this vale of tears.\nTurn then, most gracious advocate, thine eyes of mercy toward us.\nAnd after this our exile show unto us the blessed fruit of thy womb, Jesus.\nO clement, O loving, O sweet Virgin Mary."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Pray for us, O holy Mother of God."
+                  },
+                  "r": {
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Let us pray,"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Almighty, everlasting God, Who, by the co-operation of the Holy Ghost, didst so make ready the body and soul of the glorious Virgin Mother Mary that she deserved to become a meet dwelling for Thy Son; grant that we, who rejoice in her memory, may through her loving intercession be delivered the evils that hang over us, and from everlasting death. Through the same Christ our Lord."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Final Blessing"
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "May the divine assistance ✠ remain always with us."
+                  },
+                  "r": {
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -1041,28 +3426,35 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
-                "la": "Introduction\nAs at Lauds",
-                "en-US": "Introduction\nAs at Lauds"
+                "la": "Introduction",
+                "en-US": "Introduction"
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "As at Lauds",
+                "en-US": "As at Lauds"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Memento, rerum Conditor,\nNostri quod olim corporis,\nSacrata ab alvo Virginis\nNascendo formam sumpseris.\nMaria Mater gratiae,\nDulcis Parens clementiae,\nTu nos ab hoste protege,\nEt mortis hora suscipe.\nJesu, tibi sit gloria,\nQui natus es de Virgine,\nCum Patre, et almo Spiritu,\nIn sempiterna saecula.\nAmen.",
                 "en-US": "Remember, O creator Lord,\nThat in the Virgin's sacred womb\nThou wast conceived, and of her flesh\nDidst our mortality assume.\nMother of grace! O Mary blest!\nTo thee, sweet fount of love, we fly;\nShield us through life, and take us hence\nTo thy dear bosom, when we die.\nO Jesu! born of Virgin bright,\nImmortal glory be to Thee;\nPraise to the Father infinite,\nAnd Holy Ghost eternally.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1076,7 +3468,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1090,7 +3482,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1099,12 +3491,54 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "O admirabile commercium!\nPsalm 53\nDeus, in nomine tuo salvum me fac: et in virtute tua iudica me.\nDeus, exaudi orationem meam: auribus percipe verba oris mei.\nQuoniam alieni insurrexerunt adversum me, et fortes quaesierunt animam meam: et non proposuerunt Deum ante conspectum suum.\nEcce enim, Deus adiuvat me: et Dominus susceptor est animae meae.\nAverte mala inimicis meis: et in veritate tua disperde illos.\nVoluntarie sacrificabo tibi, et confitebor nomini tuo, Domine: quoniam bonum est:\nQuoniam ex omni tribulatione eripuisti me: et super inimicos meos despexit oculus meus.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nPsalm 84\nBenedixisti, Domine, terram tuam: avertisti captivitatem Iacob.\nRemisisti iniquitatem plebis tuae: operuisti omnia peccata eorum.\nMitigasti omnem iram tuam: avertisti ab ira indignationis tuae.\nConverte nos, Deus, salutaris noster: et averte iram tuam a nobis.\nNumquid in aeternum irasceris nobis? aut extendes iram tuam a generatione in generationem?\nDeus, tu conversus vivificabis nos: et plebs tua laetabitur in te.\nOstende nobis, Domine, misericordiam tuam: et salutare tuum da nobis.\naudiam quid loquatur in me Dominus Deus: quoniam loquetur pacem in plebem suam.\nEt super sanctos suos: et in eos, qui convertuntur ad cor.\nVerumtamen prope timentes eum salutare ipsius: ut inhabitet gloria in terra nostra.\nMisericordia, et veritas obviaverunt sibi: iustitia, et pax osculatae sunt.\nVeritas de terra orta est: et iustitia de caelo prospexit.\netenim Dominus dabit benignitatem: et terra nostra dabit fructum suum.\nIustitia ante eum ambulabit: et ponet in via gressus suos.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nPsalm 116\nLaudate Dominum, omnes gentes: laudate eum, omnes populi:\nQuoniam confirmata est super nos misericordia eius: et veritas Domini manet in aeternum.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "O wondrous union!\nPsalm 53\nSave me, O God, by Thy name; and judge me in Thy strength.\nHear my prayer, O God: give ear unto the words of my mouth.\nFor strangers have risen up against me, and the mighty have sought after my soul: and they have not set God before their eyes.\nFor behold, God is my helper, and the Lord is the protector of my soul.\nTurn back evil upon mine enemies: and destroy them in Thy truth.\nI will freely sacrifice unto Thee, and will give thanks to Thy name, O Lord, for it is good.\nFor Thou has delivered me out of all my trouble; and mine eye hath looked down upon mine enemies.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 84\nThou hast blessed Thy land, O Lord: Thou hast turned away the captivity of Jacob.\nThou hast forgiven the iniquity of Thy people: Thou hast covered all their sins.\nThou hast softened all Thine anger: Thou hast turned away from the wrath of Thine indignation.\nConvert us, O God, our Saviour; and turn away Thine anger from us.\nWilt Thou be angry with us for ever: or wilt Thou stretch out Thy wrath from generation to generation?\nThou wilt turn again, O God, and quicken us; and Thy people shall rejoice in Thee.\nShow us Thy mercy, O Lord; and grant us Thy salvation.\nI will hearken what the Lord shall say within me; for He will speak peace unto His people.\nAnd unto His saints; and unto them that are converted in heart.\nSurely His salvation is unto them that fear Him: that glory may dwell in our land.\nMercy and truth have met together: justice and peace have kissed.\nTruth is sprung out of the earth; and justice hath looked down from heaven.\nFor the Lord shall give goodness; and our earth shall yield her fruit.\nJustice shall walk before Him; and shall set His steps in the right way.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 116\nPraise the Lord, all ye nations: praise Him, all ye peoples.\nFor His mercy is confirmed upon us; and the truth of the Lord remaineth for ever.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "O admirabile commercium!",
+                "en-US": "O wondrous union!"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 53",
+                "en-US": "Psalm 53"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in nomine tuo salvum me fac: et in virtute tua iudica me.\nDeus, exaudi orationem meam: auribus percipe verba oris mei.\nQuoniam alieni insurrexerunt adversum me, et fortes quaesierunt animam meam: et non proposuerunt Deum ante conspectum suum.\nEcce enim, Deus adiuvat me: et Dominus susceptor est animae meae.\nAverte mala inimicis meis: et in veritate tua disperde illos.\nVoluntarie sacrificabo tibi, et confitebor nomini tuo, Domine: quoniam bonum est:\nQuoniam ex omni tribulatione eripuisti me: et super inimicos meos despexit oculus meus.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "Save me, O God, by Thy name; and judge me in Thy strength.\nHear my prayer, O God: give ear unto the words of my mouth.\nFor strangers have risen up against me, and the mighty have sought after my soul: and they have not set God before their eyes.\nFor behold, God is my helper, and the Lord is the protector of my soul.\nTurn back evil upon mine enemies: and destroy them in Thy truth.\nI will freely sacrifice unto Thee, and will give thanks to Thy name, O Lord, for it is good.\nFor Thou has delivered me out of all my trouble; and mine eye hath looked down upon mine enemies.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 84",
+                "en-US": "Psalm 84"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Benedixisti, Domine, terram tuam: avertisti captivitatem Iacob.\nRemisisti iniquitatem plebis tuae: operuisti omnia peccata eorum.\nMitigasti omnem iram tuam: avertisti ab ira indignationis tuae.\nConverte nos, Deus, salutaris noster: et averte iram tuam a nobis.\nNumquid in aeternum irasceris nobis? aut extendes iram tuam a generatione in generationem?\nDeus, tu conversus vivificabis nos: et plebs tua laetabitur in te.\nOstende nobis, Domine, misericordiam tuam: et salutare tuum da nobis.\naudiam quid loquatur in me Dominus Deus: quoniam loquetur pacem in plebem suam.\nEt super sanctos suos: et in eos, qui convertuntur ad cor.\nVerumtamen prope timentes eum salutare ipsius: ut inhabitet gloria in terra nostra.\nMisericordia, et veritas obviaverunt sibi: iustitia, et pax osculatae sunt.\nVeritas de terra orta est: et iustitia de caelo prospexit.\netenim Dominus dabit benignitatem: et terra nostra dabit fructum suum.\nIustitia ante eum ambulabit: et ponet in via gressus suos.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "Thou hast blessed Thy land, O Lord: Thou hast turned away the captivity of Jacob.\nThou hast forgiven the iniquity of Thy people: Thou hast covered all their sins.\nThou hast softened all Thine anger: Thou hast turned away from the wrath of Thine indignation.\nConvert us, O God, our Saviour; and turn away Thine anger from us.\nWilt Thou be angry with us for ever: or wilt Thou stretch out Thy wrath from generation to generation?\nThou wilt turn again, O God, and quicken us; and Thy people shall rejoice in Thee.\nShow us Thy mercy, O Lord; and grant us Thy salvation.\nI will hearken what the Lord shall say within me; for He will speak peace unto His people.\nAnd unto His saints; and unto them that are converted in heart.\nSurely His salvation is unto them that fear Him: that glory may dwell in our land.\nMercy and truth have met together: justice and peace have kissed.\nTruth is sprung out of the earth; and justice hath looked down from heaven.\nFor the Lord shall give goodness; and our earth shall yield her fruit.\nJustice shall walk before Him; and shall set His steps in the right way.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 116",
+                "en-US": "Psalm 116"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Laudate Dominum, omnes gentes: laudate eum, omnes populi:\nQuoniam confirmata est super nos misericordia eius: et veritas Domini manet in aeternum.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "Praise the Lord, all ye nations: praise Him, all ye peoples.\nFor His mercy is confirmed upon us; and the truth of the Lord remaineth for ever.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1118,7 +3552,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1132,7 +3566,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1141,23 +3575,217 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "O admirabile commercium! Creator generis humani, animatum corpus sumens, de Virgine nasci dignatus est; et procedens homo sine semine, largitus est nobis suam Deitatem.\nLittle Chapter Outside Advent - Song of Songs 6:9\nQuae est ista, quae progreditur quasi aurora consurgens, pulchra ut luna, electa ut sol, terribilis ut castrorum acies ordinata?\n℟. Deo gratias.\nLittle Chapter During Advent - Isaiah 7:14-15\nEcce virgo concipiet, et pariet filium, et vocabitur nomen eius Emmanuel. Butýrum et mel comedet, ut sciat reprobare malum, et eligere bonum.\n℟. Deo gratias.\n℣. Dignare me laudare te, Virgo sacrata.\n℟. Da mihi virtutem contra hostes tuos.\nKyrie, eleison.\nChriste, eleison.\nKyrie, eleison.",
-                "en-US": "O wondrous union! the Creator of mankind, taking a body with a living soul, vouchsafed to be born of a virgin; and becoming man without man's concurrence, bestowed upon us His Godhead.\nLittle Chapter Outside Advent - Song of Songs 6:9\nWho is she that cometh forth as the morning rising, fair as the moon, bright as the sun, terrible as an army set in array?\n℟. Thanks be to God.\nLittle Chapter During Advent - Isaiah 7:14-15\nBehold, a Virgin shall conceive and shall bear a Son, and His name shall be called Emmanuel: butter and honey shall He eat, that He may know to refuse the evil and choose the good.\n℟. Thanks be to God.\n℣. Vouchsafe that I may praise thee, O holy Virgin.\n℟. Grant me strength against thine enemies.\nLord have mercy on us,\nChrist have mercy on us,\nLord have mercy on us,"
+                "la": "O admirabile commercium! Creator generis humani, animatum corpus sumens, de Virgine nasci dignatus est; et procedens homo sine semine, largitus est nobis suam Deitatem.\nLittle Chapter Outside Advent - Song of Songs 6:9\nQuae est ista, quae progreditur quasi aurora consurgens, pulchra ut luna, electa ut sol, terribilis ut castrorum acies ordinata?",
+                "en-US": "O wondrous union! the Creator of mankind, taking a body with a living soul, vouchsafed to be born of a virgin; and becoming man without man's concurrence, bestowed upon us His Godhead.\nLittle Chapter Outside Advent - Song of Songs 6:9\nWho is she that cometh forth as the morning rising, fair as the moon, bright as the sun, terrible as an army set in array?"
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Little Chapter During Advent - Isaiah 7:14-15\nEcce virgo concipiet, et pariet filium, et vocabitur nomen eius Emmanuel. Butýrum et mel comedet, ut sciat reprobare malum, et eligere bonum.",
+                "en-US": "Little Chapter During Advent - Isaiah 7:14-15\nBehold, a Virgin shall conceive and shall bear a Son, and His name shall be called Emmanuel: butter and honey shall He eat, that He may know to refuse the evil and choose the good."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dignare me laudare te, Virgo sacrata.",
+                    "en-US": "Vouchsafe that I may praise thee, O holy Virgin."
+                  },
+                  "r": {
+                    "la": "Da mihi virtutem contra hostes tuos.",
+                    "en-US": "Grant me strength against thine enemies."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Kyrie, eleison.\nChriste, eleison.\nKyrie, eleison.",
+                "en-US": "Lord have mercy on us,\nChrist have mercy on us,\nLord have mercy on us,"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\nOutside Advent\nOremus,\nDeus, qui virginalem aulam beatae Mariae, in qua habitares, eligere dignatus es: da, quaesumus; ut, sua nos defensione munitos, jucundos facias suae interesse commemorationi. Qui vivis et regnas cum Deo Patre, in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen.\nDuring Advent\nOremus,\nDeus, qui virginalem aulam beatae Mariae, in qua habitares, eligere dignatus es: da, quaesumus; ut, sua nos defensione munitos, jucundos facias suae interesse commemorationi. Qui vivis et regnas cum Deo Patre, in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen.\nConclusion\n℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\nOutside Advent\nLet us pray,\nO God, Who didst vouchsafe to choose the virgin palace of blessed Mary for Thy dwelling; grant, we beseech Thee, that we, who are shielded by her protection, may by Thy grace join with gladness in her commemoration. Who livest and reignest with God the Father, in the unity of the Holy Ghost, God, world without end.\nAmen.\nDuring Advent\nLet us pray,\nO God, Who, by the fruitful virginity of blessed Mary, hast given to mankind the rewards of eternal salvation: grant, we beseech Thee, that we may experience her intercession for us, by whom we deserved to receive the Author of life, Our Lord Jesus Christ, Thy Son. Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\nAmen.\nConclusion\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed, through the mercy of God, rest in peace.\n℟. Amen."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Outside Advent"
               }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              },
+              "lang": "la"
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Deus, qui virginalem aulam beatae Mariae, in qua habitares, eligere dignatus es: da, quaesumus; ut, sua nos defensione munitos, jucundos facias suae interesse commemorationi. Qui vivis et regnas cum Deo Patre, in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "During Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              },
+              "lang": "la"
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Deus, qui virginalem aulam beatae Mariae, in qua habitares, eligere dignatus es: da, quaesumus; ut, sua nos defensione munitos, jucundos facias suae interesse commemorationi. Qui vivis et regnas cum Deo Patre, in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Conclusion"
+              },
+              "lang": "la"
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Outside Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who didst vouchsafe to choose the virgin palace of blessed Mary for Thy dwelling; grant, we beseech Thee, that we, who are shielded by her protection, may by Thy grace join with gladness in her commemoration. Who livest and reignest with God the Father, in the unity of the Holy Ghost, God, world without end.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who, by the fruitful virginity of blessed Mary, hast given to mankind the rewards of eternal salvation: grant, we beseech Thee, that we may experience her intercession for us, by whom we deserved to receive the Author of life, Our Lord Jesus Christ, Thy Son. Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Conclusion"
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+                    "en-US": "May the souls of the faithful departed, through the mercy of God, rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -1170,28 +3798,35 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
-                "la": "Introduction\nAs at Lauds",
-                "en-US": "Introduction\nAs at Lauds"
+                "la": "Introduction",
+                "en-US": "Introduction"
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "As at Lauds",
+                "en-US": "As at Lauds"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Memento, rerum Conditor,\nNostri quod olim corporis,\nSacrata ab alvo Virginis\nNascendo formam sumpseris.\nMaria Mater gratiae,\nDulcis Parens clementiae,\nTu nos ab hoste protege,\nEt mortis hora suscipe.\nJesu, tibi sit gloria,\nQui natus es de Virgine,\nCum Patre, et almo Spiritu,\nIn sempiterna saecula.\nAmen.",
                 "en-US": "Remember, O creator Lord,\nThat in the Virgin's sacred womb\nThou wast conceived, and of her flesh\nDidst our mortality assume.\nMother of grace! O Mary blest!\nTo thee, sweet fount of love, we fly;\nShield us through life, and take us hence\nTo thy dear bosom, when we die.\nO Jesu! born of Virgin bright,\nImmortal glory be to Thee;\nPraise to the Father infinite,\nAnd Holy Ghost eternally.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1205,7 +3840,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1219,7 +3854,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1228,12 +3863,54 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quando natus es.\nPsalm 119\nAd Dominum cum tribularer clamavi: et exaudivit me.\nDomine, libera animam meam a labiis iniquis, et a lingua dolosa.\nQuid detur tibi, aut quid apponatur tibi ad linguam dolosam?\nSagittae potentis acutae, cum carbonibus desolatoriis.\nHeu mihi, quia incolatus meus prolongatus est: habitavi cum habitantibus Cedar: multum incola fuit anima mea.\nCum his, qui oderunt pacem, eram pacificus: cum loquebar illis, impugnabant me gratis.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nPsalm 120\nLevavi oculos meos in montes, unde veniet auxilium mihi.\nAuxilium meum a Domino, qui fecit caelum et terram.\nNon det in commotionem pedem tuum: neque dormitet qui custodit te.\nEcce, non dormitabit neque dormiet, qui custodit Israel.\nDominus custodit te, Dominus protectio tua, super manum dexteram tuam.\nPer diem sol non uret te: neque luna per noctem.\nDominus custodit te ab omni malo: custodiat animam tuam Dominus.\nDominus custodiat introitum tuum, et exitum tuum: ex hoc nunc, et usque in saeculum.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nPsalm 121\nLaetatus sum in his, quae dicta sunt mihi: In domum Domini ibimus.\nStantes erant pedes nostri, in atriis tuis, Ierusalem.\nIerusalem, quae aedificatur ut civitas: cuius participatio eius in idipsum.\nIlluc enim ascenderunt tribus, tribus Domini: testimonium Israel ad confitendum nomini Domini.\nQuia illic sederunt sedes in iudicio, sedes super domum David.\nRogate quae ad pacem sunt Ierusalem: et abundantia diligentibus te:\nFiat pax in virtute tua: et abundantia in turribus tuis.\nPropter fratres meos, et proximos meos, loquebar pacem de te:\nPropter domum Domini, Dei nostri, quaesivi bona tibi.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "When thou wert born.\nPsalm 119\nWhen I was in trouble, I cried unto the Lord: and He heard me.\nO Lord, deliver my soul from wicked lips and from a deceitful tongue.\nWhat shall be given unto Thee, or what shall be added unto Thee, to a deceitful tongue?\nSharp arrows of the mighty One, with destroying coals.\nWoe is me, that my sojourn is prolonged: I have dwelt with the inhabitants of Cedar: my soul hath long been a sojourner.\nWith them that hated peace I was peaceable: when I spake unto them, they fought against me without cause.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 120\nI have lifted up mine eyes unto the hills, from whence my help shall come.\nMy help is from the Lord, Who made heaven and earth.\nLet Him not suffer thy foot to be moved; neither let Him slumber that keepeth thee.\nBehold, He that keepeth Israel, shall neither slumber nor sleep.\nThe Lord is thy keeper: the Lord is thy defence upon thy right hand.\nThe sun shall not burn thee by day, nor the moon by night.\nThe Lord keepeth thee from all evil: may the Lord keep thy soul.\nMay the Lord keep thy coming in, and thy going out, from this time forth for evermore.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 121\nI was glad at the things that were said unto me: We will go into the house of the Lord.\nOur feet were standing within thy courts, O Jerusalem.\nJerusalem, which is built as a city, that is compact together.\nFor thither the tribes went up, the tribes of the Lord: an ordinance for Israel, to give thanks to the name of the Lord.\nFor there are setup thrones of judgment, the thrones of the house of David.\nPray ye for the things that are for the peace of Jerusalem; and plenty be to them that love Thee.\nLet peace be in Thy stronghold, and plenty in Thy towers.\nFor my brethren and my neighbors' sake, I spake peace concerning thee.\nFor the sake of the house of the Lord our God, I have sought good things for thee.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Quando natus es.",
+                "en-US": "When thou wert born."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 119",
+                "en-US": "Psalm 119"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Ad Dominum cum tribularer clamavi: et exaudivit me.\nDomine, libera animam meam a labiis iniquis, et a lingua dolosa.\nQuid detur tibi, aut quid apponatur tibi ad linguam dolosam?\nSagittae potentis acutae, cum carbonibus desolatoriis.\nHeu mihi, quia incolatus meus prolongatus est: habitavi cum habitantibus Cedar: multum incola fuit anima mea.\nCum his, qui oderunt pacem, eram pacificus: cum loquebar illis, impugnabant me gratis.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "When I was in trouble, I cried unto the Lord: and He heard me.\nO Lord, deliver my soul from wicked lips and from a deceitful tongue.\nWhat shall be given unto Thee, or what shall be added unto Thee, to a deceitful tongue?\nSharp arrows of the mighty One, with destroying coals.\nWoe is me, that my sojourn is prolonged: I have dwelt with the inhabitants of Cedar: my soul hath long been a sojourner.\nWith them that hated peace I was peaceable: when I spake unto them, they fought against me without cause.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 120",
+                "en-US": "Psalm 120"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Levavi oculos meos in montes, unde veniet auxilium mihi.\nAuxilium meum a Domino, qui fecit caelum et terram.\nNon det in commotionem pedem tuum: neque dormitet qui custodit te.\nEcce, non dormitabit neque dormiet, qui custodit Israel.\nDominus custodit te, Dominus protectio tua, super manum dexteram tuam.\nPer diem sol non uret te: neque luna per noctem.\nDominus custodit te ab omni malo: custodiat animam tuam Dominus.\nDominus custodiat introitum tuum, et exitum tuum: ex hoc nunc, et usque in saeculum.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "I have lifted up mine eyes unto the hills, from whence my help shall come.\nMy help is from the Lord, Who made heaven and earth.\nLet Him not suffer thy foot to be moved; neither let Him slumber that keepeth thee.\nBehold, He that keepeth Israel, shall neither slumber nor sleep.\nThe Lord is thy keeper: the Lord is thy defence upon thy right hand.\nThe sun shall not burn thee by day, nor the moon by night.\nThe Lord keepeth thee from all evil: may the Lord keep thy soul.\nMay the Lord keep thy coming in, and thy going out, from this time forth for evermore.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 121",
+                "en-US": "Psalm 121"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Laetatus sum in his, quae dicta sunt mihi: In domum Domini ibimus.\nStantes erant pedes nostri, in atriis tuis, Ierusalem.\nIerusalem, quae aedificatur ut civitas: cuius participatio eius in idipsum.\nIlluc enim ascenderunt tribus, tribus Domini: testimonium Israel ad confitendum nomini Domini.\nQuia illic sederunt sedes in iudicio, sedes super domum David.\nRogate quae ad pacem sunt Ierusalem: et abundantia diligentibus te:\nFiat pax in virtute tua: et abundantia in turribus tuis.\nPropter fratres meos, et proximos meos, loquebar pacem de te:\nPropter domum Domini, Dei nostri, quaesivi bona tibi.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "I was glad at the things that were said unto me: We will go into the house of the Lord.\nOur feet were standing within thy courts, O Jerusalem.\nJerusalem, which is built as a city, that is compact together.\nFor thither the tribes went up, the tribes of the Lord: an ordinance for Israel, to give thanks to the name of the Lord.\nFor there are setup thrones of judgment, the thrones of the house of David.\nPray ye for the things that are for the peace of Jerusalem; and plenty be to them that love Thee.\nLet peace be in Thy stronghold, and plenty in Thy towers.\nFor my brethren and my neighbors' sake, I spake peace concerning thee.\nFor the sake of the house of the Lord our God, I have sought good things for thee.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1247,7 +3924,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1261,7 +3938,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1270,23 +3947,186 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quando natus es ineffabiliter ex Virgine, tunc impletae sunt Scripturae: sicut pluvia in vellus descendisti, ut salvum faceres genus humanum: te laudamus, Deus noster.\nLittle Chapter Outside Advent - Sirach 24:15\nEt sic in Sion firmata sum, et in civitate sanctificata similiter requievi, et in Ierusalem potestas mea.\n℟. Deo gratias.\nLittle Chapter During Advent - Isaiah 11:1-2\nEgredietur virga de radice Iesse, et flos de radice eius ascendet. Et requiescet super eum Spiritus Domini.\n℟. Deo gratias.\n℣. Diffusa est gratia in labiis tuis.\n℟Propterea benedixit te Deus in aeternum.\nKyrie, eleison.\nChriste, eleison.\nKyrie, eleison.",
-                "en-US": "When Thou wert wondrously born of a virgin, then were the Scriptures fulfilled: Thou earnest down like the rain upon the fleece, that Thou mightest save mankind. We praise Thee, our God.\nLittle Chapter Outside Advent - Sirach 24:15\nAnd so was I established in Sion, and in the holy city likewise I rested; and my power was in Jerusalem.\n℟. Thanks be to God.\nLittle Chapter During Advent - Isaiah 11:1-2\nThere shall come forth a rod out of the root of Jesse, and a flower shall rise up out of his root. And the Spirit of the Lord shall rest upon Him.\n℟. Thanks be to God.\n℣. Grace is poured forth upon thy lips.\n℟. Wherefore God hath blessed thee for ever.\nLord, have mercy on us.\nChrist, have mercy on us.\nLord, have mercy on us."
+                "la": "Quando natus es ineffabiliter ex Virgine, tunc impletae sunt Scripturae: sicut pluvia in vellus descendisti, ut salvum faceres genus humanum: te laudamus, Deus noster.\nLittle Chapter Outside Advent - Sirach 24:15\nEt sic in Sion firmata sum, et in civitate sanctificata similiter requievi, et in Ierusalem potestas mea.",
+                "en-US": "When Thou wert wondrously born of a virgin, then were the Scriptures fulfilled: Thou earnest down like the rain upon the fleece, that Thou mightest save mankind. We praise Thee, our God.\nLittle Chapter Outside Advent - Sirach 24:15\nAnd so was I established in Sion, and in the holy city likewise I rested; and my power was in Jerusalem."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Little Chapter During Advent - Isaiah 11:1-2\nEgredietur virga de radice Iesse, et flos de radice eius ascendet. Et requiescet super eum Spiritus Domini.",
+                "en-US": "Little Chapter During Advent - Isaiah 11:1-2\nThere shall come forth a rod out of the root of Jesse, and a flower shall rise up out of his root. And the Spirit of the Lord shall rest upon Him."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Diffusa est gratia in labiis tuis.",
+                    "en-US": "Grace is poured forth upon thy lips."
+                  },
+                  "r": {
+                    "la": "Propterea benedixit te Deus in aeternum.",
+                    "en-US": "Wherefore God hath blessed thee for ever."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Kyrie, eleison.\nChriste, eleison.\nKyrie, eleison.",
+                "en-US": "Lord, have mercy on us.\nChrist, have mercy on us.\nLord, have mercy on us."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\nOutside Advent\nOremus,\nDeus, qui de beatae Mariae Virginis utero, Verbum tuum, angelo nuntiante, carnem suscipere voluisti; praesta supplicibus tuis, ut qui vere eam Genetricem Dei credimus, ejus apud te intercessionibus adjuvemur. Per eundem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen.\nDuring Advent\nOremus,\nDeus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen.\nConclusion\nAs at Matins",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\nOutside Advent\nLet us pray,\nO God, Who, by the fruitful virginity of blessed Mary, hast given to mankind the rewards of eternal salvation: grant, we beseech Thee, that we may experience her intercession for us, by whom we deserved to receive the Author of life, Our Lord Jesus Christ, Thy Son. Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\nAmen.\nDuring Advent\nLet us pray,\nO God, Who didst will that Thine eternal Word should take flesh in the womb of the Blessed Virgin Mary, when the angel delivered his message: grant that Thy petitioners, who verily believe her to be the Mother of God, may be assisted by her intercession with Thee through the same Jesus Christ, Thy Son, our Lord, Who liveth and reigneth with Thee, in the unity of the Holy Ghost, God, world without end.\nAmen.\nConclusion\nAs at Matins"
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Outside Advent"
               }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              },
+              "lang": "la"
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Deus, qui de beatae Mariae Virginis utero, Verbum tuum, angelo nuntiante, carnem suscipere voluisti; praesta supplicibus tuis, ut qui vere eam Genetricem Dei credimus, ejus apud te intercessionibus adjuvemur. Per eundem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "During Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              },
+              "lang": "la"
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Deus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Conclusion"
+              },
+              "lang": "la"
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "As at Matins"
+              },
+              "lang": "la"
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Outside Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who, by the fruitful virginity of blessed Mary, hast given to mankind the rewards of eternal salvation: grant, we beseech Thee, that we may experience her intercession for us, by whom we deserved to receive the Author of life, Our Lord Jesus Christ, Thy Son. Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who didst will that Thine eternal Word should take flesh in the womb of the Blessed Virgin Mary, when the angel delivered his message: grant that Thy petitioners, who verily believe her to be the Mother of God, may be assisted by her intercession with Thee through the same Jesus Christ, Thy Son, our Lord, Who liveth and reigneth with Thee, in the unity of the Holy Ghost, God, world without end.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Conclusion"
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "As at Matins"
+              },
+              "lang": "en-US"
             }
           ]
         },
@@ -1299,28 +4139,35 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
-                "la": "Introduction\nAs at Lauds",
-                "en-US": "Introduction\nAs at Lauds"
+                "la": "Introduction",
+                "en-US": "Introduction"
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "As at Lauds",
+                "en-US": "As at Lauds"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Memento, rerum Conditor,\nNostri quod olim corporis,\nSacrata ab alvo Virginis\nNascendo formam sumpseris.\nMaria Mater gratiae,\nDulcis Parens clementiae,\nTu nos ab hoste protege,\nEt mortis hora suscipe.\nJesu, tibi sit gloria,\nQui natus es de Virgine,\nCum Patre, et almo Spiritu,\nIn sempiterna saecula.\nAmen.",
                 "en-US": "Remember, O creator Lord,\nThat in the Virgin's sacred womb\nThou wast conceived, and of her flesh\nDidst our mortality assume.\nMother of grace! O Mary blest!\nTo thee, sweet fount of love, we fly;\nShield us through life, and take us hence\nTo thy dear bosom, when we die.\nO Jesu! born of Virgin bright,\nImmortal glory be to Thee;\nPraise to the Father infinite,\nAnd Holy Ghost eternally.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1334,7 +4181,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1348,7 +4195,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1357,12 +4204,54 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Rubum, quem viderat.\nPsalm 122\nAd te levavi oculos meos, qui habitas in caelis.\nEcce, sicut oculi servorum in manibus dominorum suorum,\nSicut oculi ancillae in manibus dominae suae: ita oculi nostri ad Dominum, Deum nostrum, donec misereatur nostri.\nMiserere nostri, Domine, miserere nostri: quia multum repleti sumus despectione:\nQuia multum repleta est anima nostra: opprobrium abundantibus, et despectio superbis.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nPsalm 123\nNisi quia Dominus erat in nobis, dicat nunc Israel: nisi quia Dominus erat in nobis,\nCum exsurgerent homines in nos, forte vivos deglutissent nos:\nCum irasceretur furor eorum in nos, forsitan aqua absorbuisset nos.\nTorrentem pertransivit anima nostra: forsitan pertransisset anima nostra aquam intolerabilem.\nBenedictus Dominus qui non dedit nos in captionem dentibus eorum.\nanima nostra sicut passer erepta est de laqueo venantium:\nLaqueus contritus est, et nos liberati sumus.\nAdjutorium nostrum in nomine Domini, qui fecit caelum et terram.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nPsalm 124\nQui confidunt in Domino, sicut mons Sion: non commovebitur in aeternum, qui habitat in Jerusalem.\nMontes in circuitu ejus: et Dominus in circuitu populi sui, ex hoc nunc et usque in saeculum.\nQuia non relinquet Dominus virgam peccatorum super sortem justorum: ut non extendant justi ad iniquitatem manus suas.\nBenefac, Domine, bonis, et rectis corde.\nDeclinantes autem in obligationes adducet Dominus cum operantibus iniquitatem: pax super Israel.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "The bush which Moses.\nPsalm 122\nUnto Thee have I lifted up mine eyes, O Thou that dwellest in the heavens.\nBehold, as the eyes of slaves are on the hands of their masters;\nAs the eyes of a handmaid are on the hands of her mistress, so are our eyes unto the Lord our God, until He have mercy upon us.\nHave mercy upon us, O Lord, have mercy upon us; for we are greatly filled with contempt.\nYea, our soul is greatly filled: we are the reproach of the rich, the contempt of the proud.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 123\nIf the Lord had not been with us, now may Israel say: If the Lord had not been with us,\nWhen men rose up against us, peradventure they had swallowed us up alive;\nWhen their fury was enkindled against us, perchance the waters had swallowed us up.\nOur soul hath passed through a torrent: peradventure our soul would have passed through overwhelming waters.\nBlessed be the Lord, Who hath not given us up to be a prey unto their teeth.\nOur soul hath been delivered as a sparrow out of the snare of the fowlers.\nThe snare is broken, and we are delivered.\nOur help is in the name of the Lord, Who made heaven and earth.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 124\nThey that trust in the Lord shall be as Mount Sion: he shall not be moved for ever that dwelleth in Jerusalem.\nThe hills stand round about her: even so is the Lord round about His people from this time forth for evermore.\nFor the Lord will not leave the rod of sinners over the lot of the just: that the just may not stretch forth their hands unto wickedness.\nDo well, O Lord, unto those that are good, and unto them that are right of heart.\nBut such as turn aside unto deceits, the Lord shall number with the workers of iniquity; but peace shall be upon Israel.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Rubum, quem viderat.",
+                "en-US": "The bush which Moses."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 122",
+                "en-US": "Psalm 122"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Ad te levavi oculos meos, qui habitas in caelis.\nEcce, sicut oculi servorum in manibus dominorum suorum,\nSicut oculi ancillae in manibus dominae suae: ita oculi nostri ad Dominum, Deum nostrum, donec misereatur nostri.\nMiserere nostri, Domine, miserere nostri: quia multum repleti sumus despectione:\nQuia multum repleta est anima nostra: opprobrium abundantibus, et despectio superbis.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "Unto Thee have I lifted up mine eyes, O Thou that dwellest in the heavens.\nBehold, as the eyes of slaves are on the hands of their masters;\nAs the eyes of a handmaid are on the hands of her mistress, so are our eyes unto the Lord our God, until He have mercy upon us.\nHave mercy upon us, O Lord, have mercy upon us; for we are greatly filled with contempt.\nYea, our soul is greatly filled: we are the reproach of the rich, the contempt of the proud.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 123",
+                "en-US": "Psalm 123"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Nisi quia Dominus erat in nobis, dicat nunc Israel: nisi quia Dominus erat in nobis,\nCum exsurgerent homines in nos, forte vivos deglutissent nos:\nCum irasceretur furor eorum in nos, forsitan aqua absorbuisset nos.\nTorrentem pertransivit anima nostra: forsitan pertransisset anima nostra aquam intolerabilem.\nBenedictus Dominus qui non dedit nos in captionem dentibus eorum.\nanima nostra sicut passer erepta est de laqueo venantium:\nLaqueus contritus est, et nos liberati sumus.\nAdjutorium nostrum in nomine Domini, qui fecit caelum et terram.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "If the Lord had not been with us, now may Israel say: If the Lord had not been with us,\nWhen men rose up against us, peradventure they had swallowed us up alive;\nWhen their fury was enkindled against us, perchance the waters had swallowed us up.\nOur soul hath passed through a torrent: peradventure our soul would have passed through overwhelming waters.\nBlessed be the Lord, Who hath not given us up to be a prey unto their teeth.\nOur soul hath been delivered as a sparrow out of the snare of the fowlers.\nThe snare is broken, and we are delivered.\nOur help is in the name of the Lord, Who made heaven and earth.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 124",
+                "en-US": "Psalm 124"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Qui confidunt in Domino, sicut mons Sion: non commovebitur in aeternum, qui habitat in Jerusalem.\nMontes in circuitu ejus: et Dominus in circuitu populi sui, ex hoc nunc et usque in saeculum.\nQuia non relinquet Dominus virgam peccatorum super sortem justorum: ut non extendant justi ad iniquitatem manus suas.\nBenefac, Domine, bonis, et rectis corde.\nDeclinantes autem in obligationes adducet Dominus cum operantibus iniquitatem: pax super Israel.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "They that trust in the Lord shall be as Mount Sion: he shall not be moved for ever that dwelleth in Jerusalem.\nThe hills stand round about her: even so is the Lord round about His people from this time forth for evermore.\nFor the Lord will not leave the rod of sinners over the lot of the just: that the just may not stretch forth their hands unto wickedness.\nDo well, O Lord, unto those that are good, and unto them that are right of heart.\nBut such as turn aside unto deceits, the Lord shall number with the workers of iniquity; but peace shall be upon Israel.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1376,7 +4265,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1390,7 +4279,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1398,24 +4287,274 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Rubum, quem viderat Moyses incombustum, conservatam agnovimus tuam laudabilem virginitatem: Dei Genitrix, intercede pro nobis.\nLittle Chapter Outside Advent - Sirach 24:16\nEt radicavi in populo honorificato, et in parte Dei mei hereditas illius, et in plenitudine sanctorum detentio mea.\n℟. Deo gratias.\nLittle Chapter During Advent - Luke 1:32-33\nDabit illi Dominus Deus sedem David, patris ejus, et regnabit in domo Jacob in aeternum, et regni ejus non erit finis.\n℟. Deo gratias.\n℣. Benedicta tu in mulieribus.\n℟. Et benedictus fructus ventris tui.",
-                "en-US": "The bush which Moses saw unconsumed we acknowledge to be thine admirable virginity, which thou didst keep inviolate; Mother of God, plead for us.\nLittle Chapter Outside Advent - Sirach 24:16\nAnd I took root in an honourable people, and in the portion of my God, His inheritance: and my abode is in the full assembly of saints.\n℟. Thanks be to God.\nLittle Chapter II During Advent - Luke 1:32-33\nThe Lord God shall give Him the throne of David his father; and He shall reign in the house of Jacob for ever, and of His kingdom there shall be no end.\n℟. Thanks be to God.\n℣. Blessed art thou amongst women.\n℟. And blessed is the fruit of thy womb.\nLord, have mercy on us.\nChrist, have mercy on us.\nLord, have mercy on us."
+                "la": "Rubum, quem viderat Moyses incombustum, conservatam agnovimus tuam laudabilem virginitatem: Dei Genitrix, intercede pro nobis."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Little Chapter Outside Advent - Sirach 24:16"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Et radicavi in populo honorificato, et in parte Dei mei hereditas illius, et in plenitudine sanctorum detentio mea."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Little Chapter During Advent - Luke 1:32-33"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Dabit illi Dominus Deus sedem David, patris ejus, et regnabit in domo Jacob in aeternum, et regni ejus non erit finis."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicta tu in mulieribus."
+                  },
+                  "r": {
+                    "la": "Et benedictus fructus ventris tui."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "The bush which Moses saw unconsumed we acknowledge to be thine admirable virginity, which thou didst keep inviolate; Mother of God, plead for us."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Little Chapter Outside Advent - Sirach 24:16"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "And I took root in an honourable people, and in the portion of my God, His inheritance: and my abode is in the full assembly of saints."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Little Chapter II During Advent - Luke 1:32-33"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "The Lord God shall give Him the throne of David his father; and He shall reign in the house of Jacob for ever, and of His kingdom there shall be no end."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Blessed art thou amongst women."
+                  },
+                  "r": {
+                    "en-US": "And blessed is the fruit of thy womb."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Lord, have mercy on us.\nChrist, have mercy on us.\nLord, have mercy on us."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\nOutside Advent\nOremus,\nConcede, misericors Deus, fragilitati nostrae praesidium; ut, qui sanctae Dei Genetricis memoriam agimus; intercessionis eius auxilio, a nostris iniquitatibus resurgamus. Per eumdem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen.\nDuring Advent\nOremus,\nDeus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen.\nConclusion\nAs at Matins",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\nOutside Advent\nLet us pray,\nO Most merciful God, grant succor unto our frailty; that as we celebrate the memory of the holy Mother of God, so by the help of her intercession we may rise again from our transgressions. Through the same Jesus Christ, Thy Son, Our Lord, Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\nAmen.\nDuring Advent\nLet us pray,\nO God, Who, by the fruitful virginity of blessed Mary, hast given to mankind the rewards of eternal salvation; grant, we beseech Thee, that we may experience her intercession for us, by whom we deserved to receive the Author of life, Our Lord Jesus Christ, Thy Son, Who liveth and reigneth with Thee, in the unity of the Holy Ghost, God, world without end.\nAmen.\nConclusion\nAs at Matins"
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Outside Advent"
               }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              },
+              "lang": "la"
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Concede, misericors Deus, fragilitati nostrae praesidium; ut, qui sanctae Dei Genetricis memoriam agimus; intercessionis eius auxilio, a nostris iniquitatibus resurgamus. Per eumdem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "During Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              },
+              "lang": "la"
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Deus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Conclusion"
+              },
+              "lang": "la"
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "As at Matins"
+              },
+              "lang": "la"
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Outside Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O Most merciful God, grant succor unto our frailty; that as we celebrate the memory of the holy Mother of God, so by the help of her intercession we may rise again from our transgressions. Through the same Jesus Christ, Thy Son, Our Lord, Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who, by the fruitful virginity of blessed Mary, hast given to mankind the rewards of eternal salvation; grant, we beseech Thee, that we may experience her intercession for us, by whom we deserved to receive the Author of life, Our Lord Jesus Christ, Thy Son, Who liveth and reigneth with Thee, in the unity of the Holy Ghost, God, world without end.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Conclusion"
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "As at Matins"
+              },
+              "lang": "en-US"
             }
           ]
         },
@@ -1428,28 +4567,35 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
-                "la": "Introduction\nAs at Lauds",
-                "en-US": "Introduction\nAs at Lauds"
+                "la": "Introduction",
+                "en-US": "Introduction"
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "As at Lauds",
+                "en-US": "As at Lauds"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Memento, rerum Conditor,\nNostri quod olim corporis,\nSacrata ab alvo Virginis\nNascendo formam sumpseris.\nMaria Mater gratiae,\nDulcis Parens clementiae,\nTu nos ab hoste protege,\nEt mortis hora suscipe.\nJesu, tibi sit gloria,\nQui natus es de Virgine,\nCum Patre, et almo Spiritu,\nIn sempiterna saecula.\nAmen.",
                 "en-US": "Remember, O creator Lord,\nThat in the Virgin's sacred womb\nThou wast conceived, and of her flesh\nDidst our mortality assume.\nMother of grace! O Mary blest!\nTo thee, sweet fount of love, we fly;\nShield us through life, and take us hence\nTo thy dear bosom, when we die.\nO Jesu! born of Virgin bright,\nImmortal glory be to Thee;\nPraise to the Father infinite,\nAnd Holy Ghost eternally.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1463,7 +4609,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1477,7 +4623,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1486,12 +4632,54 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce Maria.\nPsalm 125\nIn convertendo Dominus captivitatem Sion: facti sumus sicut consolati:\nTunc repletum est gaudio os nostrum: et lingua nostra exsultatione.\nTunc dicent inter gentes: Magnificavit Dominus facere cum eis.\nMagnificavit Dominus facere nobiscum: facti sumus laetantes.\nConverte, Domine, captivitatem nostram, sicut torrens in Austro.\nQui seminant in lacrimis, in exsultatione metent.\nEuntes ibant et flebant, mittentes semina sua.\nVenientes autem venient cum exsultatione, portantes manipulos suos.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nPsalm 126\nNisi Dominus aedificaverit domum, in vanum laboraverunt qui aedificant eam.\nNisi Dominus custodierit civitatem, frustra vigilat qui custodit eam.\nVanum est vobis ante lucem surgere: surgite postquam sederitis, qui manducatis panem doloris.\nCum dederit dilectis suis somnum: ecce hereditas Domini filii: merces, fructus ventris.\nSicut sagittae in manu potentis: ita filii excussorum.\nBeatus vir, qui implevit desiderium suum ex ipsis: non confundetur cum loquetur inimicis suis in porta.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nPsalm 127\nBeati, omnes, qui timent Dominum, qui ambulant in viis ejus.\nLabores manuum tuarum quia manducabis: beatus es, et bene tibi erit.\nUxor tua sicut vitis abundans, in lateribus domus tuae.\nFilii tui sicut novellae olivarum, in circuitu mensae tuae.\nEcce, sic benedicetur homo, qui timet Dominum.\nBenedicat tibi Dominus ex Sion: et videas bona Jerusalem omnibus diebus vitae tuae.\nEt videas filios filiorum tuorum, pacem super Israel.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "Behold, Mary.\nPsalm 125\nWhen the Lord turned again the captivity of Sion, we became like men consoled.\nThen was our mouth filled with gladness, and our tongue with joy.\nThen shall they say among the Gentiles: The Lord hath done great things for them.\nThe Lord hath done great, things for us: we are become joyful.\nTurn again our captivity, O Lord, as a river in the south.\nThey that sow in tears, shall reap in joy.\nThey went forth on their way and wept, scattering their seed.\nBut returning they shall come with joy, bringing their sheaves with them.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 126\nUnless the Lord build a house, they labor in vain that build it.\nUnless the Lord keep the city, he watcheth in vain that keepeth it.\nIn vain do ye rise before the light: rise not till ye have rested, O ye that eat the bread of sorrow.\nWhen He giveth sleep to His beloved: lo, children are an heritage from the Lord, and the fruit of the womb a reward.\nLike as arrows in the hand of the mighty One, so are the children of those who have been cast out.\nBlessed is the man whose desire is satisfied with them: he shall not be confounded when he speaketh with his enemies in the gate.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 127\nBlessed are all they that fear the Lord, that walk in His ways.\nFor thou shalt eat the labours of thy hands: blessed art thou, and it shall be well with thee.\nThy wife shall be as a fruitful vine on the walls of thy house.\nThy children as olive plants, round about thy table.\nBehold, thus shall the man be blessed that feareth the Lord.\nMay the Lord bless thee out of Sion, and mayest thou see the good things of Jerusalem all the days of thy life.\nMayest thou see thy children's children, and peace upon Israel.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Ecce Maria.",
+                "en-US": "Behold, Mary."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 125",
+                "en-US": "Psalm 125"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "In convertendo Dominus captivitatem Sion: facti sumus sicut consolati:\nTunc repletum est gaudio os nostrum: et lingua nostra exsultatione.\nTunc dicent inter gentes: Magnificavit Dominus facere cum eis.\nMagnificavit Dominus facere nobiscum: facti sumus laetantes.\nConverte, Domine, captivitatem nostram, sicut torrens in Austro.\nQui seminant in lacrimis, in exsultatione metent.\nEuntes ibant et flebant, mittentes semina sua.\nVenientes autem venient cum exsultatione, portantes manipulos suos.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "When the Lord turned again the captivity of Sion, we became like men consoled.\nThen was our mouth filled with gladness, and our tongue with joy.\nThen shall they say among the Gentiles: The Lord hath done great things for them.\nThe Lord hath done great, things for us: we are become joyful.\nTurn again our captivity, O Lord, as a river in the south.\nThey that sow in tears, shall reap in joy.\nThey went forth on their way and wept, scattering their seed.\nBut returning they shall come with joy, bringing their sheaves with them.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 126",
+                "en-US": "Psalm 126"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Nisi Dominus aedificaverit domum, in vanum laboraverunt qui aedificant eam.\nNisi Dominus custodierit civitatem, frustra vigilat qui custodit eam.\nVanum est vobis ante lucem surgere: surgite postquam sederitis, qui manducatis panem doloris.\nCum dederit dilectis suis somnum: ecce hereditas Domini filii: merces, fructus ventris.\nSicut sagittae in manu potentis: ita filii excussorum.\nBeatus vir, qui implevit desiderium suum ex ipsis: non confundetur cum loquetur inimicis suis in porta.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "Unless the Lord build a house, they labor in vain that build it.\nUnless the Lord keep the city, he watcheth in vain that keepeth it.\nIn vain do ye rise before the light: rise not till ye have rested, O ye that eat the bread of sorrow.\nWhen He giveth sleep to His beloved: lo, children are an heritage from the Lord, and the fruit of the womb a reward.\nLike as arrows in the hand of the mighty One, so are the children of those who have been cast out.\nBlessed is the man whose desire is satisfied with them: he shall not be confounded when he speaketh with his enemies in the gate.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 127",
+                "en-US": "Psalm 127"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Beati, omnes, qui timent Dominum, qui ambulant in viis ejus.\nLabores manuum tuarum quia manducabis: beatus es, et bene tibi erit.\nUxor tua sicut vitis abundans, in lateribus domus tuae.\nFilii tui sicut novellae olivarum, in circuitu mensae tuae.\nEcce, sic benedicetur homo, qui timet Dominum.\nBenedicat tibi Dominus ex Sion: et videas bona Jerusalem omnibus diebus vitae tuae.\nEt videas filios filiorum tuorum, pacem super Israel.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "Blessed are all they that fear the Lord, that walk in His ways.\nFor thou shalt eat the labours of thy hands: blessed art thou, and it shall be well with thee.\nThy wife shall be as a fruitful vine on the walls of thy house.\nThy children as olive plants, round about thy table.\nBehold, thus shall the man be blessed that feareth the Lord.\nMay the Lord bless thee out of Sion, and mayest thou see the good things of Jerusalem all the days of thy life.\nMayest thou see thy children's children, and peace upon Israel.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1505,7 +4693,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1519,7 +4707,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1527,24 +4715,302 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Ecce Maria genuit nobis Salvatorem, quem Ioannes videns, exclamavit, dicens: Ecce Agnus Dei, ecce qui tollit peccata mundi, alleluia.\nLittle Chapter Outside Advent - Sirach 24:19-20\nIn plateis sicut cinnamomum et balsamum aromatizans odorem dedi: quasi myrrha electa, dedi suavitatem odoris.\n℟. Deo gratias.\n℣. Post partum, Virgo, inviolata permansisti.\n℟. Dei Genitrix, intercede pro nobis.\nLittle Chapter During Advent - Isaiah 7:14-15\nEcce virgo concipiet, et pariet filium, et vocabitur nomen ejus Emmanuel. Butýrum et mel comedet, ut sciat reprobare malum, et eligere bonum.\n℟. Deo gratias.\n℣. angelus Domini nuntiavit Mariae.\n℟. Et concepit de Spiritu Sancto.\nKyrie, eleison.\nChriste, eleison.\nKyrie, eleison.",
-                "en-US": "Behold, Mary, hath brought us forth a Saviour, Whom when John saw, he cried aloud, saying: Behold the Lamb of God! Behold Him Who taketh away the sins of the world, Alleluia.\nLittle Chapter Outside Advent - Sirach 24:19-20\nIn the ways, like cinnamon and aromatic balm, I gave forth a sweet fragrance: like the choicest myrrh, I yielded a sweet smell.\n℟Thanks be to God.\n℣. After childbirth, O Virgin, thou didst remain inviolate.\n℟. Plead for us, O Mother of God.\nLittle Chapter During Advent - Sirach 24:19-20\nBehold a virgin shall conceive, and shall bear a son; and His name shall be called Emmanuel. Butter and honey shall He eat, that He may know to refuse the evil, and to choose the good.\n℟Thanks be to God.\n℣. The angel of the Lord declared unto Mary.\n℟. And she conceived of the Holy Ghost."
+                "la": "Ecce Maria genuit nobis Salvatorem, quem Ioannes videns, exclamavit, dicens: Ecce Agnus Dei, ecce qui tollit peccata mundi, alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Little Chapter Outside Advent - Sirach 24:19-20"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "In plateis sicut cinnamomum et balsamum aromatizans odorem dedi: quasi myrrha electa, dedi suavitatem odoris."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Post partum, Virgo, inviolata permansisti."
+                  },
+                  "r": {
+                    "la": "Dei Genitrix, intercede pro nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Little Chapter During Advent - Isaiah 7:14-15"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Ecce virgo concipiet, et pariet filium, et vocabitur nomen ejus Emmanuel. Butýrum et mel comedet, ut sciat reprobare malum, et eligere bonum."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "speaker": "people",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "la",
+              "verses": [
+                {
+                  "v": {
+                    "la": "angelus Domini nuntiavit Mariae."
+                  },
+                  "r": {
+                    "la": "Et concepit de Spiritu Sancto."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Kyrie, eleison.\nChriste, eleison.\nKyrie, eleison."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Behold, Mary, hath brought us forth a Saviour, Whom when John saw, he cried aloud, saying: Behold the Lamb of God! Behold Him Who taketh away the sins of the world, Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Little Chapter Outside Advent - Sirach 24:19-20"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "In the ways, like cinnamon and aromatic balm, I gave forth a sweet fragrance: like the choicest myrrh, I yielded a sweet smell."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "After childbirth, O Virgin, thou didst remain inviolate."
+                  },
+                  "r": {
+                    "en-US": "Plead for us, O Mother of God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Little Chapter During Advent - Sirach 24:19-20"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Behold a virgin shall conceive, and shall bear a son; and His name shall be called Emmanuel. Butter and honey shall He eat, that He may know to refuse the evil, and to choose the good."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "lang": "en-US",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "The angel of the Lord declared unto Mary."
+                  },
+                  "r": {
+                    "en-US": "And she conceived of the Holy Ghost."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\nOutside Advent\nOremus,\nFamulorum tuorum, quaesumus, Domine, delictis ignosce: ut qui tibi placere de actibus nostris non valemus: Genitricis Filii tui Domini nostri intercessione salvemur: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen.\nDuring Advent\nOremus,\nDeus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen.\nConclusion\nAs at Matins",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\nOutside Advent\nLet us pray,\nForgive, O Lord, we beseech Thee, the sins of Thy servants; so that we who cannot become pleasing to Thee from our own actions, may be saved by the pleading of the Mother of Thy Son, Our Lord, Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\nAmen.\nDuring Advent\nLet us pray,\nO God, Who, by the fruitful virginity of blessed Mary, hast given to mankind the rewards of eternal salvation: grant, we beseech Thee, that we may experience her intercession for us, by whom we deserved to receive the Author of life, Our Lord Jesus Christ, Thy Son. Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\nAmen.\nConclusion\nAs at Matins"
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Outside Advent"
               }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              },
+              "lang": "la"
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Famulorum tuorum, quaesumus, Domine, delictis ignosce: ut qui tibi placere de actibus nostris non valemus: Genitricis Filii tui Domini nostri intercessione salvemur: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "During Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              },
+              "lang": "la"
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Deus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Conclusion"
+              },
+              "lang": "la"
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "As at Matins"
+              },
+              "lang": "la"
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Outside Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Forgive, O Lord, we beseech Thee, the sins of Thy servants; so that we who cannot become pleasing to Thee from our own actions, may be saved by the pleading of the Mother of Thy Son, Our Lord, Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who, by the fruitful virginity of blessed Mary, hast given to mankind the rewards of eternal salvation: grant, we beseech Thee, that we may experience her intercession for us, by whom we deserved to receive the Author of life, Our Lord Jesus Christ, Thy Son. Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Conclusion"
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "As at Matins"
+              },
+              "lang": "en-US"
             }
           ]
         },
@@ -1557,28 +5023,56 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
-                "la": "Introduction\nAs at Lauds\nPsalms\nAnt. from Candlemas until Advent Dum esset Rex.\nAnt. in Advent Missus est.\nAnt. from Christmas to Candlemas O admirabile commercium!",
-                "en-US": "Introduction\nAs at Lauds\nPsalms\nAnt. from Candlemas until Advent While the King.\nAnt. in Advent The angel Gabriel was sent.\nAnt. from Christmas to Candlemas O wondrous union!"
+                "la": "Introduction",
+                "en-US": "Introduction"
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "As at Lauds",
+                "en-US": "As at Lauds"
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalms",
+                "en-US": "Psalms"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Ant. from Candlemas until Advent: Dum esset Rex.\nAnt. in Advent: Missus est.\nAnt. from Christmas to Candlemas: O admirabile commercium!",
+                "en-US": "Ant. from Candlemas until Advent: While the King.\nAnt. in Advent: The angel Gabriel was sent.\nAnt. from Christmas to Candlemas: O wondrous union!"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Psalm 109\nDixit Dominus Domino meo: Sede a dextris meis:\nDonec ponam inimicos tuos, scabellum pedum tuorum.\nVirgam virtutis tuae emittet Dominus ex Sion: dominare in medio inimicorum tuorum.\nTecum principium in die virtutis tuae in splendoribus sanctorum: ex utero ante luciferum genui te.\nJuravit Dominus, et non pœnitebit eum: Tu es sacerdos in aeternum secundum ordinem Melchisedech.\nDominus a dextris tuis, confregit in die irae suae reges.\nJudicabit in nationibus, implebit ruinas: conquassabit capita in terra multorum.\nDe torrente in via bibet: propterea exaltabit caput.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "Psalm 109\nThe Lord said to my Lord: Sit Thou at My right hand.\nUntil I make Thine enemies Thy footstool.\nThe Lord will send forth the scepter of Thy power out of Sion: rule Thou in the midst of Thine enemies.\nThine is dominion in the day of Thy power, amid the brightness of the saints: from the womb before the day-star have I begotten Thee.\nThe Lord hath sworn, and He will not repent: Thou art a priest forever after the order of Melchisedech.\nThe Lord upon Thy right hand: hath overthrown kings in the day of His wrath.\nHe shall judge among the nations; He shall fill the land with the fallen. He shall smite in sunder the heads in the land of many.\nHe shall drink of a brook in the way: therefore shall He lift up His head.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 109",
+                "en-US": "Psalm 109"
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Dixit Dominus Domino meo: Sede a dextris meis:\nDonec ponam inimicos tuos, scabellum pedum tuorum.\nVirgam virtutis tuae emittet Dominus ex Sion: dominare in medio inimicorum tuorum.\nTecum principium in die virtutis tuae in splendoribus sanctorum: ex utero ante luciferum genui te.\nJuravit Dominus, et non pœnitebit eum: Tu es sacerdos in aeternum secundum ordinem Melchisedech.\nDominus a dextris tuis, confregit in die irae suae reges.\nJudicabit in nationibus, implebit ruinas: conquassabit capita in terra multorum.\nDe torrente in via bibet: propterea exaltabit caput.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "The Lord said to my Lord: Sit Thou at My right hand.\nUntil I make Thine enemies Thy footstool.\nThe Lord will send forth the scepter of Thy power out of Sion: rule Thou in the midst of Thine enemies.\nThine is dominion in the day of Thy power, amid the brightness of the saints: from the womb before the day-star have I begotten Thee.\nThe Lord hath sworn, and He will not repent: Thou art a priest forever after the order of Melchisedech.\nThe Lord upon Thy right hand: hath overthrown kings in the day of His wrath.\nHe shall judge among the nations; He shall fill the land with the fallen. He shall smite in sunder the heads in the land of many.\nHe shall drink of a brook in the way: therefore shall He lift up His head.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1592,7 +5086,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1606,7 +5100,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1620,7 +5114,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1634,7 +5128,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1648,7 +5142,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1657,12 +5151,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quando natus es.\nPsalm 112\nLaudate, pueri, Dominum: laudate nomen Domini.\nSit nomen Domini benedictum, ex hoc nunc, et usque in saeculum.\nA solis ortu usque ad occasum, laudabile nomen Domini.\nExcelsus super omnes gentes Dominus, et super caelos gloria ejus.\nQuis sicut Dominus, Deus noster, qui in altis habitat, et humilia respicit in caelo et in terra?\nSuscitans a terra inopem, et de stercore erigens pauperem:\nUt collocet eum cum principibus, cum principibus populi sui.\nQui habitare facit sterilem in domo, matrem filiorum laetantem.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "When thou wert wondrously born.\nPsalm 112\nPraise the Lord, ye servants: praise the name of the Lord.\nBlessed be the name of the Lord, from this time forth for evermore.\nFrom the rising of the sun unto its going down, the name of the Lord is worthy to be praised.\nThe Lord is high above all nations; and His glory is above the heavens.\nWho is like unto the Lord our God, Who dwelleth on high, yet regardeth lowly things in heaven and on earth?\nWho raiseth up the needy from the earth, and lifteth the poor out of the dunghill;\nThat He may set him with the princes, even with the princes of His people.\nWho maketh the barren woman to dwell in her house, the joyful mother of children.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Quando natus es.",
+                "en-US": "When thou wert wondrously born."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 112",
+                "en-US": "Psalm 112"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Laudate, pueri, Dominum: laudate nomen Domini.\nSit nomen Domini benedictum, ex hoc nunc, et usque in saeculum.\nA solis ortu usque ad occasum, laudabile nomen Domini.\nExcelsus super omnes gentes Dominus, et super caelos gloria ejus.\nQuis sicut Dominus, Deus noster, qui in altis habitat, et humilia respicit in caelo et in terra?\nSuscitans a terra inopem, et de stercore erigens pauperem:\nUt collocet eum cum principibus, cum principibus populi sui.\nQui habitare facit sterilem in domo, matrem filiorum laetantem.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "Praise the Lord, ye servants: praise the name of the Lord.\nBlessed be the name of the Lord, from this time forth for evermore.\nFrom the rising of the sun unto its going down, the name of the Lord is worthy to be praised.\nThe Lord is high above all nations; and His glory is above the heavens.\nWho is like unto the Lord our God, Who dwelleth on high, yet regardeth lowly things in heaven and on earth?\nWho raiseth up the needy from the earth, and lifteth the poor out of the dunghill;\nThat He may set him with the princes, even with the princes of His people.\nWho maketh the barren woman to dwell in her house, the joyful mother of children.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1676,7 +5184,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1690,7 +5198,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1704,7 +5212,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1718,7 +5226,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1732,7 +5240,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1741,12 +5249,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Rubum, quem viderat Moyses.\nPsalm 121\nLaetatus sum in his, quae dicta sunt mihi: In domum Domini ibimus.\nStantes erant pedes nostri, in atriis tuis, Jerusalem.\nJerusalem, quae aedificatur ut civitas: cujus participatio ejus in idipsum.\nIlluc enim ascenderunt tribus, tribus Domini: testimonium Israel ad confitendum nomini Domini.\nQuia illic sederunt sedes in judicio, sedes super domum David.\nRogate quae ad pacem sunt Jerusalem: et abundantia diligentibus te:\nFiat pax in virtute tua: et abundantia in turribus tuis.\nPropter fratres meos, et proximos meos, loquebar pacem de te:\nPropter domum Domini, Dei nostri, quaesivi bona tibi.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "The bush which Moses saw.\nPsalm 121\nI was glad at the things that were said unto me: We will go into the house of the Lord.\nOur feet were standing within thy courts, O Jerusalem.\nJerusalem, which is built as a city, that is compact together.\nFor thither the tribes went up, the tribes of the Lord: an ordinance for Israel, to give thanks to the name of the Lord.\nFor there are setup thrones of judgment, the thrones of the house of David.\nPray ye for the things that are for the peace of Jerusalem; and plenty be to them that love Thee.\nLet peace be in Thy stronghold, and plenty in Thy towers.\nFor my brethren and my neighbors' sake, I spake peace concerning thee.\nFor the sake of the house of the Lord our God, I have sought good things for thee.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Rubum, quem viderat Moyses.",
+                "en-US": "The bush which Moses saw."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 121",
+                "en-US": "Psalm 121"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Laetatus sum in his, quae dicta sunt mihi: In domum Domini ibimus.\nStantes erant pedes nostri, in atriis tuis, Jerusalem.\nJerusalem, quae aedificatur ut civitas: cujus participatio ejus in idipsum.\nIlluc enim ascenderunt tribus, tribus Domini: testimonium Israel ad confitendum nomini Domini.\nQuia illic sederunt sedes in judicio, sedes super domum David.\nRogate quae ad pacem sunt Jerusalem: et abundantia diligentibus te:\nFiat pax in virtute tua: et abundantia in turribus tuis.\nPropter fratres meos, et proximos meos, loquebar pacem de te:\nPropter domum Domini, Dei nostri, quaesivi bona tibi.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "I was glad at the things that were said unto me: We will go into the house of the Lord.\nOur feet were standing within thy courts, O Jerusalem.\nJerusalem, which is built as a city, that is compact together.\nFor thither the tribes went up, the tribes of the Lord: an ordinance for Israel, to give thanks to the name of the Lord.\nFor there are setup thrones of judgment, the thrones of the house of David.\nPray ye for the things that are for the peace of Jerusalem; and plenty be to them that love Thee.\nLet peace be in Thy stronghold, and plenty in Thy towers.\nFor my brethren and my neighbors' sake, I spake peace concerning thee.\nFor the sake of the house of the Lord our God, I have sought good things for thee.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1760,7 +5282,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1774,7 +5296,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1788,7 +5310,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1802,7 +5324,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1816,7 +5338,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1825,12 +5347,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Germinavit radix Jesse.\nPsalm 126\nNisi Dominus aedificaverit domum, in vanum laboraverunt qui aedificant eam.\nNisi Dominus custodierit civitatem, frustra vigilat qui custodit eam.\nVanum est vobis ante lucem surgere: surgite postquam sederitis, qui manducatis panem doloris.\nCum dederit dilectis suis somnum: ecce hereditas Domini filii: merces, fructus ventris.\nSicut sagittae in manu potentis: ita filii excussorum.\nBeatus vir, qui implevit desiderium suum ex ipsis: non confundetur cum loquetur inimicis suis in porta.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "The root of Jesse hath budded.\nPsalm 126\nUnless the Lord build a house, they labor in vain that build it.\nUnless the Lord keep the city, he watcheth in vain that keepeth it.\nIn vain do ye rise before the light: rise not till ye have rested, O ye that eat the bread of sorrow.\nWhen He giveth sleep to His beloved: lo, children are an heritage from the Lord, and the fruit of the womb a reward.\nLike as arrows in the hand of the mighty One, so are the children of the outcast.\nBlessed is the man whose desire is satisfied with them: he shall not be confounded when he speaketh with his enemies in the gate.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Germinavit radix Jesse.",
+                "en-US": "The root of Jesse hath budded."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 126",
+                "en-US": "Psalm 126"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Nisi Dominus aedificaverit domum, in vanum laboraverunt qui aedificant eam.\nNisi Dominus custodierit civitatem, frustra vigilat qui custodit eam.\nVanum est vobis ante lucem surgere: surgite postquam sederitis, qui manducatis panem doloris.\nCum dederit dilectis suis somnum: ecce hereditas Domini filii: merces, fructus ventris.\nSicut sagittae in manu potentis: ita filii excussorum.\nBeatus vir, qui implevit desiderium suum ex ipsis: non confundetur cum loquetur inimicis suis in porta.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "Unless the Lord build a house, they labor in vain that build it.\nUnless the Lord keep the city, he watcheth in vain that keepeth it.\nIn vain do ye rise before the light: rise not till ye have rested, O ye that eat the bread of sorrow.\nWhen He giveth sleep to His beloved: lo, children are an heritage from the Lord, and the fruit of the womb a reward.\nLike as arrows in the hand of the mighty One, so are the children of the outcast.\nBlessed is the man whose desire is satisfied with them: he shall not be confounded when he speaketh with his enemies in the gate.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1844,7 +5380,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1858,7 +5394,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1872,7 +5408,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1886,7 +5422,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1900,7 +5436,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1909,12 +5445,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce Maria.\nPsalm 147\nLauda, Jerusalem, Dominum: lauda Deum tuum, Sion.\nQuoniam confortavit seras portarum tuarum: benedixit filiis tuis in te.\nQui posuit fines tuos pacem: et adipe frumenti satiat te.\nQui emittit eloquium suum terrae: velociter currit sermo ejus.\nQui dat nivem sicut lanam: nebulam sicut cinerem spargit.\nMittit crystallum suam sicut buccellas: ante faciem frigoris ejus quis sustinebit?\nEmittet verbum suum, et liquefaciet ea: flabit spiritus ejus, et fluent aquae.\nQui annuntiat verbum suum Jacob: justitias, et judicia sua Israel.\nNon fecit taliter omni nationi: et judicia sua non manifestavit eis.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "Behold, Mary.\nPsalm 147\nPraise the Lord, O Jerusalem: praise thy God, O Sion.\nFor He hath strengthened the bars of thy gates: He hath blessed thy children within thee.\nWho maketh thy borders peaceful, and filleth thee with the fat of corn.\nWho sendeth forth His decree upon earth: very swiftly runneth His word.\nWho giveth snow like wool: He scattereth mist like ashes.\nHe sendeth His ice like morsels: who shall stand before the face of His cold?\nHe sendeth forth His word and melteth them; His wind bloweth, and the waters flow.\nWho declareth His word unto Jacob: His justice and judgment to Israel.\nHe hath not done so to every nation; nor hath He shown them His judgments.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Ecce Maria.",
+                "en-US": "Behold, Mary."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 147",
+                "en-US": "Psalm 147"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Lauda, Jerusalem, Dominum: lauda Deum tuum, Sion.\nQuoniam confortavit seras portarum tuarum: benedixit filiis tuis in te.\nQui posuit fines tuos pacem: et adipe frumenti satiat te.\nQui emittit eloquium suum terrae: velociter currit sermo ejus.\nQui dat nivem sicut lanam: nebulam sicut cinerem spargit.\nMittit crystallum suam sicut buccellas: ante faciem frigoris ejus quis sustinebit?\nEmittet verbum suum, et liquefaciet ea: flabit spiritus ejus, et fluent aquae.\nQui annuntiat verbum suum Jacob: justitias, et judicia sua Israel.\nNon fecit taliter omni nationi: et judicia sua non manifestavit eis.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "Praise the Lord, O Jerusalem: praise thy God, O Sion.\nFor He hath strengthened the bars of thy gates: He hath blessed thy children within thee.\nWho maketh thy borders peaceful, and filleth thee with the fat of corn.\nWho sendeth forth His decree upon earth: very swiftly runneth His word.\nWho giveth snow like wool: He scattereth mist like ashes.\nHe sendeth His ice like morsels: who shall stand before the face of His cold?\nHe sendeth forth His word and melteth them; His wind bloweth, and the waters flow.\nWho declareth His word unto Jacob: His justice and judgment to Israel.\nHe hath not done so to every nation; nor hath He shown them His judgments.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1928,7 +5478,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1942,7 +5492,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1951,26 +5501,92 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce Maria genuit nobis Salvatorem, quem Ioannes videns, exclamavit, dicens: Ecce Agnus Dei, ecce qui tollit peccata mundi, alleluia.\nLittle Chapter Outside Advent - Sir 24:24\nAb initio et ante saecula creata sum, et usque ad futurum saeculum non desinam, et in habitatione sancta coram ipso ministravi.\n℟. Deo gratias.\nLittle Chapter During Advent. - Is 11:1-2\nEgredietur virga de radice Jesse, et flos de radice ejus ascendet. Et requiescet super eum Spiritus Domini.\n℟. Deo gratias.",
-                "en-US": "Behold, Mary, hath brought us forth a Saviour, Whom when John saw, he cried aloud, saying: Behold the Lamb of God! Behold Him Who taketh away the sins of the world, Alleluia.\nLittle Chapter Outside Advent - Sir 24:24\nFrom the beginning, and before the world was I created, and unto the world to come I shall not cease to be, and in the holy dwelling-place have I ministered before Him.\n℟. Thanks be to God.\nLittle Chapter During Advent - Is 11:1-2\nThere shall come forth a rod out of the root of Jesse, and a flower shall rise up out of his root, and the Spirit of the Lord shall rest upon Him.\n℟. Thanks be to God."
+                "la": "Ecce Maria genuit nobis Salvatorem, quem Ioannes videns, exclamavit, dicens: Ecce Agnus Dei, ecce qui tollit peccata mundi, alleluia.\nLittle Chapter Outside Advent - Sir 24:24\nAb initio et ante saecula creata sum, et usque ad futurum saeculum non desinam, et in habitatione sancta coram ipso ministravi.",
+                "en-US": "Behold, Mary, hath brought us forth a Saviour, Whom when John saw, he cried aloud, saying: Behold the Lamb of God! Behold Him Who taketh away the sins of the world, Alleluia.\nLittle Chapter Outside Advent - Sir 24:24\nFrom the beginning, and before the world was I created, and unto the world to come I shall not cease to be, and in the holy dwelling-place have I ministered before Him."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Little Chapter During Advent. - Is 11:1-2\nEgredietur virga de radice Jesse, et flos de radice ejus ascendet. Et requiescet super eum Spiritus Domini.",
+                "en-US": "Little Chapter During Advent - Is 11:1-2\nThere shall come forth a rod out of the root of Jesse, and a flower shall rise up out of his root, and the Spirit of the Lord shall rest upon Him."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "The first verse of the hymn is said kneeling."
+              }
+            },
+            {
+              "type": "hymn",
+              "lang": "la",
               "inline": {
-                "la": "The first verse of the hymn is said kneeling.\nAve maris stella,\nDei Mater alma,\nAtque semper Virgo,\nFelix caeli porta.\nSumens illud Ave\nGabrielis ore,\nFunda nos in pace,\nMutans Hevae nomen.\nSolve vincla reis,\nProfer lumen caecis,\nMala nostra pelle,\nBona cuncta posce.\nMonstra te esse matrem,\nSumat per te preces,\nQui pro nobis natus,\nTulit esse tuus.\nVirgo singularis,\nInter omnes mitis,\nNos culpis solutos\nMites fac et castos.\nVitam praesta puram,\nIter para tutum,\nUt videntes Jesum,\nSemper collaetemur.\nSit laus Deo Patri,\nSummo Christo decus,\nSpiritui Sancto,\nTribus honor unus.\nAmen.\n℣. Diffusa est gratia in labiis tuis.\n℟. Propterea benedixit te Deus in aeternum.\nCanticle of the Blessed Virgin Mary - Lk 1",
-                "en-US": "The first verse of the hymn is said kneeling.\nHail, thou star of ocean!\nPortal of the sky!\nEver Virgin Mother\nOf the Lord most high!\nOh! by Gabriel's Ave,\nUttered long ago,\nEva's name reversing,\nEstablish peace below.\nBreak the captives' fetters,\nLight on blindness pour;\nAll our ills expelling,\nEvery bliss implore.\nShow thyself a Mother;\nOffer Him our sighs,\nWho for us Incarnate\nDid not thee despise.\nVirgin of all virgins!\nTo thy shelter take us:\nGentlest of the gentle!\nChaste and gentle make us.\nStill, as on we journey,\nHelp our weak endeavour,\nTill with thee and Jesus\nWe rejoice for ever.\nThrough the highest heaven,\nTo the almighty Three,\nFather, Son, and Spirit,\nOne same glory be.\nAmen.\nCanticle of the Blessed Virgin Mary - Lk 1"
+                "la": "Ave maris stella,\nDei Mater alma,\nAtque semper Virgo,\nFelix caeli porta.\nSumens illud Ave\nGabrielis ore,\nFunda nos in pace,\nMutans Hevae nomen.\nSolve vincla reis,\nProfer lumen caecis,\nMala nostra pelle,\nBona cuncta posce.\nMonstra te esse matrem,\nSumat per te preces,\nQui pro nobis natus,\nTulit esse tuus.\nVirgo singularis,\nInter omnes mitis,\nNos culpis solutos\nMites fac et castos.\nVitam praesta puram,\nIter para tutum,\nUt videntes Jesum,\nSemper collaetemur.\nSit laus Deo Patri,\nSummo Christo decus,\nSpiritui Sancto,\nTribus honor unus.\nAmen."
               }
             },
             {
               "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "The first verse of the hymn is said kneeling."
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
+                "en-US": "Hail, thou star of ocean!\nPortal of the sky!\nEver Virgin Mother\nOf the Lord most high!\nOh! by Gabriel's Ave,\nUttered long ago,\nEva's name reversing,\nEstablish peace below.\nBreak the captives' fetters,\nLight on blindness pour;\nAll our ills expelling,\nEvery bliss implore.\nShow thyself a Mother;\nOffer Him our sighs,\nWho for us Incarnate\nDid not thee despise.\nVirgin of all virgins!\nTo thy shelter take us:\nGentlest of the gentle!\nChaste and gentle make us.\nStill, as on we journey,\nHelp our weak endeavour,\nTill with thee and Jesus\nWe rejoice for ever.\nThrough the highest heaven,\nTo the almighty Three,\nFather, Son, and Spirit,\nOne same glory be.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Canticle of the Blessed Virgin Mary - Lk 1"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Diffusa est gratia in labiis tuis."
+                  },
+                  "r": {
+                    "la": "Propterea benedixit te Deus in aeternum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Canticle of the Blessed Virgin Mary - Lk 1"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1984,7 +5600,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -1992,13 +5608,41 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Spiritus Sanctus.\nDuring Eastertide, instead of the above, the following antiphon is said:\nAnt. Regina caeli.",
-                "en-US": "The Holy Ghost.\nDuring Eastertide, instead of the above, the following antiphon is said:\nAnt. O Queen of heaven."
+                "la": "Spiritus Sanctus."
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "During Eastertide, instead of the above, the following antiphon is said:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "The Holy Ghost."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Eastertide, instead of the above, the following antiphon is said:"
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Ant. Regina caeli.",
+                "en-US": "Ant. O Queen of heaven."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -2012,7 +5656,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -2026,7 +5670,49 @@
               }
             },
             {
+              "type": "subheading",
+              "text": {
+                "la": "Antiphon",
+                "en-US": "Antiphon"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Spiritus Sanctus in te descendet, Maria: ne timeas, habebis in utero Filium Dei, alleluja."
+              }
+            },
+            {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "During Eastertide, instead of the above, the following antiphon is said:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "The Holy Ghost shall come upon thee, Mary; fear not, thou shalt hold within thy womb the Son of God, Alleluia."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Eastertide, instead of the above, the following antiphon is said:"
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Ant. Regina caeli,laetare, alleluia; quia quem meruisti portare, alleluia; resurrexit, sicut dixit, alleluia: ora pro nobis Deum, alleluia.",
+                "en-US": "Ant. O Queen of heaven rejoice! alleluia: for He whom thou didst merit to bear, alleluia, hath arisen as he said, alleluia; pray for us to God, alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -2035,12 +5721,139 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Spiritus Sanctus in te descendet, Maria: ne timeas, habebis in utero Filium Dei, alleluja.\nDuring Eastertide, instead of the above, the following antiphon is said:\nAnt. Regina caeli,laetare, alleluia; quia quem meruisti portare, alleluia; resurrexit, sicut dixit, alleluia: ora pro nobis Deum, alleluia.",
-                "en-US": "The Holy Ghost shall come upon thee, Mary; fear not, thou shalt hold within thy womb the Son of God, Alleluia.\nDuring Eastertide, instead of the above, the following antiphon is said:\nAnt. O Queen of heaven rejoice! alleluia: for He whom thou didst merit to bear, alleluia, hath arisen as he said, alleluia; pray for us to God, alleluia."
+                "la": "Magnum hereditatis mysterium: templum Dei factus est uterus nescientis virum: non est pollutus ex ea carnem assumens; omnes gentes venient dicentes: Gloria tibi, Domine.\nKyrie, eleison.\nChriste, eleison.\nKyrie, eleison.",
+                "en-US": "How great the mystery of our inheritance! The womb of one that knoweth not man hath become the temple of God! He was not defiled in taking flesh of her. All nations shall come and shall say: Glory be to Thee, O Lord.\nLord, have mercy on us.\nChrist, have mercy on us.\nLord, have mercy on us."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Collect",
+                "en-US": "Collect"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "Outside Advent"
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              },
+              "lang": "la"
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Concede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis sanitate gaudere: et, gloriosa beatae Mariae semper Virginis intercessione, a praesenti liberari tristitia, et aeterna perfrui laetitia. Per Dominum nostrum Jesum Christum, Filium tuum: qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Outside Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "Grant, we beseech Thee, O Lord God, that we, Thy servants, may enjoy perpetual health of mind and body; and, by the glorious intercession of the Blessed Mary, ever virgin, be delivered from present sorrow and possess eternal joy. Through Christ our Lord."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "During Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              },
+              "lang": "la"
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Deus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who, by the fruitful virginity of blessed Mary, hast given to mankind the rewards of eternal salvation; grant, we beseech Thee, that we may experience her intercession for us, by whom we deserved to receive the Author of life, Our Lord Jesus Christ, Thy Son, Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Commemoration of the Saints Outside Advent",
+                "en-US": "Commemoration of the Saints Outside Advent"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -2049,12 +5862,55 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Magnum hereditatis mysterium: templum Dei factus est uterus nescientis virum: non est pollutus ex ea carnem assumens; omnes gentes venient dicentes: Gloria tibi, Domine.\nKyrie, eleison.\nChriste, eleison.\nKyrie, eleison.\nCollect\n℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\nOutside Advent\nOremus,\nConcede nos famulos tuos, quaesumus, Domine Deus, perpetua mentis et corporis sanitate gaudere: et, gloriosa beatae Mariae semper Virginis intercessione, a praesenti liberari tristitia, et aeterna perfrui laetitia. Per Dominum nostrum Jesum Christum, Filium tuum: qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\n℟. Amen.\nDuring Advent\nOremus,\nDeus, qui salutis aeternae, beatae Mariae virginitate fecunda, humano generi praemia praestitisti: tribue, quaesumus; ut ipsam pro nobis intercedere sentiamus, per quam meruimus auctorem vitae suscipere, Dominum nostrum Jesum Christum Filium tuum: Qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\n℟. Amen.\nCommemoration of the Saints Outside Advent",
-                "en-US": "How great the mystery of our inheritance! The womb of one that knoweth not man hath become the temple of God! He was not defiled in taking flesh of her. All nations shall come and shall say: Glory be to Thee, O Lord.\nLord, have mercy on us.\nChrist, have mercy on us.\nLord, have mercy on us.\nCollect\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\nOutside Advent\nLet us pray,\nGrant, we beseech Thee, O Lord God, that we, Thy servants, may enjoy perpetual health of mind and body; and, by the glorious intercession of the Blessed Mary, ever virgin, be delivered from present sorrow and possess eternal joy. Through Christ our Lord.\n℟. Amen.\nDuring Advent\nLet us pray,\nO God, Who, by the fruitful virginity of blessed Mary, hast given to mankind the rewards of eternal salvation; grant, we beseech Thee, that we may experience her intercession for us, by whom we deserved to receive the Author of life, Our Lord Jesus Christ, Thy Son, Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\n℟. Amen.\nCommemoration of the Saints Outside Advent"
+                "la": "Sancti Dei omnes, intercedere dignemini pro nostra omniumque salute.",
+                "en-US": "All ye saints of God, vouchsafe to plead for our salvation and for that of all mankind."
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Laetamini in Domino et exsultate, justi.",
+                    "en-US": "Be glad in the Lord, and rejoice, ye just."
+                  },
+                  "r": {
+                    "la": "Et gloriamini, omnes recti corde.",
+                    "en-US": "And be joyful, all ye that are of right heart."
+                  }
+                }
+              ]
+            },
+            {
               "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Protege, Domine, populum tuum, et, Apostolorum tuorum Petri et Pauli et aliorum Apostolorum patrocinio confidentem, perpetua defensione conserva.\nOmnes Sancti tui, quaesumus, Domine, nos ubique adjuvent: ut, dum eorum merita recolimus, patrocinia sentiamus: et pacem tuam nostris concede temporibus, et ab Ecclesia tua cunctam repelle nequitiam; iter, actus et voluntates nostras et omnium famulorum tuorum, in salutis tuae prosperitate dispone, benefactoribus nostris sempiterna bona retribue, et omnibus fidelibus defunctis requiem aeternam concede.",
+                "en-US": "Shield, O Lord, Thy people, and ever keep them in Thy care, who put their trust in the pleading of Thine apostles Peter and Paul, and of the other apostles.\nMay all Thy saints, we beseech Thee, O Lord, everywhere come to our help, that while we do honor to their merits, we may also enjoy their intercession: grant Thine own peace unto our times, and drive away all wickedness from Thy Church; direct our way, our actions, and our wishes and those of all Thy servants in the way of salvation; to our benefactors render everlasting blessings, and to all the faithful departed grant eternal rest. Through Our Lord Jesus Christ, Thy Son, Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Commemoration of the Saints During Advent",
+                "en-US": "Commemoration of the Saints During Advent"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -2063,22 +5919,75 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancti Dei omnes, intercedere dignemini pro nostra omniumque salute.\n℣. Laetamini in Domino et exsultate, justi.\n℟. Et gloriamini, omnes recti corde.\nOremus,\nProtege, Domine, populum tuum, et, Apostolorum tuorum Petri et Pauli et aliorum Apostolorum patrocinio confidentem, perpetua defensione conserva.\nOmnes Sancti tui, quaesumus, Domine, nos ubique adjuvent: ut, dum eorum merita recolimus, patrocinia sentiamus: et pacem tuam nostris concede temporibus, et ab Ecclesia tua cunctam repelle nequitiam; iter, actus et voluntates nostras et omnium famulorum tuorum, in salutis tuae prosperitate dispone, benefactoribus nostris sempiterna bona retribue, et omnibus fidelibus defunctis requiem aeternam concede.\n℟ Amen.\nCommemoration of the Saints During Advent",
-                "en-US": "All ye saints of God, vouchsafe to plead for our salvation and for that of all mankind.\n℣. Be glad in the Lord, and rejoice, ye just.\n℟. And be joyful, all ye that are of right heart.\nLet us pray,\nShield, O Lord, Thy people, and ever keep them in Thy care, who put their trust in the pleading of Thine apostles Peter and Paul, and of the other apostles.\nMay all Thy saints, we beseech Thee, O Lord, everywhere come to our help, that while we do honor to their merits, we may also enjoy their intercession: grant Thine own peace unto our times, and drive away all wickedness from Thy Church; direct our way, our actions, and our wishes and those of all Thy servants in the way of salvation; to our benefactors render everlasting blessings, and to all the faithful departed grant eternal rest. Through Our Lord Jesus Christ, Thy Son, Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\n℟. Amen.\nCommemoration of the Saints During Advent"
+                "la": "Ecce Dominus veniet, et omnes Sancti ejus cum eo: et erit in die illa lux magna, Alleluia.",
+                "en-US": "Behold, the Lord shall come, and all His saints with Him, and in that day there shall be great light, Alleluia."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ecce apparebit Dominus super nubem candidam.",
+                    "en-US": "Behold, the Lord shall appear upon a shining cloud."
+                  },
+                  "r": {
+                    "la": "Et cum eo Sanctorum millia.",
+                    "en-US": "And with Him thousands of saints."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
               "text": {
-                "la": "Antiphon",
-                "en-US": "Antiphon"
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce Dominus veniet, et omnes Sancti ejus cum eo: et erit in die illa lux magna, Alleluia.\n℣. Ecce apparebit Dominus super nubem candidam.\n℟. Et cum eo Sanctorum millia.\nOremus,\nConscientias nostras, quaesumus, Domine, visitando purifica: ut, veniens Jesus Christus, Filius tuus, Dominus noster, cum omnibus Sanctis, paratam sibi in nobis inveniat mansionem: qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\n℟ Amen.\nConclusion\nAs at Matins",
-                "en-US": "Behold, the Lord shall come, and all His saints with Him, and in that day there shall be great light, Alleluia.\n℣. Behold, the Lord shall appear upon a shining cloud.\n℟. And with Him thousands of saints.\nLet us pray,\nCleanse our consciences, we beseech Thee, O Lord, by Thy visitation, that when Jesus Christ, Thy Son, Our Lord, shall come with all the saints, He may find within us a resting-place made ready for Him. Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\n℟. Amen.\nConclusion\nAs at Matins"
+                "la": "Conscientias nostras, quaesumus, Domine, visitando purifica: ut, veniens Jesus Christus, Filius tuus, Dominus noster, cum omnibus Sanctis, paratam sibi in nobis inveniat mansionem: qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.",
+                "en-US": "Cleanse our consciences, we beseech Thee, O Lord, by Thy visitation, that when Jesus Christ, Thy Son, Our Lord, shall come with all the saints, He may find within us a resting-place made ready for Him. Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "",
+                "en-US": ""
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Conclusion"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "As at Matins"
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Conclusion"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "As at Matins"
               }
             }
           ]
@@ -2092,28 +6001,227 @@
           },
           "sections": [
             {
+              "type": "rubric",
+              "text": {
+                "en-US": "The Hail Mary is prayed silently."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "The Hail Mary is prayed silently.\nAve Maria, gratia plena; Dominus tecum: benedicta tu in mulieribus, et benedictus fructus ventris tui Jesus.\nSancta Maria, Mater Dei, ora pro nobis peccatoribus, nunc et in hora mortis nostrae. Amen.\nIn the first ℣, the sign of the cross is made with the thumb over the heart, instead of the usual manner.\n℣. Converte nos ✠ Deus, salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus ✠ in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae.\nPsalm 128\nSaepe expugnaverunt me a iuventute mea, dicat nunc Israel.\nSaepe expugnaverunt me a iuventute mea: etenim non potuerunt mihi.\nSupra dorsum meum fabricaverunt peccatores: prolongaverunt iniquitatem suam.\nDominus iustus concidit cervices peccatorum: confundantur et convertantur retrorsum omnes, qui oderunt Sion.\nFiant sicut faenum tectorum: quod priusquam evellatur, exaruit:\nDe quo non implevit manum suam qui metit, et sinum suum qui manipulos colligit.\nEt non dixerunt qui praeteribant: Benedictio Domini super vos: benediximus vobis in nomine Domini.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nPsalm 129\nDe profundis clamavi ad te, Domine: Domine, exaudi vocem meam:\nFiant aures tuae intendentes, in vocem deprecationis meae.\nSi iniquitates observaveris, Domine: Domine, quis sustinebit?\nQuia apud te propitiatio est: et propter legem tuam sustinui te, Domine.\nSustinuit anima mea in verbo eius: speravit anima mea in Domino.\nA custodia matutina usque ad noctem: speret Israel in Domino.\nQuia apud Dominum misericordia: et copiosa apud eum redemptio.\nEt ipse redimet Israel, ex omnibus iniquitatibus eius.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nPsalm 130\nDomine, non est exaltatum cor meum: neque elati sunt oculi mei.\nNeque ambulavi in magnis: neque in mirabilibus super me.\nSi non humiliter sentiebam: sed exaltavi animam meam:\nSicut ablactatus est super matre sua, ita retributio in anima mea.\nSperet Israel in Domino, ex hoc nunc et usque in saeculum.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
-                "en-US": "The Hail Mary is prayed silently.\nAve Maria, gratia plena; Dominus tecum: benedicta tu in mulieribus, et benedictus fructus ventris tui Jesus.\nSancta Maria, Mater Dei, ora pro nobis peccatoribus, nunc et in hora mortis nostrae. Amen.\nn the first ℣, the sign of the cross is made with the thumb over the heart, instead of the usual manner.\n℣. Convert us, ✠ O God, our Saviour:\n℟. And turn away Thine anger from us.\n℣. O God, ✠ hasten to mine aid.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, world without end. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Praise be to Thee, O Lord, King of glory everlasting.\nPsalm 128\nOften have they fought against me from my youth; let Israel now say.\nOften have they fought against me from my youth; but they could not prevail against me.\nThe wicked have wrought upon my back: they have prolonged their iniquity.\nThe just Lord hath hewn asunder the necks of sinners: let them all be confounded and turned back that hate Sion.\nLet them be as grass of the housetops, which withereth before it be plucked up.\nWherewith the mower filleth not his hand; nor he that gathereth sheaves, his bosom.\nAnd they that passed by say not: The blessing of the Lord be upon you: we bless you in the name of the Lord.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 129\nOut of the depths have I cried unto Thee, O Lord. Lord, hear my voice.\nO, let Thine ears be attentive to the voice of my supplication.\nIf thou, O Lord, wilt observe iniquities, Lord, who shall stand it?\nFor with Thee there is merciful forgiveness; and by reason of Thy law I have waited for Thee, O Lord.\nMy soul hath relied on His word. My soul hath hoped in the Lord.\nFrom the morning watch even until night, let Israel hope in the Lord.\nFor with the Lord there is mercy, and with Him plentiful redemption.\nAnd He shall redeem Israel from all his iniquities.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen.\nPsalm 130\nO Lord, my heart is not lifted up; nor are mine eyes lofty.\nNeither do I walk in great matters, nor in things too wonderful me.\nIf I had not been humbly minded, but have lifted up my soul,\nAs a child that is weaned upon his mother's breast, so let my reward be in my soul.\nLet Israel hope in the Lord, from this time forth for evermore.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+                "la": "Ave Maria, gratia plena; Dominus tecum: benedicta tu in mulieribus, et benedictus fructus ventris tui Jesus.\nSancta Maria, Mater Dei, ora pro nobis peccatoribus, nunc et in hora mortis nostrae. Amen.",
+                "en-US": "Ave Maria, gratia plena; Dominus tecum: benedicta tu in mulieribus, et benedictus fructus ventris tui Jesus.\nSancta Maria, Mater Dei, ora pro nobis peccatoribus, nunc et in hora mortis nostrae. Amen."
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "en-US": "In the first versicle, the sign of the cross is made with the thumb over the heart instead of in the usual manner."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos ✠ Deus, salutaris noster.",
+                    "en-US": "Convert us, ✠ O God, our Saviour:"
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis.",
+                    "en-US": "And turn away Thine anger from us."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ✠ in adjutorium meum intende.",
+                    "en-US": "O God, ✠ hasten to mine aid."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto.",
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Laus tibi, Domine, Rex aeternae gloriae.",
+                    "en-US": "As it was in the beginning, is now, and ever shall be, world without end. Amen. (outside lent:) Alleluia. (from Septuagesima to Holy Saturday:) Praise be to Thee, O Lord, King of glory everlasting."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 128",
+                "en-US": "Psalm 128"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Saepe expugnaverunt me a iuventute mea, dicat nunc Israel.\nSaepe expugnaverunt me a iuventute mea: etenim non potuerunt mihi.\nSupra dorsum meum fabricaverunt peccatores: prolongaverunt iniquitatem suam.\nDominus iustus concidit cervices peccatorum: confundantur et convertantur retrorsum omnes, qui oderunt Sion.\nFiant sicut faenum tectorum: quod priusquam evellatur, exaruit:\nDe quo non implevit manum suam qui metit, et sinum suum qui manipulos colligit.\nEt non dixerunt qui praeteribant: Benedictio Domini super vos: benediximus vobis in nomine Domini.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "Often have they fought against me from my youth; let Israel now say.\nOften have they fought against me from my youth; but they could not prevail against me.\nThe wicked have wrought upon my back: they have prolonged their iniquity.\nThe just Lord hath hewn asunder the necks of sinners: let them all be confounded and turned back that hate Sion.\nLet them be as grass of the housetops, which withereth before it be plucked up.\nWherewith the mower filleth not his hand; nor he that gathereth sheaves, his bosom.\nAnd they that passed by say not: The blessing of the Lord be upon you: we bless you in the name of the Lord.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 129",
+                "en-US": "Psalm 129"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "De profundis clamavi ad te, Domine: Domine, exaudi vocem meam:\nFiant aures tuae intendentes, in vocem deprecationis meae.\nSi iniquitates observaveris, Domine: Domine, quis sustinebit?\nQuia apud te propitiatio est: et propter legem tuam sustinui te, Domine.\nSustinuit anima mea in verbo eius: speravit anima mea in Domino.\nA custodia matutina usque ad noctem: speret Israel in Domino.\nQuia apud Dominum misericordia: et copiosa apud eum redemptio.\nEt ipse redimet Israel, ex omnibus iniquitatibus eius.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "Out of the depths have I cried unto Thee, O Lord. Lord, hear my voice.\nO, let Thine ears be attentive to the voice of my supplication.\nIf thou, O Lord, wilt observe iniquities, Lord, who shall stand it?\nFor with Thee there is merciful forgiveness; and by reason of Thy law I have waited for Thee, O Lord.\nMy soul hath relied on His word. My soul hath hoped in the Lord.\nFrom the morning watch even until night, let Israel hope in the Lord.\nFor with the Lord there is mercy, and with Him plentiful redemption.\nAnd He shall redeem Israel from all his iniquities.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Psalm 130",
+                "en-US": "Psalm 130"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Domine, non est exaltatum cor meum: neque elati sunt oculi mei.\nNeque ambulavi in magnis: neque in mirabilibus super me.\nSi non humiliter sentiebam: sed exaltavi animam meam:\nSicut ablactatus est super matre sua, ita retributio in anima mea.\nSperet Israel in Domino, ex hoc nunc et usque in saeculum.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.",
+                "en-US": "O Lord, my heart is not lifted up; nor are mine eyes lofty.\nNeither do I walk in great matters, nor in things too wonderful me.\nIf I had not been humbly minded, but have lifted up my soul,\nAs a child that is weaned upon his mother's breast, so let my reward be in my soul.\nLet Israel hope in the Lord, from this time forth for evermore.\nGlory be to the Father, and to the Son, and to the Holy Ghost.\nAs it was in the beginning, is now, and ever shall be, world without end. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymn",
                 "en-US": "Hymn"
               }
             },
             {
+              "type": "hymn",
+              "inline": {
+                "la": "Memento, rerum Conditor,\nNostri quod olim corporis,\nSacrata ab alvo Virginis\nNascendo formam sumpseris.\nMaria Mater gratiae,\nDulcis Parens clementiae,\nTu nos ab hoste protege,\nEt mortis hora suscipe.\nJesu, tibi sit gloria,\nQui natus es de Virgine,\nCum Patre, et almo Spiritu,\nIn sempiterna saecula.\nAmen.\nLittle Chapter Outside Advent - Sir 24:24\nEgo mater pulchrae dilectionis, et timoris, et agnitionis, et sanctae spei.",
+                "en-US": "Remember, O creator Lord,\nThat in the Virgin's sacred womb\nThou wast conceived, and of her flesh\nDidst our mortality assume.\nMother of grace! O Mary blest!\nTo thee, sweet fount of love, we fly;\nShield us through life, and take us hence\nTo thy dear bosom, when we die.\nO Jesu! born of Virgin bright,\nImmortal glory be to Thee;\nPraise to the Father infinite,\nAnd Holy Ghost eternally.\nAmen.\nLittle Chapter Outside Advent - Sir 24:24\nI am the Mother of fair love, and of fear, and of knowledge, and of holy hope."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Memento, rerum Conditor,\nNostri quod olim corporis,\nSacrata ab alvo Virginis\nNascendo formam sumpseris.\nMaria Mater gratiae,\nDulcis Parens clementiae,\nTu nos ab hoste protege,\nEt mortis hora suscipe.\nJesu, tibi sit gloria,\nQui natus es de Virgine,\nCum Patre, et almo Spiritu,\nIn sempiterna saecula.\nAmen.\nLittle Chapter Outside Advent - Sir 24:24\nEgo mater pulchrae dilectionis, et timoris, et agnitionis, et sanctae spei.\n℟. Deo gratias.\n℣. Ora pro nobis, sancta Dei Genitrix.\n℟. Ut digni efficiamur promissionibus Christi.\nLittle Chapter During Advent - Is 7:14-15\nEcce virgo concipiet, et pariet Filium, et vocabitur nomen ejus Emmanuel. Butyrum et mel comedet, ut sciat reprobare malum, et eligere bonum.\n℟. Deo gratias.\n℣. Angelus Domini nuntiavit Mariae.\n℟. Et concepit de Spiritu sancto.\nNunc dimittis\nAnt. from Candlemas until Advent Sub tuum praesidium.\nAnt. in Advent Spiritus Sanctus.\nDuring Eastertide, instead of the above, the following antiphon is said:\nAnt. Regina caeli.\nAnt. from Christmas to Candlemas Magnum hereditatis mysterium!",
-                "en-US": "Remember, O creator Lord,\nThat in the Virgin's sacred womb\nThou wast conceived, and of her flesh\nDidst our mortality assume.\nMother of grace! O Mary blest!\nTo thee, sweet fount of love, we fly;\nShield us through life, and take us hence\nTo thy dear bosom, when we die.\nO Jesu! born of Virgin bright,\nImmortal glory be to Thee;\nPraise to the Father infinite,\nAnd Holy Ghost eternally.\nAmen.\nLittle Chapter Outside Advent - Sir 24:24\nI am the Mother of fair love, and of fear, and of knowledge, and of holy hope.\n℟. Thanks be to God.\n℣. Pray for us, O holy Mother of God.\n℟. That we may be made worthy of the promises of Christ.\nLittle Chapter During Advent - Is 7:14-15\nBehold, a virgin shall conceive, and bear a Son, and His name will be called Emmanuel: Butter and honey shall He eat, that he may know to refuse evil and to choose good.\n℟. Thanks be to God.\n℣. The angel of the Lord declared unto Mary.\n℟. And she conceived of the Holy Ghost.\nNunc Dimittis\nAnt. from Candlemas until Advent We fly to thy patronage.\nAnt. During Advent The Holy Ghost.\nDuring Eastertide, instead of the above, the following antiphon is said:\nAnt. O Queen of heaven.\nAnt. from Christmas to Candlemas How great the mystery of our inheritance!"
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Dei Genitrix.",
+                    "en-US": "Pray for us, O holy Mother of God."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi.",
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Little Chapter During Advent - Is 7:14-15\nEcce virgo concipiet, et pariet Filium, et vocabitur nomen ejus Emmanuel. Butyrum et mel comedet, ut sciat reprobare malum, et eligere bonum.",
+                "en-US": "Little Chapter During Advent - Is 7:14-15\nBehold, a virgin shall conceive, and bear a Son, and His name will be called Emmanuel: Butter and honey shall He eat, that he may know to refuse evil and to choose good."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Angelus Domini nuntiavit Mariae.",
+                    "en-US": "The angel of the Lord declared unto Mary."
+                  },
+                  "r": {
+                    "la": "Et concepit de Spiritu sancto.",
+                    "en-US": "And she conceived of the Holy Ghost."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Nunc dimittis",
+                "en-US": "Nunc Dimittis"
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Ant. from Candlemas until Advent Sub tuum praesidium.",
+                "en-US": "Ant. from Candlemas until Advent We fly to thy patronage."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Ant. in Advent Spiritus Sanctus.",
+                "en-US": "Ant. During Advent The Holy Ghost."
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "During Eastertide, instead of the above, the following antiphon is said:"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Eastertide, instead of the above, the following antiphon is said:"
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Ant. Regina caeli.",
+                "en-US": "Ant. O Queen of heaven."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Ant. from Christmas to Candlemas Magnum hereditatis mysterium!",
+                "en-US": "Ant. from Christmas to Candlemas How great the mystery of our inheritance!"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -2127,7 +6235,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -2135,9 +6243,44 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "Sub tuum praesidium confugimus, sancta Dei Genitrix, nostras deprecationes ne despicias in necessitatibus nostris: sed a periculis cunctis libera nos semper, Virgo gloriosa et benedicta.\npiritus Sanctus in te descendet, Maria: ne timeas habebis in utero Filium Dei, Alleluia.\nDuring Eastertide, instead of the above, the following antiphon is said:\nAnt. Regina caeli,laetare, alleluia; quia quem meruisti portare, alleluia; resurrexit, sicut dixit, alleluia: ora pro nobis Deum, alleluia.\nMagnum hereditatis mysterium! Templum Dei factus est uterus nescientis virum: non est pollutus ex ea carnem assumens: omnes gentes venient dicentes: Gloria tibi, Domine.",
-                "en-US": "We fly unto thy patronage, O holy Mother of God; despise not our petitions in our necessities, but ever deliver us from all evil, O glorious and blessed Virgin.\nThe Holy Ghost shall come upon thee, Mary; fear not, thou shalt hold within thy womb the Son of God, Alleluia.\nDuring Eastertide, instead of the above, the following antiphon is said:\nAnt. O Queen of heaven rejoice, Alleluia, for He Whom thou wast to bear, Alleluia, hath risen, as He said, Alleluia; pray for us to God, Alleluia.\nHow great the mystery of our inheritance! The womb of the one that knoweth not man hath become the temple of God! He was not defiled in taking flesh of her. All nations shall come and shall say: Glory be to Thee, O Lord."
+                "la": "Sub tuum praesidium confugimus, sancta Dei Genitrix, nostras deprecationes ne despicias in necessitatibus nostris: sed a periculis cunctis libera nos semper, Virgo gloriosa et benedicta.\npiritus Sanctus in te descendet, Maria: ne timeas habebis in utero Filium Dei, Alleluia."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "During Eastertide, instead of the above, the following antiphon is said:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "We fly unto thy patronage, O holy Mother of God; despise not our petitions in our necessities, but ever deliver us from all evil, O glorious and blessed Virgin.\nThe Holy Ghost shall come upon thee, Mary; fear not, thou shalt hold within thy womb the Son of God, Alleluia."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Eastertide, instead of the above, the following antiphon is said:"
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Ant. Regina caeli,laetare, alleluia; quia quem meruisti portare, alleluia; resurrexit, sicut dixit, alleluia: ora pro nobis Deum, alleluia.",
+                "en-US": "Ant. O Queen of heaven rejoice, Alleluia, for He Whom thou wast to bear, Alleluia, hath risen, as He said, Alleluia; pray for us to God, Alleluia."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Magnum hereditatis mysterium! Templum Dei factus est uterus nescientis virum: non est pollutus ex ea carnem assumens: omnes gentes venient dicentes: Gloria tibi, Domine.",
+                "en-US": "How great the mystery of our inheritance! The womb of the one that knoweth not man hath become the temple of God! He was not defiled in taking flesh of her. All nations shall come and shall say: Glory be to Thee, O Lord."
               }
             },
             {
@@ -2148,17 +6291,209 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer",
                 "en-US": "Prayer"
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "From Candlemas until Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Beatae et gloriosae semper Virginis Mariae, quaesumus, Domine, intercessio gloriosa nos protegat, et ad vitam perducat aeternam. Per Dominum nostrum Jesum Christum, Filium tuum: qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "la",
+              "text": {
+                "la": "During Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              },
+              "lang": "la"
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Deus, qui de beatae Mariae Virginis utero Verbum tuum, angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis, ut qui vere eam Genitricem Dei credimus, ejus apud te intercessionibus adjuvemur.\nPer eumdem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "From Christmas until Candlemas"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Deus qui salutis aeternae beatae Mariae virginitate fecunda, humano generi praemia praestitisti; tribue, quaesumus, ut ipsam pro nobis intercedere sentiamus, pre quam meruimus Auctorem vitae suscipere, Dominum nostrum Jesum Christum, Filium tuum: qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Conclusion"
+              },
+              "lang": "la"
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "From Candlemas until Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "May the glorious pleading of the blessed and glorious Mary, ever a virgin, sheild us, we beseech Thee, O Lord, and bring us to life everlasting. Through Our Lord Jesus Christ, Thy Son, Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Advent"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who didst will that Thine eternal Word should take flesh in the womb of the Blessed Virgin Mary, when the angel delivered his message; grant that Thy petitioners, who verily believe her to be the Mother of God, may be assisted by her intercesstion. Through the same Jesus Christ, Thy Son, Who liveth and reigneth with Thee, in the unity of the Holy Ghost, God, world without end.\nAmen."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "From Christmas to Candlemas"
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O God, Who by the fruitful virginity of blessed Mary hast given to mankind the rewards of eternal salvation; grant, we beseech Thee, that we may experience her intercession for us, by whom we deserved to receive the Author of life,Our Lord Jesus Christ, Thy Son, Who liveth and reigneth with Thee, in the unity of the Holy Ghost, God, world without end.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "Conclusion"
+              },
+              "lang": "en-US"
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "The Blessing",
+                "en-US": "The Blessing"
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\nFrom Candlemas until Advent\nOremus,\nBeatae et gloriosae semper Virginis Mariae, quaesumus, Domine, intercessio gloriosa nos protegat, et ad vitam perducat aeternam. Per Dominum nostrum Jesum Christum, Filium tuum: qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen.\nDuring Advent\nOremus,\nDeus, qui de beatae Mariae Virginis utero Verbum tuum, angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis, ut qui vere eam Genitricem Dei credimus, ejus apud te intercessionibus adjuvemur.\nPer eumdem Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nAmen.\nFrom Christmas until Candlemas\nDeus qui salutis aeternae beatae Mariae virginitate fecunda, humano generi praemia praestitisti; tribue, quaesumus, ut ipsam pro nobis intercedere sentiamus, pre quam meruimus Auctorem vitae suscipere, Dominum nostrum Jesum Christum, Filium tuum: qui tecum vivit et regnat in unitate Spiritus Sancti, Deus, per omnia saecula saeculorum.\nConclusion\n℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\nThe Blessing\nBenedicat and custodiat nos omnipotens et misericors Dominus, ✠ Pater, et Filius, et Spiritus Sanctus\nAmen.\nAnthem as at the end of Lauds",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\nFrom Candlemas until Advent\nLet us pray,\nMay the glorious pleading of the blessed and glorious Mary, ever a virgin, sheild us, we beseech Thee, O Lord, and bring us to life everlasting. Through Our Lord Jesus Christ, Thy Son, Who liveth and reigneth with Thee in the unity of the Holy Ghost, God, world without end.\nAmen.\nDuring Advent\nLet us pray,\nO God, Who didst will that Thine eternal Word should take flesh in the womb of the Blessed Virgin Mary, when the angel delivered his message; grant that Thy petitioners, who verily believe her to be the Mother of God, may be assisted by her intercesstion. Through the same Jesus Christ, Thy Son, Who liveth and reigneth with Thee, in the unity of the Holy Ghost, God, world without end.\nAmen.\nFrom Christmas to Candlemas\nLet us pray,\nO God, Who by the fruitful virginity of blessed Mary hast given to mankind the rewards of eternal salvation; grant, we beseech Thee, that we may experience her intercession for us, by whom we deserved to receive the Author of life,Our Lord Jesus Christ, Thy Son, Who liveth and reigneth with Thee, in the unity of the Holy Ghost, God, world without end.\nAmen.\nConclusion\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\nThe Blessing\nMay the almighty and merciful Lord, ✠ Father and Son and Holy Ghost, bless and keep us.\nAmen.\nAnthem as at Lauds"
+                "la": "Benedicat and custodiat nos omnipotens et misericors Dominus, ✠ Pater, et Filius, et Spiritus Sanctus\nAmen.",
+                "en-US": "May the almighty and merciful Lord, ✠ Father and Son and Holy Ghost, bless and keep us.\nAmen."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Anthem as at the end of Lauds",
+                "en-US": "Anthem as at Lauds"
               }
             }
           ]

--- a/content/practices/little-office-bvm-sarum/flow.json
+++ b/content/practices/little-office-bvm-sarum/flow.json
@@ -27,7 +27,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Incipit officium beate Marie virginis secundum usum et consuetudinem Sarum."
               }
@@ -39,7 +39,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Invitatorium"
               }
@@ -51,7 +51,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 94"
               }
@@ -63,19 +63,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Quem terra, pontus, aethera\ncolunt, adorant, praedicant,\ntrinam regentem machinam\nclaustrum Mariae baiulat.\n\nCui luna, sol, et omnia\ndeserviunt per tempora,\nperfusa caeli gratia\ngestant puellae viscera.\n\nBeata mater munere\ncuius supernus artifex,\nmundum pugillo continens,\nventris sub arca clausus est.\n\nBeata caeli nuntio,\nfecunda sancto Spiritu,\ndesideratus gentibus,\ncuius per alvum fusus est.\n\nGloria tibi, Domine,\nqui natus es de Virgine,\ncum Patre et Sancto Spiritu\nin sempiterna saecula. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 8"
               }
@@ -87,7 +87,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 18"
               }
@@ -99,7 +99,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 23"
               }
@@ -111,7 +111,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -147,7 +147,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Benedictio"
               }
@@ -159,7 +159,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Lectio I"
               }
@@ -201,7 +201,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Benedictio"
               }
@@ -213,7 +213,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Lectio II"
               }
@@ -243,7 +243,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Benedictio"
               }
@@ -255,7 +255,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Lectio III"
               }
@@ -291,7 +291,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum"
               }
@@ -337,7 +337,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -349,7 +349,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 91"
               }
@@ -361,7 +361,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 99"
               }
@@ -373,7 +373,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 62"
               }
@@ -385,7 +385,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 66"
               }
@@ -397,7 +397,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Danielis"
               }
@@ -409,7 +409,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 148"
               }
@@ -421,7 +421,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 149"
               }
@@ -433,7 +433,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 150"
               }
@@ -445,7 +445,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -457,7 +457,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum"
               }
@@ -469,13 +469,13 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "O gloriosa domina\nexcelsa supra sydera,\nqui te creavit provide\nlactasti sacro ubere.\n\nQuod Eva tristis abstulit\ntu reddis almo germine,\nintrent ut astra flebiles,\ncaeli fenestra facta es.\n\nTu regis alti ianua et\nporta lucis fulgida,\nvitam datam per Virginem,\ngentes redemptae plaudite.\n\nGloria tibi, Domine,\nqui natus es de Virgine,\ncum Patre et Sancto Spiritu\nin sempiterna saecula. Amen."
               }
@@ -505,7 +505,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -517,13 +517,13 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum (Lc 1:68--79) Benedictus"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Zachariae (Benedictus)"
               }
@@ -535,7 +535,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -547,15 +547,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi.\n℟. Et clamor."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi."
+                  },
+                  "r": {
+                    "la": "Et clamor."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede nos famulos tuos, quaesumus, Domine Deus noster, perpetua mentis et corporis sanitate gaudere;\net gloriosa beatae Mariae semper Virginis intercessione a praesenti liberari tristitia,\net aeterna perfrui laetitia. Per Dominum, et cetera."
+                "la": "Concede nos famulos tuos, quaesumus, Domine Deus noster, perpetua mentis et corporis sanitate gaudere;\net gloriosa beatae Mariae semper Virginis intercessione a praesenti liberari tristitia,\net aeterna perfrui laetitia. Per Dominum, et cetera."
               }
             },
             {
@@ -577,7 +590,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -601,9 +614,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui corda fidelium Sancti Spiritus illustratione docuisti,\nda nobis in eodem Spiritu recta sapere, et de eius semper consolatione gaudere. Per."
+                "la": "Deus, qui corda fidelium Sancti Spiritus illustratione docuisti,\nda nobis in eodem Spiritu recta sapere, et de eius semper consolatione gaudere. Per."
               }
             },
             {
@@ -613,7 +632,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -637,9 +656,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nOmnipotens sempiterne Deus, qui dedisti nobis famulis tuis in confessione verae fidei\naeternae Trinitatis gloriam agnoscere, et in potentia maiestatis adorare Unitaten:\nquaesumus, ut eiusdem fidei firmitate ab omnibus semper muniamur adversis. Qui vivis."
+                "la": "Omnipotens sempiterne Deus, qui dedisti nobis famulis tuis in confessione verae fidei\naeternae Trinitatis gloriam agnoscere, et in potentia maiestatis adorare Unitaten:\nquaesumus, ut eiusdem fidei firmitate ab omnibus semper muniamur adversis. Qui vivis."
               }
             },
             {
@@ -667,9 +692,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui sanctam crucem tuam ascendisti et mundi tenebras illuminasti,\ntu corda et corpora nostra illuminare, visitare et confortare dignare. Qui cum Deo Patre."
+                "la": "Deus, qui sanctam crucem tuam ascendisti et mundi tenebras illuminasti,\ntu corda et corpora nostra illuminare, visitare et confortare dignare. Qui cum Deo Patre."
               }
             },
             {
@@ -709,9 +740,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui miro ordine Angelorum ministeria hominumque dispensas,\nconcede propitius, ut, quibus tibi ministrantibus in caelo semper assistitur,\nab his in terra vita nostra muniatur. Per Christum."
+                "la": "Deus, qui miro ordine Angelorum ministeria hominumque dispensas,\nconcede propitius, ut, quibus tibi ministrantibus in caelo semper assistitur,\nab his in terra vita nostra muniatur. Per Christum."
               }
             },
             {
@@ -721,7 +758,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -745,9 +782,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nPerpetuis nos, Domine, sancti Ioannis Baptistae tuere praesidiis,\net quanto fragiliores sumus, tanto magis necessariis attolle suffragiis. Per."
+                "la": "Perpetuis nos, Domine, sancti Ioannis Baptistae tuere praesidiis,\net quanto fragiliores sumus, tanto magis necessariis attolle suffragiis. Per."
               }
             },
             {
@@ -775,9 +818,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui beato Petro Apostolo tuo, collatis clavibus regni caelestis,\nanimas ligandi atque solvendi pontificium tradidisti, concede propitius;\nut intercessionis eius auxilio a cunctis peccatorum nostrorum nexibus liberemur. Per."
+                "la": "Deus, qui beato Petro Apostolo tuo, collatis clavibus regni caelestis,\nanimas ligandi atque solvendi pontificium tradidisti, concede propitius;\nut intercessionis eius auxilio a cunctis peccatorum nostrorum nexibus liberemur. Per."
               }
             },
             {
@@ -805,9 +854,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui universum mundum beati Pauli Apostoli praedicatione docuisti,\nda nobis, quaesumus, ut, qui commemorationem eius colimus,\nper eius exempla ad te gradiamur. Per."
+                "la": "Deus, qui universum mundum beati Pauli Apostoli praedicatione docuisti,\nda nobis, quaesumus, ut, qui commemorationem eius colimus,\nper eius exempla ad te gradiamur. Per."
               }
             },
             {
@@ -817,7 +872,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -853,9 +908,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nMaiestatem tuam, Domine, supplices deprecamur,\nut sicut Ecclesiae tuae beatus Andreas Apostolus extitit praedicator et rector,\nita apud te sit pro nobis pius et perpetuus intercessor. Per."
+                "la": "Maiestatem tuam, Domine, supplices deprecamur,\nut sicut Ecclesiae tuae beatus Andreas Apostolus extitit praedicator et rector,\nita apud te sit pro nobis pius et perpetuus intercessor. Per."
               }
             },
             {
@@ -883,9 +944,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nEcclesiam tuam, quaesumus, Domine, benigne illustra,\nut beati Ioannis Apostoli tui et Evangelistae illuminata doctrinis\nad dona sempiterna perveniat. Per."
+                "la": "Ecclesiam tuam, quaesumus, Domine, benigne illustra,\nut beati Ioannis Apostoli tui et Evangelistae illuminata doctrinis\nad dona sempiterna perveniat. Per."
               }
             },
             {
@@ -925,9 +992,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nEsto, Domine, plebi tuae sanctificator et custos,\nut beati Apostoli tui Iacobi munita praesidiis et conversatione tibi placeat et secura deserviat. Per."
+                "la": "Esto, Domine, plebi tuae sanctificator et custos,\nut beati Apostoli tui Iacobi munita praesidiis et conversatione tibi placeat et secura deserviat. Per."
               }
             },
             {
@@ -937,7 +1010,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -973,9 +1046,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nOmnipotens sempiterne Deus, qui huius diei venerandam laetitiam beati Apostoli tui Bartholomaei\ncommemoratione tribuisti: da Ecclesiae tuae, quaesumus, et amare quod credidit, et praedicare quod docuit. Per."
+                "la": "Omnipotens sempiterne Deus, qui huius diei venerandam laetitiam beati Apostoli tui Bartholomaei\ncommemoratione tribuisti: da Ecclesiae tuae, quaesumus, et amare quod credidit, et praedicare quod docuit. Per."
               }
             },
             {
@@ -1003,9 +1082,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nExaudi nos, Deus salutaris noster, et Apostolorum atque Evangelistarum tuorum nos tuere praesidiis,\nquorum donasti fideles esse doctrinis. Per."
+                "la": "Exaudi nos, Deus salutaris noster, et Apostolorum atque Evangelistarum tuorum nos tuere praesidiis,\nquorum donasti fideles esse doctrinis. Per."
               }
             },
             {
@@ -1015,7 +1100,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1039,9 +1124,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDa nobis, quaesumus, Domine, imitari quod colimus,\nut discamus et inimicos diligere, quia eius natalicia celebramus,\nqui novit etiam pro persecutoribus exorare. Per Dominum nostrum Iesum Christum."
+                "la": "Da nobis, quaesumus, Domine, imitari quod colimus,\nut discamus et inimicos diligere, quia eius natalicia celebramus,\nqui novit etiam pro persecutoribus exorare. Per Dominum nostrum Iesum Christum."
               }
             },
             {
@@ -1051,7 +1142,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1087,9 +1178,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDa nobis, quaesumus, Domine Deus, vitiorum nostrorum flammas extinguere,\nut cui beato Laurentio tribuisti tormentorum suorum incendia superare. Per."
+                "la": "Da nobis, quaesumus, Domine Deus, vitiorum nostrorum flammas extinguere,\nut cui beato Laurentio tribuisti tormentorum suorum incendia superare. Per."
               }
             },
             {
@@ -1117,9 +1214,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, pro cuius Ecclesia gloriosus Pontifex gladiis impiorum occubuit:\npraesta, quaesumus, ut omnes qui eius implorant auxilium petitionis suae salutarem consequantur effectum. Per."
+                "la": "Deus, pro cuius Ecclesia gloriosus Pontifex gladiis impiorum occubuit:\npraesta, quaesumus, ut omnes qui eius implorant auxilium petitionis suae salutarem consequantur effectum. Per."
               }
             },
             {
@@ -1147,9 +1250,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nOmnipotens sempiterne Deus, qui beatum Blasium, praesulem et martyrem tuum,\nin agone certaminis tuo amore roborasti: assis Ecclesiae tuae precibus,\net da, ut cuius triumphum recolimus in terris, eius precibus adiuvemur in caelis. Per Christum."
+                "la": "Omnipotens sempiterne Deus, qui beatum Blasium, praesulem et martyrem tuum,\nin agone certaminis tuo amore roborasti: assis Ecclesiae tuae precibus,\net da, ut cuius triumphum recolimus in terris, eius precibus adiuvemur in caelis. Per Christum."
               }
             },
             {
@@ -1159,7 +1268,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1195,9 +1304,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nSancti Christofori Martyris tui, Domine, confessio veneranda\nconferat in nobis piae devotionis augmentum;\nut qui in tuo nomine iugiter perseverans meruit honorari,\nin suo consortio in aeterna felicitate nos faciat perhenniter triumphare. Per."
+                "la": "Sancti Christofori Martyris tui, Domine, confessio veneranda\nconferat in nobis piae devotionis augmentum;\nut qui in tuo nomine iugiter perseverans meruit honorari,\nin suo consortio in aeterna felicitate nos faciat perhenniter triumphare. Per."
               }
             },
             {
@@ -1207,7 +1322,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1231,9 +1346,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus ineffabilis misericordiae, qui beatum Edmundum tribuisti pro tuo nomine inimicum moriendo vincere:\nconcede propitius familiae tuae, ut, eo interveniente,\nin se antiqui hostis incitamenta superando exstinguere mereatur. Per."
+                "la": "Deus ineffabilis misericordiae, qui beatum Edmundum tribuisti pro tuo nomine inimicum moriendo vincere:\nconcede propitius familiae tuae, ut, eo interveniente,\nin se antiqui hostis incitamenta superando exstinguere mereatur. Per."
               }
             },
             {
@@ -1243,7 +1364,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1267,9 +1388,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui nos beati Georgii Martyris tui meritis et intercessione laetificas,\nconcede propitius, ut cuius beneficia poscimus, dono tuae gratiae consequamur. Per Christum."
+                "la": "Deus, qui nos beati Georgii Martyris tui meritis et intercessione laetificas,\nconcede propitius, ut cuius beneficia poscimus, dono tuae gratiae consequamur. Per Christum."
               }
             },
             {
@@ -1279,7 +1406,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1303,9 +1430,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nPraesta, quaesumus, omnipotens Deus, ut qui gloriosos Martyres tuos fortes in sua confessione cognovimus,\nipsos pios apud te in nostra intercessione sentiamus. Per."
+                "la": "Praesta, quaesumus, omnipotens Deus, ut qui gloriosos Martyres tuos fortes in sua confessione cognovimus,\nipsos pios apud te in nostra intercessione sentiamus. Per."
               }
             },
             {
@@ -1315,7 +1448,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1339,9 +1472,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nPropiciare, quaesumus, Domine, nobis famulis tuis per sancti Germani Confessoris tui atque Pontificis\nqui in nostra veneratur Ecclesia merita gloriosa ut eius piaintercessione ab omnibus semper adversis protegamur. Per."
+                "la": "Propiciare, quaesumus, Domine, nobis famulis tuis per sancti Germani Confessoris tui atque Pontificis\nqui in nostra veneratur Ecclesia merita gloriosa ut eius piaintercessione ab omnibus semper adversis protegamur. Per."
               }
             },
             {
@@ -1369,9 +1508,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui beatum Nicholaum pium Pontificem tuum innumeris decorasti miraculis:\ntribue nobis, quaesumus, ut eius meritis et precibus a Gehennae incendiis liberemur. Per."
+                "la": "Deus, qui beatum Nicholaum pium Pontificem tuum innumeris decorasti miraculis:\ntribue nobis, quaesumus, ut eius meritis et precibus a Gehennae incendiis liberemur. Per."
               }
             },
             {
@@ -1381,7 +1526,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1405,9 +1550,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui conspicis quia ex nulla nostra virtute subsistimus,\nconcede propitius, ut intercessione beati Martini Confessoris tui atque Pontificis\ncontra omnia adversa muniamur. Per."
+                "la": "Deus, qui conspicis quia ex nulla nostra virtute subsistimus,\nconcede propitius, ut intercessione beati Martini Confessoris tui atque Pontificis\ncontra omnia adversa muniamur. Per."
               }
             },
             {
@@ -1417,7 +1568,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1441,9 +1592,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Ecclesiam tuam meritis et intercessionibus beatissimi Confessoris tui atque Pontificis Ioannis\nmirifico splendore clarificas, concede propitius, ut qui memoriam illius veneramur in terris,\nintercessorem apud te mereamur habere in caelis. Per."
+                "la": "Deus, qui Ecclesiam tuam meritis et intercessionibus beatissimi Confessoris tui atque Pontificis Ioannis\nmirifico splendore clarificas, concede propitius, ut qui memoriam illius veneramur in terris,\nintercessorem apud te mereamur habere in caelis. Per."
               }
             },
             {
@@ -1453,7 +1610,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1477,9 +1634,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui nos beati Willelmi Confessoris tui atque Pontificis meritis et intercessione laetificas,\nconcede propitius, ut qui eius beneficia poscimus, dono tuae gratiae consequamur. Per."
+                "la": "Deus, qui nos beati Willelmi Confessoris tui atque Pontificis meritis et intercessione laetificas,\nconcede propitius, ut qui eius beneficia poscimus, dono tuae gratiae consequamur. Per."
               }
             },
             {
@@ -1489,7 +1652,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1513,9 +1676,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nMaiestati tuae, quaesumus Domine, sanctissimi Confessoris tui Leonardi nos\npia iugiter commendet oratio; ut quem devote veneramur officio,\nipsius suffragio sublevemur optato. Per."
+                "la": "Maiestati tuae, quaesumus Domine, sanctissimi Confessoris tui Leonardi nos\npia iugiter commendet oratio; ut quem devote veneramur officio,\nipsius suffragio sublevemur optato. Per."
               }
             },
             {
@@ -1543,9 +1712,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui nos Sanctorum Confessorum tuorum confessionibus gloriosis circumdas et protegis,\nda nobis et eorum imitatione proficere, et intercessione gaudere. Per."
+                "la": "Deus, qui nos Sanctorum Confessorum tuorum confessionibus gloriosis circumdas et protegis,\nda nobis et eorum imitatione proficere, et intercessione gaudere. Per."
               }
             },
             {
@@ -1555,7 +1730,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1579,9 +1754,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui beatam Annam diu sterilem prole gloriosa et humano generi salutifera fecundari voluisti,\nda ut omnes, qui ob amorem filiae matrem venerantur,\nin hora mortis utriusque praesentia gaudere mereantur. Per."
+                "la": "Deus, qui beatam Annam diu sterilem prole gloriosa et humano generi salutifera fecundari voluisti,\nda ut omnes, qui ob amorem filiae matrem venerantur,\nin hora mortis utriusque praesentia gaudere mereantur. Per."
               }
             },
             {
@@ -1591,7 +1772,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1615,9 +1796,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nLargire nobis, elementissime Pater,\nut sicut beata Maria Magdalena Unigenitum tuum Dominum nostrum Iesum Christum super omnia diligendo\nsuorum obtinuit veniam peccaminum, ita apud tuam misericordiam sempiternam nobis impetret beatitudinem. Per."
+                "la": "Largire nobis, elementissime Pater,\nut sicut beata Maria Magdalena Unigenitum tuum Dominum nostrum Iesum Christum super omnia diligendo\nsuorum obtinuit veniam peccaminum, ita apud tuam misericordiam sempiternam nobis impetret beatitudinem. Per."
               }
             },
             {
@@ -1627,7 +1814,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1663,9 +1850,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui dedisti legem Moysi in summitate montis Sinai ab Angelis deferri iussisti,\net in eodem loco corpus beatae Katherinae Virginis et Martyris tuae mirabiliter collocasti:\ntribue, quaesumus, ut eius meritis et intercessione ad montem qui Christus est valeamus pervenire. Per."
+                "la": "Deus, qui dedisti legem Moysi in summitate montis Sinai ab Angelis deferri iussisti,\net in eodem loco corpus beatae Katherinae Virginis et Martyris tuae mirabiliter collocasti:\ntribue, quaesumus, ut eius meritis et intercessione ad montem qui Christus est valeamus pervenire. Per."
               }
             },
             {
@@ -1675,7 +1868,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1711,9 +1904,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui beatam Virginem tuam Margaretam hodierno die ad caelos per martyrii palmam venire fecisti,\nconcede propitius, ut eius exempla sequentes ad te pervenire mereamur. Per."
+                "la": "Deus, qui beatam Virginem tuam Margaretam hodierno die ad caelos per martyrii palmam venire fecisti,\nconcede propitius, ut eius exempla sequentes ad te pervenire mereamur. Per."
               }
             },
             {
@@ -1723,7 +1922,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1747,9 +1946,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui eximiae castitatis privilegio beatissimam Virginem tuam Etheldredam mirabiliter decorasti,\nda nobis famulis tuis, ut sicut eius commemoratio a nobis agitur in terris,\nita per eius interventum nostri memoria apud te semper habeatur in caelis. Per."
+                "la": "Deus, qui eximiae castitatis privilegio beatissimam Virginem tuam Etheldredam mirabiliter decorasti,\nda nobis famulis tuis, ut sicut eius commemoratio a nobis agitur in terris,\nita per eius interventum nostri memoria apud te semper habeatur in caelis. Per."
               }
             },
             {
@@ -1759,7 +1964,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1783,9 +1988,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui ad celebrandum sanctae Fidis Virginis et Martyris triumphum venerabilem tuorum excitas corda fidelium:\nda, quaesumus, ut quam sollemni veneramur officio,\neius continuo foveamur auxilio. Per."
+                "la": "Deus, qui ad celebrandum sanctae Fidis Virginis et Martyris triumphum venerabilem tuorum excitas corda fidelium:\nda, quaesumus, ut quam sollemni veneramur officio,\neius continuo foveamur auxilio. Per."
               }
             },
             {
@@ -1795,7 +2006,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1819,9 +2030,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nExaudi nos, Deus salutaris noster, ut sicut de beatarum Virginum tuarum festivitate gaudemus,\nita piae devotionis erudiamur affectu. Per."
+                "la": "Exaudi nos, Deus salutaris noster, ut sicut de beatarum Virginum tuarum festivitate gaudemus,\nita piae devotionis erudiamur affectu. Per."
               }
             },
             {
@@ -1831,7 +2048,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1855,9 +2072,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nInfirmitatem nostram, quaesumus Domine Deus, propitius respice;\net mala omnia quae iuste meremur sanctissimae Virginis Mariae Matris tuae et omnium Sanctorum tuorum\npiissima intercessione averte. Per."
+                "la": "Infirmitatem nostram, quaesumus Domine Deus, propitius respice;\net mala omnia quae iuste meremur sanctissimae Virginis Mariae Matris tuae et omnium Sanctorum tuorum\npiissima intercessione averte. Per."
               }
             },
             {
@@ -1867,7 +2090,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -1891,9 +2114,15 @@
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, a quo sancta desideria, recta consilia et iusta sunt opera:\nda servis tuis illam, quam mundus dare non potest, pacem;\nut et corda nostra mandatis tuis dedita, et hostium sublata formidine, tempora sint tua protectione tranquilla. Per Dominum nostrum Iesum Christum, et cetera."
+                "la": "Deus, a quo sancta desideria, recta consilia et iusta sunt opera:\nda servis tuis illam, quam mundus dare non potest, pacem;\nut et corda nostra mandatis tuis dedita, et hostium sublata formidine, tempora sint tua protectione tranquilla. Per Dominum nostrum Iesum Christum, et cetera."
               }
             }
           ]

--- a/content/practices/little-office-bvm/flow.json
+++ b/content/practices/little-office-bvm/flow.json
@@ -8,10 +8,10 @@
         "pt-BR": "Hora"
       },
       "map": {
+        "9": "prime",
         "0-4": "compline",
         "5-6": "matins",
         "7-8": "lauds",
-        "9": "prime",
         "10-11": "terce",
         "12-13": "sext",
         "14-16": "none",

--- a/content/practices/little-office-child-jesus-in-the-manger/flow.json
+++ b/content/practices/little-office-child-jesus-in-the-manger/flow.json
@@ -28,23 +28,55 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Gloria in excelsis Deo, et in terra pax hominibus bonae voluntatis.\n℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria in excelsis Deo, et in terra pax hominibus bonae voluntatis."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "O mi Jesu! quis hic status!\nDeus a Puella natus,\nPrinceps pro Regali aula\nVili recubas in caula\nIn Praesepre reclinatus,\nSummus compar infimo:\nCui condignum Deo Chorum\nGens sonabat Angelorum,\nNunc pro musica coelesti\nGaudes tibia agresti,\nAtque simplici Pastorum\nDelectaris lituo."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -52,13 +84,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "O Regem Caeli, cui talia famulantur obsequia! stabulo ponitur, qui continet mundum: jacet in Praesepio, qui regnat in caelis.\n℣. Exultavit ut gigas ad currendam viam.\n℟. A summo caelo egressio ejus."
+                "la": "O Regem Caeli, cui talia famulantur obsequia! stabulo ponitur, qui continet mundum: jacet in Praesepio, qui regnat in caelis."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Exultavit ut gigas ad currendam viam."
+                  },
+                  "r": {
+                    "la": "A summo caelo egressio ejus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO dulcis Jesule! O bonitas infinita! da obsecro, ut velut propter me hominem coelestis Patris reliquisti delicias: sic ego amore tui mundanis omnibus renunciem voluptatibus, nec alio tendam, nisi ad Te. Qui cum Patre et Spiritu Sancto vivis et regnas in saecula saeculorum. Amen."
+                "la": "O dulcis Jesule! O bonitas infinita! da obsecro, ut velut propter me hominem coelestis Patris reliquisti delicias: sic ego amore tui mundanis omnibus renunciem voluptatibus, nec alio tendam, nisi ad Te. Qui cum Patre et Spiritu Sancto vivis et regnas in saecula saeculorum. Amen."
               }
             }
           ]
@@ -74,23 +125,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Gloria in excelsis Deo etc.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria in excelsis Deo etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Raucos asini ruditus\nBovis inter et mugitus\nAlmi Proles dormi Patris!\nEt ad melos castae Matris\nSacros terminat vagitus;\nDormi dulcis Jesule!\nDormi gratiarum aedes,\nCharitum sacrata sedes,\nEt ignosce, dum praesumit,\nAmor tuus quem consumit\nSacros osculari pedes,\nDormi dulcis Pupule!"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -98,13 +168,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce tu pulcher es Dilecte mi et decorus. Lectulus noster floridus, tigna domorum cedrina, et laquearia nostra cypressina.\n℣. Da somnum oculis tuis.\n℟. Et palpebris tuis dormitationem."
+                "la": "Ecce tu pulcher es Dilecte mi et decorus. Lectulus noster floridus, tigna domorum cedrina, et laquearia nostra cypressina."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Da somnum oculis tuis."
+                  },
+                  "r": {
+                    "la": "Et palpebris tuis dormitationem."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO dulcis Jesule! vera et unica requies amantis animae: da, ut sicut inter castissima Matris tuae brachia suavissime obdormisti: sic ego me, meaque omnia in manus tuas semper commendem, ac unice requiescam in te. Qui cum etc."
+                "la": "O dulcis Jesule! vera et unica requies amantis animae: da, ut sicut inter castissima Matris tuae brachia suavissime obdormisti: sic ego me, meaque omnia in manus tuas semper commendem, ac unice requiescam in te. Qui cum etc."
               }
             }
           ]
@@ -120,23 +209,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Gloria in excelsis Deo etc.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria in excelsis Deo etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Belle Puer, Jesu chare,\nQuis non possit te amare;\nQuis, o Pusio formose,\nCujus genas pingunt rosae,\nQuis te nolit adorare,\nO dilecte Parvule!\nCujus oculi sagittae\nIn amantem expediatae,\nCujus residet in labris\nCum coraliò cinnabris,\nQuis, o Decor infinite?\nQuis te amet congrue?"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -144,13 +252,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Oculi ejus sicut columbae super rivulos aquarum, dentes illius, sicut arcole aromatum, labia ejus lilia distillantia myrrham primam.\n℣. Dilectus meus candidus et rubicundus.\n℟. Electus ex millibus."
+                "la": "Oculi ejus sicut columbae super rivulos aquarum, dentes illius, sicut arcole aromatum, labia ejus lilia distillantia myrrham primam."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dilectus meus candidus et rubicundus."
+                  },
+                  "r": {
+                    "la": "Electus ex millibus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO dulcis Jesule! Pulchritudo excedens omnem pulchritudinem: da, amore tui ita me capi, ut creatas elegantias facilem spernens, nec pulchrum aestimem, neque decorum, nisi te, speciosae prae Filiis hominum. Qui cum Patre etc."
+                "la": "O dulcis Jesule! Pulchritudo excedens omnem pulchritudinem: da, amore tui ita me capi, ut creatas elegantias facilem spernens, nec pulchrum aestimem, neque decorum, nisi te, speciosae prae Filiis hominum. Qui cum Patre etc."
               }
             }
           ]
@@ -166,23 +293,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Gloria in excelsis Deo etc.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria in excelsis Deo etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Heu mi Jesu! quam ut rosa\nMembra tibi speciosa\nGelu rubent! quam horrendis\nBrumae poenis saevientis\nDei soboles formosa!\nJaces hic exposita?\nEn quam tibi superfusa,\nVelut conchis interclusa,\nLilicet per genarum,\nGlobulata lachrymarum\nSacris oculis protrusa,\nGemma fluit gemina!"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -190,13 +336,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quarumus Domino nostro Regi, qui stetit coram eo, et foveat eum, dormiatque in sinu suo, et calefaciat Dominum nostrum Regem.\n℣. Fasciculus myrrhae dilectus meus mihi.\n℟. Inter ubera mea commorabitur."
+                "la": "Quarumus Domino nostro Regi, qui stetit coram eo, et foveat eum, dormiatque in sinu suo, et calefaciat Dominum nostrum Regem."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fasciculus myrrhae dilectus meus mihi."
+                  },
+                  "r": {
+                    "la": "Inter ubera mea commorabitur."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO dulcis Jesule! tenerrimum patientiae speculum! qui vix nasci, mox pati etiam voluisti: concede, quaeso, ut et ego exemplo tuo, tum vivere nolim nisi tibi, tum semper cupiam pati pro te. Qui cum Patre etc."
+                "la": "O dulcis Jesule! tenerrimum patientiae speculum! qui vix nasci, mox pati etiam voluisti: concede, quaeso, ut et ego exemplo tuo, tum vivere nolim nisi tibi, tum semper cupiam pati pro te. Qui cum Patre etc."
               }
             }
           ]
@@ -212,23 +377,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Gloria in excelsis Deo etc.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria in excelsis Deo etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Ecquid inter hos dolores,\nQuos mi Jesu digne plores!\nTamen blandule renides,\nDum me peccatorem vides,\nTibi, inter Pastores\nGenibus adrepere!\nNempè mei quod ardore\nPrimae mox ab ortu horae\nHaec sustines, atque plura\nAdhuc ferre petas dura,\nAtque tuo sic amore\nMeum tibi quaerere."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -236,13 +420,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ludens erat in Orbe terrarum, et deliciae ejus esse cum filiis hominum.\n℣. Dilexit Patres suos.\n℟. Et elegit semen eorum post eos."
+                "la": "Ludens erat in Orbe terrarum, et deliciae ejus esse cum filiis hominum."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dilexit Patres suos."
+                  },
+                  "r": {
+                    "la": "Et elegit semen eorum post eos."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO dulcis Jesule! mirande amator hominum! da, ut dum sine causa meriti ab aeterno me praedilexisti; Ego quoque nec spe praemii nec metu poenae, sed solum redamem te Deus propter te. Qui cum Patre etc."
+                "la": "O dulcis Jesule! mirande amator hominum! da, ut dum sine causa meriti ab aeterno me praedilexisti; Ego quoque nec spe praemii nec metu poenae, sed solum redamem te Deus propter te. Qui cum Patre etc."
               }
             }
           ]
@@ -258,23 +461,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Gloria in excelsis Deo etc.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria in excelsis Deo etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "O mi Jesu! qui sic amas,\nAbsit, quin et meas flammas\nTuis velim sociare,\nSicque tibi adornare,\nUt quod unice inclamas\nLectulum calidulum;\nSed o sacri vos Amores!\nVestros meum per ardores\nOcyus Cor inflammate\nEt frigenti praeparate\nSacros inter calores\nJesu meo Lectulum!"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -282,13 +504,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Si invenieritis dilectum meum, nuntiate Ei, quia amore langueo.\n℣. Concalvit cor meum intra me.\n℟. Et in meditatione mea exardescet ignis."
+                "la": "Si invenieritis dilectum meum, nuntiate Ei, quia amore langueo."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Concalvit cor meum intra me."
+                  },
+                  "r": {
+                    "la": "Et in meditatione mea exardescet ignis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO dulcis Jesule! Ignis qui semper ardes, et nunquam tepes: inflamma, obsecro cor meum, ne unquam tepeat, sed in omni opere suo, fervore dilectionis tuae succensus, jugiter ardescat ex te. Qui cum Patre etc."
+                "la": "O dulcis Jesule! Ignis qui semper ardes, et nunquam tepes: inflamma, obsecro cor meum, ne unquam tepeat, sed in omni opere suo, fervore dilectionis tuae succensus, jugiter ardescat ex te. Qui cum Patre etc."
               }
             }
           ]
@@ -304,23 +545,55 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Gloria in excelsis Deo etc.\n℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria in excelsis Deo etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Sine Jesu! ut frigentem\nToto corpore trementem\nCorde meo te abscondam,\nEt amoris lecto condam.\nSubi Jesule! calentem,\nSubi, precor, lectulum!\nNil hic frigoris timendum,\nNihil turbinis verendum,\nEtsi levis aura flaret,\nQuam fors amor excitaret,\nSuavius est dormiendum;\nDormi Cordis Corculum!"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -328,13 +601,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Adjuro vos filiae Jerusalem, per capreas, cervosque camporum, ne suscitetis, neque evigilare faciatis dilectum meum, donec ipse velit.\n℣. Haec requies mea.\n℟. Hic habitabo, quoniam elegi eam."
+                "la": "Adjuro vos filiae Jerusalem, per capreas, cervosque camporum, ne suscitetis, neque evigilare faciatis dilectum meum, donec ipse velit."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Haec requies mea."
+                  },
+                  "r": {
+                    "la": "Hic habitabo, quoniam elegi eam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO dulcis Jesule! Mentis desideratissime Hospes! Ecce pando tibi ostium Cordis mei, ut, cui non erat locus in diversorio, tu solus illud inhabites, omnesque saeculi vanitates, magnifica tua praesentia, ab eo longe praecludas. Qui cum Patre etc."
+                "la": "O dulcis Jesule! Mentis desideratissime Hospes! Ecce pando tibi ostium Cordis mei, ut, cui non erat locus in diversorio, tu solus illud inhabites, omnesque saeculi vanitates, magnifica tua praesentia, ab eo longe praecludas. Qui cum Patre etc."
               }
             }
           ]
@@ -354,7 +646,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Ant."
       }
@@ -362,13 +654,32 @@
     {
       "type": "prayer",
       "inline": {
-        "la": "Hodie in domo tua oportet me manere: Hodie huic domui salus facta est.\n℣. Inveni quem diligit anima mea.\n℟. Tenui eum, nec dimittam."
+        "la": "Hodie in domo tua oportet me manere: Hodie huic domui salus facta est."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Inveni quem diligit anima mea."
+          },
+          "r": {
+            "la": "Tenui eum, nec dimittam."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nO dulcis Jesule! o vera et unica Dilectio mea! largire, obsecro, ut quoties Cor meum superna gratiae inspiratione, vel Eucharistica praesentia tua visitare dignaris: non illud hodie tantum, aut una saltem vel altera die, sed in Charitate, statuque Gratiae tuae constanter perseverans, aeternum maneat in te, et tu Deus in eo. Qui cum Patre etc."
+        "la": "O dulcis Jesule! o vera et unica Dilectio mea! largire, obsecro, ut quoties Cor meum superna gratiae inspiratione, vel Eucharistica praesentia tua visitare dignaris: non illud hodie tantum, aut una saltem vel altera die, sed in Charitate, statuque Gratiae tuae constanter perseverans, aeternum maneat in te, et tu Deus in eo. Qui cum Patre etc."
       }
     }
   ]

--- a/content/practices/little-office-compassion-of-the-blessed-virgin-mary-for-a-happy-death/flow.json
+++ b/content/practices/little-office-compassion-of-the-blessed-virgin-mary-for-a-happy-death/flow.json
@@ -32,25 +32,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Eia mea labia nunc annunciate."
+                  },
+                  "r": {
+                    "la": "Dolores et suspiria Virginis beatae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Et in hora mortis me potenter defende."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Eia mea labia nunc annunciate.\n℟. Dolores et suspiria Virginis beatae.\n℣. Domina in adjutorium meum intende.\n℟. Et in hora mortis me potenter defende.\nGloria Patri, et Filio, et Spiritui Sancto, sicut erat in principio et nunc et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto, sicut erat in principio et nunc et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Veni Virgo speciosa,\nVeni Mater dolorosa,\nFunde pias lacrymas.\nVidetum dulcem Natum,\nVide Jesum desolatum,\nCordis tui gladium.\nAmat meus amor flere,\nTibi Jesum condolere,\nTibi Virgo compati.\nJesu mi solamen esto,\nAdsis mihi, Virgo maesto,\nMortis in certamine. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -58,11 +84,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quod est tibi cor Maria, quanta surgit Virgo pia, animo tristitia? Tibi Jesus valedixit, et cor tuum crucifixit, dum ad crucem properat.\n℣. O Virgo stans sub cruce, tristi corde,\n℟. Adsis mihi pia consolatrix in morte.\nDomina exaudi orationem meam.\nEt clamor meus ad te veniat."
+                "la": "Quod est tibi cor Maria, quanta surgit Virgo pia, animo tristitia? Tibi Jesus valedixit, et cor tuum crucifixit, dum ad crucem properat."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "O Virgo stans sub cruce, tristi corde,"
+                  },
+                  "r": {
+                    "la": "Adsis mihi pia consolatrix in morte."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Domina exaudi orationem meam.\nEt clamor meus ad te veniat."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -74,9 +119,22 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina exaudi, etc."
+                  },
+                  "r": {
+                    "la": "Et clamor meus, etc."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domina exaudi, etc.\n℟. Et clamor meus, etc.\nBenedicamus Domino.\nDeo gratias."
+                "la": "Benedicamus Domino.\nDeo gratias."
               }
             }
           ]
@@ -90,19 +148,32 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Et in hora mortis me potenter defende."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domina in adjutorium meum intende.\n℟. Et in hora mortis me potenter defende.\nGloria Patri, et Filio, et Spiritui Sancto, etc."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Jesus orat, Jesus plorat,\nSanguis hinc, et inde torat,\nJesus sudat sanguinem.\nMoestus pallet in agone,\nMoestus in oratione,\nMetu mortis angitur.\nAmat meus amor flere, etc.\nJesu mi solamen esto, etc."
               }
@@ -114,7 +185,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -122,19 +193,57 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Amor Jesu te fatigat, amor mei captum ligat, amor tradit hostibus: hic se tibi colligare, hic amoris vicem dare, ardet, amat animus.\n℣. O Virgo stans sub cruce tristi corde,\n℟. Adsis mihi pia consolatrix in morte.\nDomina exaudi, etc.\nEt clamor meus, etc."
+                "la": "Amor Jesu te fatigat, amor mei captum ligat, amor tradit hostibus: hic se tibi colligare, hic amoris vicem dare, ardet, amat animus."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "O Virgo stans sub cruce tristi corde,"
+                  },
+                  "r": {
+                    "la": "Adsis mihi pia consolatrix in morte."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Domina exaudi, etc.\nEt clamor meus, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Sancta Maria Regina caelorum, Mater Domini nostri Jesu Christi, etc. ut supra."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina exaudi, etc."
+                  },
+                  "r": {
+                    "la": "Et clamor meus, etc."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Sancta Maria Regina caelorum, Mater Domini nostri Jesu Christi, etc. ut supra.\n℣. Domina exaudi, etc.\n℟. Et clamor meus, etc.\nBenedicamus Domino.\nDeo gratias."
+                "la": "Benedicamus Domino.\nDeo gratias."
               }
             }
           ]
@@ -148,25 +257,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Et in hora mortis me potenter defende."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domina in adjutorium meum intende.\n℟. Et in hora mortis me potenter defende.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Veste Jesus spoliatur,\nSubsannatur, flagellatur,\nManant rivii sanguinis.\nVide Virgo cor afflictum,\nJesum tuum derelictum,\nVide corpus lividum.\nAmat meus amor flere, etc. ut supra.\nJesu mi solamen esto, etc. ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -174,11 +296,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Virgo pia quid sensisti, si vidisti, vel audisti, quas dedisti lacrymas? Virgae Christi te petebant, cor maternum absorbebant, Filii supplicia.\n℣. O Virgo stans sub cruce, tristi corde,\n℟. Adsis mihi pia consolatrix in morte.\nDomina exaudi, etc.\nEt clamor meus, etc."
+                "la": "Virgo pia quid sensisti, si vidisti, vel audisti, quas dedisti lacrymas? Virgae Christi te petebant, cor maternum absorbebant, Filii supplicia."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "O Virgo stans sub cruce, tristi corde,"
+                  },
+                  "r": {
+                    "la": "Adsis mihi pia consolatrix in morte."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Domina exaudi, etc.\nEt clamor meus, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -186,7 +327,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancta Maria, Regina caelorum, Mater Domini nostri Jesu Christi, etc.\n℣. Domina exaudi, etc.\n℟. Et clamor meus, etc.\nBenedicamus Domino.\nDeo gratias."
+                "la": "Sancta Maria, Regina caelorum, Mater Domini nostri Jesu Christi, etc."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina exaudi, etc."
+                  },
+                  "r": {
+                    "la": "Et clamor meus, etc."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Benedicamus Domino.\nDeo gratias."
               }
             }
           ]
@@ -200,25 +360,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Et in hora mortis me potenter defende."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domina in adjutorium meum intende.\n℟. Et in hora mortis me potenter defende.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Irae spinae in hoc audent,\nSacrum caput, in quod gaudent,\nAngeli prospicere.\nEcce homo: jam non homo,\nEcce Adam hoc de pomo,\nPoenae monstrum generas.\nAmat meus amor flere, etc.\nJesu mi solamen esto, etc. ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -226,11 +399,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Circum ferox miles ruit, vultus in divinos spuit: quid audes impietas? En Maria bellum vulrum, en in quo sic fuit vulnus, crimen nostri generis.\n℣. O Virgo stans sub cruce, tristi corde,\n℟. Adsis mihi pia consolatrix in morte.\nDomina exaudi, etc.\nEt clamor meus, etc."
+                "la": "Circum ferox miles ruit, vultus in divinos spuit: quid audes impietas? En Maria bellum vulrum, en in quo sic fuit vulnus, crimen nostri generis."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "O Virgo stans sub cruce, tristi corde,"
+                  },
+                  "r": {
+                    "la": "Adsis mihi pia consolatrix in morte."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Domina exaudi, etc.\nEt clamor meus, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -238,7 +430,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancta Maria, Regina caelorum, Mater Domini nostri Jesu Christi, etc.\n℣. Domina exaudi, etc.\n℟. Et clamor meus, etc.\nBenedicamus Domino.\nDeo gratias."
+                "la": "Sancta Maria, Regina caelorum, Mater Domini nostri Jesu Christi, etc."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina exaudi, etc."
+                  },
+                  "r": {
+                    "la": "Et clamor meus, etc."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Benedicamus Domino.\nDeo gratias."
               }
             }
           ]
@@ -252,25 +463,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Et in hora mortis me potenter defende."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domina in adjutorium meum intende.\n℟. Et in hora mortis me potenter defende.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Ple Jesu, Cruce pressus,\nPloras, cadis, gemis fessus,\nSub immensum pondere.\nSumis Pastor pedum crucis,\nAnte vadens oves ducis,\nAd aura pascua.\nAmat meus amor flere, etc.\nJesu mi solamen esto, etc. ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -278,11 +502,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pastor bonus, lupum cernis, venientem cruce sternis, vitam das pro ovibus: Grex est iste tibi charus, sed est carus, est amarus, est ingentis pretii.\n℣. O Virgo stans sub cruce, tristi corde,\n℟. Adsis mihi pia consolatrix in morte.\nDomina exaudi, etc.\nEt clamor meus, etc."
+                "la": "Pastor bonus, lupum cernis, venientem cruce sternis, vitam das pro ovibus: Grex est iste tibi charus, sed est carus, est amarus, est ingentis pretii."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "O Virgo stans sub cruce, tristi corde,"
+                  },
+                  "r": {
+                    "la": "Adsis mihi pia consolatrix in morte."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Domina exaudi, etc.\nEt clamor meus, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -290,7 +533,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancta Maria, Regina caelorum, Mater Domini nostri Jesu Christi, etc.\n℣. Domina exaudi, etc.\n℟. Et clamor meus, etc.\nBenedicamus Domino.\nDeo gratias."
+                "la": "Sancta Maria, Regina caelorum, Mater Domini nostri Jesu Christi, etc."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina exaudi, etc."
+                  },
+                  "r": {
+                    "la": "Et clamor meus, etc."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Benedicamus Domino.\nDeo gratias."
               }
             }
           ]
@@ -304,25 +566,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Et in hora mortis me potenter defende."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domina in adjutorium meum intende.\n℟. Et in hora mortis me potenter defende.\nGloria Patri, et Filio, etc."
+                "la": "Gloria Patri, et Filio, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Stabas Mater dolorosa,\nJuxta crucem laerymosa,\nDum pendebat Filius.\nAstetisti scenae tristi,\nVidens latus mite Christi,\nPerforari lancea.\nAmat meus amor flere, etc.\nJesu mi solamen esto, etc. ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -330,11 +605,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Expuasisti cum vidisti, vulnus datum tu sensisti, tuo Jesu mortuo: O doloris hora dura, quanta cor maternum cura, quanto scindis gladio!\n℣. O Virgo stans sub cruce tristi corde,\n℟. Adsis mihi pia consolatrix in morte.\nDomina exaudi, etc.\nEt clamor meus, etc."
+                "la": "Expuasisti cum vidisti, vulnus datum tu sensisti, tuo Jesu mortuo: O doloris hora dura, quanta cor maternum cura, quanto scindis gladio!"
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "O Virgo stans sub cruce tristi corde,"
+                  },
+                  "r": {
+                    "la": "Adsis mihi pia consolatrix in morte."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Domina exaudi, etc.\nEt clamor meus, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -342,7 +636,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancta Maria, Regina caelorum, Mater Domini nostri Jesu Christi, etc.\n℣. Domina exaudi, etc.\n℟. Et clamor meus, etc.\nBenedicamus Domino.\nDeo gratias."
+                "la": "Sancta Maria, Regina caelorum, Mater Domini nostri Jesu Christi, etc."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina exaudi, etc."
+                  },
+                  "r": {
+                    "la": "Et clamor meus, etc."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Benedicamus Domino.\nDeo gratias."
               }
             }
           ]
@@ -358,23 +671,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Converte nos Virgo Maria,\nAverte a nobis Filii iram.\n℣. Domina in adjutorium meum intende.\n℟. Et in hora mortis me potenter defende.\nGloria Patri, etc."
+                "la": "Converte nos Virgo Maria,\nAverte a nobis Filii iram."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Et in hora mortis me potenter defende."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Quo vivebas Mater fato,\nDulci Nato tumulato,\nDulci Jesu Mortuo?\nTota Nato parentabas,\nQuem amabas, quem plorabas,\nCuris multis saucia.\nAmat meus amor flere, etc.\nJesu mi solamen esto, etc. ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -382,19 +714,57 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Fac me Virgo tecum flere, crucifixo condolere, donec ego vixero: Quando corpus morietur, fac ut animae donetur, paradisi gloria.\n℣. O Virgo stans sub cruce tristi corde,\n℟. Adsis mihi pia consolatrix in morte.\nDomina exaudi, etc.\nEt clamor meus, etc."
+                "la": "Fac me Virgo tecum flere, crucifixo condolere, donec ego vixero: Quando corpus morietur, fac ut animae donetur, paradisi gloria."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "O Virgo stans sub cruce tristi corde,"
+                  },
+                  "r": {
+                    "la": "Adsis mihi pia consolatrix in morte."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Domina exaudi, etc.\nEt clamor meus, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
             },
             {
+              "type": "rubric",
+              "text": {
+                "la": "Sancta Maria, Regina caelorum, Mater Domini nostri Jesu Christi, et mundi Domina, etc. ut supra."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina exaudi, etc."
+                  },
+                  "r": {
+                    "la": "Et clamor meus, etc."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "Sancta Maria, Regina caelorum, Mater Domini nostri Jesu Christi, et mundi Domina, etc. ut supra.\n℣. Domina exaudi, etc.\n℟. Et clamor meus, etc.\nBenedicamus Domino.\nDeo gratias."
+                "la": "Benedicamus Domino.\nDeo gratias."
               }
             }
           ]

--- a/content/practices/little-office-dead/flow.json
+++ b/content/practices/little-office-dead/flow.json
@@ -32,31 +32,32 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O vos, fideles animae\nIn Christo defunctorum,\nSed merito prohibita\nAb aditu coelorum:"
+                "la": "O vos, fideles animae\nIn Christo defunctorum,\nSed merito prohibita\nAb aditu coelorum:\n\nQuam velim vobis dexteram,\nOpemque praesentare!\nUthine ad caeli gloriam\nPossitis evolare!"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Quam velim vobis dexteram,\nOpemque praesentare!\nUthine ad caeli gloriam\nPossitis evolare!"
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -68,10 +69,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Si iniquitates observaveris, Domine,\n℟. Domine, quis sustinebit?"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Si iniquitates observaveris, Domine,"
+                  },
+                  "r": {
+                    "la": "Domine, quis sustinebit?"
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -82,14 +90,40 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Fidelium Deus omnium Conditor et Redemptor, animabus famularum famulorumque tuarum remissionem cunctorum tribue peccatorum: ut indulgentiam quam semper optaverunt, piis supplicationibus consequantur. Qui vivis et regnas in saecula saeculorum.\n℟. Amen."
+                "la": "Fidelium Deus omnium Conditor et Redemptor, animabus famularum famulorumque tuarum remissionem cunctorum tribue peccatorum: ut indulgentiam quam semper optaverunt, piis supplicationibus consequantur. Qui vivis et regnas in saecula saeculorum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Requiem aeternam dona eis, Domine.\n℟. Et lux perpetua luceat eis.\n℣. Requiescant in pace.\n℟. Amen."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Requiem aeternam dona eis, Domine."
+                  },
+                  "r": {
+                    "la": "Et lux perpetua luceat eis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -108,25 +142,32 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "O magne Pater, nomine\nMisericordiarum,\nFacturas tuas respice,\nSed timorem remorum:\nPoenas sunt quidem merita,\nTe tamen non negabam;\nHinc locus sit clementiae:\nIgnosce, quod peccaram."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -160,31 +201,32 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O Jesu clementissime,\nO optime Salvator,\nTuo redemptis sanguine\nSis mitis liberator."
+                "la": "O Jesu clementissime,\nO optime Salvator,\nTuo redemptis sanguine\nSis mitis liberator.\n\nIndulge te amantibus\nTuum benignitatem,\nPoenamque deprecantibus\nOstende bonitatem."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Indulge te amantibus\nTuum benignitatem,\nPoenamque deprecantibus\nOstende bonitatem."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -218,31 +260,32 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O consolator optime,\nO dulcis Paraclete,\nHos tu deserto respice,\nEt indignos quaerite"
+                "la": "O consolator optime,\nO dulcis Paraclete,\nHos tu deserto respice,\nEt indignos quaerite\n\nIn aestu hoc temperiem,\nVeraeque pacis bona,\nEt post laborem requiem\nAeternam his dona."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "In aestu hoc temperiem,\nVeraeque pacis bona,\nEt post laborem requiem\nAeternam his dona."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -276,31 +319,32 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O dulcis mater gratiae,\nSolatrix afflictorum,\nVim cohibe justitiae,\nRigorem tormentorum."
+                "la": "O dulcis mater gratiae,\nSolatrix afflictorum,\nVim cohibe justitiae,\nRigorem tormentorum.\n\nFlammam voracem tempera,\nEt mitiga dolores,\nIncendium refrigera,\nEt fini hos angores."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Flammam voracem tempera,\nEt mitiga dolores,\nIncendium refrigera,\nEt fini hos angores."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -334,31 +378,32 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Vos, tutelaris genii,\nQuorum sunt hi clientes,\nQuantum vestra subsidii\nSunt ipsis indigentes!"
+                "la": "Vos, tutelaris genii,\nQuorum sunt hi clientes,\nQuantum vestra subsidii\nSunt ipsis indigentes!\n\nPlorem desideria\nEt vestro excitatae:\nOptata refrigeria\nClientibus curate."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Plorem desideria\nEt vestro excitatae:\nOptata refrigeria\nClientibus curate."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -392,31 +437,32 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Vos omnes quoque coelites,\nIn regno triumphante,\nSolamini hos milites,\nIn flamma hac purgante."
+                "la": "Vos omnes quoque coelites,\nIn regno triumphante,\nSolamini hos milites,\nIn flamma hac purgante.\n\nVestri in terris socii\nCum fuerint laborum,\nNunc et beati otii\nSors vocat et bonorum."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Vestri in terris socii\nCum fuerint laborum,\nNunc et beati otii\nSors vocat et bonorum."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -456,10 +502,30 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Requiem aeternam dona eis, Domine.\n℟. Et lux perpetua luceat eis.\n℣. Requiescant in pace.\n℟. Amen."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Requiem aeternam dona eis, Domine."
+          },
+          "r": {
+            "la": "Et lux perpetua luceat eis."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Requiescant in pace."
+          },
+          "r": {
+            "la": "Amen."
+          }
+        }
+      ]
     },
     {
       "type": "subheading",

--- a/content/practices/little-office-divine-love/flow.json
+++ b/content/practices/little-office-divine-love/flow.json
@@ -32,25 +32,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adiutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adiuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adiutorium meum intende.\n℟. Domine ad adiuvandum me festina.\nGloria Patri, & Filio, & Spiritui sancto:\nSicut erat, &c."
+                "la": "Gloria Patri, & Filio, & Spiritui sancto:\nSicut erat, &c."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "O Fidelis anima, tora spiritualis,\nLeva te magnanim a charitatis alis.\nSurge, surge, fervidos iaculans amores,\nSi non amas, rigidos senties dolores.\nO imago nobilis tui creatoris,\nAngelorum similis, sponsa salvatoris,\nTuo prototypo redde speciosam,\nDivino archetypo pulchram, et formosam.\nObonorum omnium pelagus profundum,\nAmoris hicium blandum, et sacundum:\nAmo te; quid extra te volo, vel requiro?\nAmplius mi extra te pote, nec suspirro.\nArdeo et insiliens meum creatorem,\nMilles, et millies, inem salvatoren amem.\nAbsque te pro nihilo, perituque fore sum,\nMeum quanto nihilu vendicas amorem.\nDeus meus amo te, plus quam mille mundos,\nPlus quam aurum amo te, plus quam mille mundos.\nSupra quamvis amo te sensus voluptatem,\nSupra caelum amo te, et beatitatem."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -58,11 +84,24 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Diligam te, Domine, fortitudo mea: Dominus firmamentum meum, et refugium meum, et liberator meus.\n℣. Diligite Dominum omnes sancti eius.\n℟. Quoniam nihil deest timentibus eum."
+                "la": "Diligam te, Domine, fortitudo mea: Dominus firmamentum meum, et refugium meum, et liberator meus."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Diligite Dominum omnes sancti eius."
+                  },
+                  "r": {
+                    "la": "Quoniam nihil deest timentibus eum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -84,25 +123,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adiutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adiuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adiutorium meum intende.\n℟. Domine ad adiuvandum me festina.\nGloria Patri, et Filio, et Spiritui sancto:\nSicut erat, etc."
+                "la": "Gloria Patri, et Filio, et Spiritui sancto:\nSicut erat, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Cum Sol mane suibus se levat Eois,\nEt terram fulgoribus lustrat radiosis,\nMe divinis ignibus gelaidum exornans,\nEt noctis tenebris vespertinis expellens.\nMox dammata frigora procul exulantes,\nEt divinae flammulae pectora cremantis,\nAeus cael magnetica motibus assueta,\nNi se versis Arctici gyrans stet quieta.\nSic sum ego mobilis, vagus et inconstans,\nMille mille fluctibus hic et hinc inundans.\nAh! innovam fingere posim me figuram,\nEt meam me vertere versus cynosuram,\nAmans hic quiescerem, placidusqque starem,\nMeam raptus cenerem stellulam polarem.\nNolo nolo vivere absque charitate,\nStat Deum diligere cum alacritate.\nAltis surgat ignibus pura flamma mentis,\nEt horis, et singulis ardcat momentis.\nDeus meus amo te, plusquam mille mundos,\nPlus quam aurum amo te, plus quam mille mundos.\nSupra quamvis amo te sensus voluptatem,\nSupra caelum amo te, et beatitatem."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -110,11 +162,24 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Scimus, quoniam diligentibus Deum omnia cooperantur in bonum, iis qui secundum propositum vocati sunt sancti.\n℣. Fortis est, ut mors dilectio.\n℟. Lampades eius lampades ignis, atque flammarum."
+                "la": "Scimus, quoniam diligentibus Deum omnia cooperantur in bonum, iis qui secundum propositum vocati sunt sancti."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fortis est, ut mors dilectio."
+                  },
+                  "r": {
+                    "la": "Lampades eius lampades ignis, atque flammarum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -136,25 +201,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adiutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adiuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adiutorium meum intende.\n℟. Domine ad adiuvandum me festina.\nGloria Patri, c.et"
+                "la": "Gloria Patri, c.et"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Ah cor quid hic deperis, incubans desesum?\nQuid vagando reperis, hortum et itsorum?\nFumus, vapor, somnia, umbra, larva, hullae,\nFallis, haec omnia, verisqque ruina.\nVanitas, vanitas, quidquid hic amatur,\nFraudes, nugacitias, quibus inhabitur,\nPecorum beatitas, gaudia brutorum,\nMendax sunt felicitas mundi amatorum.\nDixi nunc, et saepius dicam: Creature,\nNon amo vos amplius, nec moriuntur.\nQui me sibi postulant, et meos amores,\nEgo nullus aliorum, spretus stansiores.\nIgnis mei pabula sintes inquirere,\nPost momenta pauca in mortem incidere.\nDeus fit materies, mea constans flammae,\nNon silex, ancodes, fragileqque scamnum.\nPosui cor et animum tibi consecratam,\nTotum in Basilicam sponte dedicavam.\nJure mei, cedere, sacri sunt amores,\nRes mortales cedite, fugiunt et vapores.\nDeus meus amo te, plus quam mille mundos,\nPlus quam aurum amo te, plus quam mille mundos.\nSupra quamvis amo te sensus voluptatem,\nSupra caelum amo te, et beatitatem."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -162,11 +240,24 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Scimus, quoniam diligentibus Deum omnia cooperantur in bonum iis, qui secundum propositum vocati sunt sancti.\n℣. Filii hominum, usquequo gravi corde?\n℟. Ut quid diligitis vanitatem, et quaeritis mendacium?"
+                "la": "Scimus, quoniam diligentibus Deum omnia cooperantur in bonum iis, qui secundum propositum vocati sunt sancti."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Filii hominum, usquequo gravi corde?"
+                  },
+                  "r": {
+                    "la": "Ut quid diligitis vanitatem, et quaeritis mendacium?"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -188,25 +279,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adiutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adiuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adiutorium meum intende.\n℟. Domine ad adiuvandum me festina.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Amor doctor omnium maxime doctorum,\nDocce me coelitum regulas amorum.\nQuas satten notulas, praecipe syllabarum,\nNon est artis musica, dicitur parabum.\nTota virtus pectoris, mentis promptitudo,\nTotum robur corporis, animae vigor.\nAmor est concentricus, radius et ignis,\nCohibens affectibus, suavitas et laboris.\nAgam ex imperio Domini amoris,\nQuovis motu licet, magno vel pusillo,\nObsignabit aureo charitas sigillo.\nSed quid meus amor est? ad tuos amores?\nGlacies et algor est, febrium tremores.\nSi et mille cordibus unus adamantem,\nUna gutta, vel tribus, mare non aquarem.\nSi fratrum chorovium ignes calerem,\nAngelorum omnium flammulis arderem.\nAd vasta incendia tuorum amorum,\nBruma fisset facula horum et istorum.\nDeus meus amo te, plus quam mille mundos,\nPlus quam aurum amo te, plus quam mille fundos.\nSupra quamvis amo te sensus voluptatem,\nSupra caelum amo te, et beatitatem."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -214,11 +318,24 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Diliges Dominum Deum tuum ex toto corde tuo, et ex tota anima tua, et ex tota mente tua, et ex omnibus viribus tuis, et proximum tuum sicut teipsum.\n℣. Gloriabuntur in te omnes, qui diligunt nomen tuum.\n℟. Quoniam tu benedices iusto."
+                "la": "Diliges Dominum Deum tuum ex toto corde tuo, et ex tota anima tua, et ex tota mente tua, et ex omnibus viribus tuis, et proximum tuum sicut teipsum."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloriabuntur in te omnes, qui diligunt nomen tuum."
+                  },
+                  "r": {
+                    "la": "Quoniam tu benedices iusto."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -240,25 +357,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adiutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adiuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adiutorium meum intende.\n℟. Domine ad adiuvandum me festina.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Coronemus hodie charitatem sanctam,\nEia sursum tollite, solus Deus amandus.\nSolus ipse possidet, meritum amorem,\nSolus ipse distribuit gaudia perennes.\nGaudium sit maximum in Dei amore,\nIucundum sit carmen, dulce sit favorem.\nAmor est beatorum, spes et remedium,\nAmor est solatium in omni tedio.\nAmor tollit omnia, quae nocent amanti,\nAmor dat et omnia, quae decent amorem.\nAmor portat omnia, quae graviora videntur,\nAmor vincit omnia, nec timet labores.\nO Deus, qui charitas, charitas tua es ipsa,\nO Iesu amantissime, esto cor meum vita.\nDeus meus amo te, plus quam mille mundos,\nPlus quam aurum amo te, plus quam mille fundos.\nSupra quamvis amo te sensus voluptatem,\nSupra caelum amo te, et beatitatem."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -266,11 +396,24 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Qui manet in caritate, in Deo manet, et Deus in eo: in hoc est caritas, non quasi nos dilexerimus Deum, sed quoniam ipse prior dilexit nos.\n℣. Vivit Dominus, et benedictus Deus meus.\n℟. Et exaltetur Deus salutis meae."
+                "la": "Qui manet in caritate, in Deo manet, et Deus in eo: in hoc est caritas, non quasi nos dilexerimus Deum, sed quoniam ipse prior dilexit nos."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Vivit Dominus, et benedictus Deus meus."
+                  },
+                  "r": {
+                    "la": "Et exaltetur Deus salutis meae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -292,25 +435,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adiutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adiuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adiutorium meum intende.\n℟. Domine ad adiuvandum me festina.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Amor Iesu dulcissime, cor meum inflammavit,\nEt in sinu dulciter, quasi ignis ardebat.\nNihil aliud volo, nisi Deum amare,\nNihil aliud scio, nisi Deum quaerere.\nAmor est infinitus, amor est praecipuus,\nAmor est mirabilis, amor est pretiosus.\nQuis amat, ipse vivit, quis amat, ipse gaudet,\nQuis amat, regnat, triumphat, ipse coronatur.\nO amor suavissime, totus es amabilis,\nEt mihi amantissimo, totus es desiderabilis.\nDeus meus amo te, plus quam mille mundos,\nPlus quam aurum amo te, plus quam mille fundos.\nSupra quamvis amo te sensus voluptatem,\nSupra caelum amo te, et beatitatem."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -318,11 +474,24 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Diligamus nos invicem, quia caritas ex Deo est, et omnis qui diligit, ex Deo natus est, et cognoscit Deum.\n℣. Mane nobiscum Domine.\n℟. Quoniam advesperascit, et inclinata est iam dies."
+                "la": "Diligamus nos invicem, quia caritas ex Deo est, et omnis qui diligit, ex Deo natus est, et cognoscit Deum."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Mane nobiscum Domine."
+                  },
+                  "r": {
+                    "la": "Quoniam advesperascit, et inclinata est iam dies."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -344,25 +513,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adiutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adiuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adiutorium meum intende.\n℟. Domine ad adiuvandum me festina.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Amor meus dulcissime, Iesu spes amantissime,\nQuid aliud in corde meo desidero, nisi te?\nTu es vita dulcissima, tu es pax suavissima,\nTu es spes certissima, tu es lux clarissima.\nAmor meus, te sequar, amor meus, te quaerar,\nAmor meus, te teneam, amor meus, te videam.\nSine fine gaudere, sine fine laudare,\nSine fine possidere, sine fine amare.\nDeus meus amo te, plus quam mille mundos,\nPlus quam aurum amo te, plus quam mille fundos.\nSupra quamvis amo te sensus voluptatem,\nSupra caelum amo te, et beatitatem."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -370,11 +565,24 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "In pace in idipsum dormiam, et requiescam: quoniam tu Domine singulariter in spe constituisti me.\n℣. Custodi nos Domine ut pupillam oculi.\n℟. Sub umbra alarum tuarum protege nos."
+                "la": "In pace in idipsum dormiam, et requiescam: quoniam tu Domine singulariter in spe constituisti me."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Custodi nos Domine ut pupillam oculi."
+                  },
+                  "r": {
+                    "la": "Sub umbra alarum tuarum protege nos."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }

--- a/content/practices/little-office-evil-spirits/flow.json
+++ b/content/practices/little-office-evil-spirits/flow.json
@@ -1,13 +1,26 @@
 {
   "sections": [
     {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Deus in adjutorium meum intende."
+          },
+          "r": {
+            "la": "Domine ad adjuvandum me festina."
+          }
+        }
+      ]
+    },
+    {
       "type": "prayer",
       "inline": {
-        "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+        "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Antiphona"
       }
@@ -19,7 +32,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Psalmus"
       }
@@ -31,7 +44,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Antiphona"
       }
@@ -43,13 +56,20 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Dignare me laudare te, o ✠ crux sancta.\n℟. Da mihi virtutem contra hostes tuos."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Dignare me laudare te, o ✠ crux sancta."
+          },
+          "r": {
+            "la": "Da mihi virtutem contra hostes tuos."
+          }
+        }
+      ]
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Oratio"
       }

--- a/content/practices/little-office-glorious-martyrs-of-christ/flow.json
+++ b/content/practices/little-office-glorious-martyrs-of-christ/flow.json
@@ -29,35 +29,55 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Regem Martyrum Dominum, venite adOremus,\n℣. Domine labia mea aperies:\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende:\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Regem Martyrum Dominum, venite adOremus,"
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies:"
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende:"
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Salvete Sancti Martyres,\nMarcelline et Petre:\nSalvete Christi pugiles,\nRomulides Athletae."
+                "la": "Salvete Sancti Martyres,\nMarcelline et Petre:\nSalvete Christi pugiles,\nRomulides Athletae.\n\nIlluminastis Ethnicos,\nChristi fidem serendo:\nRomae imbuistis barbaros,\nVerum Deum docendo.\n\nSit Trinitati gloria,\nQuae Martyres coronat:\nSit laus huic per saecula,\nNam Martyres decorat.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Illuminastis Ethnicos,\nChristi fidem serendo:\nRomae imbuistis barbaros,\nVerum Deum docendo."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit Trinitati gloria,\nQuae Martyres coronat:\nSit laus huic per saecula,\nNam Martyres decorat.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Eccles. 44)"
               }
@@ -65,26 +85,111 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sapientiam ipsorum narrent populi, et laudem eorum nuntiet Ecclesia.\n℣. In omnem terram exivit sonus eorum.\n℟. Et in fines orbis terrae verba eorum. (Psalm 18)"
+                "la": "Sapientiam ipsorum narrent populi, et laudem eorum nuntiet Ecclesia."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In omnem terram exivit sonus eorum."
+                  },
+                  "r": {
+                    "la": "Et in fines orbis terrae verba eorum. (Psalm 18)"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Dominus vobiscum.\n℟. Et cum spiritu tuo."
+                "la": "Propitiare, quaesumus Domine,\nnobis famulis tuis,\nper Sanctorum Martyrum tuorum\nMarcellini et Petri\naliorumque Patronorum nostrorum merita gloriosa:\nut eorum pia intercessione,\nab omnibus protegamar adversis.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui tecum vivit et regnat in unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nPropitiare, quaesumus Domine,\nnobis famulis tuis,\nper Sanctorum Martyrum tuorum\nMarcellini et Petri\naliorumque Patronorum nostrorum merita gloriosa:\nut eorum pia intercessione,\nab omnibus protegamar adversis.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui tecum vivit et regnat in unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum.\nAmen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Dominus vobiscum.\n℟. Et cum spiritu tuo.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -99,35 +204,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudemus viros gloriosos\net Patronos nostros in generatione sua. (Eccles. 44)\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Laudemus viros gloriosos\net Patronos nostros in generatione sua. (Eccles. 44)"
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Familias vos integras\nBaptismate sacrastis:\nEt Daemonum vos copias\nSigno Crucis fugastis."
+                "la": "Familias vos integras\nBaptismate sacrastis:\nEt Daemonum vos copias\nSigno Crucis fugastis.\n\nVos ne malo consentiam,\nAh! impetrate lumen,\nAmore Dei ut ardeam,\nVos invocate Numen.\n\nSit Trinitati gloria,\nQuae Martyres coronat:\nSit laus huic per saecula,\nNam Martyres decorat.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Vos ne malo consentiam,\nAh! impetrate lumen,\nAmore Dei ut ardeam,\nVos invocate Numen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit Trinitati gloria,\nQuae Martyres coronat:\nSit laus huic per saecula,\nNam Martyres decorat.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Zach. 4"
               }
@@ -135,14 +247,60 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Hi sunt duo filii olei, qui assistunt Dominatori universae terrae.\n℣. Pretiosa in conspectu Domini. (Psalm 115)\n℟. Mors Sanctorum ejus."
+                "la": "Hi sunt duo filii olei, qui assistunt Dominatori universae terrae."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Pretiosa in conspectu Domini. (Psalm 115)"
+                  },
+                  "r": {
+                    "la": "Mors Sanctorum ejus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -157,35 +315,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudate Dominum in sanctis ejus:\nlaudate eum in firmamento virtutis ejus. (Psalm 150)\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Laudate Dominum in sanctis ejus:\nlaudate eum in firmamento virtutis ejus. (Psalm 150)"
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Praeclara Luminaria,\nEstis poli solique:\nCeu viva exemplaria\nPlacetis vos cuique."
+                "la": "Praeclara Luminaria,\nEstis poli solique:\nCeu viva exemplaria\nPlacetis vos cuique.\n\nAh Lumen oro spargite!\nNe mens fess' opprimatur\nNe criminum caligine\nNe corpus obruatur.\n\nSit Trinitati gloria,\nQuae Martyres coronat:\nSit laus huic per saecula,\nNam Martyres decorat.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Ah Lumen oro spargite!\nNe mens fess' opprimatur\nNe criminum caligine\nNe corpus obruatur."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit Trinitati gloria,\nQuae Martyres coronat:\nSit laus huic per saecula,\nNam Martyres decorat.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Eccles. 50"
               }
@@ -193,14 +358,60 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quasi stella matutina in medio nebulae, et quasi sol refulgens: sic illuxerunt in templo Dei.\n℣. Qui ad justitiam erudiunt multos.\n℟. Fulgebunt quasi stellae in perpetuas aeternitates. (Dan. 2)"
+                "la": "Quasi stella matutina in medio nebulae, et quasi sol refulgens: sic illuxerunt in templo Dei."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Qui ad justitiam erudiunt multos."
+                  },
+                  "r": {
+                    "la": "Fulgebunt quasi stellae in perpetuas aeternitates. (Dan. 2)"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -215,35 +426,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Isti viri misericordiae sunt, quorum pietates non defuerunt. (Eccles. 44)\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Isti viri misericordiae sunt, quorum pietates non defuerunt. (Eccles. 44)"
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ut nocte caeli sidera\nIn axibus nitescunt,\nUt vere florum germina\nIn hortulis virescunt:"
+                "la": "Ut nocte caeli sidera\nIn axibus nitescunt,\nUt vere florum germina\nIn hortulis virescunt:\n\nSic estis ambo fulgidi,\nArdore caritatis:\nSic estis ambo lucidi,\nFulgore castitatis.\n\nSit Trinitati gloria,\nQuae Martyres coronat:\nSit laus huic per saecula,\nNam Martyres decorat.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sic estis ambo fulgidi,\nArdore caritatis:\nSic estis ambo lucidi,\nFulgore castitatis."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit Trinitati gloria,\nQuae Martyres coronat:\nSit laus huic per saecula,\nNam Martyres decorat.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Apoc. 7)"
               }
@@ -251,14 +469,60 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Hi sunt qui venerunt de tribulatione magna, et laverunt stolas suas in sanguine Agni: ideo sunt ante thronum Dei, et serviunt ei die ac nocte in templo ejus.\n℣. Justorum animae in manu Dei sunt.\n℟. Et non tanget illos tormentum mortis. (Sap. 3)"
+                "la": "Hi sunt qui venerunt de tribulatione magna, et laverunt stolas suas in sanguine Agni: ideo sunt ante thronum Dei, et serviunt ei die ac nocte in templo ejus."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Justorum animae in manu Dei sunt."
+                  },
+                  "r": {
+                    "la": "Et non tanget illos tormentum mortis. (Sap. 3)"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -273,35 +537,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Stabunt justi in magna constantia adversus eos, qui se angustiaverunt. (Sap. 5)\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Stabunt justi in magna constantia adversus eos, qui se angustiaverunt. (Sap. 5)"
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Avete Christi milites,\nCaeliique Candidati:\nFuso cruore nobiles,\nAc asperis probati:"
+                "la": "Avete Christi milites,\nCaeliique Candidati:\nFuso cruore nobiles,\nAc asperis probati:\n\nRosas rubore vincitis,\nQuas Flora purpuravit;\nJudex rubore sanguinis\nSerenus vos notavit.\n\nSit Trinitati gloria,\nQuae Martyres coronat:\nSit laus huic per saecula,\nNam Martyres decorat.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Rosas rubore vincitis,\nQuas Flora purpuravit;\nJudex rubore sanguinis\nSerenus vos notavit."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit Trinitati gloria,\nQuae Martyres coronat:\nSit laus huic per saecula,\nNam Martyres decorat.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -309,14 +580,60 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Visi sunt oculis insipientium mori, et aestimata est afflictio exitus illorum: illi autem sunt in pace. (Sap. 3)\n℣. Exultabunt sancti in gloria. (Psalm 149)\n℟. Laetabuntur in cubilibus suis."
+                "la": "Visi sunt oculis insipientium mori, et aestimata est afflictio exitus illorum: illi autem sunt in pace. (Sap. 3)"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Exultabunt sancti in gloria. (Psalm 149)"
+                  },
+                  "r": {
+                    "la": "Laetabuntur in cubilibus suis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -335,37 +652,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Vicistis enses, carceres,\nMinas, rotas, catenas,\nStramenta vitri, acinaces\nVirgasque flagris plenas:"
+                "la": "Vicistis enses, carceres,\nMinas, rotas, catenas,\nStramenta vitri, acinaces\nVirgasque flagris plenas:\n\nUt dura latus perferam,\nCor impetrate forte:\nBeatus ut sic gaudeam\nCum caelica cohorte.\n\nSit Trinitati gloria,\nEt honor et potestas,\nPer aeterna saecula,\nPer infinita vastas."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Ut dura latus perferam,\nCor impetrate forte:\nBeatus ut sic gaudeam\nCum caelica cohorte."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit Trinitati gloria,\nEt honor et potestas,\nPer aeterna saecula,\nPer infinita vastas."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Sap. 15)"
               }
@@ -373,14 +691,60 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "In paucis vexati in multis bene disponuntur, quoniam Deus tentavit eos, et invenit illos dignos se.\n℣. Euntes ibant et flebant mittentes semina sua. (Ps. 25)\n℟. Venientes autem venient cum exultatione."
+                "la": "In paucis vexati in multis bene disponuntur, quoniam Deus tentavit eos, et invenit illos dignos se."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Euntes ibant et flebant mittentes semina sua. (Ps. 25)"
+                  },
+                  "r": {
+                    "la": "Venientes autem venient cum exultatione."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -399,31 +763,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Vos purpuratos Pugiles,\nNunc ore praedicamus;\nEt Laureatos Martyres\nEx corde honoramus:"
+                "la": "Vos purpuratos Pugiles,\nNunc ore praedicamus;\nEt Laureatos Martyres\nEx corde honoramus:\n\nIn arduis laboribus\nAd sanguinem stetistis\nFame, siti, sudoribus,\nPericula quot subistis?"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "In arduis laboribus\nAd sanguinem stetistis\nFame, siti, sudoribus,\nPericula quot subistis?"
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Eccles. 44)"
               }
@@ -431,14 +802,60 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Isti in generationibus gentis suae gloriam adepti sunt,\net in diebus suis habentur in laudibus.\n℣. Laetamini in Domino et exultate justi.\n℟. Et gloriamini omnes recti corde. (Ps. 31)"
+                "la": "Isti in generationibus gentis suae gloriam adepti sunt,\net in diebus suis habentur in laudibus."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Laetamini in Domino et exultate justi."
+                  },
+                  "r": {
+                    "la": "Et gloriamini omnes recti corde. (Ps. 31)"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -457,37 +874,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Beata vere Civitas\nIn quam ossa portavit\nEinhardus: ejus incolas\nHis valde nam beavit."
+                "la": "Beata vere Civitas\nIn quam ossa portavit\nEinhardus: ejus incolas\nHis valde nam beavit.\n\nStupent Nepotum saecula\nMiracula, quae patrastis:\nEt gratiarum flumina\nQuaeis Patriam rigastis.\n\nSit Trinitati gloria,\nEt honor et potestas,\nPer aeterna saecula,\nPer infinita vastas."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Stupent Nepotum saecula\nMiracula, quae patrastis:\nEt gratiarum flumina\nQuaeis Patriam rigastis."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit Trinitati gloria,\nEt honor et potestas,\nPer aeterna saecula,\nPer infinita vastas."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Apoc. 21)"
               }
@@ -495,14 +913,60 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Vidi Civitatem sanctam, habentem claritatem Dei vivi:\net Civitas non eget Sole neque Luna;\net Reges terrae afferent gloriam suam et honorem in illam.\n℣. Dominus custodiat ossa eorum.\n℟. Unum ex his non conteretur. (Ps. 33)"
+                "la": "Vidi Civitatem sanctam, habentem claritatem Dei vivi:\net Civitas non eget Sole neque Luna;\net Reges terrae afferent gloriam suam et honorem in illam."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus custodiat ossa eorum."
+                  },
+                  "r": {
+                    "la": "Unum ex his non conteretur. (Ps. 33)"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         }

--- a/content/practices/little-office-god-the-father/flow.json
+++ b/content/practices/little-office-god-the-father/flow.json
@@ -26,51 +26,116 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus Pater in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Te Deum Patrem laudamus,"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Te Conditorem coeli, et terrae confitemur."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\nEt os meum annuntiabit laudem tuam.\n℣. Deus Pater in adjutorium meum intende.\n℟. Te Deum Patrem laudamus,\n℣. Te Conditorem coeli, et terrae confitemur.\n℟. Domine ad adjuvandum me festina.\nGloria Deo Patri:\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluja."
+                "la": "Gloria Deo Patri:\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluja."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Lucis Creator optime,\nLucem dierum proferens,\nPrimordiis lucis novae,\nMundi paras originem.\nQui mane junctum vesperi,\nDiem vocari praecipis,\nFac, cedat omne noxium,\nPurgetur omne pessimum."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Benedicamus Deum Patrem.\n℟. Laudemus, et superexaltemus eum in saecula."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Deum Patrem."
+                  },
+                  "r": {
+                    "la": "Laudemus, et superexaltemus eum in saecula."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Benedictio, et claritas, et sapientia, et gratiarum actio, honor, virtus, et fortitudo, Deo Patri in saecula saeculorum.\nAmen."
+              "type": "subheading",
+              "text": {
+                "la": "Benedictio, et claritas, et sapientia, et gratiarum actio, honor, virtus, et fortitudo, Deo Patri in saecula saeculorum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDa nobis, quaesumus Omnipotens et aeterne Deus, auxilium gratiosae tuae pietatis: ut Te Patrem ingenitum, Deum verum, Creatorem coeli et terrae, visibilium omnium et invisibilium, esse credimus; in exequendis quoque mandatis tuis voluntate, et actione, semper tibi placeamus: qui Deus es in saecula saeculorum.\nAmen."
+                "la": "Da nobis, quaesumus Omnipotens et aeterne Deus, auxilium gratiosae tuae pietatis: ut Te Patrem ingenitum, Deum verum, Creatorem coeli et terrae, visibilium omnium et invisibilium, esse credimus; in exequendis quoque mandatis tuis voluntate, et actione, semper tibi placeamus: qui Deus es in saecula saeculorum.\nAmen."
               }
             }
           ]
@@ -84,13 +149,13 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Immense Coeli Conditor,\nQui mixta ne confunderent,\nAquae fluenta dividens,\nCoelum dedisti limitem.\nInfunde nunc piissime\nDonum perennis gratiae,\nFraudis novae ne casibus\nNos error vetus afficiat."
               }
@@ -98,11 +163,11 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Benedicamus Deum Patrem, etc. ut supra."
+                "la": "versus Benedicamus Deum Patrem, etc. ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -116,7 +181,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Cum Orat. ut supra in Matut."
+                "la": "versus Cum Orat. ut supra in Matut."
               }
             }
           ]
@@ -130,13 +195,13 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Telluris alma Conditor,\nMundi solum qui separans,\nPulsis aquae molestiis,\nTerram dedisti immobilem:\nUt germen aptum proferens,\nStaret decora floribus:\nMunda virore gratiae,\nMentis perusta vulnera."
               }
@@ -144,11 +209,11 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Benedicamus Deum Patrem, etc. ut supra."
+                "la": "versus Benedicamus Deum Patrem, etc. ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -162,7 +227,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Cum Orat. ut supra in Matut."
+                "la": "versus Cum Orat. ut supra in Matut."
               }
             }
           ]
@@ -176,13 +241,13 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Coeli Deus Sanctissime,\nQui lucidas mundi plagas,\nCandore pingis igneo,\nAugens decoro lumine.\nExpelle noctem cordium,\nAbsterge somnos mentium,\nResolve culpae vinculum,\nEverte moles criminum."
               }
@@ -190,11 +255,11 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Benedicamus Deum Patrem, etc. ut supra."
+                "la": "versus Benedicamus Deum Patrem, etc. ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -208,7 +273,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Cum Orat. ut supra in Matut."
+                "la": "versus Cum Orat. ut supra in Matut."
               }
             }
           ]
@@ -222,13 +287,13 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Magne Deus potentiae,\nQui fertili natos aquae\nPartim relinquis gurgiti,\nPartim levas in aera:\nDa, culpa nullum deprimat,\nNullum efferat jactantia,\nElisa mens ne concidat,\nElata mens ne corruat."
               }
@@ -236,11 +301,11 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Benedicamus Deum Patrem, etc. ut supra."
+                "la": "versus Benedicamus Deum Patrem, etc. ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -254,7 +319,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Cum Orat. ut supra in Matut."
+                "la": "versus Cum Orat. ut supra in Matut."
               }
             }
           ]
@@ -268,13 +333,13 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Hominis superne Conditor,\nQui cuncta solus ordinans,\nHumum jubes producere\nReptantis et ferae genus\nEt magna rerum corpora.\nDa gaudiorum praemia,\nDa gratiarum munera,\nTuaeque pacis foedera."
               }
@@ -282,11 +347,11 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Benedicamus Deum Patrem, etc. ut supra."
+                "la": "versus Benedicamus Deum Patrem, etc. ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -300,7 +365,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Cum Orat. ut supra in Matut."
+                "la": "versus Cum Orat. ut supra in Matut."
               }
             }
           ]
@@ -314,13 +379,13 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Scrutator alme cordium,\nInfirma tu scis virium:\nAd te reversis exhibe\nRemissionis gratiam.\nMultum quidem peccavimus,\nSed parce confitentibus:\nConfer medelam languidis,\nInfunde laudem cordium.\nTe mane laudum carmine,\nTe deprecamur vesperi:\nDigneris, ut te supplices,\nLaudemus inter coelites.\nAmen."
               }
@@ -328,19 +393,25 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Benedicamus Deum Patrem, etc. ut supra."
+                "la": "versus Benedicamus Deum Patrem, etc. ut supra."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Te Deum laudamus,\nTe Dominum confitemur.\nTe aeternum Patrem omnis terra veneratur."
+                "la": "Te Deum laudamus,"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Te Dominum confitemur.\nTe aeternum Patrem omnis terra veneratur."
               }
             },
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Cum Orat. ut supra in Matut."
+                "la": "versus Cum Orat. ut supra in Matut."
               }
             }
           ]
@@ -360,7 +431,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Alia cum sui plena resignatione ad Deum patrem."
       }

--- a/content/practices/little-office-guardian-angel/flow.json
+++ b/content/practices/little-office-guardian-angel/flow.json
@@ -15,11 +15,19 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.",
-        "en-US": "℣. O Lord, open my lips.\n℟. And my mouth will announce Thy praise."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine labia mea aperies.",
+            "en-US": "O Lord, open my lips."
+          },
+          "r": {
+            "la": "Et os meum annuntiabit laudem tuam.",
+            "en-US": "And my mouth will announce Thy praise."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -29,11 +37,34 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Deus in adiutorium meum intende.\n℟. Domine ad adiuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Alleluia.",
-        "en-US": "℣. O God, come to my aid.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Spirit.\n℟. As it was in the beginning, is now, and ever shall be, world without end. Alleluia."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Deus in adiutorium meum intende.",
+            "en-US": "O God, come to my aid."
+          },
+          "r": {
+            "la": "Domine ad adiuvandum me festina.",
+            "en-US": "O Lord, make haste to help me."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Gloria Patri, et Filio, et Spiritui Sancto.",
+            "en-US": "Glory be to the Father, and to the Son, and to the Holy Spirit."
+          },
+          "r": {
+            "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Alleluia.",
+            "en-US": "As it was in the beginning, is now, and ever shall be, world without end. Alleluia."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -43,11 +74,19 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Cor Iesu, flagrans amore nostri.\n℟. Inflamma cor nostrum amore tui.",
-        "en-US": "℣. Heart of Jesus, flaming with love of us.\n℟. Inflame our hearts with love of Thee."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Cor Iesu, flagrans amore nostri.",
+            "en-US": "Heart of Jesus, flaming with love of us."
+          },
+          "r": {
+            "la": "Inflamma cor nostrum amore tui.",
+            "en-US": "Inflame our hearts with love of Thee."
+          }
+        }
+      ]
     },
     {
       "type": "select",
@@ -197,8 +236,37 @@
     {
       "type": "prayer",
       "inline": {
-        "la": "Sancti Angeli, custodes nostri, defendite nos in proelio,\nut non pereamus in tremendo iudicio.\n℣. In conspectu Angelorum psallam tibi, Deus meus.\n℟. Adorabo ad templum sanctum tuum et confitebor nomini tuo.\nOremus,\nDeus, qui ineffabili providentia sanctos Angelos tuos\nad nostram custodiam mittere digneris,\nlargire supplicibus tuis, et eorum semper protectione defendi,\net aeterna sociate gaudere. Per Dominum nostrum Iesum Christum.",
-        "en-US": "O ye holy Angels, our guardians, defend us in battle\nthat we may not perish in the awful judgment.\n℣. In the sight of Angels I will sing to Thee, O God.\n℟. I will worship facing Thy holy temple and confess Thy name.\nLet us pray,\nO God, who in Thine ineffable providence hast deigned\nto send Thy holy Angels to watch over us,\ngrant to us, Thy supplicants, to be always defended\nby their protection and in eternity to share their joy.\nThrough our Lord Jesus Christ."
+        "la": "Sancti Angeli, custodes nostri, defendite nos in proelio,\nut non pereamus in tremendo iudicio.",
+        "en-US": "O ye holy Angels, our guardians, defend us in battle\nthat we may not perish in the awful judgment."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "In conspectu Angelorum psallam tibi, Deus meus.",
+            "en-US": "In the sight of Angels I will sing to Thee, O God."
+          },
+          "r": {
+            "la": "Adorabo ad templum sanctum tuum et confitebor nomini tuo.",
+            "en-US": "I will worship facing Thy holy temple and confess Thy name."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus.",
+        "en-US": "Let us pray."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Deus, qui ineffabili providentia sanctos Angelos tuos\nad nostram custodiam mittere digneris,\nlargire supplicibus tuis, et eorum semper protectione defendi,\net aeterna sociate gaudere. Per Dominum nostrum Iesum Christum.",
+        "en-US": "O God, who in Thine ineffable providence hast deigned\nto send Thy holy Angels to watch over us,\ngrant to us, Thy supplicants, to be always defended\nby their protection and in eternity to share their joy.\nThrough our Lord Jesus Christ."
       }
     },
     {

--- a/content/practices/little-office-holy-cross/flow.json
+++ b/content/practices/little-office-holy-cross/flow.json
@@ -26,22 +26,50 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Per signum Crucis de inimicis nostris:\n℟. Libera nos Deus noster.\nIta dicitur in principio horarum."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per signum Crucis de inimicis nostris:"
+                  },
+                  "r": {
+                    "la": "Libera nos Deus noster."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Ita dicitur in principio horarum."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -56,19 +84,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Patris sapientia, veritas divina:\nDeus homo captus est hora matutina.\nA notis discipulis cito derelictus:\nA Judaeis traditus, venditus, et afflictus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -80,15 +108,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Adoramus te Christe, et benedicimus tibi.\n℟. Quia per sanctam Crucem tuam redemisti mundum."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Adoramus te Christe, et benedicimus tibi."
+                  },
+                  "r": {
+                    "la": "Quia per sanctam Crucem tuam redemisti mundum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe, Fili Dei vivi, pone Passionem, Crucem, et mortem tuam inter judicium tuum, et animam meam, nunc, et in hora mortis meae: et mihi largiri digneris gratiam et misericordiam: vivis et defunctis requiem et veniam: Ecclesiae tuae pacem et concordiam et nobis peccatoribus vitam et gloriam sempiternam. Qui vivis et regnas in saecula saeculorum.\nAmen."
+                "la": "Domine Jesu Christe, Fili Dei vivi, pone Passionem, Crucem, et mortem tuam inter judicium tuum, et animam meam, nunc, et in hora mortis meae: et mihi largiri digneris gratiam et misericordiam: vivis et defunctis requiem et veniam: Ecclesiae tuae pacem et concordiam et nobis peccatoribus vitam et gloriam sempiternam. Qui vivis et regnas in saecula saeculorum.\nAmen."
               }
             }
           ]
@@ -102,16 +143,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Per signum Crucis de inimicis nostris:\n℟. Libera nos Deus noster."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per signum Crucis de inimicis nostris:"
+                  },
+                  "r": {
+                    "la": "Libera nos Deus noster."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -120,19 +175,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Hora prima Dominum ducunt ad Pilatum,\nEt a falsis testibus multum accusatum:\nColaphis percutiunt, manibus ligatum:\nVultum Dei conspuunt, lumen caeli gratum."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -144,15 +199,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Adoramus te Christe, et benedicimus tibi.\n℟. Quia per sanctam Crucem tuam redemisti mundum."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Adoramus te Christe, et benedicimus tibi."
+                  },
+                  "r": {
+                    "la": "Quia per sanctam Crucem tuam redemisti mundum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe, Fili Dei vivi, pone Passionem, Crucem, et mortem tuam inter judicium tuum, et animam meam, nunc, et in hora mortis meae: et mihi largiri digneris gratiam, et misericordiam: vivis, et defunctis requiem, et veniam: Ecclesiae tuae pacem, et concordiam; et nobis peccatoribus vitam, et gloriam sempiternam. Qui vivis et regnas in saecula saeculorum.\nAmen."
+                "la": "Domine Jesu Christe, Fili Dei vivi, pone Passionem, Crucem, et mortem tuam inter judicium tuum, et animam meam, nunc, et in hora mortis meae: et mihi largiri digneris gratiam, et misericordiam: vivis, et defunctis requiem, et veniam: Ecclesiae tuae pacem, et concordiam; et nobis peccatoribus vitam, et gloriam sempiternam. Qui vivis et regnas in saecula saeculorum.\nAmen."
               }
             }
           ]
@@ -166,16 +234,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Per signum Crucis de inimicis nostris:\n℟. Libera nos Deus noster."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per signum Crucis de inimicis nostris:"
+                  },
+                  "r": {
+                    "la": "Libera nos Deus noster."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -184,19 +266,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Crucifige, crucifige, clamitat hora tertiam:\nIllusus induitur veste purpuram:\nCaput ejus pungitur corona spinarum:\nCrucem portat humeris ad locum poenarum."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -208,15 +290,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Adoramus te Christe, et benedicimus tibi.\n℟. Quia per sanctam Crucem tuam redemisti mundum."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Adoramus te Christe, et benedicimus tibi."
+                  },
+                  "r": {
+                    "la": "Quia per sanctam Crucem tuam redemisti mundum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe, Fili Dei vivi, pone Passionem, Crucem, et mortem tuam inter judicium tuum, et animam meam, nunc, et in hora mortis meae: et mihi largiri digneris gratiam, et misericordiam: vivis, et defunctis requiem, et veniam: Ecclesiae tuae pacem, et concordiam; et nobis peccatoribus vitam, et gloriam sempiternam. Qui vivis et regnas in saecula saeculorum.\nAmen."
+                "la": "Domine Jesu Christe, Fili Dei vivi, pone Passionem, Crucem, et mortem tuam inter judicium tuum, et animam meam, nunc, et in hora mortis meae: et mihi largiri digneris gratiam, et misericordiam: vivis, et defunctis requiem, et veniam: Ecclesiae tuae pacem, et concordiam; et nobis peccatoribus vitam, et gloriam sempiternam. Qui vivis et regnas in saecula saeculorum.\nAmen."
               }
             }
           ]
@@ -232,8 +327,21 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Per signum, etc.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina."
+                "la": "Per signum, etc."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -242,19 +350,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Hora sexta Jesus est Cruci con­clavatus.\nEt cum latronibus pendens est deputatus:\nPrae tormentis sitiens felle saturatus:\nAgnus crimen diluens, sic est ludificatus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -268,13 +376,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Adoramus te Christe, etc."
+                "la": "Adoramus te Christe, etc."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe, Fili Dei vivi, pone Passionem, Crucem, et mortem tuam inter judicium tuum, et animam meam, nunc, et in hora mortis meae: et mihi largiri digneris gratiam, et misericordiam: vivis, et defunctis requiem, et veniam: Ecclesiae tuae pacem, et concordiam; et nobis peccatoribus vitam, et gloriam sempiternam. Qui vivis et regnas in saecula saeculorum.\nAmen."
+                "la": "Domine Jesu Christe, Fili Dei vivi, pone Passionem, Crucem, et mortem tuam inter judicium tuum, et animam meam, nunc, et in hora mortis meae: et mihi largiri digneris gratiam, et misericordiam: vivis, et defunctis requiem, et veniam: Ecclesiae tuae pacem, et concordiam; et nobis peccatoribus vitam, et gloriam sempiternam. Qui vivis et regnas in saecula saeculorum.\nAmen."
               }
             }
           ]
@@ -290,8 +404,21 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Per signum, etc.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina."
+                "la": "Per signum, etc."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -300,19 +427,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Hora nona Dominus Jesus expiravit:\nEli clamans spiritum Patri commendavit:\nLatus ejus lancea miles perforavit:\nTerra tunc contremuit, et sol se obscuravit."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -326,13 +453,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Adoramus te Christe, etc."
+                "la": "Adoramus te Christe, etc."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe, Fili Dei vivi, pone Passionem, Crucem, et mortem tuam inter judicium tuum, et animam meam, nunc, et in hora mortis meae: et mihi largiri digneris gratiam, et misericordiam: vivis, et defunctis requiem, et veniam: Ecclesiae tuae pacem, et concordiam; et nobis peccatoribus vitam, et gloriam sempiternam. Qui vivis et regnas in saecula saeculorum.\nAmen."
+                "la": "Domine Jesu Christe, Fili Dei vivi, pone Passionem, Crucem, et mortem tuam inter judicium tuum, et animam meam, nunc, et in hora mortis meae: et mihi largiri digneris gratiam, et misericordiam: vivis, et defunctis requiem, et veniam: Ecclesiae tuae pacem, et concordiam; et nobis peccatoribus vitam, et gloriam sempiternam. Qui vivis et regnas in saecula saeculorum.\nAmen."
               }
             }
           ]
@@ -348,8 +481,21 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Per signum, etc.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina."
+                "la": "Per signum, etc."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -358,19 +504,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "De Cruce deponitur hora vespertina:\nFortitudo latuit in mente divina:\nTalem mortem subiit vitae medicina:\nHeu corona gloriae jacuit supina!"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -384,13 +530,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Adoramus te Christe, etc."
+                "la": "Adoramus te Christe, etc."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe, Fili Dei vivi, pone Passionem, Crucem, et mortem tuam inter judicium tuum, et animam meam, nunc, et in hora mortis meae: et mihi largiri digneris gratiam, et misericordiam: vivis, et defunctis requiem, et veniam: Ecclesiae tuae pacem, et concordiam; et nobis peccatoribus vitam, et gloriam sempiternam. Qui vivis et regnas in saecula saeculorum.\nAmen."
+                "la": "Domine Jesu Christe, Fili Dei vivi, pone Passionem, Crucem, et mortem tuam inter judicium tuum, et animam meam, nunc, et in hora mortis meae: et mihi largiri digneris gratiam, et misericordiam: vivis, et defunctis requiem, et veniam: Ecclesiae tuae pacem, et concordiam; et nobis peccatoribus vitam, et gloriam sempiternam. Qui vivis et regnas in saecula saeculorum.\nAmen."
               }
             }
           ]
@@ -406,8 +558,34 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Per signum, etc.\n℣. Convertere nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina."
+                "la": "Per signum, etc."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Convertere nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -416,19 +594,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Hora Completorii datur sepulturae\nCorpus Christi nobile, spes vitae futurae:\nConduntur aromate: complentur Scripturae.\nJugis sit memoria mortis suae dura."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -442,13 +620,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Adoramus te Christe, etc."
+                "la": "Adoramus te Christe, etc."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe, Fili Dei vivi, pone Passionem, Crucem, et mortem tuam inter judicium tuum, et animam meam, nunc, et in hora mortis meae: et mihi largiri digneris gratiam, et misericordiam: vivis, et defunctis requiem, et veniam: Ecclesiae tuae pacem, et concordiam; et nobis peccatoribus vitam, et gloriam sempiternam. Qui vivis et regnas in saecula saeculorum.\nAmen."
+                "la": "Domine Jesu Christe, Fili Dei vivi, pone Passionem, Crucem, et mortem tuam inter judicium tuum, et animam meam, nunc, et in hora mortis meae: et mihi largiri digneris gratiam, et misericordiam: vivis, et defunctis requiem, et veniam: Ecclesiae tuae pacem, et concordiam; et nobis peccatoribus vitam, et gloriam sempiternam. Qui vivis et regnas in saecula saeculorum.\nAmen."
               }
             }
           ]
@@ -468,57 +652,15 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Hymnus"
       }
     },
     {
-      "type": "prayer",
+      "type": "hymn",
       "inline": {
-        "la": "Vexilla Regis prodeunt:\nFulget Crucis mysterium,\nQua vita mortem pertulit,\nEt morte vitam protulit."
-      }
-    },
-    {
-      "type": "prayer",
-      "inline": {
-        "la": "Quae vulnerata lanceae\nMucrone diro, criminum\nUt nos lavaret sordibus,\nManavit unda, et sanguine."
-      }
-    },
-    {
-      "type": "prayer",
-      "inline": {
-        "la": "Impleta sunt quae concinit\nDavid fideli carmine;\nDicendo nationibus:\nRegnavit a ligno Deus."
-      }
-    },
-    {
-      "type": "prayer",
-      "inline": {
-        "la": "Arbor decora, et fulgida,\nOrnata Regis purpura,\nElecta digno stipite\nTam sancta membra tangere."
-      }
-    },
-    {
-      "type": "prayer",
-      "inline": {
-        "la": "Beata, cujus brachiis\nPretium pependit saeculi,\nStatera facta corporis\nTulitque praedam tartari."
-      }
-    },
-    {
-      "type": "prayer",
-      "inline": {
-        "la": "O Crux ave spes unica,\nHoc passionis tempore,\nPiis adauge gratiam,\nReisque dele crimina."
-      }
-    },
-    {
-      "type": "prayer",
-      "inline": {
-        "la": "Te, fons salutis, Trinitas:\nCollaudet omnis spiritus:\nQuibus Crucis victoriam\nLargiris, adde praemium."
-      }
-    },
-    {
-      "type": "prayer",
-      "inline": {
-        "la": "Amen."
+        "la": "Vexilla Regis prodeunt:\nFulget Crucis mysterium,\nQua vita mortem pertulit,\nEt morte vitam protulit.\n\nQuae vulnerata lanceae\nMucrone diro, criminum\nUt nos lavaret sordibus,\nManavit unda, et sanguine.\n\nImpleta sunt quae concinit\nDavid fideli carmine;\nDicendo nationibus:\nRegnavit a ligno Deus.\n\nArbor decora, et fulgida,\nOrnata Regis purpura,\nElecta digno stipite\nTam sancta membra tangere.\n\nBeata, cujus brachiis\nPretium pependit saeculi,\nStatera facta corporis\nTulitque praedam tartari.\n\nO Crux ave spes unica,\nHoc passionis tempore,\nPiis adauge gratiam,\nReisque dele crimina.\n\nTe, fons salutis, Trinitas:\nCollaudet omnis spiritus:\nQuibus Crucis victoriam\nLargiris, adde praemium.\n\nAmen."
       }
     },
     {
@@ -534,9 +676,15 @@
       }
     },
     {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
+      }
+    },
+    {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nRespice, quaesumus Domine, super hanc familiam tuam, pro qua Dominus noster Jesus Christus non dubitavit manibus tradi nocentium, et crucis subire tormentum.\nQui tecum vivit, et regnat in saecula saeculorum.\nAmen."
+        "la": "Respice, quaesumus Domine, super hanc familiam tuam, pro qua Dominus noster Jesus Christus non dubitavit manibus tradi nocentium, et crucis subire tormentum.\nQui tecum vivit, et regnat in saecula saeculorum.\nAmen."
       }
     }
   ]

--- a/content/practices/little-office-holy-ghost-2/flow.json
+++ b/content/practices/little-office-holy-ghost-2/flow.json
@@ -32,7 +32,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -44,10 +44,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Sancti Spiritus adsit nobis gratia.\n℟. Qui corda nostra sibi faciat habitacula."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sancti Spiritus adsit nobis gratia."
+                  },
+                  "r": {
+                    "la": "Qui corda nostra sibi faciat habitacula."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -56,16 +63,30 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -80,7 +101,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -92,7 +113,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus I"
               }
@@ -104,7 +125,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -122,7 +143,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum (Rom. 5)"
               }
@@ -130,55 +151,25 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Caritas Dei diffusa est in cordibus nostris per Spiritum Sanctum qui datus est nobis.\n℟. Deo gratias."
+                "la": "Caritas Dei diffusa est in cordibus nostris per Spiritum Sanctum qui datus est nobis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Veni Creator Spiritus,\nMentes tuorum visita,\nImple superna gratia,\nQuae tu creasti pectora."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Qui Paraclitus diceris,\nDonum Dei altissimi,\nFons vivus, ignis, caritas,\nEt spiritualis unctio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Tu septiformis munere,\nDextrae Dei tu digitus,\nTu rite promissum Patris,\nSermone ditans guttura."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Accende lumen sensibus,\nInfunde amorem cordibus,\nInfirma nostri corporis,\nVirtute firmans perpeti."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Hostem repellas longius,\nPacemque dones protinus,\nDuctore sic te praevio,\nVitemus omne noxium."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Per te sciamus da Patrem,\nNoscamus atque Filium,\nTe utriusque Spiritum\nCredamus omni tempore."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit laus Patri cum Filio,\nSancto simul Paraclito,\nNobis quoque mittat Filius\nCharisma Sancti Spiritus.\nAmen."
+                "la": "Veni Creator Spiritus,\nMentes tuorum visita,\nImple superna gratia,\nQuae tu creasti pectora.\n\nQui Paraclitus diceris,\nDonum Dei altissimi,\nFons vivus, ignis, caritas,\nEt spiritualis unctio.\n\nTu septiformis munere,\nDextrae Dei tu digitus,\nTu rite promissum Patris,\nSermone ditans guttura.\n\nAccende lumen sensibus,\nInfunde amorem cordibus,\nInfirma nostri corporis,\nVirtute firmans perpeti.\n\nHostem repellas longius,\nPacemque dones protinus,\nDuctore sic te praevio,\nVitemus omne noxium.\n\nPer te sciamus da Patrem,\nNoscamus atque Filium,\nTe utriusque Spiritum\nCredamus omni tempore.\n\nSit laus Patri cum Filio,\nSancto simul Paraclito,\nNobis quoque mittat Filius\nCharisma Sancti Spiritus.\nAmen."
               }
             },
             {
@@ -188,13 +179,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Spiritus Domini replevit orbem terrarum.\n℟. Et hoc quod continet omnia scientiam habet vocis."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Spiritus Domini replevit orbem terrarum."
+                  },
+                  "r": {
+                    "la": "Et hoc quod continet omnia scientiam habet vocis."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -206,7 +204,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Zachariae (Luc. 1)"
               }
@@ -218,7 +216,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -236,22 +234,74 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus qui corda fidelium Sancti Spiritus illustratione docuisti: da nobis in eodem Spiritu recta sapere et de ejus semper consolatione gaudere. Per Dominum nostrum Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate ejusdem Spiritus Sancti Deus, per omnia saecula saeculorum.\n℟. Amen."
+                "la": "Deus qui corda fidelium Sancti Spiritus illustratione docuisti: da nobis in eodem Spiritu recta sapere et de ejus semper consolatione gaudere. Per Dominum nostrum Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate ejusdem Spiritus Sancti Deus, per omnia saecula saeculorum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. In omnibus bonis operibus confortet nos Spiritus almus.\n℟. Amen."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In omnibus bonis operibus confortet nos Spiritus almus."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -270,7 +320,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -284,41 +334,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium, etc."
+                "la": "Deus in adjutorium, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Veni Creator Spiritus,\nMentes tuorum visita,\nImple superna gratia,\nQuae tu creasti pectora."
+                "la": "Veni Creator Spiritus,\nMentes tuorum visita,\nImple superna gratia,\nQuae tu creasti pectora.\n\nQui Paraclitus diceris,\nDonum Dei altissimi,\nFons vivus, ignis, caritas,\nEt spiritualis unctio.\n\nPer te sciamus da Patrem,\nNoscamus atque Filium,\nTe utriusque Spiritum\nCredimus omni tempore.\n\nSit laus Patri cum Filio,\nSancto simul Paraclito,\nNobis quoque mittat Filius\nCharisma Sancti Spiritus.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Qui Paraclitus diceris,\nDonum Dei altissimi,\nFons vivus, ignis, caritas,\nEt spiritualis unctio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Per te sciamus da Patrem,\nNoscamus atque Filium,\nTe utriusque Spiritum\nCredimus omni tempore."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit laus Patri cum Filio,\nSancto simul Paraclito,\nNobis quoque mittat Filius\nCharisma Sancti Spiritus.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -330,7 +362,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 14"
               }
@@ -342,7 +374,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -354,7 +386,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum (Rom. 5)"
               }
@@ -362,11 +394,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Caritas Dei diffusa est in cordibus nostris per Spiritum Sanctum qui datus est nobis.\n℟. Deo gratias."
+                "la": "Caritas Dei diffusa est in cordibus nostris per Spiritum Sanctum qui datus est nobis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsorium Breve"
               }
@@ -374,19 +412,51 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Jesu Christe, Fili Dei vivi, Miserere nobis. Jesu Christe.\n℣. Qui misisti Spiritum Sanctum Apostolis. Miserere nobis. Gloria Patri. Jesu Christe."
+                "la": "Jesu Christe, Fili Dei vivi, Miserere nobis. Jesu Christe."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Cor mundum crea in me Deus.\n℟. Et Spiritum rectum innova in visceribus meis.\n℣. Domine, exaudi.\n℟. Et clamor meus."
+                "la": "Qui misisti Spiritum Sanctum Apostolis. Miserere nobis. Gloria Patri. Jesu Christe."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Cor mundum crea in me Deus."
+                  },
+                  "r": {
+                    "la": "Et Spiritum rectum innova in visceribus meis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi."
+                  },
+                  "r": {
+                    "la": "Et clamor meus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nAdsit nobis, quaesumus, Domine, virtus Spiritus Sancti: quae et corda nostra clementer expurget, et ab omnibus tueatur adversis. Per Dominum etc. in unitate ejusdem Spiritus."
+                "la": "Adsit nobis, quaesumus, Domine, virtus Spiritus Sancti: quae et corda nostra clementer expurget, et ab omnibus tueatur adversis. Per Dominum etc. in unitate ejusdem Spiritus."
               }
             }
           ]
@@ -400,37 +470,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Veni Creator Spiritus,\nMentes tuorum visita,\nImple superna gratia,\nQuae tu creasti pectora."
+                "la": "Veni Creator Spiritus,\nMentes tuorum visita,\nImple superna gratia,\nQuae tu creasti pectora.\n\nTu septiformis munere,\nDextrae Dei tu digitus,\nTu rite promissum Patris,\nSermone ditans guttura.\n\nPer te sciamus da Patrem,\nNoscamus atque Filium,\nTe utriusque Spiritum\nCredamus omni tempore.\n\nSit laus Patri cum Filio,\nSancto simul Paraclito,\nNobis quoque mittat Filius\nCharisma Sancti Spiritus.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Tu septiformis munere,\nDextrae Dei tu digitus,\nTu rite promissum Patris,\nSermone ditans guttura."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Per te sciamus da Patrem,\nNoscamus atque Filium,\nTe utriusque Spiritum\nCredamus omni tempore."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit laus Patri cum Filio,\nSancto simul Paraclito,\nNobis quoque mittat Filius\nCharisma Sancti Spiritus.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -442,7 +494,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 53"
               }
@@ -454,7 +506,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -466,7 +518,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum (Rom. 5)"
               }
@@ -474,11 +526,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Caritas Dei diffusa est in cordibus nostris per Spiritum Sanctum qui datus est nobis.\n℟. Deo gratias."
+                "la": "Caritas Dei diffusa est in cordibus nostris per Spiritum Sanctum qui datus est nobis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsorium Breve"
               }
@@ -486,19 +544,51 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Emitte Spiritum tuum, Et creabuntur. Emitte.\n℣. Et renovabis faciem terrae. Et creabuntur. Gloria Patri. Emitte."
+                "la": "Emitte Spiritum tuum, Et creabuntur. Emitte."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Ne projicias me a facie tua.\n℟. Et Spiritum Sanctum tuum ne auferas a me.\n℣. Domine, exaudi.\n℟. Et clamor meus."
+                "la": "Et renovabis faciem terrae. Et creabuntur. Gloria Patri. Emitte."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ne projicias me a facie tua."
+                  },
+                  "r": {
+                    "la": "Et Spiritum Sanctum tuum ne auferas a me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi."
+                  },
+                  "r": {
+                    "la": "Et clamor meus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus qui Apostolis tuis Sanctum dedisti Spiritum: concede plebi tuae piae petitionis effectum; ut quibus dedisti fidem largiaris et pacem. Per Dominum etc. in unitate ejusdem Spiritus."
+                "la": "Deus qui Apostolis tuis Sanctum dedisti Spiritum: concede plebi tuae piae petitionis effectum; ut quibus dedisti fidem largiaris et pacem. Per Dominum etc. in unitate ejusdem Spiritus."
               }
             }
           ]
@@ -512,37 +602,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Veni Creator Spiritus,\nMentes tuorum visita,\nImple superna gratia,\nQuae tu creasti pectora."
+                "la": "Veni Creator Spiritus,\nMentes tuorum visita,\nImple superna gratia,\nQuae tu creasti pectora.\n\nAccende lumen sensibus,\nInfunde amorem cordibus,\nInfirma nostri corporis,\nVirtute firmans perpeti.\n\nPer te sciamus da Patrem,\nNoscamus atque Filium,\nTe utriusque Spiritum\nCredamus omni tempore.\n\nSit laus Patri cum Filio,\nSancto simul Paraclito,\nNobis quoque mittat Filius\nCharisma Sancti Spiritus.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Accende lumen sensibus,\nInfunde amorem cordibus,\nInfirma nostri corporis,\nVirtute firmans perpeti."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Per te sciamus da Patrem,\nNoscamus atque Filium,\nTe utriusque Spiritum\nCredamus omni tempore."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit laus Patri cum Filio,\nSancto simul Paraclito,\nNobis quoque mittat Filius\nCharisma Sancti Spiritus.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -554,7 +626,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 69"
               }
@@ -566,7 +638,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -578,7 +650,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum (Rom. 5)"
               }
@@ -586,11 +658,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Caritas Dei diffusa est in cordibus nostris per Spiritum Sanctum qui datus est nobis.\n℟. Deo gratias."
+                "la": "Caritas Dei diffusa est in cordibus nostris per Spiritum Sanctum qui datus est nobis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsorium Breve"
               }
@@ -598,19 +676,51 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Spiritus, Paraclitus. Spiritus.\n℣. Docebit vos omnia. Paraclitus. Gloria Patri. Spiritus."
+                "la": "Spiritus, Paraclitus. Spiritus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Redde mihi laetitiam salutaris tui.\n℟. Et spiritu principali confirma me.\n℣. Domine, exaudi.\n℟. Et clamor meus."
+                "la": "Docebit vos omnia. Paraclitus. Gloria Patri. Spiritus."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Redde mihi laetitiam salutaris tui."
+                  },
+                  "r": {
+                    "la": "Et spiritu principali confirma me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi."
+                  },
+                  "r": {
+                    "la": "Et clamor meus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nVere igne Sancti Spiritus renes nostros et cor nostrum, Domine: ut tibi casto corpore serviamus et mundo corde placeamus. Per Dominum etc. in unitate ejusdem."
+                "la": "Vere igne Sancti Spiritus renes nostros et cor nostrum, Domine: ut tibi casto corpore serviamus et mundo corde placeamus. Per Dominum etc. in unitate ejusdem."
               }
             }
           ]
@@ -624,37 +734,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Veni Creator Spiritus,\nMentes tuorum visita,\nImple superna gratia,\nQuae tu creasti pectora."
+                "la": "Veni Creator Spiritus,\nMentes tuorum visita,\nImple superna gratia,\nQuae tu creasti pectora.\n\nHostem repellas longius,\nPacemque dones protinus;\nDuctore sic te praevio\nVitemus omne noxium.\n\nPer te sciamus da Patrem,\nNoscamus atque Filium,\nTe utriusque Spiritum\nCredamus omni tempore.\n\nSit laus Patri cum Filio,\nSancto simul Paraclito,\nNobis quoque mittat Filius\nCharisma Sancti Spiritus.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Hostem repellas longius,\nPacemque dones protinus;\nDuctore sic te praevio\nVitemus omne noxium."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Per te sciamus da Patrem,\nNoscamus atque Filium,\nTe utriusque Spiritum\nCredamus omni tempore."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit laus Patri cum Filio,\nSancto simul Paraclito,\nNobis quoque mittat Filius\nCharisma Sancti Spiritus.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -666,7 +758,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 86"
               }
@@ -678,7 +770,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -690,7 +782,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum (Rom. 5)"
               }
@@ -698,11 +790,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Caritas Dei diffusa est in cordibus nostris per Spiritum Sanctum qui datus est nobis.\n℟. Deo gratias."
+                "la": "Caritas Dei diffusa est in cordibus nostris per Spiritum Sanctum qui datus est nobis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsorium Breve"
               }
@@ -710,19 +808,51 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Loquebantur variis Linguis Apostoli. Loquebantur.\n℣. Magnalia Dei. Linguis Apostoli. Gloria Patri. Loquebantur."
+                "la": "Loquebantur variis Linguis Apostoli. Loquebantur."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Spiritus Domini replevit orbem terrarum.\n℟. Et hoc quod continet omnia, scientiam habet vocis.\n℣. Domine, exaudi.\n℟. Et clamor meus."
+                "la": "Magnalia Dei. Linguis Apostoli. Gloria Patri. Loquebantur."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Spiritus Domini replevit orbem terrarum."
+                  },
+                  "r": {
+                    "la": "Et hoc quod continet omnia, scientiam habet vocis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi."
+                  },
+                  "r": {
+                    "la": "Et clamor meus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nPresta, quaesumus, omnipotens Deus, ut Spiritus Sanctus adveniens templum nos gloriae suae digne inhabitando perficiat. Per Dominum etc. in unitate ejusdem."
+                "la": "Presta, quaesumus, omnipotens Deus, ut Spiritus Sanctus adveniens templum nos gloriae suae digne inhabitando perficiat. Per Dominum etc. in unitate ejusdem."
               }
             }
           ]
@@ -736,7 +866,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -748,7 +878,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 127"
               }
@@ -760,7 +890,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -778,7 +908,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum (Rom. 5)"
               }
@@ -786,65 +916,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Caritas Dei diffusa est in cordibus nostris per Spiritum Sanctum qui datus est nobis.\n℟. Deo gratias."
+                "la": "Caritas Dei diffusa est in cordibus nostris per Spiritum Sanctum qui datus est nobis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Veni Creator Spiritus,\nMentes tuorum visita,\nImple superna gratia,\nQuae tu creasti pectora."
+                "la": "Veni Creator Spiritus,\nMentes tuorum visita,\nImple superna gratia,\nQuae tu creasti pectora.\n\nQui Paraclitus diceris,\nDonum Dei Altissimi,\nFons vivus, ignis, caritas,\nEt spiritualis unctio.\n\nTu septiformis munere,\nDextrae Dei tu digitus,\nTu rite promissum Patris,\nSermone ditans guttura.\n\nAccende lumen sensibus,\nInfunde amorem cordibus,\nInfirma nostri corporis,\nVirtute firmans perpeti.\n\nHostem repellas longius,\nPacemque dones protinus,\nDuctore sic te praevio,\nVitemus omne noxium.\n\nPer te sciamus da Patrem,\nNoscamus atque Filium,\nTe utriusque Spiritum\nCredamus omni tempore.\n\nSit laus Patri cum Filio,\nSancto simul Paraclito,\nNobis quoque mittat Filius\nCharisma Sancti Spiritus.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Qui Paraclitus diceris,\nDonum Dei Altissimi,\nFons vivus, ignis, caritas,\nEt spiritualis unctio."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Emitte Spiritum tuum et creabuntur."
+                  },
+                  "r": {
+                    "la": "Et renovabis faciem terrae."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Tu septiformis munere,\nDextrae Dei tu digitus,\nTu rite promissum Patris,\nSermone ditans guttura."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Accende lumen sensibus,\nInfunde amorem cordibus,\nInfirma nostri corporis,\nVirtute firmans perpeti."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Hostem repellas longius,\nPacemque dones protinus,\nDuctore sic te praevio,\nVitemus omne noxium."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Per te sciamus da Patrem,\nNoscamus atque Filium,\nTe utriusque Spiritum\nCredamus omni tempore."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit laus Patri cum Filio,\nSancto simul Paraclito,\nNobis quoque mittat Filius\nCharisma Sancti Spiritus.\nAmen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Emitte Spiritum tuum et creabuntur.\n℟. Et renovabis faciem terrae."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -856,7 +963,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Beatae Mariae Virginis (Luc. 1)"
               }
@@ -868,7 +975,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -880,15 +987,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi.\n℟. Et clamor meus."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi."
+                  },
+                  "r": {
+                    "la": "Et clamor meus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus cui omne cor patet et omnis voluntas loquitur, et quem nullum latet secretum: purifica per infusionem Sancti Spiritus cogitationes cordis nostri, ut te perfecte diligere, et digne laudare mereamur. Per Dominum etc. in unitate ejusdem."
+                "la": "Deus cui omne cor patet et omnis voluntas loquitur, et quem nullum latet secretum: purifica per infusionem Sancti Spiritus cogitationes cordis nostri, ut te perfecte diligere, et digne laudare mereamur. Per Dominum etc. in unitate ejusdem."
               }
             }
           ]
@@ -902,7 +1022,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -916,17 +1036,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Sancti Spiritus, etc. (as at the beginning)"
+                "la": "Sancti Spiritus, etc. (as at the beginning)"
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium, etc."
+                "la": "Deus in adjutorium, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -938,7 +1071,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 128"
               }
@@ -950,7 +1083,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -962,7 +1095,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum (Rom. 5)"
               }
@@ -970,11 +1103,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Caritas Dei diffusa est in cordibus nostris per Spiritum Sanctum qui datus est nobis.\n℟. Deo gratias."
+                "la": "Caritas Dei diffusa est in cordibus nostris per Spiritum Sanctum qui datus est nobis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsorium Breve"
               }
@@ -982,29 +1121,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "In manus tuas Domine Commendo spiritum meum. In manus.\n℣. Qui Spiritu Sancto replevisti omnem terram. Commendo. Gloria Patri. In manus."
+                "la": "In manus tuas Domine Commendo spiritum meum. In manus."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Qui Spiritu Sancto replevisti omnem terram. Commendo. Gloria Patri. In manus."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Veni Creator Spiritus ut supra in Vesperis."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Cor mundum crea in me Deus.\n℟. Et spiritum rectum innova in visceribus meis."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Cor mundum crea in me Deus."
+                  },
+                  "r": {
+                    "la": "Et spiritum rectum innova in visceribus meis."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -1016,7 +1168,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Simeonis (Luc. 2)"
               }
@@ -1028,7 +1180,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -1040,22 +1192,68 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi.\n℟. Et clamor meus."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi."
+                  },
+                  "r": {
+                    "la": "Et clamor meus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nSancti Spiritus, quaesumus Domine, corda nostra mundet infusio, et sui roris intima aspersione foecundet. Per Dominum etc. in unitate ejusdem."
+                "la": "Sancti Spiritus, quaesumus Domine, corda nostra mundet infusio, et sui roris intima aspersione foecundet. Per Dominum etc. in unitate ejusdem."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi.\n℟. Et clamor meus.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. In omnibus bonis operibus confortet nos Spiritus almus.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi."
+                  },
+                  "r": {
+                    "la": "Et clamor meus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In omnibus bonis operibus confortet nos Spiritus almus."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1064,7 +1262,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon Prima"
               }
@@ -1076,7 +1274,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona altera"
               }
@@ -1088,15 +1286,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ecce ancilla Domini.\n℟. Fiat mihi secundum verbum tuum."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ecce ancilla Domini."
+                  },
+                  "r": {
+                    "la": "Fiat mihi secundum verbum tuum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus qui de Beata Maria Virginis utero, Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis; ut qui vere eam Dei Genitricem credimus, ejus apud te intercessionibus adjuvemur. Per eundem Jesum Christum Dominum nostrum.\n℟. Amen."
+                "la": "Deus qui de Beata Maria Virginis utero, Verbum tuum, Angelo nuntiante, carnem suscipere voluisti: praesta supplicibus tuis; ut qui vere eam Dei Genitricem credimus, ejus apud te intercessionibus adjuvemur. Per eundem Jesum Christum Dominum nostrum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             }
           ]

--- a/content/practices/little-office-holy-ghost-for-obtaining-the-true-love-of-god/flow.json
+++ b/content/practices/little-office-holy-ghost-for-obtaining-the-true-love-of-god/flow.json
@@ -45,49 +45,77 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Veni Sancte Spiritus, reple tuorum corda fidelium, et tui amoris ignem in eis accende.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Veni Sancte Spiritus, reple tuorum corda fidelium, et tui amoris ignem in eis accende."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Tu procedens a duobus,\nCoaequalis es ambobus,\nNulla est disparitas;\nPar Majestas Personarum,\nPar Potestas singularum,\nEt communis Deitas."
+                "la": "Tu procedens a duobus,\nCoaequalis es ambobus,\nNulla est disparitas;\nPar Majestas Personarum,\nPar Potestas singularum,\nEt communis Deitas.\n\nAmor Patris, Filiique,\nPar amborum, et utrique\nGloria consimilis,\nCoelos imples, terras foves,\nMare domas, cuncta moves,\nPermanens immobilis."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Amor Patris, Filiique,\nPar amborum, et utrique\nGloria consimilis,\nCoelos imples, terras foves,\nMare domas, cuncta moves,\nPermanens immobilis."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ure igne, Sancte Spiritus, renes nostros, et cor nostrum Domine."
+                  },
+                  "r": {
+                    "la": "Ut tibi casto corpore serviamus, et mundo corde placeamus."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ure igne, Sancte Spiritus, renes nostros, et cor nostrum Domine.\n℟. Ut tibi casto corpore serviamus, et mundo corde placeamus."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -99,10 +127,43 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Et Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -117,31 +178,44 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Veni Sancte Spiritus, reple, etc.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Veni Sancte Spiritus, reple, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Tu commutas elementa,\nPer te sua sacramenta\nPraestant efficaciam.\nTu malignam vim repellis,\nTu subvertis et refellis\nHostium nequitiam."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Te docente nil obscurum,\nTe praesente nil impurum,\nCuncta sunt splendida;\nGloriatur mens jucunda,\nPer te sana, per te munda,\nGaudet conscientia."
+                "la": "Tu commutas elementa,\nPer te sua sacramenta\nPraestant efficaciam.\nTu malignam vim repellis,\nTu subvertis et refellis\nHostium nequitiam.\n\nTe docente nil obscurum,\nTe praesente nil impurum,\nCuncta sunt splendida;\nGloriatur mens jucunda,\nPer te sana, per te munda,\nGaudet conscientia."
               }
             },
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Ure igne, etc. cum Oratione."
+                "la": "versus Ure igne, etc. cum Oratione."
               }
             }
           ]
@@ -157,31 +231,44 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Veni Sancte Spiritus, reple, etc.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Veni Sancte Spiritus, reple, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Quando venis, corda lenis,\nQuando subis, atrae nubis\nPellitur obscuritas.\nSacer ignis pectus uris,\nNon comburis, sed a curis\nEruis, dum visitas."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mentes prius imperitas,\nEt sopitas et oblitas\nInstrui et excitas,\nCor ad fidem facis pronum,\nOri muto reddis sonum,\nManans ex te claritas."
+                "la": "Quando venis, corda lenis,\nQuando subis, atrae nubis\nPellitur obscuritas.\nSacer ignis pectus uris,\nNon comburis, sed a curis\nEruis, dum visitas.\n\nMentes prius imperitas,\nEt sopitas et oblitas\nInstrui et excitas,\nCor ad fidem facis pronum,\nOri muto reddis sonum,\nManans ex te claritas."
               }
             },
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Ure igne, etc. cum Oratione."
+                "la": "versus Ure igne, etc. cum Oratione."
               }
             }
           ]
@@ -197,31 +284,44 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Veni Sancte Spiritus, reple, etc.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Veni Sancte Spiritus, reple, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O quam felix, quam festiva\nDies, in qua primitiva\nConditur Ecclesia,\nSunt primitias jam vivae,\nNeonatae Matris Divae\nTria plebis millia;"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Panes Legis primitivi,\nUna fiant adoptivi\nFide duo populi;\nNempes duos unum fecit,\nCum duobus se praefecit\nLapis caput anguli."
+                "la": "O quam felix, quam festiva\nDies, in qua primitiva\nConditur Ecclesia,\nSunt primitias jam vivae,\nNeonatae Matris Divae\nTria plebis millia;\n\nPanes Legis primitivi,\nUna fiant adoptivi\nFide duo populi;\nNempes duos unum fecit,\nCum duobus se praefecit\nLapis caput anguli."
               }
             },
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Ure igne, etc. cum Oratione."
+                "la": "versus Ure igne, etc. cum Oratione."
               }
             }
           ]
@@ -237,31 +337,44 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Veni Sancte Spiritus, reple, etc.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Veni Sancte Spiritus, reple, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Tu perversos corde vitas,\nSed sinceros mente ditas\nDono sapientiae,\nVeritatem notam facis,\nEt ostendis viam pacis,\nSemitas justitiae."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Dat liquorem Helisaeus,\nLargum fundit rorem Deus,\nUbi vasa vacua,\nUtres novi non vetusti\nSunt capaces novi musti,\nSint et nostra pectora."
+                "la": "Tu perversos corde vitas,\nSed sinceros mente ditas\nDono sapientiae,\nVeritatem notam facis,\nEt ostendis viam pacis,\nSemitas justitiae.\n\nDat liquorem Helisaeus,\nLargum fundit rorem Deus,\nUbi vasa vacua,\nUtres novi non vetusti\nSunt capaces novi musti,\nSint et nostra pectora."
               }
             },
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Ure igne, etc. cum Oratione."
+                "la": "versus Ure igne, etc. cum Oratione."
               }
             }
           ]
@@ -277,31 +390,44 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Veni Sancte Spiritus, reple, etc.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Veni Sancte Spiritus, reple, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Sed nec musto vel liquore,\nNec hoc digni sumus rore,\nSi discordes moribus.\nIn obscuris vel divis,\nSancta nequit Paraclysis\nHabitare cordibus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Consolator ergo veni,\nLinguas rege, corda leni,\nPelle fel et toxica,\nNil salubre, nil serenum,\nNihil dulce, nihil plenum,\nSine tua gratia."
+                "la": "Sed nec musto vel liquore,\nNec hoc digni sumus rore,\nSi discordes moribus.\nIn obscuris vel divis,\nSancta nequit Paraclysis\nHabitare cordibus.\n\nConsolator ergo veni,\nLinguas rege, corda leni,\nPelle fel et toxica,\nNil salubre, nil serenum,\nNihil dulce, nihil plenum,\nSine tua gratia."
               }
             },
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Ure igne, etc. cum Oratione."
+                "la": "versus Ure igne, etc. cum Oratione."
               }
             }
           ]
@@ -317,31 +443,44 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Veni Sancte Spiritus, reple, etc.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Veni Sancte Spiritus, reple, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O ter salubre unguentum!\nAquae ditans elementum\nSacro in baptismate!\nTe laudamus mente pura,\nPrius irae, ex natura,\nGratiae nunc filii!"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Tu quid dator es et donum,\nEx quo omne fluit bonum,\nCor perfunde gaudio,\nTange mentem, purga sordes,\nVinclo pacis fac concordes,\nJugi sis praesidio."
+                "la": "O ter salubre unguentum!\nAquae ditans elementum\nSacro in baptismate!\nTe laudamus mente pura,\nPrius irae, ex natura,\nGratiae nunc filii!\n\nTu quid dator es et donum,\nEx quo omne fluit bonum,\nCor perfunde gaudio,\nTange mentem, purga sordes,\nVinclo pacis fac concordes,\nJugi sis praesidio."
               }
             },
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Ure igne, etc. cum Oratione."
+                "la": "versus Ure igne, etc. cum Oratione."
               }
             }
           ]
@@ -357,31 +496,57 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Veni Sancte Spiritus, reple, etc.\n℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Veni Sancte Spiritus, reple, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Sicut post Ascensum Christi\nRudes linguis inbuisti\nVaris discipulos,\nSic nos vise, sic dignare,\nDissidentes congregare,\nUna fide populos."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Demum mortis ab hac valle\nDuc ad vitam recto calle,\nLaetos de victoria,\nUbi Patris, ubi tui,\nEt aeterni Verbi frui\nMereamur gloria."
+                "la": "Sicut post Ascensum Christi\nRudes linguis inbuisti\nVaris discipulos,\nSic nos vise, sic dignare,\nDissidentes congregare,\nUna fide populos.\n\nDemum mortis ab hac valle\nDuc ad vitam recto calle,\nLaetos de victoria,\nUbi Patris, ubi tui,\nEt aeterni Verbi frui\nMereamur gloria."
               }
             },
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Ure igne, etc. cum Oratione."
+                "la": "versus Ure igne, etc. cum Oratione."
               }
             }
           ]

--- a/content/practices/little-office-holy-ghost/flow.json
+++ b/content/practices/little-office-holy-ghost/flow.json
@@ -14,27 +14,48 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Domine, labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine, labia mea aperies."
+          },
+          "r": {
+            "la": "Et os meum annuntiabit laudem tuam."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Converte nos, Deus salutaris noster."
+          },
+          "r": {
+            "la": "Et averte iram tuam a nobis."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Deus, in adjutorium meum intende."
+          },
+          "r": {
+            "la": "Domine, ad adjuvandum me festina."
+          }
+        }
+      ]
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis."
-      }
-    },
-    {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina."
-      }
-    },
-    {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Gloria Patri. Alleluia."
+        "la": "Gloria Patri. Alleluia."
       }
     },
     {
@@ -182,7 +203,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Ant."
       }
@@ -194,15 +215,28 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Emitte Spiritum tuum, et creabuntur.\n℟. Et renovabis faciem terrae."
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Emitte Spiritum tuum, et creabuntur."
+          },
+          "r": {
+            "la": "Et renovabis faciem terrae."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nAdsit nobis, quaesumus,\nDomine, virtus Spiritus sancti,\nquae et corda nostra clementer expurget,\net ab omnibus tueatur adversis.\nPer Dominum."
+        "la": "Adsit nobis, quaesumus,\nDomine, virtus Spiritus sancti,\nquae et corda nostra clementer expurget,\net ab omnibus tueatur adversis.\nPer Dominum."
       }
     },
     {

--- a/content/practices/little-office-holy-innocents/flow.json
+++ b/content/practices/little-office-holy-innocents/flow.json
@@ -33,31 +33,51 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Mirum plane rerum thema!\nChristo negans diadema\nRex Herodes impius,\nRosas legit, serta nectit,\nIpseque coronas nectit\nPueris infantibus;"
+                "la": "Mirum plane rerum thema!\nChristo negans diadema\nRex Herodes impius,\nRosas legit, serta nectit,\nIpseque coronas nectit\nPueris infantibus;\n\nDum praeclaros Milites\nChristi Jesu exultantis,\nViam Crucis incohantis,\nPromovet in Martyres."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Dum praeclaros Milites\nChristi Jesu exultantis,\nViam Crucis incohantis,\nPromovet in Martyres."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -69,15 +89,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Agnelli debent immolari,\n℟. Quia Agnus debebit crucifigi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Agnelli debent immolari,"
+                  },
+                  "r": {
+                    "la": "Quia Agnus debebit crucifigi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, cujus praeconium Innocentes Martyres non loquendo, sed moriendo confessi sunt: Omnia in nobis vitiorum mala mortifica, ut fidem tuam, quam lingua nostra loquitur, moribus etiam vita fateatur. Per Dominum nostrum etc."
+                "la": "Deus, cujus praeconium Innocentes Martyres non loquendo, sed moriendo confessi sunt: Omnia in nobis vitiorum mala mortifica, ut fidem tuam, quam lingua nostra loquitur, moribus etiam vita fateatur. Per Dominum nostrum etc."
               }
             }
           ]
@@ -91,31 +124,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Sed et Mater Jesu chara,\nVirgo Virginum praeclara\nCampos per Aegyptios\nLilia jam nive tincta,\nLauro viridi distincta\nCongerit in calathos:"
+                "la": "Sed et Mater Jesu chara,\nVirgo Virginum praeclara\nCampos per Aegyptios\nLilia jam nive tincta,\nLauro viridi distincta\nCongerit in calathos:\n\nVobis, casti Martyres,\nUt coronas ex his formet,\nHisque vestros exornet\nVirgin ales vertices."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Vobis, casti Martyres,\nUt coronas ex his formet,\nHisque vestros exornet\nVirgin ales vertices."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -127,10 +167,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Innocentes illi debentur victima,\n℟. Qui venit damnare mundi malitiam."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Innocentes illi debentur victima,"
+                  },
+                  "r": {
+                    "la": "Qui venit damnare mundi malitiam."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -149,31 +196,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "En jam invide Tyranne!\nArma tua tibi sannae\nFiunt et opprobrium,\nTu dum ipsemet coronas,\nUnum Regno ut seponas,\nTotum agmen prolium;"
+                "la": "En jam invide Tyranne!\nArma tua tibi sannae\nFiunt et opprobrium,\nTu dum ipsemet coronas,\nUnum Regno ut seponas,\nTotum agmen prolium;\n\nDic, quae haec dementia?\nPupos ferro sustulisti,\nPer quod ipse succidisti\nVitae tibi stamina."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Dic, quae haec dementia?\nPupos ferro sustulisti,\nPer quod ipse succidisti\nVitae tibi stamina."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -185,10 +239,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Jacebunt mali ante bonos,\n℟. Et impii ante portas justorum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Jacebunt mali ante bonos,"
+                  },
+                  "r": {
+                    "la": "Et impii ante portas justorum."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -207,31 +268,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Saevit chalybs in infantes,\nMatres ingemunt balantes,\nProles lugent bimulas,\nJesulum quae jam sectantur,\nCumque Matre comitantur\nOras per Niliacas;"
+                "la": "Saevit chalybs in infantes,\nMatres ingemunt balantes,\nProles lugent bimulas,\nJesulum quae jam sectantur,\nCumque Matre comitantur\nOras per Niliacas;\n\nCaela rigent corpora,\nSed animulae dilectae\nJesu gratiae refectae\nNon sensere funera."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Caela rigent corpora,\nSed animulae dilectae\nJesu gratiae refectae\nNon sensere funera."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -243,10 +311,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Oves ululant Matres,\n℟. Quia Agnos perdunt sine voce balantes."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Oves ululant Matres,"
+                  },
+                  "r": {
+                    "la": "Quia Agnos perdunt sine voce balantes."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -265,31 +340,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Respirate lachrymosae\nMatres, Matris dolorosae\nJam sub Cruce symbola!\nNatis vestris una datum\nCaede mori: Sed hunc Natum\nMille iterent vulnera,"
+                "la": "Respirate lachrymosae\nMatres, Matris dolorosae\nJam sub Cruce symbola!\nNatis vestris una datum\nCaede mori: Sed hunc Natum\nMille iterent vulnera,\n\nCujus quondam rigidus\nAnimam et Matris flentem,\nContristantem ac dolentem\nPertransibit gladius."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Cujus quondam rigidus\nAnimam et Matris flentem,\nContristantem ac dolentem\nPertransibit gladius."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -301,10 +383,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Cum Tyrannus jactabat infantes,\n℟. Matres crines capitis dissipab"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Cum Tyrannus jactabat infantes,"
+                  },
+                  "r": {
+                    "la": "Matres crines capitis dissipab"
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -323,25 +412,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Eja! moestae genitrices!\nPlausus date jam victrices\nParvulis Heroibus,\nHilares indutae vultus\nTristes ponite singultus,\nCernite, quam inclitus\nSanguis vester rosea\nMartyrum futuri Regis,\nNove Platis quondam Legis,\nJam micescat purpura."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -353,10 +455,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Effuderunt sanguinem Sanctorum,\n℟. Velut aquam in circuitu Jerusalem."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Effuderunt sanguinem Sanctorum,"
+                  },
+                  "r": {
+                    "la": "Velut aquam in circuitu Jerusalem."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -375,25 +484,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Cernite, quo vestimento\nVirginali ex argento\nInnocentis animi,\nJesu Mater, chare Matres!\nNatos vestros sui fratres\nExornarit Filii;\nParadyso gaudiis\nUna se jam delectantes,\nLaetos Christum exspectantes\nReducem a mortuis."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -405,10 +527,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Isti sunt, qui non inquinaverunt vestimenta sua,\n℟. Ambulabunt mecum in albis, quia digni sunt."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Isti sunt, qui non inquinaverunt vestimenta sua,"
+                  },
+                  "r": {
+                    "la": "Ambulabunt mecum in albis, quia digni sunt."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -427,25 +556,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Christo Crucem sed perpesso,\nEt a mortuis regressso\nQui coelorum Principi\nAnte thronum jam servitis,\nSplendidaque superbitiis\nPurpura Martyrii;\nVestro nos precamine\nPromptos, simul, atque fortes\nPer adversitatum sortes\nHic in terris reddite."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -457,10 +612,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Hi empti sunt ex hominibus,\n℟. Primitiae Deo et Agno."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Hi empti sunt ex hominibus,"
+                  },
+                  "r": {
+                    "la": "Primitiae Deo et Agno."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -485,7 +647,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Ant."
       }
@@ -497,13 +659,20 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Orate pro nobis SS. Innocentes,\n℟. Ut digni efficiamur promissionibus Christi."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Orate pro nobis SS. Innocentes,"
+          },
+          "r": {
+            "la": "Ut digni efficiamur promissionibus Christi."
+          }
+        }
+      ]
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Oratio"
       }

--- a/content/practices/little-office-holy-name-of-god/flow.json
+++ b/content/practices/little-office-holy-name-of-god/flow.json
@@ -29,12 +29,34 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater noster.\n℣. Domine, labia mea aperies.\n℟. Et os meum exaltabit Nomen tuum.\nUsquequo, Deus, improperavit inimicus? irritat adversarius Nomen tuum in finem?\nNescient quia tu ipse es Deus noster, qui conteris bella, et Dominus Nomen est tibi.\nImple facies eorum ignominia, et quaerent Nomen tuum, Domine.\nConfiteantur Nomini tuo magno, quoniam terribile et sanctum est.\nEt benedicant Nomini gloriae tuae excelsi, in omni laude et benedictione.\nGloria Patri.",
-                "en-US": "Our Father.\n℣. Lord, Thou wilt open my lips.\n℟. And my mouth shall extol Thy Name.\nHow long, O God, shall the enemy outrage Thee? Is the adversary to provoke Thy Name forever?\nThey know not that Thou art our God, who destroyest wars from the beginning, and that the Lord is Thy Name.\nFill their faces with shame, and they shall seek Thy Name, O Lord.\nLet them give praise to Thy great Name: because it is terrible and holy.\nAnd blessed be the great Name of Thy glory with all blessing and praise.\nGlory be to the Father."
+                "la": "Pater noster.",
+                "en-US": "Our Father."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies.",
+                    "en-US": "Lord, Thou wilt open my lips."
+                  },
+                  "r": {
+                    "la": "Et os meum exaltabit Nomen tuum.",
+                    "en-US": "And my mouth shall extol Thy Name."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Usquequo, Deus, improperavit inimicus? irritat adversarius Nomen tuum in finem?\nNescient quia tu ipse es Deus noster, qui conteris bella, et Dominus Nomen est tibi.\nImple facies eorum ignominia, et quaerent Nomen tuum, Domine.\nConfiteantur Nomini tuo magno, quoniam terribile et sanctum est.\nEt benedicant Nomini gloriae tuae excelsi, in omni laude et benedictione.\nGloria Patri.",
+                "en-US": "How long, O God, shall the enemy outrage Thee? Is the adversary to provoke Thy Name forever?\nThey know not that Thou art our God, who destroyest wars from the beginning, and that the Lord is Thy Name.\nFill their faces with shame, and they shall seek Thy Name, O Lord.\nLet them give praise to Thy great Name: because it is terrible and holy.\nAnd blessed be the great Name of Thy glory with all blessing and praise.\nGlory be to the Father."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -48,7 +70,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum",
                 "en-US": "Chapter"
@@ -57,8 +79,66 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sanctificabo Nomen meum magnum, quod pollutum est inter gentes, dicit Dominus: et assumam zelum pro Nomine sancto meo, ut sciant gentes quia ego Dominus.\n℟. Deo gratias.\n℣. Quis non timebit te, Domine?\n℟. Et magnificabit Nomen tuum?\nOremus,\nDeus, cujus sanctum et terribile Nomen jugiter tota die blasphematur, illumina oculos improperantium tibi, ut majestatem tui Nominis agnoscentes, illud nobiscum et reveraentur et ament. Per Dominum.\n℣. Sit Nomen Domini benedictum.\n℟. Ex hoc nunc, et usque in saeculum.\nAmen.",
-                "en-US": "I will sanctify my great Name, which was profaned among the Gentiles, saith the Lord; and I will become jealous for the honour of my holy Name in order that the nations may know that I am the Lord.\n℟. Let us give thanks to God.\n℣. Who shall not fear Thee, O Lord?\n℟. And who shall not magnify Thy Name?\nLet us pray,\nO God, whose holy and terrible Name is unceasingly profaned by blasphemers, lighten the eyes of those who outrage Thee, that confessing the majesty of Thy Name, they may, together with us, revere and love it. Through Jesus Christ our Lord.\n℣. May the Name of the Lord be blessed.\n℟. Now and for ever.\nAmen."
+                "la": "Sanctificabo Nomen meum magnum, quod pollutum est inter gentes, dicit Dominus: et assumam zelum pro Nomine sancto meo, ut sciant gentes quia ego Dominus.",
+                "en-US": "I will sanctify my great Name, which was profaned among the Gentiles, saith the Lord; and I will become jealous for the honour of my holy Name in order that the nations may know that I am the Lord."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Let us give thanks to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Quis non timebit te, Domine?",
+                    "en-US": "Who shall not fear Thee, O Lord?"
+                  },
+                  "r": {
+                    "la": "Et magnificabit Nomen tuum?",
+                    "en-US": "And who shall not magnify Thy Name?"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, cujus sanctum et terribile Nomen jugiter tota die blasphematur, illumina oculos improperantium tibi, ut majestatem tui Nominis agnoscentes, illud nobiscum et reveraentur et ament. Per Dominum.",
+                "en-US": "O God, whose holy and terrible Name is unceasingly profaned by blasphemers, lighten the eyes of those who outrage Thee, that confessing the majesty of Thy Name, they may, together with us, revere and love it. Through Jesus Christ our Lord."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sit Nomen Domini benedictum.",
+                    "en-US": "May the Name of the Lord be blessed."
+                  },
+                  "r": {
+                    "la": "Ex hoc nunc, et usque in saeculum.",
+                    "en-US": "Now and for ever."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
               }
             }
           ]
@@ -74,12 +154,34 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater noster.\n℣. Domine, labia mea aperies.\n℟. Et os meum exaltabit Nomen tuum.\nLaudate Dominum de caelis; laudate eum in excelsis.\nLaudate eum, omnes angeli ejus; laudate eum, omnes virtutes ejus.\nLaudate eum, sol et luna; laudate eum, omnes stellae et lumen.\nLaudate eum, caeli caelorum; et aquae omnes quae super caelos sunt laudent Nomen Domini.\nBestiae et universa pecora, serpentes et volucres pennatae;\nReges terrae et omnes populi, principes et omnes judices terrae;\nJuvenes et virgines, senes cum junioribus laudent Nomen Domini, quia exaltatum est Nomen ejus solius.\nGloria Patri.",
-                "en-US": "Our Father.\n℣. Lord, Thou wilt open my lips.\n℟. And my mouth shall extol Thy name.\nPraise ye the Lord from the heavens: praise ye him in the high places.\nPraise ye him, all his angels: praise ye him, all his hosts.\nPraise ye him, sun and moon: praise him, all ye stars and light.\nPraise him, ye heavens of heavens, and let all the waters that are above the heavens praise the name of the Lord.\nPraise him, beasts and all cattle, serpents and feathered fowl;\nKings of the earth and all people, princes and all judges of the earth;\nYoung men and maidens: let the old with the younger, praise the name of the Lord, for his name alone is exalted.\nGlory to the Father."
+                "la": "Pater noster.",
+                "en-US": "Our Father."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies.",
+                    "en-US": "Lord, Thou wilt open my lips."
+                  },
+                  "r": {
+                    "la": "Et os meum exaltabit Nomen tuum.",
+                    "en-US": "And my mouth shall extol Thy name."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Laudate Dominum de caelis; laudate eum in excelsis.\nLaudate eum, omnes angeli ejus; laudate eum, omnes virtutes ejus.\nLaudate eum, sol et luna; laudate eum, omnes stellae et lumen.\nLaudate eum, caeli caelorum; et aquae omnes quae super caelos sunt laudent Nomen Domini.\nBestiae et universa pecora, serpentes et volucres pennatae;\nReges terrae et omnes populi, principes et omnes judices terrae;\nJuvenes et virgines, senes cum junioribus laudent Nomen Domini, quia exaltatum est Nomen ejus solius.\nGloria Patri.",
+                "en-US": "Praise ye the Lord from the heavens: praise ye him in the high places.\nPraise ye him, all his angels: praise ye him, all his hosts.\nPraise ye him, sun and moon: praise him, all ye stars and light.\nPraise him, ye heavens of heavens, and let all the waters that are above the heavens praise the name of the Lord.\nPraise him, beasts and all cattle, serpents and feathered fowl;\nKings of the earth and all people, princes and all judges of the earth;\nYoung men and maidens: let the old with the younger, praise the name of the Lord, for his name alone is exalted.\nGlory to the Father."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -93,7 +195,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum",
                 "en-US": "Chapter"
@@ -102,8 +204,66 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Benedictus es, Domine Deus patrum nostrorum; et laudabilis, et gloriosus, et superexaltatus in saecula, et benedictum Nomen gloriae tuae sanctum, et laudabile, et superexaltatum in omnibus saeculis.\n℟. Deo gratias.\n℣. A solis ortu usque ad occasum.\n℟. Laudabile Nomen Domini.\nOremus,\nConcede nobis, omnipotens Deus, ita Nomen sanctum tuum in terra venerari, ut cum angelis et sanctis tuis in caelo ipsum laudare et exaltare mereamur. Per Dominum.\n℣. Sit Nomen Domini benedictum.\n℟. Ex hoc nunc et usque in saeculum.\nAmen.",
-                "en-US": "Blessed art Thou, O Lord, God of our fathers; and worthy to be praised, and glorified, and exalted above all for ever; and blessed is the holy name of Thy glory: and worthy to be praised, and exalted above all from century to century.\n℟. Thanks be to God.\n℣. From the rising to the setting of the sun.\n℟. The name of the Lord shall be blessed.\nLet us pray,\nGrant to us, almighty God, grace so to venerate thy holy name on earth, that we may merit to praise and bless it with the angels and saints in heaven. Through our Lord Jesus Christ.\n℣. Blessed be the name of the Lord.\n℟. Now and evermore.\nAmen."
+                "la": "Benedictus es, Domine Deus patrum nostrorum; et laudabilis, et gloriosus, et superexaltatus in saecula, et benedictum Nomen gloriae tuae sanctum, et laudabile, et superexaltatum in omnibus saeculis.",
+                "en-US": "Blessed art Thou, O Lord, God of our fathers; and worthy to be praised, and glorified, and exalted above all for ever; and blessed is the holy name of Thy glory: and worthy to be praised, and exalted above all from century to century."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "A solis ortu usque ad occasum.",
+                    "en-US": "From the rising to the setting of the sun."
+                  },
+                  "r": {
+                    "la": "Laudabile Nomen Domini.",
+                    "en-US": "The name of the Lord shall be blessed."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Concede nobis, omnipotens Deus, ita Nomen sanctum tuum in terra venerari, ut cum angelis et sanctis tuis in caelo ipsum laudare et exaltare mereamur. Per Dominum.",
+                "en-US": "Grant to us, almighty God, grace so to venerate thy holy name on earth, that we may merit to praise and bless it with the angels and saints in heaven. Through our Lord Jesus Christ."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sit Nomen Domini benedictum.",
+                    "en-US": "Blessed be the name of the Lord."
+                  },
+                  "r": {
+                    "la": "Ex hoc nunc et usque in saeculum.",
+                    "en-US": "Now and evermore."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
               }
             }
           ]
@@ -119,12 +279,34 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater noster.\n℣. Domine, labia mea aperies.\n℟. Et os meum exaltabit Nomen tuum.\nDeus meus, aperi oculos, et vide desolationem nostram et civitatem super quam invocatum est Nomen tuum.\nExurge; quare obdormis, Domine? Exsurge, Domine, adjuva nos, et redime nos propter Nomen tuum.\nNoli meminisse iniquitatem patrum nostrorum, sed memento manus tuae et Nominis tui in tempore isto.\nPeccavimus cum patribus nostris; injuste egimus, et iniquitatem fecimus.\nSi iniquitates nostrae responderint nobis, Domine, fac propter Nomen tuum; quoniam multae sunt aversiones nostrae, et tibi peccavimus.\nAdjuva nos, Deus salutaris noster, et propter gloriam Nominis tui libera nos, et propitius esto peccatis nostris, propter Nomen tuum.\nGloria Patri.",
-                "en-US": "Our Father.\n℣. Lord, Thou wilt open my lips.\n℟. And my mouth shall extol Thy name.\nMy God, open Thine eyes, and consider our desolation, and the city upon which Thy name is invoked.\nArise, O Lord; why sleepest Thou? Arise, O Lord, help us and redeem us for Thy Name's sake.\nRemember not the iniquities of our fathers, but think at this time upon Thy power and upon Thy Name.\nWe confess that we have sinned with our fathers; that we have acted unjustly, and wrought iniquity.\nIf our iniquities cry out against us, O Lord, nevertheless be merciful to us for Thy Name's sake, for our rebellions are many, we have sinned against Thee.\nHelp us, O God our Saviour; deliver us for the glory of Thy Name, and forgive us our sins for Thy Name's sake.\nGlory be to the Father."
+                "la": "Pater noster.",
+                "en-US": "Our Father."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies.",
+                    "en-US": "Lord, Thou wilt open my lips."
+                  },
+                  "r": {
+                    "la": "Et os meum exaltabit Nomen tuum.",
+                    "en-US": "And my mouth shall extol Thy name."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus meus, aperi oculos, et vide desolationem nostram et civitatem super quam invocatum est Nomen tuum.\nExurge; quare obdormis, Domine? Exsurge, Domine, adjuva nos, et redime nos propter Nomen tuum.\nNoli meminisse iniquitatem patrum nostrorum, sed memento manus tuae et Nominis tui in tempore isto.\nPeccavimus cum patribus nostris; injuste egimus, et iniquitatem fecimus.\nSi iniquitates nostrae responderint nobis, Domine, fac propter Nomen tuum; quoniam multae sunt aversiones nostrae, et tibi peccavimus.\nAdjuva nos, Deus salutaris noster, et propter gloriam Nominis tui libera nos, et propitius esto peccatis nostris, propter Nomen tuum.\nGloria Patri.",
+                "en-US": "My God, open Thine eyes, and consider our desolation, and the city upon which Thy name is invoked.\nArise, O Lord; why sleepest Thou? Arise, O Lord, help us and redeem us for Thy Name's sake.\nRemember not the iniquities of our fathers, but think at this time upon Thy power and upon Thy Name.\nWe confess that we have sinned with our fathers; that we have acted unjustly, and wrought iniquity.\nIf our iniquities cry out against us, O Lord, nevertheless be merciful to us for Thy Name's sake, for our rebellions are many, we have sinned against Thee.\nHelp us, O God our Saviour; deliver us for the glory of Thy Name, and forgive us our sins for Thy Name's sake.\nGlory be to the Father."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -138,7 +320,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum",
                 "en-US": "Chapter"
@@ -147,8 +329,66 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Si conversus autem populus meus, super quos invocatum est Nomen meum, deprecatus me fuerit, et exquisierit faciem meam, et egerit poenitentiam a viis suis pessimis, et ego exaudiam de caelo, et propitius ero peccatis eorum.\n℟. Deo gratias.\n℣. In eo laetabitur cor nostrum.\n℟. Et in Nomine sancto ejus speravimus.\nOremus,\nIneffabilem nobis, Domine, propter Nomen sanctum tuum, misericordiam tuam clementer ostende, ut simul nos, et a peccatis omnibus exuas et a poenis quas pro his mereamur eripias. Per Dominum.\n℣. Sit Nomen Domini benedictum.\n℟. Ex hoc nunc et usque in saeculum.\nAmen.",
-                "en-US": "And my people, upon whom my Name is called being converted, shall make supplication to me, and seek out my Face; and do penance for their most wicked ways: then will I hear from heaven, and will pardon their sins.\n℟. Let us give thanks to God.\n℣. Our heart finds its joy in him.\n℟. And we hope in his holy Name.\nLet us pray,\nDeign, O Lord, for Thy Name's sake, to show to us thy mercy that we may be delivered, both from our sins and from the chastisements they have deserved. Through our Lord Jesus Christ.\n℣. Blessed be the Name of the Lord.\n℟. Now and for evermore.\nAmen."
+                "la": "Si conversus autem populus meus, super quos invocatum est Nomen meum, deprecatus me fuerit, et exquisierit faciem meam, et egerit poenitentiam a viis suis pessimis, et ego exaudiam de caelo, et propitius ero peccatis eorum.",
+                "en-US": "And my people, upon whom my Name is called being converted, shall make supplication to me, and seek out my Face; and do penance for their most wicked ways: then will I hear from heaven, and will pardon their sins."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Let us give thanks to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In eo laetabitur cor nostrum.",
+                    "en-US": "Our heart finds its joy in him."
+                  },
+                  "r": {
+                    "la": "Et in Nomine sancto ejus speravimus.",
+                    "en-US": "And we hope in his holy Name."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Ineffabilem nobis, Domine, propter Nomen sanctum tuum, misericordiam tuam clementer ostende, ut simul nos, et a peccatis omnibus exuas et a poenis quas pro his mereamur eripias. Per Dominum.",
+                "en-US": "Deign, O Lord, for Thy Name's sake, to show to us thy mercy that we may be delivered, both from our sins and from the chastisements they have deserved. Through our Lord Jesus Christ."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sit Nomen Domini benedictum.",
+                    "en-US": "Blessed be the Name of the Lord."
+                  },
+                  "r": {
+                    "la": "Ex hoc nunc et usque in saeculum.",
+                    "en-US": "Now and for evermore."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
               }
             },
             {
@@ -159,7 +399,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -173,7 +413,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum",
                 "en-US": "Chapter"
@@ -182,8 +422,66 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Turris fortissima Nomen Domini: ad ipsum currit justus, et exaltabitur.\n℟. Deo gratias.\n℣. Benedic, anima mea, Domino.\n℟. Et omnia quae intra me sunt, Nomini sancto ejus.\nOremus,\nDanobis, omnipotens et sempiterne Deus, Nomen sanctum tuum ita pura mente benedicere et fiducialiter invocare, ut quodcumque sic petierimus obtinere mereamur. Per Dominum.\n℣. Sit Nomen Domini benedictum.\n℟. Ex hoc nunc et usque in saeculum.\nAmen.",
-                "en-US": "The Name of the Lord is a strong tower: the just runneth to it, and shall be exalted.\n℟. Thanks be to God.\n℣. Bless the Lord, O my soul.\n℟. And let all that is within me bless his Holy Name.\nLet us pray,\nGrant us, almighty and eternal God, grace to bless Thy Name with such pure heart and to invoke it with such confidence, that we may deserve to obtain all that we have asked of Thee. Through Jesus Christ.\n℣. Blessed be the Name of the Lord.\n℟. From this time forth, for evermore.\nAmen."
+                "la": "Turris fortissima Nomen Domini: ad ipsum currit justus, et exaltabitur.",
+                "en-US": "The Name of the Lord is a strong tower: the just runneth to it, and shall be exalted."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedic, anima mea, Domino.",
+                    "en-US": "Bless the Lord, O my soul."
+                  },
+                  "r": {
+                    "la": "Et omnia quae intra me sunt, Nomini sancto ejus.",
+                    "en-US": "And let all that is within me bless his Holy Name."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Danobis, omnipotens et sempiterne Deus, Nomen sanctum tuum ita pura mente benedicere et fiducialiter invocare, ut quodcumque sic petierimus obtinere mereamur. Per Dominum.",
+                "en-US": "Grant us, almighty and eternal God, grace to bless Thy Name with such pure heart and to invoke it with such confidence, that we may deserve to obtain all that we have asked of Thee. Through Jesus Christ."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sit Nomen Domini benedictum.",
+                    "en-US": "Blessed be the Name of the Lord."
+                  },
+                  "r": {
+                    "la": "Ex hoc nunc et usque in saeculum.",
+                    "en-US": "From this time forth, for evermore."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
               }
             }
           ]
@@ -199,12 +497,34 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater noster.\n℣. Domine, labia mea aperies.\n℟. Et os meum exaltabit Nomen tuum.\nExaltabo te, Deus meus Rex, et benedicam Nomen tuum in saeculum et in saeculum saeculi.\nEt in conspectu angelorum psallam tibi; adorabo ad templum sanctum tuum, et confitebor Nomini tuo.\nPer singulos dies benedicam tibi, et laudabo Nomen tuum, in saeculum et in saeculum saeculi.\nSic benedicam te in vita mea, et in Nomine tuo levabo manus meas.\nEt tu, Domine, fac mecum propter Nomen tuum, quia suavis est misericordia tua.\nAspice in me, et miserere mei, secundum judicium diligentium Nomen tuum.\nExultabit cor meum in salutare tuo; cantabo Domino qui bona tribuit mihi, et psallam Nomini Domini altissimi.\nGloria Patri.",
-                "en-US": "Our Father.\n℣. Lord, Thou wilt open my lips.\n℟. And my mouth shall extol Thy Name.\nI will extol Thee, O God my king: and I will bless Thy Name for ever, yea for ever and ever.\nI will sing praise to Thee in the sight of the angels: I will worship towards Thy holy temple, and I will give glory to Thy Name.\nEvery day I will bless Thee: and I will praise Thy Name for ever, yea for ever and ever.\nI will bless Thee as long as I live: and in Thy Name I will lift up my hands to heaven.\nAnd Thou, O Lord, defend me for Thy Name's sake: because Thy mercy is sweet.\nLook upon me, O Lord, and have mercy on me, according to the judgment of them that love Thy Name.\nMy heart will thrill with joy in Thy salvation: I will sing to the Lord, who giveth me good things: yea I will sing to the Name of the Lord the most High.\nGlory be to the Father."
+                "la": "Pater noster.",
+                "en-US": "Our Father."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies.",
+                    "en-US": "Lord, Thou wilt open my lips."
+                  },
+                  "r": {
+                    "la": "Et os meum exaltabit Nomen tuum.",
+                    "en-US": "And my mouth shall extol Thy Name."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Exaltabo te, Deus meus Rex, et benedicam Nomen tuum in saeculum et in saeculum saeculi.\nEt in conspectu angelorum psallam tibi; adorabo ad templum sanctum tuum, et confitebor Nomini tuo.\nPer singulos dies benedicam tibi, et laudabo Nomen tuum, in saeculum et in saeculum saeculi.\nSic benedicam te in vita mea, et in Nomine tuo levabo manus meas.\nEt tu, Domine, fac mecum propter Nomen tuum, quia suavis est misericordia tua.\nAspice in me, et miserere mei, secundum judicium diligentium Nomen tuum.\nExultabit cor meum in salutare tuo; cantabo Domino qui bona tribuit mihi, et psallam Nomini Domini altissimi.\nGloria Patri.",
+                "en-US": "I will extol Thee, O God my king: and I will bless Thy Name for ever, yea for ever and ever.\nI will sing praise to Thee in the sight of the angels: I will worship towards Thy holy temple, and I will give glory to Thy Name.\nEvery day I will bless Thee: and I will praise Thy Name for ever, yea for ever and ever.\nI will bless Thee as long as I live: and in Thy Name I will lift up my hands to heaven.\nAnd Thou, O Lord, defend me for Thy Name's sake: because Thy mercy is sweet.\nLook upon me, O Lord, and have mercy on me, according to the judgment of them that love Thy Name.\nMy heart will thrill with joy in Thy salvation: I will sing to the Lord, who giveth me good things: yea I will sing to the Name of the Lord the most High.\nGlory be to the Father."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -218,7 +538,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum",
                 "en-US": "Chapter"
@@ -227,8 +547,66 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Turris fortissima Nomen Domini: ad ipsum currit justus, et exaltabitur.\n℟. Deo gratias.\n℣. Benedic, anima mea, Domino.\n℟. Et omnia quae intra me sunt, Nomini sancto ejus.\nOremus,\nDa nobis, omnipotens et sempiterne Deus, Nomen sanctum tuum ita pura mente benedicere et fiducialiter invocare, ut quodcumque sic petierimus obtinere mereamur. Per Dominum.\n℣. Sit Nomen Domini benedictum.\n℟. Ex hoc nunc et usque in saeculum.\nAmen.",
-                "en-US": "The Name of the Lord is a strong tower: the just runneth to it, and shall be exalted.\n℟. Thanks be to God.\n℣. Bless the Lord, O my soul.\n℟. And let all that is within me bless his Holy Name.\nLet us pray,\nGrant us, almighty and eternal God, grace to bless Thy Name with such pure heart and to invoke it with such confidence, that we may deserve to obtain all that we have asked of Thee. Through Jesus Christ.\n℣. Blessed be the Name of the Lord.\n℟. From this time forth, for evermore.\nAmen."
+                "la": "Turris fortissima Nomen Domini: ad ipsum currit justus, et exaltabitur.",
+                "en-US": "The Name of the Lord is a strong tower: the just runneth to it, and shall be exalted."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedic, anima mea, Domino.",
+                    "en-US": "Bless the Lord, O my soul."
+                  },
+                  "r": {
+                    "la": "Et omnia quae intra me sunt, Nomini sancto ejus.",
+                    "en-US": "And let all that is within me bless his Holy Name."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Da nobis, omnipotens et sempiterne Deus, Nomen sanctum tuum ita pura mente benedicere et fiducialiter invocare, ut quodcumque sic petierimus obtinere mereamur. Per Dominum.",
+                "en-US": "Grant us, almighty and eternal God, grace to bless Thy Name with such pure heart and to invoke it with such confidence, that we may deserve to obtain all that we have asked of Thee. Through Jesus Christ."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sit Nomen Domini benedictum.",
+                    "en-US": "Blessed be the Name of the Lord."
+                  },
+                  "r": {
+                    "la": "Ex hoc nunc et usque in saeculum.",
+                    "en-US": "From this time forth, for evermore."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
               }
             }
           ]
@@ -244,12 +622,34 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater noster.\n℣. Domine, labia mea aperies.\n℟. Et os meum exaltabit Nomen tuum.\nBeatus vir cujus est Nomen Domini spes ejus, et non respexit in vanitates et insania falsas.\nCircumdantes circumdederunt me; et in Nomine Domini quia ultus sum in eos.\nCircumdederunt me sicut apes, et exarserunt sicut ignis in spinis; et in Nomine Domini, quia ultus sum in eos.\nConfitebor Nomini tuo, Domine, quoniam adjutor et protector factus es mihi.\nEt liberasti me, secundum multitudinem misericordiae Nominis tui, de manibus quaerentium animam meam.\nSperent in te qui noverunt Nomen tuum, quoniam non dereliquisti quaerentes te, Domine.\nPropterea confitebor tibi in nationibus, Domine, et Nomini tuo psalmum dicam.\nGloria Patri.",
-                "en-US": "Our Father.\n℣. Lord, Thou wilt open my lips.\n℟. And my mouth shall extol Thy Name.\nBlessed is the man whose trust is in the Name of the Lord; and who hath not had regard to vanities, and lying follies.\nMy enemies have surrounded me and compassed me about: and in the Name of the Lord, I have been revenged on them.\nThey surrounded me like bees, and they burnt like fire among thorns: and in the Name of the Lord I was revenged on them.\nI will give glory to Thy Name, O Lord: for Thou hast been a helper and protector to me.\nAnd Thou hast delivered me, according to the multitude of the mercy of Thy Name from the hands of those who sought after my life.\nLet those who know Thy Name trust in Thee: for Thou hast not forsaken those who seek Thee, O Lord.\nTherefore, O Lord, I will confess Thee among the nations; and I will sing a psalm to the glory of Thy Name.\nGlory to the Father."
+                "la": "Pater noster.",
+                "en-US": "Our Father."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies.",
+                    "en-US": "Lord, Thou wilt open my lips."
+                  },
+                  "r": {
+                    "la": "Et os meum exaltabit Nomen tuum.",
+                    "en-US": "And my mouth shall extol Thy Name."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Beatus vir cujus est Nomen Domini spes ejus, et non respexit in vanitates et insania falsas.\nCircumdantes circumdederunt me; et in Nomine Domini quia ultus sum in eos.\nCircumdederunt me sicut apes, et exarserunt sicut ignis in spinis; et in Nomine Domini, quia ultus sum in eos.\nConfitebor Nomini tuo, Domine, quoniam adjutor et protector factus es mihi.\nEt liberasti me, secundum multitudinem misericordiae Nominis tui, de manibus quaerentium animam meam.\nSperent in te qui noverunt Nomen tuum, quoniam non dereliquisti quaerentes te, Domine.\nPropterea confitebor tibi in nationibus, Domine, et Nomini tuo psalmum dicam.\nGloria Patri.",
+                "en-US": "Blessed is the man whose trust is in the Name of the Lord; and who hath not had regard to vanities, and lying follies.\nMy enemies have surrounded me and compassed me about: and in the Name of the Lord, I have been revenged on them.\nThey surrounded me like bees, and they burnt like fire among thorns: and in the Name of the Lord I was revenged on them.\nI will give glory to Thy Name, O Lord: for Thou hast been a helper and protector to me.\nAnd Thou hast delivered me, according to the multitude of the mercy of Thy Name from the hands of those who sought after my life.\nLet those who know Thy Name trust in Thee: for Thou hast not forsaken those who seek Thee, O Lord.\nTherefore, O Lord, I will confess Thee among the nations; and I will sing a psalm to the glory of Thy Name.\nGlory to the Father."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -263,7 +663,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum",
                 "en-US": "Chapter"
@@ -272,8 +672,66 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Qui ambulaverit in tenebris et non est lumen ei, speret in Nomine Domini, et innitetur super Deum suum.\n℟. Deo gratias.\n℣. In te, Domine, inimicos nostros ventilabimus cornu.\n℟. Et in Nomine tuo spernemus insurgentes in nobis.\nOremus,\nDeus, qui in Nomine tuo sperantes nunquam deseris, concede fragilitati nostrae praesidium; ut sancti Nominis tui protectione muniti, omnia salutis nostrae adversantia superare valeamus. Per Dominum.\n℣. Sit Nomen Domini benedictum.\n℟. Ex hoc nunc et usque in saeculum.\nAmen.",
-                "en-US": "Let him who hath walked in darkness and who hath no light, hope in the Name of the Lord, and lean upon his God.\n℟. Thanks be to God.\n℣. In Thee, O Lord, we shall have strength to fight against our enemies.\n℟. And in Thy Name we will despise those who rise up against us.\nLet us pray,\nO God, who never forsakest those who hope in Thy Name, grant us Thy help in our weakness, so that under the protection of Thy holy Name we may triumph over all the obstacles which we may encounter in the way of salvation. Through Jesus Christ our Lord.\n℣. May the Name of the Lord be blessed.\n℟. Now and for evermore.\nAmen."
+                "la": "Qui ambulaverit in tenebris et non est lumen ei, speret in Nomine Domini, et innitetur super Deum suum.",
+                "en-US": "Let him who hath walked in darkness and who hath no light, hope in the Name of the Lord, and lean upon his God."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In te, Domine, inimicos nostros ventilabimus cornu.",
+                    "en-US": "In Thee, O Lord, we shall have strength to fight against our enemies."
+                  },
+                  "r": {
+                    "la": "Et in Nomine tuo spernemus insurgentes in nobis.",
+                    "en-US": "And in Thy Name we will despise those who rise up against us."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui in Nomine tuo sperantes nunquam deseris, concede fragilitati nostrae praesidium; ut sancti Nominis tui protectione muniti, omnia salutis nostrae adversantia superare valeamus. Per Dominum.",
+                "en-US": "O God, who never forsakest those who hope in Thy Name, grant us Thy help in our weakness, so that under the protection of Thy holy Name we may triumph over all the obstacles which we may encounter in the way of salvation. Through Jesus Christ our Lord."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sit Nomen Domini benedictum.",
+                    "en-US": "May the Name of the Lord be blessed."
+                  },
+                  "r": {
+                    "la": "Ex hoc nunc et usque in saeculum.",
+                    "en-US": "Now and for evermore."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
               }
             }
           ]
@@ -289,12 +747,34 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater noster.\n℣. Domine, labia mea aperies.\n℟. Et os meum exaltabit Nomen tuum.\nDomine Deus noster, quam admirabile est Nomen tuum in universa terra!\nNon est similis tui, Domine: magnus es tu, et magnum Nomen tuum in fortitudine.\nQuis non timebit te, et magnificabit Nomen tuum?\nSit auris tua attendens adorationem servorum tuorum qui volunt timere Nomen tuum.\nTu exaudies de caelo, in firmamento habitaculi tui, ut discant universi populi terrarum Nomen tuum timere, sicut populus tuus Israel.\nEt omnes gentes, quascumque fecisti, venient, et adorabunt coram te, et glorificabunt Nomen tuum.\nSecundum Nomen tuum, sic et laus tua in fines terrae.\nEt memores erunt Nominis tui in omni generatione et generationem.\nGloria Patri.",
-                "en-US": "Our Father.\n℣. Lord, Thou open wilt my lips.\n℟. And my mouth shall extol Thy Name.\nO Lord our God, how admirable is Thy Name throughout the whole earth!\nThere is none like to Thee, O Lord: Thou art great, and great is Thy Name in might.\nWho shall not fear Thee, O Lord, and magnify Thy Name?\nLet Thy ear, Lord, be attentive to the prayer of Thy servants who desire to fear Thy Name.\nThou wilt hear us from the firmament where Thou dwellest, in order that all people, throughout the whole earth, may learn to fear Thy Name, like Thy people Israel.\nAnd all the nations Thou hast made shall come and adore before Thee, O Lord: and they shall glorify Thy Name.\nAccording to Thy Name O God, so also is Thy praise unto the ends of the earth.\nAnd Thy Name shall be remembered from generation to generation.\nGlory to the Father."
+                "la": "Pater noster.",
+                "en-US": "Our Father."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies.",
+                    "en-US": "Lord, Thou open wilt my lips."
+                  },
+                  "r": {
+                    "la": "Et os meum exaltabit Nomen tuum.",
+                    "en-US": "And my mouth shall extol Thy Name."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Domine Deus noster, quam admirabile est Nomen tuum in universa terra!\nNon est similis tui, Domine: magnus es tu, et magnum Nomen tuum in fortitudine.\nQuis non timebit te, et magnificabit Nomen tuum?\nSit auris tua attendens adorationem servorum tuorum qui volunt timere Nomen tuum.\nTu exaudies de caelo, in firmamento habitaculi tui, ut discant universi populi terrarum Nomen tuum timere, sicut populus tuus Israel.\nEt omnes gentes, quascumque fecisti, venient, et adorabunt coram te, et glorificabunt Nomen tuum.\nSecundum Nomen tuum, sic et laus tua in fines terrae.\nEt memores erunt Nominis tui in omni generatione et generationem.\nGloria Patri.",
+                "en-US": "O Lord our God, how admirable is Thy Name throughout the whole earth!\nThere is none like to Thee, O Lord: Thou art great, and great is Thy Name in might.\nWho shall not fear Thee, O Lord, and magnify Thy Name?\nLet Thy ear, Lord, be attentive to the prayer of Thy servants who desire to fear Thy Name.\nThou wilt hear us from the firmament where Thou dwellest, in order that all people, throughout the whole earth, may learn to fear Thy Name, like Thy people Israel.\nAnd all the nations Thou hast made shall come and adore before Thee, O Lord: and they shall glorify Thy Name.\nAccording to Thy Name O God, so also is Thy praise unto the ends of the earth.\nAnd Thy Name shall be remembered from generation to generation.\nGlory to the Father."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -308,7 +788,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum",
                 "en-US": "Chapter"
@@ -317,8 +797,66 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ab ortu solis usque ad occasum magnum est Nomen meum in gentibus, et in omni loco sacrificatur et offertur Nomini meo oblatio munda, quia magnum est Nomen meum in gentibus, dicit Dominus exercituum.\n℟. Deo gratias.\n℣. Sanctum et terribile Nomen ejus.\n℟. Initium sapientiae timor Domini.\nOremus,\nSancti Nominis tui, Domine, timorem pariter et amorem fac nos habere perpetuum, quia nunquam tua gubernatione destituis, quos in soliditate tuae dilectionis instituis. Per Dominum.\n℣. Sit Nomen Domini benedictum.\n℟. Ex hoc nunc et usque in saeculum.\nAmen.",
-                "en-US": "From the rising to the setting of the sun, my Name is great among the Gentiles, and in every place there is sacrifice, and there is offered to my Name a clean oblation: for great is my Name, among the Gentiles, saith the Lord of hosts.\n℟. Thanks be to God.\n℣. Holy and terrible is His Name.\n℟. The fear of the Lord is the beginning of wisdom.\nLet us pray,\nMake us, O Lord, to have a perpetual fear and love of Thy holy Name, for Thou never ceasest to govern those whom Thou dost solidly establish in Thy love. Through Jesus Christ our Lord.\n℣. May the Name of the Lord be blessed.\n℟. Now and for evermore.\nAmen."
+                "la": "Ab ortu solis usque ad occasum magnum est Nomen meum in gentibus, et in omni loco sacrificatur et offertur Nomini meo oblatio munda, quia magnum est Nomen meum in gentibus, dicit Dominus exercituum.",
+                "en-US": "From the rising to the setting of the sun, my Name is great among the Gentiles, and in every place there is sacrifice, and there is offered to my Name a clean oblation: for great is my Name, among the Gentiles, saith the Lord of hosts."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sanctum et terribile Nomen ejus.",
+                    "en-US": "Holy and terrible is His Name."
+                  },
+                  "r": {
+                    "la": "Initium sapientiae timor Domini.",
+                    "en-US": "The fear of the Lord is the beginning of wisdom."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Sancti Nominis tui, Domine, timorem pariter et amorem fac nos habere perpetuum, quia nunquam tua gubernatione destituis, quos in soliditate tuae dilectionis instituis. Per Dominum.",
+                "en-US": "Make us, O Lord, to have a perpetual fear and love of Thy holy Name, for Thou never ceasest to govern those whom Thou dost solidly establish in Thy love. Through Jesus Christ our Lord."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sit Nomen Domini benedictum.",
+                    "en-US": "May the Name of the Lord be blessed."
+                  },
+                  "r": {
+                    "la": "Ex hoc nunc et usque in saeculum.",
+                    "en-US": "Now and for evermore."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
               }
             }
           ]
@@ -334,12 +872,34 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater noster.\nAve, Maria.\n℣. Domine, labia mea aperies.\n℟. Et os meum exaltabit Nomen tuum.\nMagnificate Dominum mecum, et exaltemus Nomen ejus in idipsum.\nIntroitte portas ejus in confessione, atria ejus in hymnis; confitemini ; laudate Nomen ejus.\nIlluc enim ascenderunt tribus, tribus Domini, testimonium Israel ad confitendum Nomini Domini.\nAfferte Domino gloriam et honorem, afferte Domino gloriam Nomini ejus; adorate Dominum in atrio sancto ejus.\nCantate Domino, et benedicite Nomini ejus; annuntiate de die in diem salutare ejus.\nCantate Deo, psalmum dicite Nomini ejus; iter facite ei qui ascendit super occasum: Dominus Nomen illi.\nModulamini illi psalmum novum; exaltate et invocate Nomen ejus.\nGloria Patri.",
-                "en-US": "Our Father.\nHail, Mary.\n℣. Lord, Thou wilt open my lips.\n℟. And my mouth shall extol Thy Name.\nMagnify the Lord with me, and let us extol his Name together.\nGo ye into his temple with praise, and into his courts with hymns: glorify him: and praise ye his Name.\nFor thither did the tribes go up, the tribes of the Lord: the testimony of Israel, to praise the Name of the Lord.\nBring to the Lord glory and honour: bring to the Lord glory to his Name: adore ye the Lord in his holy court.\nSing ye to the Lord and bless his Name: shew forth his salvation from day to day.\nSing ye to God, sing a psalm to his Name: make a way for him who ascendeth upon the west: the Lord is his Name.\nSing ye to him a new psalm, extol and call upon his Name.\nGlory be to the Father."
+                "la": "Pater noster.\nAve, Maria.",
+                "en-US": "Our Father.\nHail, Mary."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies.",
+                    "en-US": "Lord, Thou wilt open my lips."
+                  },
+                  "r": {
+                    "la": "Et os meum exaltabit Nomen tuum.",
+                    "en-US": "And my mouth shall extol Thy Name."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Magnificate Dominum mecum, et exaltemus Nomen ejus in idipsum.\nIntroitte portas ejus in confessione, atria ejus in hymnis; confitemini ; laudate Nomen ejus.\nIlluc enim ascenderunt tribus, tribus Domini, testimonium Israel ad confitendum Nomini Domini.\nAfferte Domino gloriam et honorem, afferte Domino gloriam Nomini ejus; adorate Dominum in atrio sancto ejus.\nCantate Domino, et benedicite Nomini ejus; annuntiate de die in diem salutare ejus.\nCantate Deo, psalmum dicite Nomini ejus; iter facite ei qui ascendit super occasum: Dominus Nomen illi.\nModulamini illi psalmum novum; exaltate et invocate Nomen ejus.\nGloria Patri.",
+                "en-US": "Magnify the Lord with me, and let us extol his Name together.\nGo ye into his temple with praise, and into his courts with hymns: glorify him: and praise ye his Name.\nFor thither did the tribes go up, the tribes of the Lord: the testimony of Israel, to praise the Name of the Lord.\nBring to the Lord glory and honour: bring to the Lord glory to his Name: adore ye the Lord in his holy court.\nSing ye to the Lord and bless his Name: shew forth his salvation from day to day.\nSing ye to God, sing a psalm to his Name: make a way for him who ascendeth upon the west: the Lord is his Name.\nSing ye to him a new psalm, extol and call upon his Name.\nGlory be to the Father."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -353,7 +913,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum",
                 "en-US": "Chapter"
@@ -362,12 +922,34 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Elegi et sanctificavi locum istum, dicit Dominus, ut sit Nomen meum ibi in sempiternum, et permaneant oculi mei et cor meum ibi cunctis diebus.\n℟. Deo gratias.\n℣. Sanctum et terribile Nomen ejus.\n℟. Initium sapientiae timor Domini.",
-                "en-US": "I have chosen and I have sanctified this place, saith the Lord, that my Name may be there for ever, and that my eyes and my heart may remain there perpetually.\n℟. Thanks be to God.\n℣. Holy and terrible is His Name.\n℟. The fear of the Lord is the beginning of wisdom."
+                "la": "Elegi et sanctificavi locum istum, dicit Dominus, ut sit Nomen meum ibi in sempiternum, et permaneant oculi mei et cor meum ibi cunctis diebus.",
+                "en-US": "I have chosen and I have sanctified this place, saith the Lord, that my Name may be there for ever, and that my eyes and my heart may remain there perpetually."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sanctum et terribile Nomen ejus.",
+                    "en-US": "Holy and terrible is His Name."
+                  },
+                  "r": {
+                    "la": "Initium sapientiae timor Domini.",
+                    "en-US": "The fear of the Lord is the beginning of wisdom."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Canticum Beatae Mariae Virginis",
                 "en-US": "Canticle Of the Blessed Virgin"
@@ -381,7 +963,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -390,8 +972,59 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Fecit mihi magna qui potens est, et sanctum Nomen ejus.\n℣. Adorabo ad templum sanctum tuum.\n℟. Et confitebor Nomini tuo, Domine.\nOremus,\nRespice, quaesumus, Domine, super famulos tuos in Nomine tuo congregatos, et concede illis ut operibus, et non tantum verbis, injurias sancto Nomini tuo illatas reparare valeant. Per Dominum.\n℣. Sit Nomen Domini benedictum.\n℟. Ex hoc nunc et usque in saeculum.\nAmen.",
-                "en-US": "For he that is mighty hath done great things to me; and holy is his Name.\n℣. I will worship Thee towards Thy holy temple.\n℟. And I will give glory to Thy Name, O Lord.\nLet us pray,\nLord, we beseech Thee, look upon Thy family which is gathered together in Thy Name and grant to them that, not only by their words, but by their actions, they may make reparation for the outrages committed against Thy holy Name. Through Jesus Christ our Lord.\n℣. May the Name of the Lord be blessed.\n℟. Now and for evermore.\nAmen."
+                "la": "Fecit mihi magna qui potens est, et sanctum Nomen ejus.",
+                "en-US": "For he that is mighty hath done great things to me; and holy is his Name."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Adorabo ad templum sanctum tuum.",
+                    "en-US": "I will worship Thee towards Thy holy temple."
+                  },
+                  "r": {
+                    "la": "Et confitebor Nomini tuo, Domine.",
+                    "en-US": "And I will give glory to Thy Name, O Lord."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Respice, quaesumus, Domine, super famulos tuos in Nomine tuo congregatos, et concede illis ut operibus, et non tantum verbis, injurias sancto Nomini tuo illatas reparare valeant. Per Dominum.",
+                "en-US": "Lord, we beseech Thee, look upon Thy family which is gathered together in Thy Name and grant to them that, not only by their words, but by their actions, they may make reparation for the outrages committed against Thy holy Name. Through Jesus Christ our Lord."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sit Nomen Domini benedictum.",
+                    "en-US": "May the Name of the Lord be blessed."
+                  },
+                  "r": {
+                    "la": "Ex hoc nunc et usque in saeculum.",
+                    "en-US": "Now and for evermore."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
               }
             }
           ]
@@ -407,12 +1040,34 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater noster.\n℣. Domine, labia mea aperies.\n℟. Et os meum exaltabit nomen tuum.\nConfitebor tibi in saeculum, et exspectabo Nomen tuum, quoniam bonum est in conspectu sanctorum tuorum.\nGloriabuntur in te omnes qui diligunt Nomen tuum, quoniam tu benedices justo.\nQuoniam tu, Deus meus, exaudisti orationem meam; dedisti haereditatem timentibus Nomen tuum;\nUt annuntient in Sion Nomen Domini, et laudem ejus in Jerusalem.\nEt laudent Nomen ejus in choro; in tympano et psalterio psallant ei.\nVoluntarie sacrificabo tibi, et confitebor Nomini tuo, quoniam bonum est.\nSic psalmum dicam Nomini tuo in saeculum saeculi, ut reddam vota mea de die in diem.\nConfitebor tibi, Domine Deus meus, in toto corde meo; et glorificabo Nomen tuum in aeternum.\nSpiritus tuus bonus deducet me in terram rectam; propter Nomen tuum, Domine, vivificabis me in aequitate tua.\nEduce de custodia animam meam ad confitendum Nomini tuo: me exspectant justi donec retribuas mihi.\nGloria Patri.",
-                "en-US": "Our Father.\n℣. Lord, Thou wilt open my lips.\n℟. And my mouth shall extol Thy Name.\nI will praise Thee for ever, O Lord; and I will wait on Thy Name for it is good in the sight of Thy Saints.\nAll those who love Thy Name shall glory in Thee: for Thou wilt bless the just.\nBecause Thou hast heard the voice of my prayer, O Lord my God: Thou hast given a heritage to those who fear Thy Name.\nThat they may declare the Name of the Lord in Sion: and publish his praise in Jerusalem.\nLet them praise his Name in holy songs; Let them sing to him with instruments of music.\nThen I will freely sacrifice to Thee, and I will give praise to Thy Name: for it is good.\nI will sing a psalm to Thy Name for ever and ever: that I may pay my vows from day to day.\nI will praise Thee, O Lord my God, with my whole heart, and I will glorify Thy Name for ever.\nThy Good Spirit shall lead me into the right Land: for the sake of Thy Name, O Lord, Thou wilt quicken me in Thy justice.\nBring my soul out of prison, that I may praise Thy Name: the just wait for me until Thou reward me.\nGlory be to the Father."
+                "la": "Pater noster.",
+                "en-US": "Our Father."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies.",
+                    "en-US": "Lord, Thou wilt open my lips."
+                  },
+                  "r": {
+                    "la": "Et os meum exaltabit nomen tuum.",
+                    "en-US": "And my mouth shall extol Thy Name."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Confitebor tibi in saeculum, et exspectabo Nomen tuum, quoniam bonum est in conspectu sanctorum tuorum.\nGloriabuntur in te omnes qui diligunt Nomen tuum, quoniam tu benedices justo.\nQuoniam tu, Deus meus, exaudisti orationem meam; dedisti haereditatem timentibus Nomen tuum;\nUt annuntient in Sion Nomen Domini, et laudem ejus in Jerusalem.\nEt laudent Nomen ejus in choro; in tympano et psalterio psallant ei.\nVoluntarie sacrificabo tibi, et confitebor Nomini tuo, quoniam bonum est.\nSic psalmum dicam Nomini tuo in saeculum saeculi, ut reddam vota mea de die in diem.\nConfitebor tibi, Domine Deus meus, in toto corde meo; et glorificabo Nomen tuum in aeternum.\nSpiritus tuus bonus deducet me in terram rectam; propter Nomen tuum, Domine, vivificabis me in aequitate tua.\nEduce de custodia animam meam ad confitendum Nomini tuo: me exspectant justi donec retribuas mihi.\nGloria Patri.",
+                "en-US": "I will praise Thee for ever, O Lord; and I will wait on Thy Name for it is good in the sight of Thy Saints.\nAll those who love Thy Name shall glory in Thee: for Thou wilt bless the just.\nBecause Thou hast heard the voice of my prayer, O Lord my God: Thou hast given a heritage to those who fear Thy Name.\nThat they may declare the Name of the Lord in Sion: and publish his praise in Jerusalem.\nLet them praise his Name in holy songs; Let them sing to him with instruments of music.\nThen I will freely sacrifice to Thee, and I will give praise to Thy Name: for it is good.\nI will sing a psalm to Thy Name for ever and ever: that I may pay my vows from day to day.\nI will praise Thee, O Lord my God, with my whole heart, and I will glorify Thy Name for ever.\nThy Good Spirit shall lead me into the right Land: for the sake of Thy Name, O Lord, Thou wilt quicken me in Thy justice.\nBring my soul out of prison, that I may praise Thy Name: the just wait for me until Thou reward me.\nGlory be to the Father."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphon",
                 "en-US": "Antiphon"
@@ -426,7 +1081,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum",
                 "en-US": "Chapter"
@@ -435,8 +1090,74 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce Agnus stabat super montem Sion, et cum eo centum quadraginta quatuor millia habentes Nomen ejus, et Nomen Patris ejus scriptum in frontibus suis.\n℟. Deo gratias.\n℣. Gloriabuntur in te omnes qui diligunt Nomen tuum.\n℟. Quoniam tu benedices justo.\nRepleatur os nostrum laude, omnipotens Deus, ut semper benedicentes te, dum peregrinamur exules, canticum aeternum cantare mereamur in coelis, habentes scriptum in frontibus nostris Nomen sanctum tuum et Nomen Filii tui. Qui tecum vivit et regnat in unitate Spiritus sancti Deus, per omnia saecula saeculorum.\nAmen.\n℣. Sit Nomen Domini benedictum.\n℟. Ex hoc nunc et usque in saeculum.\n℣. Erue nos in mirabilibus tuis.\n℟. Et da gloriam Nomini tuo, Domine.\nDei Patris omnipotentis Verbum, te, Domine Jesu Christe, deprecamur ut nos in Fide Nominis tui roborees per spem perseverantiam, et caritatis excellentiam. Qui vivis et regnas cum Deo Patre in unitate Spiritus sancti Deus, per omnia saecula saeculorum.\nAmen.",
-                "en-US": "Then I saw the Lamb standing upon mount Sion, and with him one hundred and forty-four thousand persons who had his Name, and the Name of his Father, written on their foreheads.\n℟. Thanks be to God.\n℣. Let all who love Thy Name, glorify themselves in Thee.\n℟. Because Thou wilt bless the just.\nGrant, O almighty God, that our mouths may not cease to celebrate Thy glory, and that having blessed Thee during our exile here on earth, we may deserve to praise Thee eternally in heaven, bearing written on our foreheads Thy holy Name, and the Name of Thy Son Jesus Christ; who liveth and reigneth with Thee, in the unity of the Holy Ghost for ever and ever.\nAmen.\n℣. May the Name of the Lord be blessed.\n℟. Now and for evermore.\n℣. Deliver us by Thy miraculous power.\n℟. And give glory to Thy Name, O Lord.\nO Word of the omnipotent God, our Lord Jesus Christ, we beg of Thee to fortify us in the faith of Thy Name by the hope of perseverance and by the excellence of charity, Thou who livest and reignest with God the Father in the unity of the Holy Ghost for ever and ever.\nAmen."
+                "la": "Ecce Agnus stabat super montem Sion, et cum eo centum quadraginta quatuor millia habentes Nomen ejus, et Nomen Patris ejus scriptum in frontibus suis.",
+                "en-US": "Then I saw the Lamb standing upon mount Sion, and with him one hundred and forty-four thousand persons who had his Name, and the Name of his Father, written on their foreheads."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloriabuntur in te omnes qui diligunt Nomen tuum.",
+                    "en-US": "Let all who love Thy Name, glorify themselves in Thee."
+                  },
+                  "r": {
+                    "la": "Quoniam tu benedices justo.",
+                    "en-US": "Because Thou wilt bless the just."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Repleatur os nostrum laude, omnipotens Deus, ut semper benedicentes te, dum peregrinamur exules, canticum aeternum cantare mereamur in coelis, habentes scriptum in frontibus nostris Nomen sanctum tuum et Nomen Filii tui. Qui tecum vivit et regnat in unitate Spiritus sancti Deus, per omnia saecula saeculorum.\nAmen.",
+                "en-US": "Grant, O almighty God, that our mouths may not cease to celebrate Thy glory, and that having blessed Thee during our exile here on earth, we may deserve to praise Thee eternally in heaven, bearing written on our foreheads Thy holy Name, and the Name of Thy Son Jesus Christ; who liveth and reigneth with Thee, in the unity of the Holy Ghost for ever and ever.\nAmen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sit Nomen Domini benedictum.",
+                    "en-US": "May the Name of the Lord be blessed."
+                  },
+                  "r": {
+                    "la": "Ex hoc nunc et usque in saeculum.",
+                    "en-US": "Now and for evermore."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Erue nos in mirabilibus tuis.",
+                    "en-US": "Deliver us by Thy miraculous power."
+                  },
+                  "r": {
+                    "la": "Et da gloriam Nomini tuo, Domine.",
+                    "en-US": "And give glory to Thy Name, O Lord."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Dei Patris omnipotentis Verbum, te, Domine Jesu Christe, deprecamur ut nos in Fide Nominis tui roborees per spem perseverantiam, et caritatis excellentiam. Qui vivis et regnas cum Deo Patre in unitate Spiritus sancti Deus, per omnia saecula saeculorum.\nAmen.",
+                "en-US": "O Word of the omnipotent God, our Lord Jesus Christ, we beg of Thee to fortify us in the faith of Thy Name by the hope of perseverance and by the excellence of charity, Thou who livest and reignest with God the Father in the unity of the Holy Ghost for ever and ever.\nAmen."
               }
             }
           ]

--- a/content/practices/little-office-holy-tear-of-our-lord-jesus-christ/flow.json
+++ b/content/practices/little-office-holy-tear-of-our-lord-jesus-christ/flow.json
@@ -38,19 +38,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "O splendor of the King of angels,\ngrant that a holy and divine zeal\nmay inspire us to sing thy praises.\nO fair eyes that caused this innocent stream to flow,\nenkindle in our hearts a languishing zeal."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -62,13 +62,26 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Rare are the marvels of wonders,"
+                  },
+                  "r": {
+                    "en-US": "To see water flow from a rock."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Rare are the marvels of wonders,\n℟. To see water flow from a rock.\nBut what makes these wonders unparalleled\nis that this rock is God himself."
+                "en-US": "But what makes these wonders unparalleled\nis that this rock is God himself."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Oration"
               }
@@ -89,19 +102,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "Miracle of holy love!\nThis God who casts thunder\nand forms the joys of the day,\nweeps and groans upon the earth.\nSeeing Lazarus dead, his heart is moved,\nand he washes his sin with a stream of tears.\n\nThrough thy mercy, O Lord, draw near to me;\ncome and subdue the insolence of those who oppose thy law.\nGlory be to thee, divine essence;\nglory to thee, adorable Trinity, who art the reward of immortality."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -113,13 +126,26 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "As waters flow from two fountains,"
+                  },
+                  "r": {
+                    "en-US": "Let my eyes pour forth streams of tears."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. As waters flow from two fountains,\n℟. Let my eyes pour forth streams of tears.\nThe love they hold within\nshall become the drink of Heaven."
+                "en-US": "The love they hold within\nshall become the drink of Heaven."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Oration"
               }
@@ -140,19 +166,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "O Word, almighty and noble support of creation,\nwhy is thy heart faint under the blows of nature?\nNo, cruel death, halt thy fury.\nCease to be a spectacle of horror before his eyes.\n\nThrough thy mercy, O Lord, draw near to me;\ncome and subdue the insolence of those who oppose thy law.\nGlory be to thee, divine essence;\nglory to thee, adorable Trinity, who art the reward of immortality."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -164,13 +190,26 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O divine source of life,"
+                  },
+                  "r": {
+                    "en-US": "Abundant fountain of clarity,"
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. O divine source of life,\n℟. Abundant fountain of clarity,\ngrant that my soul, enslaved,\nmay find liberty in thee."
+                "en-US": "grant that my soul, enslaved,\nmay find liberty in thee."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Oration"
               }
@@ -191,19 +230,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "O living star, divine sun,\nsplendor of the Father's glory,\ncast thy gaze upon the excess of our misery.\nThrough this overwhelming love that caused thee to weep,\ngrant us the blessings for which we sigh.\n\nThrough thy mercy, O Lord, draw near to me;\ncome and subdue the insolence of those who oppose thy law.\nGlory be to thee, divine essence;\nglory to thee, adorable Trinity, who art the reward of immortality."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -215,13 +254,26 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let our eyes pour forth tears;"
+                  },
+                  "r": {
+                    "en-US": "Let us flow with fountains of weeping."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Let our eyes pour forth tears;\n℟. Let us flow with fountains of weeping.\nIn our deepest afflictions,\nno sweeter solace can we find."
+                "en-US": "In our deepest afflictions,\nno sweeter solace can we find."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Oration"
               }
@@ -242,19 +294,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "O sun of eternity,\nthou who formest this chaste light,\nwhich restores our original innocence,\ndispel by thy tears this mournful night\nthat hides the joy thy love produces.\n\nThrough thy mercy, O Lord, draw near to me;\ncome and subdue the insolence of those who oppose thy law.\nGlory be to thee, divine essence;\nglory to thee, adorable Trinity, who art the reward of immortality."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -266,13 +318,26 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O august and divine power,"
+                  },
+                  "r": {
+                    "en-US": "That causeth waters and oil to flow in abundance"
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. O august and divine power,\n℟. That causeth waters and oil to flow in abundance\nfrom the mere touch of thy hand."
+                "en-US": "from the mere touch of thy hand."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Oration"
               }
@@ -305,7 +370,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -317,13 +382,26 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Thou who, with a mighty tear,"
+                  },
+                  "r": {
+                    "en-US": "Cleanseth the sins of mortals,"
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Thou who, with a mighty tear,\n℟. Cleanseth the sins of mortals,\nreceive the innocent ardor\nthat bows us at thy altars."
+                "en-US": "receive the innocent ardor\nthat bows us at thy altars."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Oration"
               }
@@ -344,19 +422,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "Sweet and delightful vessel,\nrare marvel of wonders,\nO tear, the virtue of thy water\nknows no equal.\nHaving despoiled death of its spoils,\nbreak for our sake its harsh strength.\n\nThrough thy mercy, O Lord, draw near to me;\ncome and subdue the insolence of those who oppose thy law.\nGlory be to thee, divine essence;\nglory to thee, adorable Trinity, who art the reward of immortality."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Ant."
               }
@@ -368,9 +446,22 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Tears flow from my visage,"
+                  },
+                  "r": {
+                    "en-US": "To intoxicate with their water."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Tears flow from my visage,\n℟. To intoxicate with their water.\nYet their intoxication brings wisdom\nto those who drink of this stream."
+                "en-US": "Yet their intoxication brings wisdom\nto those who drink of this stream."
               }
             },
             {
@@ -389,19 +480,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "By so precious a token,\nby this incomparable love,\ngrant, O Jesus, that our eyes may see\nthy venerable face,\nfrom which this sacred stream flowed on earth,\nconquering sin and subduing death.\n\nThrough thy mercy, O Lord, draw near to me;\ncome and subdue the insolence of those who oppose thy law.\nGlory be to thee, divine essence;\nglory to thee, adorable Trinity, who art the reward of immortality."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Ant."
               }
@@ -413,13 +504,26 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "With joy shall ye draw water"
+                  },
+                  "r": {
+                    "en-US": "From the fountains of the Saviour."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. With joy shall ye draw water\n℟. From the fountains of the Saviour.\nThe waters sent from Heaven\nflow from the opening of his heart."
+                "en-US": "The waters sent from Heaven\nflow from the opening of his heart."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Oration"
               }
@@ -431,7 +535,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Oration for the healing of the eyes."
               }

--- a/content/practices/little-office-holy-three-japanese-martyrs/flow.json
+++ b/content/practices/little-office-holy-three-japanese-martyrs/flow.json
@@ -32,31 +32,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Fortes avete milites,\nQuorum cruore Japonens,\nEt purpurascit inclytae\nAger ferax Ecclesiae."
+                "la": "Fortes avete milites,\nQuorum cruore Japonens,\nEt purpurascit inclytae\nAger ferax Ecclesiae.\n\nVestro hunc rigate sanguine,\nTerramque cordis aridam.\nFecunda fructus proferat,\nQuos horreis caeli inferat."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Vestro hunc rigate sanguine,\nTerramque cordis aridam.\nFecunda fructus proferat,\nQuos horreis caeli inferat."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -68,15 +75,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Nos autem oportet gloriari in cruce Domini nostri Jesu Christi.\n℟. Per quem nobis mundus crucifixus est, et nos mundo."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Nos autem oportet gloriari in cruce Domini nostri Jesu Christi."
+                  },
+                  "r": {
+                    "la": "Per quem nobis mundus crucifixus est, et nos mundo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Beatos Martyres tuos Joannem, Paulum, et Jacobum Martyrio gloria decorasti:\nConcede, quaesumus, ut, quorum gloria coronam in caelis veneramur, eorum fortitudinis exemplum\net passionis constantiam imitemur in terris.\nPer Dominum nostrum, etc."
+                "la": "Deus, qui Beatos Martyres tuos Joannem, Paulum, et Jacobum Martyrio gloria decorasti:\nConcede, quaesumus, ut, quorum gloria coronam in caelis veneramur, eorum fortitudinis exemplum\net passionis constantiam imitemur in terris.\nPer Dominum nostrum, etc."
               }
             }
           ]
@@ -90,34 +110,48 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto, etc."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O lata animos viscera;\nO caritatis pectora!\nQuae non tyranni vincula\nStringere valent, aut verbera."
+                "la": "O lata animos viscera;\nO caritatis pectora!\nQuae non tyranni vincula\nStringere valent, aut verbera.\n\nPer vestra solvi vincula\nNexus rogamus criminum,\nMens ut beatis libera\nCaeli fruatur sedibus."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Per vestra solvi vincula\nNexus rogamus criminum,\nMens ut beatis libera\nCaeli fruatur sedibus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Nos autem oportet gloriari in cruce Domini nostri Jesu Christi.\n℟. Per quem nobis mundus crucifixus est, et nos mundo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Nos autem oportet gloriari in cruce Domini nostri Jesu Christi."
+                  },
+                  "r": {
+                    "la": "Per quem nobis mundus crucifixus est, et nos mundo."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -130,34 +164,48 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto, etc."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ad carceres, ad judices\nLaeti trahuntur Martyres,\nIn vinculis, in carcere\nDeum fatentur jugiter."
+                "la": "Ad carceres, ad judices\nLaeti trahuntur Martyres,\nIn vinculis, in carcere\nDeum fatentur jugiter.\n\nConfessione supplices\nVestra precamur, Martyres,\nNumen, quod ore credimus,\nNostris feramus moribus."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Confessione supplices\nVestra precamur, Martyres,\nNumen, quod ore credimus,\nNostris feramus moribus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Nos autem oportet gloriari in cruce Domini nostri Jesu Christi.\n℟. Per quem nobis mundus crucifixus est, et nos mundo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Nos autem oportet gloriari in cruce Domini nostri Jesu Christi."
+                  },
+                  "r": {
+                    "la": "Per quem nobis mundus crucifixus est, et nos mundo."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -170,34 +218,48 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Fame premuntur viscera,\nSitique fauces asperae,\nCaeli tamen mens gaudiis\nSolatiisque pascitur."
+                "la": "Fame premuntur viscera,\nSitique fauces asperae,\nCaeli tamen mens gaudiis\nSolatiisque pascitur.\n\nSitim, famemque pellite,\nManna supremum promite,\nVitae perennis rivulos\nDesideratos fundite."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sitim, famemque pellite,\nManna supremum promite,\nVitae perennis rivulos\nDesideratos fundite."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Nos autem oportet gloriari in cruce Domini nostri Jesu Christi.\n℟. Per quem nobis mundus crucifixus est, et nos mundo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Nos autem oportet gloriari in cruce Domini nostri Jesu Christi."
+                  },
+                  "r": {
+                    "la": "Per quem nobis mundus crucifixus est, et nos mundo."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -210,34 +272,48 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Nares et aures impie\nTibi Tyranne tollito,\nMens verba Sponsi percipiat,\nMelosque gratum personet."
+                "la": "Nares et aures impie\nTibi Tyranne tollito,\nMens verba Sponsi percipiat,\nMelosque gratum personet.\n\nVitae relictis gaudiis,\nChristo vocanti optemperat:\nMundus vilescit, desipit,\nChristusque solus perplacet."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Vitae relictis gaudiis,\nChristo vocanti optemperat:\nMundus vilescit, desipit,\nChristusque solus perplacet."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Nos autem oportet gloriari in cruce Domini nostri Jesu Christi.\n℟. Per quem nobis mundus crucifixus est, et nos mundo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Nos autem oportet gloriari in cruce Domini nostri Jesu Christi."
+                  },
+                  "r": {
+                    "la": "Per quem nobis mundus crucifixus est, et nos mundo."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -250,34 +326,48 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Gratam Deo se victimam\nIn stipite crucis consecrant,\nUt veriores asseclae\nChristi sui sint Principis."
+                "la": "Gratam Deo se victimam\nIn stipite crucis consecrant,\nUt veriores asseclae\nChristi sui sint Principis.\n\nNobis superno a Numine\nConstantiam depositae,\nCrucem ut feramus alacriter\nAd usque finem fortiter."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Nobis superno a Numine\nConstantiam depositae,\nCrucem ut feramus alacriter\nAd usque finem fortiter."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Nos autem oportet gloriari in cruce Domini nostri Jesu Christi.\n℟. Per quem nobis mundus crucifixus est, et nos mundo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Nos autem oportet gloriari in cruce Domini nostri Jesu Christi."
+                  },
+                  "r": {
+                    "la": "Per quem nobis mundus crucifixus est, et nos mundo."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -290,34 +380,61 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos, Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus, in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O gloriosi Martyres!\nVestrum polorum Principi\nCruore fuso spiritum\nQui reddidistis ultimum,"
+                "la": "O gloriosi Martyres!\nVestrum polorum Principi\nCruore fuso spiritum\nQui reddidistis ultimum,\n\nCor nostrum amoris spiculo\nOfferte Christo saucium,\nIn spiritu vitae ultimo\nOpemque nobis mittite."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Cor nostrum amoris spiculo\nOfferte Christo saucium,\nIn spiritu vitae ultimo\nOpemque nobis mittite."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Nos autem oportet gloriari in cruce Domini nostri Jesu Christi.\n℟. Per quem nobis mundus crucifixus est, et nos mundo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Nos autem oportet gloriari in cruce Domini nostri Jesu Christi."
+                  },
+                  "r": {
+                    "la": "Per quem nobis mundus crucifixus est, et nos mundo."
+                  }
+                }
+              ]
             }
           ]
         }
@@ -342,15 +459,28 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Orate pro nobis, beati Martyres.\n℟. Ut digni efficiamur promissionibus Christi."
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Orate pro nobis, beati Martyres."
+          },
+          "r": {
+            "la": "Ut digni efficiamur promissionibus Christi."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nOmnipotens aeterne Deus,\nqui servis tuis Paulo, Joanni, et Jacobo\nin Societatem Filii tui vocatis,\nApostolicum studium in Gentium conversionem\net Haereticorum reductionem inspirasti;\nideoque Martyrii gloria decorasti:\nconcede propitius, ut ipsis,\net Passionis Sociis in hoc mundo\net consolationis deinde in aeterna beatitudine esse mereamur.\nPer Dominum nostrum Jesum Christum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum. Amen."
+        "la": "Omnipotens aeterne Deus,\nqui servis tuis Paulo, Joanni, et Jacobo\nin Societatem Filii tui vocatis,\nApostolicum studium in Gentium conversionem\net Haereticorum reductionem inspirasti;\nideoque Martyrii gloria decorasti:\nconcede propitius, ut ipsis,\net Passionis Sociis in hoc mundo\net consolationis deinde in aeterna beatitudine esse mereamur.\nPer Dominum nostrum Jesum Christum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum. Amen."
       }
     }
   ]

--- a/content/practices/little-office-immaculate-conception/flow.json
+++ b/content/practices/little-office-immaculate-conception/flow.json
@@ -29,11 +29,19 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Convertat nos, Domina, tuis precibus placatur Iesus Christus Filius tuus.\n℟. Et avertat iram suam a nobis.",
-        "en-US": "℣. May Jesus Christ, thy Son, reconciled by thy prayers, O Lady, convert our hearts.\n℟. And turn away His anger from us."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Convertat nos, Domina, tuis precibus placatur Iesus Christus Filius tuus.",
+            "en-US": "May Jesus Christ, thy Son, reconciled by thy prayers, O Lady, convert our hearts."
+          },
+          "r": {
+            "la": "Et avertat iram suam a nobis.",
+            "en-US": "And turn away His anger from us."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -43,11 +51,34 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Domina, in adiutorium meum intende.\n℟. Me de manu hostium potenter defende.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Alleluia.",
-        "en-US": "℣. O Lady, make speed to befriend me.\n℟. From the hands of the enemy mightily defend me.\n℣. Glory be to the Father, and to the Son, and to the Holy Spirit.\n℟. As it was in the beginning, is now, and ever shall be, world without end. Alleluia."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domina, in adiutorium meum intende.",
+            "en-US": "O Lady, make speed to befriend me."
+          },
+          "r": {
+            "la": "Me de manu hostium potenter defende.",
+            "en-US": "From the hands of the enemy mightily defend me."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Gloria Patri, et Filio, et Spiritui Sancto.",
+            "en-US": "Glory be to the Father, and to the Son, and to the Holy Spirit."
+          },
+          "r": {
+            "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Alleluia.",
+            "en-US": "As it was in the beginning, is now, and ever shall be, world without end. Alleluia."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -89,11 +120,19 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Elegit eam Deus, et praeelegit eam.\n℟. In tabernaculo suo habitare fecit eam.",
-                "en-US": "℣. God elected her, and pre-elected her.\n℟. He made her to dwell in His tabernacle."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Elegit eam Deus, et praeelegit eam.",
+                    "en-US": "God elected her, and pre-elected her."
+                  },
+                  "r": {
+                    "la": "In tabernaculo suo habitare fecit eam.",
+                    "en-US": "He made her to dwell in His tabernacle."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -113,11 +152,19 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ipse creavit illam in Spiritu Sancto.\n℟. Et effundit illam super omnia opera sua.",
-                "en-US": "℣. The Lord Himself created her in the Holy Ghost.\n℟. And poured her out over all His works."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ipse creavit illam in Spiritu Sancto.",
+                    "en-US": "The Lord Himself created her in the Holy Ghost."
+                  },
+                  "r": {
+                    "la": "Et effundit illam super omnia opera sua.",
+                    "en-US": "And poured her out over all His works."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -137,11 +184,19 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ego in altissimis habito.\n℟. Et thronus meus in columna nubis.",
-                "en-US": "℣. I dwell in the highest.\n℟. And my throne is on the pillar of the clouds."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ego in altissimis habito.",
+                    "en-US": "I dwell in the highest."
+                  },
+                  "r": {
+                    "la": "Et thronus meus in columna nubis.",
+                    "en-US": "And my throne is on the pillar of the clouds."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -161,11 +216,19 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Sicut lilium inter spinas\n℟. Sic amica mea inter filias Adae.",
-                "en-US": "℣. As the lily among the thorns.\n℟. So is my beloved among the daughters of Adam."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sicut lilium inter spinas",
+                    "en-US": "As the lily among the thorns."
+                  },
+                  "r": {
+                    "la": "Sic amica mea inter filias Adae.",
+                    "en-US": "So is my beloved among the daughters of Adam."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -185,11 +248,19 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Tota pulchra es, amica mea.\n℟. Et macula originalis numquam fuit in te.",
-                "en-US": "℣. Thou art all fair, my beloved.\n℟. And the original stain was never in thee."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Tota pulchra es, amica mea.",
+                    "en-US": "Thou art all fair, my beloved."
+                  },
+                  "r": {
+                    "la": "Et macula originalis numquam fuit in te.",
+                    "en-US": "And the original stain was never in thee."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -209,11 +280,19 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ego feci in caelis ut oriretur lumen indeficiens.\n℟. Et quasi nebula texi omnem terram.",
-                "en-US": "℣. I made an unfailing light to arise in heaven.\n℟. And as a mist I overspread the whole earth."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ego feci in caelis ut oriretur lumen indeficiens.",
+                    "en-US": "I made an unfailing light to arise in heaven."
+                  },
+                  "r": {
+                    "la": "Et quasi nebula texi omnem terram.",
+                    "en-US": "And as a mist I overspread the whole earth."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -233,11 +312,19 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Oleum effusum, Maria, nomen tuum.\n℟. Servi tui dilexerunt te nimis.",
-                "en-US": "℣. Thy name, O Mary, is an oil poured out.\n℟. Thy servants have loved thee exceedingly."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Oleum effusum, Maria, nomen tuum.",
+                    "en-US": "Thy name, O Mary, is an oil poured out."
+                  },
+                  "r": {
+                    "la": "Servi tui dilexerunt te nimis.",
+                    "en-US": "Thy servants have loved thee exceedingly."
+                  }
+                }
+              ]
             }
           ]
         }
@@ -251,25 +338,78 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Domina, protege orationem meam.\n℟. Et clamor meus ad te veniat.",
-        "en-US": "℣. O Lady, aid my prayer.\n℟. And let my cry come unto thee."
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domina, protege orationem meam.",
+            "en-US": "O Lady, aid my prayer."
+          },
+          "r": {
+            "la": "Et clamor meus ad te veniat.",
+            "en-US": "And let my cry come unto thee."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus.",
+        "en-US": "Let us pray."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nSancta Maria, Regina caelorum, Mater Domini nostri Iesu Christi, et mundi Domina, quae nullum derelinquis, et nullum despicis: respice me, Domina, clementer oculo pietatis, et impetra mihi apud tuum dilectum Filium cunctorum veniam peccatorum: ut qui nunc tuam sanctam et immaculatam conceptionem devoto affectu recolo, aeternae in futurum beatitudinis, bravium capiam, ipso, quem virgo peperisti, donante Domino nostro Iesu Christo: qui cum Patre et Sancto Spiritu vivit et regnat, in Trinitate1 perfecta, Deus, in saecula saeculorum. Amen.",
-        "en-US": "Let us pray,\nHoly Mary, Queen of heaven, Mother of Our Lord Jesus Christ, and Mistress of the world, who forsakest no one and despisest no one, look upon me, O Lady, with an eye of pity and entreat for me, of thy beloved Son, the forgiveness of all my sins that, as I now celebrate, with devout affection, thy holy and immaculate conception, so here-after, I may receive the prize of eternal blessedness, by the grace of Him Whom thou, in virginity, didst bring forth, Jesus Christ our Lord: Who with the Father and the Holy Spirit, liveth and reigneth in perfect Trinity, God, forever. Amen."
+        "la": "Sancta Maria, Regina caelorum, Mater Domini nostri Iesu Christi, et mundi Domina, quae nullum derelinquis, et nullum despicis: respice me, Domina, clementer oculo pietatis, et impetra mihi apud tuum dilectum Filium cunctorum veniam peccatorum: ut qui nunc tuam sanctam et immaculatam conceptionem devoto affectu recolo, aeternae in futurum beatitudinis, bravium capiam, ipso, quem virgo peperisti, donante Domino nostro Iesu Christo: qui cum Patre et Sancto Spiritu vivit et regnat, in Trinitate1 perfecta, Deus, in saecula saeculorum. Amen.",
+        "en-US": "Holy Mary, Queen of heaven, Mother of Our Lord Jesus Christ, and Mistress of the world, who forsakest no one and despisest no one, look upon me, O Lady, with an eye of pity and entreat for me, of thy beloved Son, the forgiveness of all my sins that, as I now celebrate, with devout affection, thy holy and immaculate conception, so here-after, I may receive the prize of eternal blessedness, by the grace of Him Whom thou, in virginity, didst bring forth, Jesus Christ our Lord: Who with the Father and the Holy Spirit, liveth and reigneth in perfect Trinity, God, forever. Amen."
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Domina, protege orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.",
-        "en-US": "℣. O Lady, aid my prayer\n℟. And let my cry come unto thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful, through the mercy of God, rest in peace.\n℟. Amen."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domina, protege orationem meam.",
+            "en-US": "O Lady, aid my prayer"
+          },
+          "r": {
+            "la": "Et clamor meus ad te veniat.",
+            "en-US": "And let my cry come unto thee."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Benedicamus Domino.",
+            "en-US": "Let us bless the Lord."
+          },
+          "r": {
+            "la": "Deo gratias.",
+            "en-US": "Thanks be to God."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+            "en-US": "May the souls of the faithful, through the mercy of God, rest in peace."
+          },
+          "r": {
+            "la": "Amen.",
+            "en-US": "Amen."
+          }
+        }
+      ]
     },
     {
       "type": "subheading",
@@ -288,12 +428,12 @@
     {
       "type": "prayer",
       "inline": {
-        "la": "℟. Deo gratias.",
-        "en-US": "℟. Thanks be to God."
+        "la": "Deo gratias.",
+        "en-US": "Thanks be to God."
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Ant.",
         "en-US": "Ant."
@@ -307,17 +447,32 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. In conceptione tua virgo immaculata fuisti.\n℟. Ora pro nobis Patrem, cuius Filium peperisti.",
-        "en-US": "℣. In thy conception, O Virgin, thou wast immaculate.\n℟. Pray for us to the Father, Whose Son thou didst bring forth."
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "In conceptione tua virgo immaculata fuisti.",
+            "en-US": "In thy conception, O Virgin, thou wast immaculate."
+          },
+          "r": {
+            "la": "Ora pro nobis Patrem, cuius Filium peperisti.",
+            "en-US": "Pray for us to the Father, Whose Son thou didst bring forth."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus.",
+        "en-US": "Let us pray."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nDeus, qui per immaculatam Virginis conceptionem dignum Filio tuo habitaculum praeparasti: quaesumus, ut qui ex morte eiusdem Filii tui praevisa eam ab omni labe praeservasti, nos quoque mundos eius intercessione ad te pervenire concedas. Per eundem Christum Dominum nostrum. Amen.",
-        "en-US": "Let us pray,\nO God, Who by the immaculate conception of the Virgin, didst prepare a worthy habitation for Thy Son, we beseech Thee that, as in view of the death of that Son, Thou didst preserve her from all stain of sin, so Thou wouldst enable us, being made pure by her intercession, to come unto Thee. Through the same Christ our Lord. Amen."
+        "la": "Deus, qui per immaculatam Virginis conceptionem dignum Filio tuo habitaculum praeparasti: quaesumus, ut qui ex morte eiusdem Filii tui praevisa eam ab omni labe praeservasti, nos quoque mundos eius intercessione ad te pervenire concedas. Per eundem Christum Dominum nostrum. Amen.",
+        "en-US": "O God, Who by the immaculate conception of the Virgin, didst prepare a worthy habitation for Thy Son, we beseech Thee that, as in view of the death of that Son, Thou didst preserve her from all stain of sin, so Thou wouldst enable us, being made pure by her intercession, to come unto Thee. Through the same Christ our Lord. Amen."
       }
     }
   ]

--- a/content/practices/little-office-immaculate-heart-of-mary/flow.json
+++ b/content/practices/little-office-immaculate-heart-of-mary/flow.json
@@ -31,22 +31,81 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Come, Holy Ghost, fill the hearts of Thy faithful.\n℟. And enkindle in them the fire of Thy love.\n℣. Send forth Thy Spirit, and they shall be created.\n℟. And Thou shalt renew the face of the earth."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Come, Holy Ghost, fill the hearts of Thy faithful."
+                  },
+                  "r": {
+                    "en-US": "And enkindle in them the fire of Thy love."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Send forth Thy Spirit, and they shall be created."
+                  },
+                  "r": {
+                    "en-US": "And Thou shalt renew the face of the earth."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nO God, Who by the light of the Holy Ghost, didst instruct the hearts of the faithful, grant us by that same Holy Ghost that we may be made truly wise, and ever to rejoice in His consolation. Through Christ our Lord. Amen."
+                "en-US": "O God, Who by the light of the Holy Ghost, didst instruct the hearts of the faithful, grant us by that same Holy Ghost that we may be made truly wise, and ever to rejoice in His consolation. Through Christ our Lord. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Come, my lips and loud proclaim.\n℟. The Blessed Virgin's spotless fame.\n℣. O Lady, make speed to befriend me.\n℟. From the hands of the enemy mightily defend me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, forever, unto ages of ages. Amen. (Alleluia) From Septuagesima to Easter, Alleluia is replaced by: Praised be to Thee, O Lord, King of eternal glory."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Come, my lips and loud proclaim."
+                  },
+                  "r": {
+                    "en-US": "The Blessed Virgin's spotless fame."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, make speed to befriend me."
+                  },
+                  "r": {
+                    "en-US": "From the hands of the enemy mightily defend me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now, and ever shall be, forever, unto ages of ages. Amen. (Alleluia) From Septuagesima to Easter, Alleluia is replaced by: Praised be to Thee, O Lord, King of eternal glory."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -55,22 +114,94 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. God elected her and pre-elected her.\n℟. He made her to dwell in His tabernacle.\n℣. O Lady, hear my prayer.\n℟. And let my cry come unto thee."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "God elected her and pre-elected her."
+                  },
+                  "r": {
+                    "en-US": "He made her to dwell in His tabernacle."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray\nO Holy Mary, Mother of our Lord Jesus Christ, Queen of Heaven and Mistress of the whole world, who never forsakest or despisest anyone, look upon us with an eye of pity, and beg of thy beloved Son the pardon of all our sins, that we who now devoutly celebrate thy Immaculate Conception may receive the reward of eternal joy, through the mercy of Jesus Christ our Lord, Whom thou, pure Virgin, didst bring into the world, and Who with the Father and the Holy Ghost, in perfect Trinity, liveth and reigneth one God, forever, unto ages of ages. Amen."
+                "en-US": "O Holy Mary, Mother of our Lord Jesus Christ, Queen of Heaven and Mistress of the whole world, who never forsakest or despisest anyone, look upon us with an eye of pity, and beg of thy beloved Son the pardon of all our sins, that we who now devoutly celebrate thy Immaculate Conception may receive the reward of eternal joy, through the mercy of Jesus Christ our Lord, Whom thou, pure Virgin, didst bring into the world, and Who with the Father and the Holy Ghost, in perfect Trinity, liveth and reigneth one God, forever, unto ages of ages. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lady, hear my prayer.\n℟. And let my cry come unto thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed through the mercy of God and the intercession of Mary rest in peace.\n℟. Amen.\n℣. Jesus, Mary, and Joseph.\n℟. We love Thee, save souls."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "May the souls of the faithful departed through the mercy of God and the intercession of Mary rest in peace."
+                  },
+                  "r": {
+                    "en-US": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Jesus, Mary, and Joseph."
+                  },
+                  "r": {
+                    "en-US": "We love Thee, save souls."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -82,10 +213,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lady, make speed to befriend me.\n℟. From the hands of the enemy mightily defend me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, forever, unto ages of ages. Amen. (Alleluia) From Septuagesima to Easter: Praised be to Thee, O Lord, King of eternal glory."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, make speed to befriend me."
+                  },
+                  "r": {
+                    "en-US": "From the hands of the enemy mightily defend me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now, and ever shall be, forever, unto ages of ages. Amen. (Alleluia) From Septuagesima to Easter: Praised be to Thee, O Lord, King of eternal glory."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -94,22 +245,94 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. The Lord Himself created her in the Holy Ghost.\n℟. And poured her out among all His works.\n℣. O Lady, hear my prayer.\n℟. And let my cry come unto thee."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "The Lord Himself created her in the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "And poured her out among all His works."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nO Holy Mary, Mother of our Lord Jesus Christ, Queen of Heaven and Mistress of the whole world, who never forsakest or despisest anyone, look upon us with an eye of pity, and beg of thy beloved Son the pardon of all our sins, that we who now devoutly celebrate thy Immaculate Conception may receive the reward of eternal joy, through the mercy of Jesus Christ our Lord, Whom thou, pure Virgin, didst bring into the world, and Who with the Father and the Holy Ghost, in perfect Trinity, liveth and reigneth one God, forever, unto ages of ages. Amen."
+                "en-US": "O Holy Mary, Mother of our Lord Jesus Christ, Queen of Heaven and Mistress of the whole world, who never forsakest or despisest anyone, look upon us with an eye of pity, and beg of thy beloved Son the pardon of all our sins, that we who now devoutly celebrate thy Immaculate Conception may receive the reward of eternal joy, through the mercy of Jesus Christ our Lord, Whom thou, pure Virgin, didst bring into the world, and Who with the Father and the Holy Ghost, in perfect Trinity, liveth and reigneth one God, forever, unto ages of ages. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lady, hear my prayer.\n℟. And let my cry come unto thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed through the mercy of God and the intercession of Mary rest in peace.\n℟. Amen.\n℣. Jesus, Mary, and Joseph.\n℟. We love Thee, save souls."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "May the souls of the faithful departed through the mercy of God and the intercession of Mary rest in peace."
+                  },
+                  "r": {
+                    "en-US": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Jesus, Mary, and Joseph."
+                  },
+                  "r": {
+                    "en-US": "We love Thee, save souls."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -121,10 +344,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lady, make speed to befriend me.\n℟. From the hands of the enemy mightily defend me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, forever, unto ages of ages. Amen. (Alleluia)"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, make speed to befriend me."
+                  },
+                  "r": {
+                    "en-US": "From the hands of the enemy mightily defend me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now, and ever shall be, forever, unto ages of ages. Amen. (Alleluia)"
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -133,15 +376,41 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. I dwell in the highest.\n℟. And my throne is on the pillar of the clouds.\n℣. O Lady, hear my prayer.\n℟. And let my cry come unto thee."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "I dwell in the highest."
+                  },
+                  "r": {
+                    "en-US": "And my throne is on the pillar of the clouds."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nO Holy Mary, Mother of our Lord Jesus Christ, Queen of Heaven and Mistress of the whole world, who never forsakest or despisest anyone, look upon us with an eye of pity, and beg of thy beloved Son the pardon of all our sins, that we who now devoutly celebrate thy Immaculate Conception may receive the reward of eternal joy, through the mercy of Jesus Christ our Lord, Whom thou, pure Virgin, didst bring into the world, and Who with the Father and the Holy Ghost, in perfect Trinity, liveth and reigneth one God, forever, unto ages of ages. Amen."
+                "en-US": "O Holy Mary, Mother of our Lord Jesus Christ, Queen of Heaven and Mistress of the whole world, who never forsakest or despisest anyone, look upon us with an eye of pity, and beg of thy beloved Son the pardon of all our sins, that we who now devoutly celebrate thy Immaculate Conception may receive the reward of eternal joy, through the mercy of Jesus Christ our Lord, Whom thou, pure Virgin, didst bring into the world, and Who with the Father and the Holy Ghost, in perfect Trinity, liveth and reigneth one God, forever, unto ages of ages. Amen."
               }
             },
             {
@@ -157,10 +426,56 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lady, hear my prayer.\n℟. And let my cry come unto thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed through the mercy of God and the intercession of Mary rest in peace.\n℟. Amen.\n℣. Jesus, Mary, and Joseph.\n℟. We love Thee, save souls."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "May the souls of the faithful departed through the mercy of God and the intercession of Mary rest in peace."
+                  },
+                  "r": {
+                    "en-US": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Jesus, Mary, and Joseph."
+                  },
+                  "r": {
+                    "en-US": "We love Thee, save souls."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -172,10 +487,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lady, make speed to befriend me.\n℟. From the hands of the enemy mightily defend me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, forever, unto ages of ages. Amen. (Alleluia)"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, make speed to befriend me."
+                  },
+                  "r": {
+                    "en-US": "From the hands of the enemy mightily defend me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now, and ever shall be, forever, unto ages of ages. Amen. (Alleluia)"
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -184,15 +519,41 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. As the lily among the thorns.\n℟. So is my Beloved among the daughters of Adam.\n℣. O Lady, hear my prayer.\n℟. And let my cry come unto thee."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "As the lily among the thorns."
+                  },
+                  "r": {
+                    "en-US": "So is my Beloved among the daughters of Adam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nO Holy Mary, Mother of our Lord Jesus Christ, Queen of Heaven and Mistress of the whole world, who never forsakest or despisest anyone, look upon us with an eye of pity, and beg of thy beloved Son the pardon of all our sins, that we who now devoutly celebrate thy Immaculate Conception may receive the reward of eternal joy, through the mercy of Jesus Christ our Lord, Whom thou, pure Virgin, didst bring into the world, and Who with the Father and the Holy Ghost, in perfect Trinity, liveth and reigneth one God, forever, unto ages of ages. Amen."
+                "en-US": "O Holy Mary, Mother of our Lord Jesus Christ, Queen of Heaven and Mistress of the whole world, who never forsakest or despisest anyone, look upon us with an eye of pity, and beg of thy beloved Son the pardon of all our sins, that we who now devoutly celebrate thy Immaculate Conception may receive the reward of eternal joy, through the mercy of Jesus Christ our Lord, Whom thou, pure Virgin, didst bring into the world, and Who with the Father and the Holy Ghost, in perfect Trinity, liveth and reigneth one God, forever, unto ages of ages. Amen."
               }
             },
             {
@@ -208,10 +569,56 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lady, hear my prayer.\n℟. And let my cry come unto thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed through the mercy of God and the intercession of Mary rest in peace.\n℟. Amen.\n℣. Jesus, Mary, and Joseph.\n℟. We love Thee, save souls."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "May the souls of the faithful departed through the mercy of God and the intercession of Mary rest in peace."
+                  },
+                  "r": {
+                    "en-US": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Jesus, Mary, and Joseph."
+                  },
+                  "r": {
+                    "en-US": "We love Thee, save souls."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -223,10 +630,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lady, make speed to befriend me.\n℟. From the hands of the enemy mightily defend me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, forever, unto ages of ages. Amen. (Alleluia)"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, make speed to befriend me."
+                  },
+                  "r": {
+                    "en-US": "From the hands of the enemy mightily defend me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now, and ever shall be, forever, unto ages of ages. Amen. (Alleluia)"
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -235,15 +662,41 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Thou art all fair, my Beloved.\n℟. And the original stain was never in thee.\n℣. O Lady, hear my prayer.\n℟. And let my cry come unto thee."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Thou art all fair, my Beloved."
+                  },
+                  "r": {
+                    "en-US": "And the original stain was never in thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nO Holy Mary, Mother of our Lord Jesus Christ, Queen of Heaven and Mistress of the whole world, who never forsakest or despisest anyone, look upon us with an eye of pity, and beg of thy beloved Son the pardon of all our sins, that we who now devoutly celebrate thy Immaculate Conception may receive the reward of eternal joy, through the mercy of Jesus Christ our Lord, Whom thou, pure Virgin, didst bring into the world, and Who with the Father and the Holy Ghost, in perfect Trinity, liveth and reigneth one God, forever, unto ages of ages. Amen."
+                "en-US": "O Holy Mary, Mother of our Lord Jesus Christ, Queen of Heaven and Mistress of the whole world, who never forsakest or despisest anyone, look upon us with an eye of pity, and beg of thy beloved Son the pardon of all our sins, that we who now devoutly celebrate thy Immaculate Conception may receive the reward of eternal joy, through the mercy of Jesus Christ our Lord, Whom thou, pure Virgin, didst bring into the world, and Who with the Father and the Holy Ghost, in perfect Trinity, liveth and reigneth one God, forever, unto ages of ages. Amen."
               }
             },
             {
@@ -259,10 +712,56 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lady, hear my prayer.\n℟. And let my cry come unto thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed through the mercy of God and the intercession of Mary rest in peace.\n℟. Amen.\n℣. Jesus, Mary, and Joseph.\n℟. We love Thee, save souls."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "May the souls of the faithful departed through the mercy of God and the intercession of Mary rest in peace."
+                  },
+                  "r": {
+                    "en-US": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Jesus, Mary, and Joseph."
+                  },
+                  "r": {
+                    "en-US": "We love Thee, save souls."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -274,10 +773,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lady, make speed to befriend me.\n℟. From the hands of the enemy mightily defend me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, forever, unto ages of ages. Amen. (Alleluia)"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, make speed to befriend me."
+                  },
+                  "r": {
+                    "en-US": "From the hands of the enemy mightily defend me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now, and ever shall be, forever, unto ages of ages. Amen. (Alleluia)"
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -286,22 +805,94 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. I made an unfailing light to arise in Heaven.\n℟. And as a mist I overspread the whole earth.\n℣. O Lady, hear my prayer.\n℟. And let my cry come unto thee."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "I made an unfailing light to arise in Heaven."
+                  },
+                  "r": {
+                    "en-US": "And as a mist I overspread the whole earth."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nO Holy Mary, Mother of our Lord Jesus Christ, Queen of Heaven and Mistress of the whole world, who never forsakest or despisest anyone, look upon us with an eye of pity, and beg of thy beloved Son the pardon of all our sins, that we who now devoutly celebrate thy Immaculate Conception may receive the reward of eternal joy, through the mercy of Jesus Christ our Lord, Whom thou, pure Virgin, didst bring into the world, and Who with the Father and the Holy Ghost, in perfect Trinity, liveth and reigneth one God, forever, unto ages of ages. Amen."
+                "en-US": "O Holy Mary, Mother of our Lord Jesus Christ, Queen of Heaven and Mistress of the whole world, who never forsakest or despisest anyone, look upon us with an eye of pity, and beg of thy beloved Son the pardon of all our sins, that we who now devoutly celebrate thy Immaculate Conception may receive the reward of eternal joy, through the mercy of Jesus Christ our Lord, Whom thou, pure Virgin, didst bring into the world, and Who with the Father and the Holy Ghost, in perfect Trinity, liveth and reigneth one God, forever, unto ages of ages. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lady, hear my prayer.\n℟. And let my cry come unto thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed through the mercy of God and the intercession of Mary rest in peace.\n℟. Amen.\n℣. Jesus, Mary, and Joseph.\n℟. We love Thee, save souls."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "May the souls of the faithful departed through the mercy of God and the intercession of Mary rest in peace."
+                  },
+                  "r": {
+                    "en-US": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Jesus, Mary, and Joseph."
+                  },
+                  "r": {
+                    "en-US": "We love Thee, save souls."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -313,10 +904,43 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. May Jesus Christ thy Son, reconciled by thy prayers, O Lady, convert our hearts.\n℟. And turn away His anger from us.\n℣. O Lady, make speed to befriend me.\n℟. From the hands of the enemy mightily defend me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, forever, unto ages of ages. Amen. (Alleluia)"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "May Jesus Christ thy Son, reconciled by thy prayers, O Lady, convert our hearts."
+                  },
+                  "r": {
+                    "en-US": "And turn away His anger from us."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, make speed to befriend me."
+                  },
+                  "r": {
+                    "en-US": "From the hands of the enemy mightily defend me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now, and ever shall be, forever, unto ages of ages. Amen. (Alleluia)"
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -325,10 +949,30 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Thy name, O Mary, is as oil poured out.\n℟. Thy servants have loved thee exceedingly.\n℣. O Lady, hear my prayer.\n℟. And let my cry come unto thee."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Thy name, O Mary, is as oil poured out."
+                  },
+                  "r": {
+                    "en-US": "Thy servants have loved thee exceedingly."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lady, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto thee."
+                  }
+                }
+              ]
             }
           ]
         }
@@ -343,11 +987,17 @@
     {
       "type": "prayer",
       "inline": {
-        "en-US": "These praises and prayers I lay at thy feet,\nO Virgin of virgins, O Mary most sweet.\nBe thou my true Guide through this pilgrimage here,\nAnd stand by my side when death draweth near.\n℣. Deo Gratias."
+        "en-US": "These praises and prayers I lay at thy feet,\nO Virgin of virgins, O Mary most sweet.\nBe thou my true Guide through this pilgrimage here,\nAnd stand by my side when death draweth near."
       }
     },
     {
-      "type": "rubric",
+      "type": "prayer",
+      "inline": {
+        "en-US": "Deo Gratias."
+      }
+    },
+    {
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon:"
       }
@@ -359,15 +1009,28 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "en-US": "℣. In thy Conception, O Virgin, thou wast Immaculate.\n℟. Pray for us to the Father, Whose Son thou didst bear."
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "In thy Conception, O Virgin, thou wast Immaculate."
+          },
+          "r": {
+            "en-US": "Pray for us to the Father, Whose Son thou didst bear."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "en-US": "Let us pray."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "en-US": "Let us pray,\nO God, Who by the Immaculate Conception of the Blessed Virgin Mary didst prepare a worthy habitation for Thy Son, we beseech Thee, that as by the foresight of His death Thou didst exempt her from all stain, so we, purified by her intercession, may come to Thee, through the same Jesus Christ, Thy Son, our Lord, Who liveth and reigneth with Thee and the Holy Ghost, forever, unto ages of ages. Amen."
+        "en-US": "O God, Who by the Immaculate Conception of the Blessed Virgin Mary didst prepare a worthy habitation for Thy Son, we beseech Thee, that as by the foresight of His death Thou didst exempt her from all stain, so we, purified by her intercession, may come to Thee, through the same Jesus Christ, Thy Son, our Lord, Who liveth and reigneth with Thee and the Holy Ghost, forever, unto ages of ages. Amen."
       }
     }
   ]

--- a/content/practices/little-office-most-amiable-child-jesus/flow.json
+++ b/content/practices/little-office-most-amiable-child-jesus/flow.json
@@ -26,39 +26,66 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Mea o Domine labia pandas,\n℟. Tuas ad laudes digne cantandas."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Mea o Domine labia pandas,"
+                  },
+                  "r": {
+                    "la": "Tuas ad laudes digne cantandas."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Meas ad preces te Deus inclina,\n℟. Et ope mihi succurre divina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Meas ad preces te Deus inclina,"
+                  },
+                  "r": {
+                    "la": "Et ope mihi succurre divina."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Jesu puer dulcissime,\nter millies ave to:\ncor moerens tu suavissime\nunguento mulces lato:\nqui amat te, prosentitur\ndulcedinum in mare;\ntuus dum amor cernitur,\nquis nollet te amare?\nqui meum te fraterculum\nnasci fecit pauperculum."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Qui Deus erat in principio,\n℟. Et factus par mancipio."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Qui Deus erat in principio,"
+                  },
+                  "r": {
+                    "la": "Et factus par mancipio."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO Deus, cujus tam fortis amor est, ut te parvum fieri infantulum compulerit, tanti nobis tui amoris cognitionem concede, ut ad reciprocum amorem animati, te aeternum amare, laudare, et benedicere valeamus.\nAmen."
+                "la": "O Deus, cujus tam fortis amor est, ut te parvum fieri infantulum compulerit, tanti nobis tui amoris cognitionem concede, ut ad reciprocum amorem animati, te aeternum amare, laudare, et benedicere valeamus.\nAmen."
               }
             }
           ]
@@ -72,28 +99,42 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Meas ad preces te Deus inclina,\n℟. Et ope mihi succurre divina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Meas ad preces te Deus inclina,"
+                  },
+                  "r": {
+                    "la": "Et ope mihi succurre divina."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Deus ingens infantulum\ninduere volebat,\nparvum, tenellum, blandulum\nse terris exhibebat:\nut cunctis sic amabilis\nforet, praesertim reis,\nnon esset formidabilis,\nculpas indulgens eis:\nridens blande nos aspicit\nsuavi nos spe sic afficit."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Infans, Deus peccator te\n℟. Ade funibus trahit ad se."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Infans, Deus peccator te"
+                  },
+                  "r": {
+                    "la": "Ade funibus trahit ad se."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -112,28 +153,42 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Meas ad preces te Deus inclina,\n℟. Et ope mihi succurre divina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Meas ad preces te Deus inclina,"
+                  },
+                  "r": {
+                    "la": "Et ope mihi succurre divina."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Puer in quo mirifice\ndivinitas se celat,\nformae tamen deificae\nvenustas te revelat:\nlucis divinae radius\nex oculis dimanat,\ncor meum velut gladius\namoris ictu tranat:\namore quis det moriari,\nhac morte caelis oriar!"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Natum amemus Dominum\n℟. Decorum pra natis hominum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Natum amemus Dominum"
+                  },
+                  "r": {
+                    "la": "Decorum pra natis hominum."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -152,28 +207,42 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Meas ad preces te Deus inclina,\n℟. Et ope mihi succurre divina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Meas ad preces te Deus inclina,"
+                  },
+                  "r": {
+                    "la": "Et ope mihi succurre divina."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Fleo puer ac rideo,\nridens cogor plorare\ntuisdum stellas video\nin oculis micare:\ncandor ostrum eximitum\nrosarum genis nectit,\nac lux corusca nivium\nse artubus implectit:\nauro dant crispo splendicant\ncrines, cor sibi vindicant."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Quia ergo tam suavis es,\n℟. Praecunctis charus favis es."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Quia ergo tam suavis es,"
+                  },
+                  "r": {
+                    "la": "Praecunctis charus favis es."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -192,28 +261,42 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Meas ad preces te Deus inclina,\n℟. Et ope mihi succurre divina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Meas ad preces te Deus inclina,"
+                  },
+                  "r": {
+                    "la": "Et ope mihi succurre divina."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Dum lachrymis tam bellulos\naspicio natare\ntuos Jesu ocellulos,\nqueis culpas vis lavare:\nlatis cor meum gestibus\nexultans tenerescit,\net sic amoris aestibus\nut cera colliquescit:\namorem hunc perpendere,\ncor suum est accendere."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus, dum flet ut pusio,\n℟. Amoris est effusio."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, dum flet ut pusio,"
+                  },
+                  "r": {
+                    "la": "Amoris est effusio."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -232,28 +315,42 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Meas ad preces te Deus inclina,\n℟. Et ope mihi succurre divina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Meas ad preces te Deus inclina,"
+                  },
+                  "r": {
+                    "la": "Et ope mihi succurre divina."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Saepe cor meum angitur,\nsua volvens delicta.\nVix non desperans frangitur,\nmens metu jacet icta:\nsed dum infantis cogito\nmei blandum amorem,\ndimitti culpas, rogito\nexutiens timorem.\nA se me non projiciet,\npropitius aspiciet."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Nolo mortem peccatoris,\n℟. Infans inquit, fons amoris."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Nolo mortem peccatoris,"
+                  },
+                  "r": {
+                    "la": "Infans inquit, fons amoris."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -272,34 +369,55 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Converte nos o puer chare,\n℟. Ut sic possimus te amare."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos o puer chare,"
+                  },
+                  "r": {
+                    "la": "Ut sic possimus te amare."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Meas ad preces te Deus inclina,\n℟. Et ope mihi succurre divina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Meas ad preces te Deus inclina,"
+                  },
+                  "r": {
+                    "la": "Et ope mihi succurre divina."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Dum frigore constringeris,\nqui ignis es divinus:\ntotus rigore cingeris,\nmeos veni in sinus.\nCor meum ardens flammulis\namoris te fovebit,\na tuis nunquam famulis\nme ullus dimovebit:\ntenebo, nec dimittam te,\ndonec mors advocabit me."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Versans in terra finibus,\n℟. Est lubens cum hominibus."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Versans in terra finibus,"
+                  },
+                  "r": {
+                    "la": "Est lubens cum hominibus."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",

--- a/content/practices/little-office-most-holy-name-of-jesus/flow.json
+++ b/content/practices/little-office-most-holy-name-of-jesus/flow.json
@@ -13,16 +13,30 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Domine, labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine, labia mea aperies."
+          },
+          "r": {
+            "la": "Et os meum annuntiabit laudem tuam."
+          }
+        }
+      ]
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Deus, in adjutorium meum intende."
+          },
+          "r": {
+            "la": "Domine, ad adjuvandum me festina."
+          }
+        }
+      ]
     },
     {
       "type": "prayer",
@@ -55,55 +69,32 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Jesu dulcis memoria;\nDans vera cordis gaudia,\nSed super mel et omnia;\nEjus dulcis praesentia."
+                "la": "Jesu dulcis memoria;\nDans vera cordis gaudia,\nSed super mel et omnia;\nEjus dulcis praesentia.\n\nNil canitur suavius;\nNil auditur jucundius,\nNil cogitatur dulcius;\nQuam Jesus, Dei Filius.\n\nJesu, spes poenitentibus;\nQuam pius es petentibus!\nQuam bonus te quaerentibus!\nSed quid Invenientibus?\n\nJesu, dulcedo cordium;\nFons vivus, lumen mentium,\nExcedens omne gaudium;\nEt omne desiderium.\n\nNec lingua valet dicere;\nNec littera exprimere,\nExpertus potest credere;\nQuid sit Jesum diligere.\n\nJesum quaeram in lectulo;\nClauso cordis cubiculo,\nPrivatim et in publico;\nQuaeram amore sedulo."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Nil canitur suavius;\nNil auditur jucundius,\nNil cogitatur dulcius;\nQuam Jesus, Dei Filius."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sit nomen Domini benedictum."
+                  },
+                  "r": {
+                    "la": "Ex hoc nunc et usque in saeculum."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Jesu, spes poenitentibus;\nQuam pius es petentibus!\nQuam bonus te quaerentibus!\nSed quid Invenientibus?"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Jesu, dulcedo cordium;\nFons vivus, lumen mentium,\nExcedens omne gaudium;\nEt omne desiderium."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Nec lingua valet dicere;\nNec littera exprimere,\nExpertus potest credere;\nQuid sit Jesum diligere."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Jesum quaeram in lectulo;\nClauso cordis cubiculo,\nPrivatim et in publico;\nQuaeram amore sedulo."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Sit nomen Domini benedictum.\n℟. Ex hoc nunc et usque in saeculum."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -115,15 +106,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nSancti nominis tui, Domine,\ntimorem pariter et amorem fac nos habere perpetuum;\nquia nunquam tua gubernatione destituis,\nquos in soliditate tuae dilectionis instituis.\nQui vivis et regnas cum Deo Patre\nin unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum.\n℟. Amen."
+                "la": "Sancti nominis tui, Domine,\ntimorem pariter et amorem fac nos habere perpetuum;\nquia nunquam tua gubernatione destituis,\nquos in soliditate tuae dilectionis instituis.\nQui vivis et regnas cum Deo Patre\nin unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             }
           ]
@@ -137,61 +147,32 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Cum Maria diluculo;\nJesum quaeram in tumulo,\nClamore cordis querulo;\nMente quaeram, non oculo."
+                "la": "Cum Maria diluculo;\nJesum quaeram in tumulo,\nClamore cordis querulo;\nMente quaeram, non oculo.\n\nTumbam perfundam fletibus;\nLocum replens gemitibus:\nJesu provolar pedibus;\nStrictis haerens amplexibus.\n\nJesu rex admirabilis;\nEt triumphator nobilis,\nDulcedo ineffabilis;\nTotus desiderabilis.\n\nMane nobiscum, Domine;\nEt nos illustra lumine,\nPulsa mentis caligne;\nMundum replens dulcedine.\n\nQuando cor nostrum visitas; Tunc lucet ei veritas,\nMundi vilescit vanitas,\nEt intus fervet caritas.\n\nAmor Jesu dulcissimus;\nEt vere suavissimus,\nPlus millies gratissimus;\nQuam dicere sufficimus.\n\nHoc probat ejus passio;\nHoc sanguinis effusio,\nPer quam nobis redemptio;\nDatur, et Dei visio."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Tumbam perfundam fletibus;\nLocum replens gemitibus:\nJesu provolar pedibus;\nStrictis haerens amplexibus."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sit nomen Domini benedictum."
+                  },
+                  "r": {
+                    "la": "Ex hoc nunc et usque in saeculum."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Jesu rex admirabilis;\nEt triumphator nobilis,\nDulcedo ineffabilis;\nTotus desiderabilis."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mane nobiscum, Domine;\nEt nos illustra lumine,\nPulsa mentis caligne;\nMundum replens dulcedine."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Quando cor nostrum visitas; Tunc lucet ei veritas,\nMundi vilescit vanitas,\nEt intus fervet caritas."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Amor Jesu dulcissimus;\nEt vere suavissimus,\nPlus millies gratissimus;\nQuam dicere sufficimus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Hoc probat ejus passio;\nHoc sanguinis effusio,\nPer quam nobis redemptio;\nDatur, et Dei visio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Sit nomen Domini benedictum.\n℟. Ex hoc nunc et usque in saeculum."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -203,15 +184,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nSancti nominis tui, Domine,\ntimorem pariter et amorem fac nos habere perpetuum;\nquia nunquam tua gubernatione destituis,\nquos in soliditate tuae dilectionis instituis.\nQui vivis et regnas cum Deo Patre\nin unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum.\n℟. Amen."
+                "la": "Sancti nominis tui, Domine,\ntimorem pariter et amorem fac nos habere perpetuum;\nquia nunquam tua gubernatione destituis,\nquos in soliditate tuae dilectionis instituis.\nQui vivis et regnas cum Deo Patre\nin unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             }
           ]
@@ -225,61 +225,32 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Jesum omnes agnoscite;\nAmorem ejus poscite,\nJesum ardenter quaerite;\nQuaerendo inardescite."
+                "la": "Jesum omnes agnoscite;\nAmorem ejus poscite,\nJesum ardenter quaerite;\nQuaerendo inardescite.\n\nSic amantem diligite;\nAmoris vicem reddite,\nIn hunc odorem currite;\nEt vota votis reddite.\n\nJesu auctor clementiae;\nTotius spes laetitiae:\nDulcoris fons et gratiae;\nVerae cordis deliciae.\n\nJesu mi bone, sentiam;\nAmoris tui copiam,\nDa mihi per praesentiam;\nTuam videre gloriam.\n\nCum digne loqui nequeam;\nDe Te tamen ne sileam,\nAmor facit, ut audeam;\nCum de Te solum gaudeam.\n\nTua, Jesu, dilectio;\nGrata mentis refectio,\nReplens sine fastidio;\nDans famem desiderio.\n\nQui Te gustant, esuriunt;\nQui bibunt, adhuc sitiunt,\nDesiderare nesciunt;\nNisi Jesum, quem diligunt."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sic amantem diligite;\nAmoris vicem reddite,\nIn hunc odorem currite;\nEt vota votis reddite."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sit nomen Domini benedictum."
+                  },
+                  "r": {
+                    "la": "Ex hoc nunc et usque in saeculum."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Jesu auctor clementiae;\nTotius spes laetitiae:\nDulcoris fons et gratiae;\nVerae cordis deliciae."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Jesu mi bone, sentiam;\nAmoris tui copiam,\nDa mihi per praesentiam;\nTuam videre gloriam."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Cum digne loqui nequeam;\nDe Te tamen ne sileam,\nAmor facit, ut audeam;\nCum de Te solum gaudeam."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Tua, Jesu, dilectio;\nGrata mentis refectio,\nReplens sine fastidio;\nDans famem desiderio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Qui Te gustant, esuriunt;\nQui bibunt, adhuc sitiunt,\nDesiderare nesciunt;\nNisi Jesum, quem diligunt."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Sit nomen Domini benedictum.\n℟. Ex hoc nunc et usque in saeculum."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -291,15 +262,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nSancti nominis tui, Domine,\ntimorem pariter et amorem fac nos habere perpetuum;\nquia nunquam tua gubernatione destituis,\nquos in soliditate tuae dilectionis instituis.\nQui vivis et regnas cum Deo Patre\nin unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum.\n℟. Amen."
+                "la": "Sancti nominis tui, Domine,\ntimorem pariter et amorem fac nos habere perpetuum;\nquia nunquam tua gubernatione destituis,\nquos in soliditate tuae dilectionis instituis.\nQui vivis et regnas cum Deo Patre\nin unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             }
           ]
@@ -313,55 +303,32 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Quocumque loco fuero;\nMecum Jesum desidero:\nQuam laetus, cum invenero!\nQuam felix, cum tenuero!"
+                "la": "Quocumque loco fuero;\nMecum Jesum desidero:\nQuam laetus, cum invenero!\nQuam felix, cum tenuero!\n\nJam, quod quaesivi, video;\nQuod concupivi, teneo,\nAmore Jesu langueo;\nEt corde totus ardeo.\n\nJesus cum sic diligitur;\nHic amor non extinguitur;\nNon tepescit, nec moritur;\nPlus crescit, et accenditur.\n\nHic amor ardet jugiter;\nDulcescit mirabiliter,\nSapit delectabiliter;\nDelectat et feliciter.\n\nHic amor missus coelitus;\nHaeret mihi medullitus,\nMentem incendit penitus;\nHoc delectatur spiritus.\n\nO beatum incendium;\nEt ardens desiderium,\nO dulce refrigerium;\nAmare Dei Filium!"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Jam, quod quaesivi, video;\nQuod concupivi, teneo,\nAmore Jesu langueo;\nEt corde totus ardeo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sit nomen Domini benedictum."
+                  },
+                  "r": {
+                    "la": "Ex hoc nunc et usque in saeculum."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Jesus cum sic diligitur;\nHic amor non extinguitur;\nNon tepescit, nec moritur;\nPlus crescit, et accenditur."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Hic amor ardet jugiter;\nDulcescit mirabiliter,\nSapit delectabiliter;\nDelectat et feliciter."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Hic amor missus coelitus;\nHaeret mihi medullitus,\nMentem incendit penitus;\nHoc delectatur spiritus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "O beatum incendium;\nEt ardens desiderium,\nO dulce refrigerium;\nAmare Dei Filium!"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Sit nomen Domini benedictum.\n℟. Ex hoc nunc et usque in saeculum."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -373,15 +340,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nSancti nominis tui, Domine,\ntimorem pariter et amorem fac nos habere perpetuum;\nquia nunquam tua gubernatione destituis,\nquos in soliditate tuae dilectionis instituis.\nQui vivis et regnas cum Deo Patre\nin unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum.\n℟. Amen."
+                "la": "Sancti nominis tui, Domine,\ntimorem pariter et amorem fac nos habere perpetuum;\nquia nunquam tua gubernatione destituis,\nquos in soliditate tuae dilectionis instituis.\nQui vivis et regnas cum Deo Patre\nin unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             }
           ]
@@ -395,61 +381,32 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Jesu, flos matris virginis;\nAmor nostrae dulcedinis,\nTibi laus, honor numinis;\nRegnum beatitudinis!"
+                "la": "Jesu, flos matris virginis;\nAmor nostrae dulcedinis,\nTibi laus, honor numinis;\nRegnum beatitudinis!\n\nVeni, veni, rex optime;\nPater immensae gloriae,\nAffulge menti clarius;\nJam exspectatus saepius.\n\nJesu sole serenior;\nEt balsamo suavior,\nOmni dulcore dulcior;\nPrae cunctis amabilior.\n\nCujus gustus sic afficit;\nCujus odor sic reficit,\nIn quo mens mea deficit;\nSolus amanti sufficit.\n\nTu mentis delectatio;\nAmoris consummatio,\nTu mea gloriatio;\nJesu, mundi salvatio:\n\nDilecte mi, revertere;\nConsors paternae dexterae,\nHostem vicisti prospere;\nJam coeli regno fruere.\n\nSequar Te, quoquo ieris;\nMihi tolli non poteris,\nCum meum cor abstuleris;\nJesu, laus nostri generis."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Veni, veni, rex optime;\nPater immensae gloriae,\nAffulge menti clarius;\nJam exspectatus saepius."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sit nomen Domini benedictum."
+                  },
+                  "r": {
+                    "la": "Ex hoc nunc et usque in saeculum."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Jesu sole serenior;\nEt balsamo suavior,\nOmni dulcore dulcior;\nPrae cunctis amabilior."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Cujus gustus sic afficit;\nCujus odor sic reficit,\nIn quo mens mea deficit;\nSolus amanti sufficit."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Tu mentis delectatio;\nAmoris consummatio,\nTu mea gloriatio;\nJesu, mundi salvatio:"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Dilecte mi, revertere;\nConsors paternae dexterae,\nHostem vicisti prospere;\nJam coeli regno fruere."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sequar Te, quoquo ieris;\nMihi tolli non poteris,\nCum meum cor abstuleris;\nJesu, laus nostri generis."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Sit nomen Domini benedictum.\n℟. Ex hoc nunc et usque in saeculum."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -461,15 +418,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nSancti nominis tui, Domine,\ntimorem pariter et amorem fac nos habere perpetuum;\nquia nunquam tua gubernatione destituis,\nquos in soliditate tuae dilectionis instituis.\nQui vivis et regnas cum Deo Patre\nin unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum.\n℟. Amen."
+                "la": "Sancti nominis tui, Domine,\ntimorem pariter et amorem fac nos habere perpetuum;\nquia nunquam tua gubernatione destituis,\nquos in soliditate tuae dilectionis instituis.\nQui vivis et regnas cum Deo Patre\nin unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             }
           ]
@@ -483,61 +459,32 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Coeli cives, occurrite;\nPortas vestras attolite,\nTriumphatori dicite:\nAve Jesus, rex inclyte!"
+                "la": "Coeli cives, occurrite;\nPortas vestras attolite,\nTriumphatori dicite:\nAve Jesus, rex inclyte!\n\nRex virtutum, rex gloriae;\nRex insignis victoriae,\nJesu, largitor vaniae;\nHonor coelestis curiae.\n\nTu fons misericordiae;\nTu verae lumen patriae,\nPelle nubem tristitiae;\nDans nobis lucem gloriae.\n\nTe coeli chorus praedicat;\nEt tuas laudes replicat,\nJesus orbem laetificat;\nEt nos Deo pacificat.\n\nJesus in pace imperat;\nQuae omnem sensum superat:\nHanc mea mens desiderat;\nEt ea frui properat.\n\nJesus ad Patrem rediit;\nCoeleste regnum subiit,\nCor meum a me transiit;\nPost Jesum simul abiit.\n\nQuem prosequamur laudibus;\nVotis, hymnis et precibus,\nUt nos donet coelestibus;\nCum ipso frui sedibus."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Rex virtutum, rex gloriae;\nRex insignis victoriae,\nJesu, largitor vaniae;\nHonor coelestis curiae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sit nomen Domini benedictum."
+                  },
+                  "r": {
+                    "la": "Ex hoc nunc et usque in saeculum."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Tu fons misericordiae;\nTu verae lumen patriae,\nPelle nubem tristitiae;\nDans nobis lucem gloriae."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Te coeli chorus praedicat;\nEt tuas laudes replicat,\nJesus orbem laetificat;\nEt nos Deo pacificat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Jesus in pace imperat;\nQuae omnem sensum superat:\nHanc mea mens desiderat;\nEt ea frui properat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Jesus ad Patrem rediit;\nCoeleste regnum subiit,\nCor meum a me transiit;\nPost Jesum simul abiit."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Quem prosequamur laudibus;\nVotis, hymnis et precibus,\nUt nos donet coelestibus;\nCum ipso frui sedibus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Sit nomen Domini benedictum.\n℟. Ex hoc nunc et usque in saeculum."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -549,15 +496,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nSancti nominis tui, Domine,\ntimorem pariter et amorem fac nos habere perpetuum;\nquia nunquam tua gubernatione destituis,\nquos in soliditate tuae dilectionis instituis.\nQui vivis et regnas cum Deo Patre\nin unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum.\n℟. Amen."
+                "la": "Sancti nominis tui, Domine,\ntimorem pariter et amorem fac nos habere perpetuum;\nquia nunquam tua gubernatione destituis,\nquos in soliditate tuae dilectionis instituis.\nQui vivis et regnas cum Deo Patre\nin unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             }
           ]

--- a/content/practices/little-office-most-holy-sacrament-of-the-eucharist/flow.json
+++ b/content/practices/little-office-most-holy-sacrament-of-the-eucharist/flow.json
@@ -26,37 +26,77 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Panem coeli dedit nobis Dominus:\n℟. Panem Angelorum manducat homo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Panem coeli dedit nobis Dominus:"
+                  },
+                  "r": {
+                    "la": "Panem Angelorum manducat homo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annunciabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annunciabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, etc."
+                "la": "Gloria Patri, et Filio, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Lauda Sion Salvatorem,\nlauda Ducem, et Pastorem, in hymnis, et canticis.\nQuantum potes, tantum aude:\nquia major omni laude: nec laudare sufficis.\nLaudis thema specialis;\npanis vivus, et vitalis, hodie proponitur.\nQuem in sacra mensa coenae,\nturbae fratrum duodenae, datum non ambigitur."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Panem de coelo praestitisti eis Domine.\n℟. Omne delectamentum in se habentem."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Panem de coelo praestitisti eis Domine."
+                  },
+                  "r": {
+                    "la": "Omne delectamentum in se habentem."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -68,15 +108,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui nobis sub Sacramento mirabili passionis tuae memoriam reliquisti, tribue, quaesumus, ita nos Corporis, et Sanguinis tui sacra mysteria venerari, ut redemptionis tuae fructum in nobis jugiter sentiamus. Qui vivis, et regnas cum Deo Patre in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\nAmen."
+                "la": "Deus, qui nobis sub Sacramento mirabili passionis tuae memoriam reliquisti, tribue, quaesumus, ita nos Corporis, et Sanguinis tui sacra mysteria venerari, ut redemptionis tuae fructum in nobis jugiter sentiamus. Qui vivis, et regnas cum Deo Patre in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\nAmen."
               }
             }
           ]
@@ -90,34 +143,41 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Panem coeli dedit nobis etc. ut supra in Mat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium etc. ut supra in Matutin."
+              "type": "rubric",
+              "text": {
+                "la": "Panem coeli dedit nobis etc. ut supra in Mat."
               }
             },
             {
               "type": "rubric",
               "text": {
+                "la": "Deus in adjutorium etc. ut supra in Matutin."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Sit laus plena, sit sonora:\nsit jucunda, sit decora, mentis jubilatio.\nDies enim solemnis agitur,\nin qua mensae primae recollitur hujus institutio.\nIn hac mensa novi Regis,\nnovum Pascha novae legis, Phase vetus terminat.\nVetustatem novitas;\numbram fugat veritas, noctem lux eliminat."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Panem de coelo praestitisti etc. ut supra.\n℟. Omnem suavitatem etc."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Panem de coelo praestitisti etc. ut supra."
+                  },
+                  "r": {
+                    "la": "Omnem suavitatem etc."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -126,14 +186,14 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi, etc. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Domine exaudi, etc. ut supra."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oratio Deus, qui nobis, etc. ut supra."
               }
             }
@@ -148,37 +208,37 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Panem coeli dedit nobis, etc. ut supra."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium etc. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Panem coeli dedit nobis, etc. ut supra."
               }
             },
             {
               "type": "rubric",
               "text": {
+                "la": "Deus in adjutorium etc. ut supra."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Quod in coena Christus gessit,\nfacidendum hoc expressit in sui memoriam.\nDocti sacris institutis,\nPanem, Vinum in salutis\nconsecramus hostiam.\nDogma datur Christianis,\nquod in carnem transit panis,\net in sanguinem.\nQuod non capis, quod non vides,\nanimosa firmat fides,\npraeter rerum ordinem."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Panem de coelo, etc. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Panem de coelo, etc. ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -192,12 +252,12 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi, etc."
+                "la": "Domine exaudi, etc."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Orat. Deus, qui nobis, etc. ut supra."
               }
             }
@@ -212,37 +272,37 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Panem coeli dedit nobis, etc. ut supra."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium, etc. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Panem coeli dedit nobis, etc. ut supra."
               }
             },
             {
               "type": "rubric",
               "text": {
+                "la": "Deus in adjutorium, etc. ut supra."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Sub diversis speciebus\nsignis tantum, et non rebus, latent res eximiae.\nCaro cibus, Sanguis potus,\nmanet tamen Christus totus sub utraque specie.\nA sumente non concisus,\nnon confractus, non divisus,\ninteger accipitur."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Panem de coelo, etc. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Panem de coelo, etc. ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -256,12 +316,12 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi, etc."
+                "la": "Domine exaudi, etc."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Orat. Deus, qui nobis, etc. ut supra."
               }
             }
@@ -276,31 +336,37 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Panem coeli dedit nobis, etc. ut supra.\n℣. Deus in adjutorium, etc. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Panem coeli dedit nobis, etc. ut supra."
               }
             },
             {
               "type": "rubric",
               "text": {
+                "la": "Deus in adjutorium, etc. ut supra."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Sumit unus, sumunt mille:\nquantum isti, tantum ille;\nnec sumptus consumitur.\nSumunt boni, sumunt mali:\nforte tamen inaequali,\nvitae, vel interitus.\nMors est malis, vita bonis,\nvide, paris sumptionis\nquam sit dispar exitus."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Panem de coelo, etc. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Panem de coelo, etc. ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -312,14 +378,14 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi, etc. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Domine exaudi, etc. ut supra."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Orat. Deus, qui nobis, etc. ut supra."
               }
             }
@@ -334,37 +400,37 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Panem coeli dedit, etc. ut supra."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium, etc. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Panem coeli dedit, etc. ut supra."
               }
             },
             {
               "type": "rubric",
               "text": {
+                "la": "Deus in adjutorium, etc. ut supra."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Fracto demum Sacramento,\nne vacilles, sed memento,\ntantum esse sub fragmento,\nquantum totum tegitur.\nNulla rei fit scissura,\nsigni tantum fit fractura,\nnec status, nec statura\nsignati minuitur.\nEcce Panis Angelorum\nfactus cibus viatorum:\nvere panis filiorum,\nnon mittendus canibus."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Panem de coelo, etc. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Panem de coelo, etc. ut supra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -376,14 +442,14 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi, etc. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Domine exaudi, etc. ut supra."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Orat. Deus, qui nobis, etc. ut supra."
               }
             }
@@ -398,43 +464,57 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Panem coeli dedit nobis, etc. ut supra."
+              "type": "rubric",
+              "text": {
+                "la": "Panem coeli dedit nobis, etc. ut supra."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium, etc. ut supra."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Deus in adjutorium, etc. ut supra."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "In figuris praesignatur,\ncum Isaac immolatur:\nAgnus Paschae deputatur:\ndatur manna Patribus.\nBone Pastor, panis vere,\nJesu nostri miserere tu\nnos pasce, nos tuere,\nut tuos bona fac videre in terra viventium.\nTu, qui cuncta scis, et vales,\nqui nos pascis hic mortales,\ntuos ibi commensales,\ncohaeredes, et sodales fac sanctorum civium.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Panem de coelo praestitisti eis Domine.\n℟. Omne delectamentum in se habentem."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Panem de coelo praestitisti eis Domine."
+                  },
+                  "r": {
+                    "la": "Omne delectamentum in se habentem."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -446,15 +526,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui nobis sub Sacramento mirabili Passionis tuae memoriam reliquisti: tribue, quaesumus, ita nos Corporis, et Sanguinis tui sacra mysteria venerari, ut redemptionis tuae fructum in nobis jugiter sentiamus. Qui vivis, et regnas cum Deo Patre, in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\nAmen."
+                "la": "Deus, qui nobis sub Sacramento mirabili Passionis tuae memoriam reliquisti: tribue, quaesumus, ita nos Corporis, et Sanguinis tui sacra mysteria venerari, ut redemptionis tuae fructum in nobis jugiter sentiamus. Qui vivis, et regnas cum Deo Patre, in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\nAmen."
               }
             }
           ]

--- a/content/practices/little-office-most-holy-trinity/flow.json
+++ b/content/practices/little-office-most-holy-trinity/flow.json
@@ -19,10 +19,17 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Domine, labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine, labia mea aperies."
+          },
+          "r": {
+            "la": "Et os meum annuntiabit laudem tuam."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -31,10 +38,17 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Converte nos, Deus salutaris noster."
+          },
+          "r": {
+            "la": "Et averte iram tuam a nobis."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -43,15 +57,35 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Deus, in adjutorium meum intende."
+          },
+          "r": {
+            "la": "Domine, ad adjuvandum me festina."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+          },
+          "r": {
+            "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+          }
+        }
+      ]
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+        "la": "Amen. Alleluia."
       }
     },
     {
@@ -92,19 +126,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "O lux beata Trinitas,\nEt principalis unitas,\nJam sol recedit igneus;\nInfunde lumen cordibus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -126,19 +160,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Ortus refulget lucifer,\nSparsamque lucem nuntiat;\nCadunt tenebrae noctium,\nLux sancta nos illuminet."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -160,19 +194,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Summae Deus clementiae,\nMundi que factor machinae,\nUnus potentialiter,\nTrinusque personaliter."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -194,19 +228,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Da dexteram surgentibus,\nExurgat ut mens sobria,\nFlagrans et in laudem Dei\nGrates rependat debitas."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -228,19 +262,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Tu, Trinitatis unitas,\nOrbem potenter quae regis,\nAttende laudis canticum\nQuod excubantes psallimus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -262,19 +296,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Te mane laudum carmine,\nTe deprecamur vespere,\nTe nostra supplex gloria\nPer cuncta laudet saecula."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -296,19 +330,19 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Gloria tibi, Trinitas,\nAequalis, una Deitas;\nEt ante omnia saecula,\nEt nunc, et in perpetuum."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -330,15 +364,28 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Benedicamus Patrem, et Filium, cum Sancto Spiritu.\n℟. Laudemus et superexaltemus eum in saecula."
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Benedicamus Patrem, et Filium, cum Sancto Spiritu."
+          },
+          "r": {
+            "la": "Laudemus et superexaltemus eum in saecula."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nOmnipotens sempiterne Deus, qui dedisti famulis tuis in confessione verae fidei aeternae Trinitatis gloriam agnoscere, et in potentia Majestatis adorare Unitatem, quaesumus, ut ejusdem fidei firmitate ab omnibus semper muniamur adversis. Per Dominum."
+        "la": "Omnipotens sempiterne Deus, qui dedisti famulis tuis in confessione verae fidei aeternae Trinitatis gloriam agnoscere, et in potentia Majestatis adorare Unitatem, quaesumus, ut ejusdem fidei firmitate ab omnibus semper muniamur adversis. Per Dominum."
       }
     },
     {

--- a/content/practices/little-office-most-sacred-five-wounds-of-our-saviour-jesus-christ/flow.json
+++ b/content/practices/little-office-most-sacred-five-wounds-of-our-saviour-jesus-christ/flow.json
@@ -26,10 +26,43 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium, etc.\n℟. Domine ad adjuvandum, etc.\n℣. Gloria Patri, etc.\n℟. Sicut erat, etc. Alleluja."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium, etc."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum, etc."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, etc."
+                  },
+                  "r": {
+                    "la": "Sicut erat, etc. Alleluja."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -38,37 +71,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Avete sacra Vulnera,\nIn carne Christi fulgida,\nNostrae salutis inclita\nJam restitutae pignora."
+                "la": "Avete sacra Vulnera,\nIn carne Christi fulgida,\nNostrae salutis inclita\nJam restitutae pignora.\n\nManus ave te sauciae,\nPedesque tincti sanguine,\nDiro pendentes stipite,\nTransfixi clavi cuspide.\n\nAveto Latus roseum,\nTam late patens ostium\nAmanti Domicilium,\nErranti Diversorium.\n\nLaus tibi sit, et Gloria,\nRex Christe pro victoria,\nPer sacra parta Vulnera,\nMagnae salutis Pretia."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Manus ave te sauciae,\nPedesque tincti sanguine,\nDiro pendentes stipite,\nTransfixi clavi cuspide."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Aveto Latus roseum,\nTam late patens ostium\nAmanti Domicilium,\nErranti Diversorium."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus tibi sit, et Gloria,\nRex Christe pro victoria,\nPer sacra parta Vulnera,\nMagnae salutis Pretia."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -80,16 +95,42 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Foderunt manus meas et pedes meos:\n℟. Et unus militum lancea Latus meum aperuit."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Foderunt manus meas et pedes meos:"
+                  },
+                  "r": {
+                    "la": "Et unus militum lancea Latus meum aperuit."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe, Fili Dei vivi, qui ad aeterna redemptionis nostrae, et charitatis tuae monumenta, quinque Vulnerum Cicatrices in glorioso tuo Corpore retinere, easque post resurrectionem tuam discipulis tuis videndas et palpandas offerre voluisti: Concede, quaesumus, ut his fidei luminibus cum Thoma Apostolo illustrati, in divinae Benignitatis tuae oceano penitus absorbeamur, usque dum Majestatis tuae, et sacratissimorum Vulnerum tuorum Gloriam in coelo perenniter contemplaturi assumamur. Qui vivis et regnas cum Deo Patre, in unitate Spiritus sancti Deus, per, etc.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
+                "la": "Domine Jesu Christe, Fili Dei vivi, qui ad aeterna redemptionis nostrae, et charitatis tuae monumenta, quinque Vulnerum Cicatrices in glorioso tuo Corpore retinere, easque post resurrectionem tuam discipulis tuis videndas et palpandas offerre voluisti: Concede, quaesumus, ut his fidei luminibus cum Thoma Apostolo illustrati, in divinae Benignitatis tuae oceano penitus absorbeamur, usque dum Majestatis tuae, et sacratissimorum Vulnerum tuorum Gloriam in coelo perenniter contemplaturi assumamur. Qui vivis et regnas cum Deo Patre, in unitate Spiritus sancti Deus, per, etc."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -102,37 +143,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium, etc."
+                  },
+                  "r": {
+                    "la": "Domine, etc."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium, etc.\n℟. Domine, etc.\n℣. Gloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Hic scatet fons viventibus,\nExuberans liquoribus,\nQuinque decurrens amnibus\nDe totidem canalibus."
+                "la": "Hic scatet fons viventibus,\nExuberans liquoribus,\nQuinque decurrens amnibus\nDe totidem canalibus.\n\nHuc sine nummis pauperes,\nHuc properate divites,\nHuc sitientes animae,\nQuas urit amor, bibite.\n\nLaus tibi sit, et Gloria,\nRex Christe pro victoria,\nPer sacra parta vulnera,\nMagnae salutis Pretia."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Huc sine nummis pauperes,\nHuc properate divites,\nHuc sitientes animae,\nQuas urit amor, bibite."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus tibi sit, et Gloria,\nRex Christe pro victoria,\nPer sacra parta vulnera,\nMagnae salutis Pretia."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -144,21 +186,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Haurietis aquas in gaudio de fontibus Salvatoris.\n℟. Qui factus est vobis in salutem."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Haurietis aquas in gaudio de fontibus Salvatoris."
+                  },
+                  "r": {
+                    "la": "Qui factus est vobis in salutem."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe Fili Dei vivi, qui in cruce aperuisti nobis quinque fontes gratiarum, sicut aquarum viventium, quae fluunt impetu de Libano: Concede, ut extincta siti carnalis concupiscentiae, aestuque mundanae delictionis, in te solo sitiat anima nostra, et desideret ad has nobilissimas misericordiae tuae Venas, sicut cervus ad fontes aquarum: ut hauriamus vitam et salutem a te Jesu Salvatore nostro. Qui vivis et regnas, etc."
+                "la": "Domine Jesu Christe Fili Dei vivi, qui in cruce aperuisti nobis quinque fontes gratiarum, sicut aquarum viventium, quae fluunt impetu de Libano: Concede, ut extincta siti carnalis concupiscentiae, aestuque mundanae delictionis, in te solo sitiat anima nostra, et desideret ad has nobilissimas misericordiae tuae Venas, sicut cervus ad fontes aquarum: ut hauriamus vitam et salutem a te Jesu Salvatore nostro. Qui vivis et regnas, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Fidelium animae, etc."
+                "la": "Fidelium animae, etc."
               }
             }
           ]
@@ -172,37 +227,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium, etc."
+                  },
+                  "r": {
+                    "la": "Domine, etc."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium, etc.\n℟. Domine, etc.\n℣. Gloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Hic Botrus, haec orantia\nTerrae promissae munera,\nSub prelo crucis placida\nDesudat vini flumina."
+                "la": "Hic Botrus, haec orantia\nTerrae promissae munera,\nSub prelo crucis placida\nDesudat vini flumina.\n\nSapore quae dulcedinis,\nLaetificant cor hominis.\nCor levant ex angustiis,\nMirisque mulcent gaudiis.\n\nLaus tibi sit, et Gloria,\nRex Christe pro victoria,\nPer sacra parta Vulnera,\nMagnae salutis Pretia."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sapore quae dulcedinis,\nLaetificant cor hominis.\nCor levant ex angustiis,\nMirisque mulcent gaudiis."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus tibi sit, et Gloria,\nRex Christe pro victoria,\nPer sacra parta Vulnera,\nMagnae salutis Pretia."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -214,21 +270,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Leo de tribu Juda lavit in vino Stolam suam.\n℟. Et in sanguine uvae pallium suum."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Leo de tribu Juda lavit in vino Stolam suam."
+                  },
+                  "r": {
+                    "la": "Et in sanguine uvae pallium suum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe Fili Dei vivi, qui de corpore tuo quinque pretiosissimi sanguinis flumina in remissionem peccatorum effudisti, quando in cruce torcular solus calcasti: Te humiliter deprecamur, reconcilia nos Deo in sanguine tuo quos tam copiose redemisti, et pota nos torrente hujus dulcedinis, ut ardentissima tui charitate inebriati portemus semper in corde nostro tua sacratissima amoris stigmata, unde pietate, gratia et justitia repleamur. Qui vivis et regnas, etc."
+                "la": "Domine Jesu Christe Fili Dei vivi, qui de corpore tuo quinque pretiosissimi sanguinis flumina in remissionem peccatorum effudisti, quando in cruce torcular solus calcasti: Te humiliter deprecamur, reconcilia nos Deo in sanguine tuo quos tam copiose redemisti, et pota nos torrente hujus dulcedinis, ut ardentissima tui charitate inebriati portemus semper in corde nostro tua sacratissima amoris stigmata, unde pietate, gratia et justitia repleamur. Qui vivis et regnas, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Fidelium animae, etc."
+                "la": "Fidelium animae, etc."
               }
             }
           ]
@@ -242,37 +311,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium, etc."
+                  },
+                  "r": {
+                    "la": "Domine, etc."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium, etc.\n℟. Domine, etc.\n℣. Gloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Hic castrum non vincibile,\nDavidis Turri simile,\nAc hostibus terribile,\nHuc fugiens te recipe."
+                "la": "Hic castrum non vincibile,\nDavidis Turri simile,\nAc hostibus terribile,\nHuc fugiens te recipe.\n\nSunt quinque propugnacula,\nFidelium refugia,\nSecura diversoria,\nTutissima Praesidia.\n\nLaus tibi sit et Gloria,\nRex Christe pro victoria,\nPer sacra parta Vulnera,\nMagnae salutis Pretia."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sunt quinque propugnacula,\nFidelium refugia,\nSecura diversoria,\nTutissima Praesidia."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus tibi sit et Gloria,\nRex Christe pro victoria,\nPer sacra parta Vulnera,\nMagnae salutis Pretia."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -284,21 +354,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Videte manus meas, et pedes meos,\n℟. Ego sum, nolite timere."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Videte manus meas, et pedes meos,"
+                  },
+                  "r": {
+                    "la": "Ego sum, nolite timere."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe Fili Dei vivi, qui nobis in sacratissimis tuis Vulneribus, in omni tribulatione et angustia tutum asylum, et singulare praesidium benignissime praeparasti: Libera nos, quaesumus, a vinculis iniquitatum, propter quas vulneratus es: et in omnibus mentis, corporis quae periculis abscondé nos intra tua Vulnera, ut non timeat cor nostrum, quoniam facta sunt illa nobis Turris fortitudinis a facie inimici. Qui vivis et regnas cum Deo Patre, etc."
+                "la": "Domine Jesu Christe Fili Dei vivi, qui nobis in sacratissimis tuis Vulneribus, in omni tribulatione et angustia tutum asylum, et singulare praesidium benignissime praeparasti: Libera nos, quaesumus, a vinculis iniquitatum, propter quas vulneratus es: et in omnibus mentis, corporis quae periculis abscondé nos intra tua Vulnera, ut non timeat cor nostrum, quoniam facta sunt illa nobis Turris fortitudinis a facie inimici. Qui vivis et regnas cum Deo Patre, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Fidelium animae, etc."
+                "la": "Fidelium animae, etc."
               }
             }
           ]
@@ -312,37 +395,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium, etc."
+                  },
+                  "r": {
+                    "la": "Domine, etc."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium, etc.\n℟. Domine, etc.\n℣. Gloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Hic arbor vitae tenera\nDistendit quinque folia,\nEt umbrae suae suavia\nLargitur refrigeria."
+                "la": "Hic arbor vitae tenera\nDistendit quinque folia,\nEt umbrae suae suavia\nLargitur refrigeria.\n\nNon urit hic sol radiis,\nAut serpens mortis spiculis,\nTot tutus es umbraculis,\nQuot arbor haec stat foliis.\n\nLaus tibi sit, et Gloria,\nRex Christe pro victoria,\nPer sacra parta Vulnera,\nMagnae salutis Praetia."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Non urit hic sol radiis,\nAut serpens mortis spiculis,\nTot tutus es umbraculis,\nQuot arbor haec stat foliis."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus tibi sit, et Gloria,\nRex Christe pro victoria,\nPer sacra parta Vulnera,\nMagnae salutis Praetia."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -354,21 +438,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Sub umbra alarum tuarum protege me, Domine.\n℟. A facie impiorum, qui me afflixerunt."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sub umbra alarum tuarum protege me, Domine."
+                  },
+                  "r": {
+                    "la": "A facie impiorum, qui me afflixerunt."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe Fili Dei vivi, qui afflictos, et ad sacra Vulnera tua confugientes umbra consolationis reficis, et in sinu dulcissimi cordis tui, ad quod per lanceam nobis aditus patefactus est, placide requiescere facis: Largire nobis, ut miseriarum et tentationum aestibus fatigati in sanctissimis Vulneribus tuis quietem ac refrigerium inveniamus, et sub hac umbra sedentes a nullo malorum incursu perturbemur, nec a te separari valeamus. Qui vivis, et regnas, etc."
+                "la": "Domine Jesu Christe Fili Dei vivi, qui afflictos, et ad sacra Vulnera tua confugientes umbra consolationis reficis, et in sinu dulcissimi cordis tui, ad quod per lanceam nobis aditus patefactus est, placide requiescere facis: Largire nobis, ut miseriarum et tentationum aestibus fatigati in sanctissimis Vulneribus tuis quietem ac refrigerium inveniamus, et sub hac umbra sedentes a nullo malorum incursu perturbemur, nec a te separari valeamus. Qui vivis, et regnas, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Fidelium animae, etc."
+                "la": "Fidelium animae, etc."
               }
             }
           ]
@@ -382,37 +479,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium, etc."
+                  },
+                  "r": {
+                    "la": "Domine, etc."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium, etc.\n℟. Domine, etc.\n℣. Gloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Haec signa caelis intulit\nChristus, dum viam finivit.\nPatri suo proposuit,\nPaccémque mundo reddidit."
+                "la": "Haec signa caelis intulit\nChristus, dum viam finivit.\nPatri suo proposuit,\nPaccémque mundo reddidit.\n\nPer ista Victor Vulnera,\nMagna potitur gloria,\nHonoris sunt insignia,\nNobilitatis Symbola.\n\nLaus tibi sit, et Gloria,\nRex Christe pro victoria,\nPer sacra parta Vulnera,\nMagnae salutis Praetia."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Per ista Victor Vulnera,\nMagna potitur gloria,\nHonoris sunt insignia,\nNobilitatis Symbola."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus tibi sit, et Gloria,\nRex Christe pro victoria,\nPer sacra parta Vulnera,\nMagnae salutis Praetia."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -424,21 +522,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Praevenisti eos Domine in benedictionibus.\n℟. Qui humanae salutis signacula assidue venerantur."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Praevenisti eos Domine in benedictionibus."
+                  },
+                  "r": {
+                    "la": "Qui humanae salutis signacula assidue venerantur."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe Fili Dei vivi, qui per proprium sanguinem introivisti in sancta sanctorum, et sedes ad dexteram Dei Patris interpellans pro nobis: Pateant, obsecro, in ejus conspectu Vulnera tua, ut delitescant scelera nostra, et qui factus es Advocatus noster apud Patrem, non obliviscaris servorum in te sperantium, quorum memoriam manibus, pedibus, et lateri tuo tam pretiose insculptam geris. Qui vivis et regnas, etc."
+                "la": "Domine Jesu Christe Fili Dei vivi, qui per proprium sanguinem introivisti in sancta sanctorum, et sedes ad dexteram Dei Patris interpellans pro nobis: Pateant, obsecro, in ejus conspectu Vulnera tua, ut delitescant scelera nostra, et qui factus es Advocatus noster apud Patrem, non obliviscaris servorum in te sperantium, quorum memoriam manibus, pedibus, et lateri tuo tam pretiose insculptam geris. Qui vivis et regnas, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Fidelium animae, etc."
+                "la": "Fidelium animae, etc."
               }
             }
           ]
@@ -452,37 +563,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium, etc."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum, etc."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium, etc.\n℟. Domine ad adjuvandum, etc.\n℣. Gloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O Sacra Jesu Stigmata\nFirmate nos in gratia,\nDum Judicis sententia\nPartitur justis praemia."
+                "la": "O Sacra Jesu Stigmata\nFirmate nos in gratia,\nDum Judicis sententia\nPartitur justis praemia.\n\nVestras tunc alas pandite,\nIn sinum nos recipite,\nEt nos indignos, gloriae\nCapaces vestrae reddite.\n\nLaus tibi sit, et Gloria,\nRex Christe pro victoria,\nPer sacra parta Vulnera,\nMagnae salutis Praetia."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Vestras tunc alas pandite,\nIn sinum nos recipite,\nEt nos indignos, gloriae\nCapaces vestrae reddite."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus tibi sit, et Gloria,\nRex Christe pro victoria,\nPer sacra parta Vulnera,\nMagnae salutis Praetia."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -494,21 +619,34 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Signa Vulnerum suorum monstrabit Dominus.\n℟. Cum judicabit vivos et mortuos, et saeculum per ignem."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Signa Vulnerum suorum monstrabit Dominus."
+                  },
+                  "r": {
+                    "la": "Cum judicabit vivos et mortuos, et saeculum per ignem."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe Fili Dei vivi, qui venturus es in gloria et majestate tua, cum splendore magno quinque Vulnerum tuorum, et judicaturus orbem terrae in aequitate, et populos in justitia: Fac benigne Domine, ut nunc sperent in te, qui noverunt nomen tuum, et coluerunt haec sacrosancta stigmata tua, quorum meritis ad Dextram tuam audire mereantur, venite Benedicti. Qui vivis et regnas, etc."
+                "la": "Domine Jesu Christe Fili Dei vivi, qui venturus es in gloria et majestate tua, cum splendore magno quinque Vulnerum tuorum, et judicaturus orbem terrae in aequitate, et populos in justitia: Fac benigne Domine, ut nunc sperent in te, qui noverunt nomen tuum, et coluerunt haec sacrosancta stigmata tua, quorum meritis ad Dextram tuam audire mereantur, venite Benedicti. Qui vivis et regnas, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Fidelium animae, etc."
+                "la": "Fidelium animae, etc."
               }
             }
           ]
@@ -528,13 +666,20 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Omnis terra adoret te, et psallat tibi.\n℟. Psalmum dicat sacris Vulneribus tuis, Domine."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Omnis terra adoret te, et psallat tibi."
+          },
+          "r": {
+            "la": "Psalmum dicat sacris Vulneribus tuis, Domine."
+          }
+        }
+      ]
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Oratio S. Francisci Xaverii"
       }

--- a/content/practices/little-office-our-holy-father-blaise/flow.json
+++ b/content/practices/little-office-our-holy-father-blaise/flow.json
@@ -44,43 +44,44 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit etc."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit etc.\n℣. Deus in adjutorium etc.\nGloria etc. per annum Alleluia. a Sept. usque ad Pasch. Laus tibi Domine Rex aeternae gloriae."
+                "la": "Deus in adjutorium etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria etc. per annum Alleluia. a Sept. usque ad Pasch. Laus tibi Domine Rex aeternae gloriae."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Mens incalesce laudibus\nEt blasi honores\nPange devotis plausibus:\nAttende quid perores."
+                "la": "Mens incalesce laudibus\nEt blasi honores\nPange devotis plausibus:\nAttende quid perores.\n\nPeroras virum nobilem,\nNatalibus magnatem;\nSed pietate supparem\nCoelestibus achatem.\n\nNon ergo diu latuit\nIn tenebris hoc lumen,\nCum praesulem mox statuit\nEum supremum numen.\n\nSit trinitati gloria,\nQuae blasi per ortum,\nEmenso vitae stadio,\nDucat ad caeli portum.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Peroras virum nobilem,\nNatalibus magnatem;\nSed pietate supparem\nCoelestibus achatem."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Non ergo diu latuit\nIn tenebris hoc lumen,\nCum praesulem mox statuit\nEum supremum numen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit trinitati gloria,\nQuae blasi per ortum,\nEmenso vitae stadio,\nDucat ad caeli portum.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -88,11 +89,24 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Domine Rex aeterne, qui es tuorum spes certa Sanctorum, per orationem servi tui blasi memento nostri.\n℣. Ora pro nobis s. blasi.\n℟. Ut digni efficiamur promissionibus Christi."
+                "la": "Domine Rex aeterne, qui es tuorum spes certa Sanctorum, per orationem servi tui blasi memento nostri."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis s. blasi."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -100,8 +114,21 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Domine Jesu Christe! qui s. blasium, gloriosum martyrem tuum, vita laudabili ac pontificali honore sublimasti, et ad palmam martyrii invitasti; concede propitius, ut qui ejus gloriosam passionem devote recolimus, ipsius meritis et precibus ab universis mentis et corporis periculis liberemur: per Dominum nostrum etc.\n℣. Domine exaudi etc.\n℟. Fidelium animae etc. Amen."
+                "la": "Domine Jesu Christe! qui s. blasium, gloriosum martyrem tuum, vita laudabili ac pontificali honore sublimasti, et ad palmam martyrii invitasti; concede propitius, ut qui ejus gloriosam passionem devote recolimus, ipsius meritis et precibus ab universis mentis et corporis periculis liberemur: per Dominum nostrum etc."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi etc."
+                  },
+                  "r": {
+                    "la": "Fidelium animae etc. Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -116,41 +143,29 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium etc.\nGloria etc."
+                "la": "Deus in adjutorium etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ne mundus ei subdolum\nObiceret glaucoma,\nAut caro triveneficum\nIngereret aroma;"
+                "la": "Ne mundus ei subdolum\nObiceret glaucoma,\nAut caro triveneficum\nIngereret aroma;\n\nSe montium in abdito\nRecondidit spelæo,\nContentus, eucharistico\nQui frueretur Deo.\n\nMirum! qui fugit homines,\nIn suos cucurrabat\nFeras silvarum, comites,\nQuas aegras per sanabat.\n\nSit trinitati gloria,\nQuae blasi recessit,\nAb omni nos in mundo hoc\nCustodiat excessit.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Se montium in abdito\nRecondidit spelæo,\nContentus, eucharistico\nQui frueretur Deo."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mirum! qui fugit homines,\nIn suos cucurrabat\nFeras silvarum, comites,\nQuas aegras per sanabat."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit trinitati gloria,\nQuae blasi recessit,\nAb omni nos in mundo hoc\nCustodiat excessit.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -158,7 +173,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ab omni nos Domine abstrahe tumultu saeculi, ut cum divo blasio soli vivamus tibi.\n℣. Ora pro nobis s. blasi etc. cum oratione ut supra."
+                "la": "Ab omni nos Domine abstrahe tumultu saeculi, ut cum divo blasio soli vivamus tibi."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Ora pro nobis s. blasi etc. cum oratione ut supra."
               }
             }
           ]
@@ -174,23 +195,29 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium etc.\nGloria etc."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+                "la": "Deus in adjutorium etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Gloria etc."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Cum sic in silvis floruit\nUt palma, Dei servus;\nEt pietatis semitam\nCucurrit, quasi cervus,\nForte tyranni milites\nExierant venatum;\nUt inde sui Domini\nReficerent palatum.\nSed ecce qui vestigia\nBrutorum indaguarunt,\nAd blasi latibula\nErrore declinarunt.\nSit trinitati gloria,\nQuae blasi secreta\nVita, in nobis deleat\nAeternae mortis theta. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -198,7 +225,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Per s. blasi intercessionem omnes ferae in nobis manfuefiant passiones: ut cum illo sequamur agnum, quocumque ierit.\n℣. Ora pro nobis s. blasi etc. cum oratione ut supra."
+                "la": "Per s. blasi intercessionem omnes ferae in nobis manfuefiant passiones: ut cum illo sequamur agnum, quocumque ierit."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Ora pro nobis s. blasi etc. cum oratione ut supra."
               }
             }
           ]
@@ -214,41 +247,29 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium etc.\nGloria etc."
+                "la": "Deus in adjutorium etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Hic jam non cervus timidus,\nSed fortis inclamatur;\nQui vinci nescit blasus,\nEt vinculis ligatur:"
+                "la": "Hic jam non cervus timidus,\nSed fortis inclamatur;\nQui vinci nescit blasus,\nEt vinculis ligatur:\n\nVinctus ex antro rapitur\nIn carcerem, multorum,\nIn quo est praesentissimus\nMachoan infirmorum,\n\nPraecipue sed gutturum\nDoloribus medetur.\nEum dictatis precibus\nQui pie reveretur.\n\nSit trinitati gloria,\nQuae blasi medela\nAvertat male noxia,\nMorbi, lethique tela.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Vinctus ex antro rapitur\nIn carcerem, multorum,\nIn quo est praesentissimus\nMachoan infirmorum,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Praecipue sed gutturum\nDoloribus medetur.\nEum dictatis precibus\nQui pie reveretur."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit trinitati gloria,\nQuae blasi medela\nAvertat male noxia,\nMorbi, lethique tela.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -256,7 +277,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancte blasi signo crucis guttur pueri medicate, opitulare, ne unquam in gutture nostro tuae praefocentur laudes.\n℣. Ora pro nobis s. blasi etc. cum oratione ut supra."
+                "la": "Sancte blasi signo crucis guttur pueri medicate, opitulare, ne unquam in gutture nostro tuae praefocentur laudes."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Ora pro nobis s. blasi etc. cum oratione ut supra."
               }
             }
           ]
@@ -272,41 +299,29 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium etc.\nGloria etc."
+                "la": "Deus in adjutorium etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Urget tyrannus blassium,\nUt supplex adoraret Jovem,\ndeorum prodorum,\nEt Christum ejuraret:"
+                "la": "Urget tyrannus blassium,\nUt supplex adoraret Jovem,\ndeorum prodorum,\nEt Christum ejuraret:\n\nSed frustra; nam, ut caucasus,\nImmotus Christi cultum\nPropugnat, neque metuit\nMinis flagrantem vultum.\n\nVerbis succedunt verbera,\nEquuleus, tortura:\nNon tamen a proposito\nHeroem amotura.\n\nSit trinitati gloria,\nQuae blasi per fidem\nElanguidis impertiat\nOpem, et robur idem.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sed frustra; nam, ut caucasus,\nImmotus Christi cultum\nPropugnat, neque metuit\nMinis flagrantem vultum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Verbis succedunt verbera,\nEquuleus, tortura:\nNon tamen a proposito\nHeroem amotura."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit trinitati gloria,\nQuae blasi per fidem\nElanguidis impertiat\nOpem, et robur idem.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -314,7 +329,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Domine Jesu Christe, qui gloriosum martyrem in suis tormentis insigni constantia decorasti; fac, ut nos nullae perfringant adversitates.\n℣. Ora pro nobis s. blasi etc. cum oratione ut supra."
+                "la": "Domine Jesu Christe, qui gloriosum martyrem in suis tormentis insigni constantia decorasti; fac, ut nos nullae perfringant adversitates."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Ora pro nobis s. blasi etc. cum oratione ut supra."
               }
             }
           ]
@@ -330,41 +351,29 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium etc.\nGloria etc."
+                "la": "Deus in adjutorium etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Haec in tyranno rabidum\nExasperant furorem,\nIn martyre, martyrii\nExstimulant amorem."
+                "la": "Haec in tyranno rabidum\nExasperant furorem,\nIn martyre, martyrii\nExstimulant amorem.\n\nIlle proin, quo blasi\nSaevum restinguit aestum,\nImmergi jubet lacui;\nAt en tyranni quaestum!\n\nIn fluctibus nec fluctuat,\nNec undis submersatur\nVir Dei, sed ab angelo\nIncolumis servatur.\n\nSit trinitati gloria,\nQuam blasius exorat,\nSi quando quod periculum\nNos obruturum foret.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Ille proin, quo blasi\nSaevum restinguit aestum,\nImmergi jubet lacui;\nAt en tyranni quaestum!"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "In fluctibus nec fluctuat,\nNec undis submersatur\nVir Dei, sed ab angelo\nIncolumis servatur."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit trinitati gloria,\nQuam blasius exorat,\nSi quando quod periculum\nNos obruturum foret.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -372,7 +381,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Fortis Christi athleta, qui alter Petrus stetisti, et ambulasti in fluctibus, intercede, ne nos peccatorum tempestas demergat, nec inferni absorbeat profundum.\n℣. Ora pro nobis s. blasi etc. cum oratione ut supra."
+                "la": "Fortis Christi athleta, qui alter Petrus stetisti, et ambulasti in fluctibus, intercede, ne nos peccatorum tempestas demergat, nec inferni absorbeat profundum."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Ora pro nobis s. blasi etc. cum oratione ut supra."
               }
             }
           ]
@@ -386,43 +401,44 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium etc.\nGloria etc."
+                "la": "Deus in adjutorium etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Aqua tyranno haeserat,\nNec furere cessabat,\nNum sanguis forte flueret\nAd vota, pertentabat."
+                "la": "Aqua tyranno haeserat,\nNec furere cessabat,\nNum sanguis forte flueret\nAd vota, pertentabat.\n\nFluxit: nam plexus capite,\nProfudit miles Christi\nVitam una cum sanguine:\nJam furor, jam vicisti!\n\nQuin victus es: cum lauream\nPlexerit plectendo,\nEt blasium in martyrium\nSic album evehendo.\n\nSit trinitati gloria,\nQuae blasium donavit,\nTam nobili victoria\nTyrannidem prostravit.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Fluxit: nam plexus capite,\nProfudit miles Christi\nVitam una cum sanguine:\nJam furor, jam vicisti!"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Quin victus es: cum lauream\nPlexerit plectendo,\nEt blasium in martyrium\nSic album evehendo."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sit trinitati gloria,\nQuae blasium donavit,\nTam nobili victoria\nTyrannidem prostravit.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -430,7 +446,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Dive blasi, cujus preces in ultimo agone exauditae sunt, potenti patrocinio tuo nobis assiste in hora mortis.\n℣. Ora pro nobis s. blasi etc. cum oratione ut supra."
+                "la": "Dive blasi, cujus preces in ultimo agone exauditae sunt, potenti patrocinio tuo nobis assiste in hora mortis."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Ora pro nobis s. blasi etc. cum oratione ut supra."
               }
             }
           ]

--- a/content/practices/little-office-passion-by-s-francis-of-assisi/flow.json
+++ b/content/practices/little-office-passion-by-s-francis-of-assisi/flow.json
@@ -44,7 +44,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -56,7 +56,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm"
               }
@@ -68,7 +68,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -102,7 +102,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -114,7 +114,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm"
               }
@@ -136,7 +136,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -148,7 +148,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm"
               }
@@ -170,7 +170,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -182,7 +182,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm"
               }
@@ -204,7 +204,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -216,7 +216,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm"
               }
@@ -238,7 +238,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -250,7 +250,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm"
               }
@@ -272,7 +272,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -284,7 +284,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm"
               }
@@ -330,7 +330,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -342,7 +342,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
@@ -366,7 +366,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -378,7 +378,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
@@ -414,7 +414,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -426,14 +426,14 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
     },
     {
-      "type": "prayer",
-      "inline": {
+      "type": "rubric",
+      "text": {
         "en-US": "Have mercy on me, etc.—as above."
       }
     },
@@ -444,14 +444,14 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
     },
     {
-      "type": "prayer",
-      "inline": {
+      "type": "rubric",
+      "text": {
         "en-US": "Sing ye to the Lord, etc.—as above."
       }
     },
@@ -462,14 +462,14 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
     },
     {
-      "type": "prayer",
-      "inline": {
+      "type": "rubric",
+      "text": {
         "en-US": "O clap your hands, etc.—as above."
       }
     },
@@ -486,7 +486,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -498,7 +498,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
@@ -516,7 +516,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -528,14 +528,14 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
     },
     {
-      "type": "prayer",
-      "inline": {
+      "type": "rubric",
+      "text": {
         "en-US": "Sing ye to the Lord, etc.,—as above."
       }
     },
@@ -546,7 +546,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -558,14 +558,14 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
     },
     {
-      "type": "prayer",
-      "inline": {
+      "type": "rubric",
+      "text": {
         "en-US": "Have mercy on me, etc.—as above."
       }
     },
@@ -576,7 +576,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -588,7 +588,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
@@ -606,7 +606,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -618,7 +618,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
@@ -636,7 +636,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -648,7 +648,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
@@ -666,7 +666,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -678,14 +678,14 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
     },
     {
-      "type": "prayer",
-      "inline": {
+      "type": "rubric",
+      "text": {
         "en-US": "O clap your hands. . . as above."
       }
     },
@@ -702,7 +702,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -714,7 +714,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
@@ -732,7 +732,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -744,7 +744,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
@@ -762,7 +762,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -774,14 +774,14 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
     },
     {
-      "type": "prayer",
-      "inline": {
+      "type": "rubric",
+      "text": {
         "en-US": "Have mercy on me, etc.—as above."
       }
     },
@@ -792,7 +792,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -804,14 +804,14 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
     },
     {
-      "type": "prayer",
-      "inline": {
+      "type": "rubric",
+      "text": {
         "en-US": "Shout with joy, etc.—as above."
       }
     },
@@ -822,7 +822,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -834,14 +834,14 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
     },
     {
-      "type": "prayer",
-      "inline": {
+      "type": "rubric",
+      "text": {
         "en-US": "May the Lord hear thee in the day, etc.—as above."
       }
     },
@@ -852,7 +852,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -864,14 +864,14 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
     },
     {
-      "type": "prayer",
-      "inline": {
+      "type": "rubric",
+      "text": {
         "en-US": "In Thee, O Lord, have I hoped—as above."
       }
     },
@@ -882,7 +882,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -894,14 +894,14 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }
     },
     {
-      "type": "prayer",
-      "inline": {
+      "type": "rubric",
+      "text": {
         "en-US": "O clap your hands, etc.—as above."
       }
     },
@@ -918,7 +918,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Antiphon"
       }
@@ -930,7 +930,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm"
       }

--- a/content/practices/little-office-passion-of-our-lord-by-s-bonaventure/flow.json
+++ b/content/practices/little-office-passion-of-our-lord-by-s-bonaventure/flow.json
@@ -26,25 +26,71 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Thou shalt open my lips, O Lord."
+                  },
+                  "r": {
+                    "en-US": "And my mouth shall shew forth Thy praise."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto mine aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father and to the Son and to the Holy Ghost,"
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now and ever shall be, world without end."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Thou shalt open my lips, O Lord.\n℟. And my mouth shall shew forth Thy praise.\n℣. Incline unto mine aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father and to the Son and to the Holy Ghost,\n℟. As it was in the beginning, is now and ever shall be, world without end.\nAmen.\nPraise be to Thee, O Lord, King of everlasting glory."
+                "en-US": "Amen.\nPraise be to Thee, O Lord, King of everlasting glory."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Invitatory"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Christ is captured and put to scorn, scourged and crucified. Oh, come, let us adore Him!\n℟. Christ is captured and put to scorn, scourged and crucified. Oh, come, let us adore Him!"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Christ is captured and put to scorn, scourged and crucified. Oh, come, let us adore Him!"
+                  },
+                  "r": {
+                    "en-US": "Christ is captured and put to scorn, scourged and crucified. Oh, come, let us adore Him!"
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm XCIV"
               }
@@ -58,55 +104,32 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℟. Oh, come, let us adore Him!\n℣. Christ is captured and put to scorn, scourged and crucified.\n℟. Oh, come, let us adore Him."
+                "en-US": "Oh, come, let us adore Him!"
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Christ is captured and put to scorn, scourged and crucified."
+                  },
+                  "r": {
+                    "en-US": "Oh, come, let us adore Him."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "Oh, may the Passion of the Lord, Whereby salvation is restored,\nThe mind with love for Him inspire, Our solace and our hearts' desire."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "In memory, let us ever hold, Christ's thorny crown, His pains untold,\nThe bitter cross whereon He died, The nails, the lance that pierced His Side."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "And may we constantly recall\nThe reed, the vinegar, the gall, The anguish of that last dread hour,\nThose Sacred Wounds whence graces shower."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "O, may these thoughts our souls imbue With sweetness of celestial dew,\n'Til, fostered by His tender care, The glorious fruits of grace they bear."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "O crucified, we worship Thee\nAnd beg with all our hearts that we May be united through Thy love With all the saints in Heav'n above."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "To Christ, the Lord of Majesty,\nBetrayed and sold to set us free, Who suffered on the cruel tree, Be praise and honour endlessly."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "Amen."
+                "en-US": "Oh, may the Passion of the Lord, Whereby salvation is restored,\nThe mind with love for Him inspire, Our solace and our hearts' desire.\n\nIn memory, let us ever hold, Christ's thorny crown, His pains untold,\nThe bitter cross whereon He died, The nails, the lance that pierced His Side.\n\nAnd may we constantly recall\nThe reed, the vinegar, the gall, The anguish of that last dread hour,\nThose Sacred Wounds whence graces shower.\n\nO, may these thoughts our souls imbue With sweetness of celestial dew,\n'Til, fostered by His tender care, The glorious fruits of grace they bear.\n\nO crucified, we worship Thee\nAnd beg with all our hearts that we May be united through Thy love With all the saints in Heav'n above.\n\nTo Christ, the Lord of Majesty,\nBetrayed and sold to set us free, Who suffered on the cruel tree, Be praise and honour endlessly.\n\nAmen."
               }
             },
             {
@@ -116,7 +139,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -128,7 +151,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm II"
               }
@@ -140,7 +163,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -152,10 +175,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. I have forsaken my house; I have left mine inheritance.\n℟. I have given my dear soul into the hands of sinners."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "I have forsaken my house; I have left mine inheritance."
+                  },
+                  "r": {
+                    "en-US": "I have given my dear soul into the hands of sinners."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -164,31 +194,52 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Absolution"
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "May the Passion of our Lord Jesus Christ bring us to the joys of Paradise."
+                  },
+                  "r": {
+                    "en-US": "Amen."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
+              "speaker": "people",
               "inline": {
-                "en-US": "℣. May the Passion of our Lord Jesus Christ bring us to the joys of Paradise.\n℟. Amen.\n(℟. Pray, Father, a blessing.)"
+                "en-US": "Pray, Father, a blessing."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Blessing"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Through His holy Passion, may our Lord grant unto us His benediction.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Through His holy Passion, may our Lord grant unto us His benediction."
+                  },
+                  "r": {
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "First Lesson (S. John 19. 1-3)"
               }
@@ -196,29 +247,56 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Pilate took Jesus, and scourged Him. And the soldiers, platting a crown of thorns, put it upon His head: and they put on Him a purple garment. And they came to Him and said: Hail, King of the Jews. And they buffeted Him and, spitting upon Him, they took the reed and struck His Head.\n℣. But Thou, O Lord, have mercy upon us.\n℟. Thanks be to God."
+                "en-US": "Pilate took Jesus, and scourged Him. And the soldiers, platting a crown of thorns, put it upon His head: and they put on Him a purple garment. And they came to Him and said: Hail, King of the Jews. And they buffeted Him and, spitting upon Him, they took the reed and struck His Head."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "But Thou, O Lord, have mercy upon us."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. The ancients consulted together, that, by subtlety, they might apprehend Jesus and put Him to death. They went out, as it were to a robber, with swords and clubs.\n(℟. Pray, Father, a blessing.)"
+                "en-US": "The ancients consulted together, that, by subtlety, they might apprehend Jesus and put Him to death. They went out, as it were to a robber, with swords and clubs."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Pray, Father, a blessing."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Blessing"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Through the might of His Holy Cross, may our Lord bring us to the joys of light and truth.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Through the might of His Holy Cross, may our Lord bring us to the joys of light and truth."
+                  },
+                  "r": {
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Second Lesson (S. John 19. 16-18; S. Luke 23. 34)"
               }
@@ -226,20 +304,66 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "But the soldiers took Jesus and led Him forth, and, bearing His own cross, He went forth to that place which is called Calvary but, in Hebrew, Golgotha, where they crucified Him and, with Him, two others, one on each side, and Jesus in the midst. And Jesus said: Father, forgive them, for they know not what they do.\n℣. But Thou, Lord, have mercy upon us.\n℟. Thanks be to God."
+                "en-US": "But the soldiers took Jesus and led Him forth, and, bearing His own cross, He went forth to that place which is called Calvary but, in Hebrew, Golgotha, where they crucified Him and, with Him, two others, one on each side, and Jesus in the midst. And Jesus said: Father, forgive them, for they know not what they do."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "But Thou, Lord, have mercy upon us."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. You are come out, as it were, to a robber, with swords and clubs, to apprehend Me.\n℣. I was daily with you in the temple teaching, and you laid not hands on Me, and lo!, you scourge Me and lead Me to be crucified.\n℟. And when they had laid hands on Jesus and taken Him, He said to them:\n℣. I was daily with you in the temple teaching, and you laid not hands on Me, and lo!, you scourge Me and lead Me to be crucified.\n(℟. Pray, Father, a blessing.)"
+                "en-US": "You are come out, as it were, to a robber, with swords and clubs, to apprehend Me."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "I was daily with you in the temple teaching, and you laid not hands on Me, and lo!, you scourge Me and lead Me to be crucified."
+                  },
+                  "r": {
+                    "en-US": "And when they had laid hands on Jesus and taken Him, He said to them:"
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. I have forsaken my house; I have left mine inheritance.\n℟. I have given my dear soul into the hands of sinners."
+                "en-US": "I was daily with you in the temple teaching, and you laid not hands on Me, and lo!, you scourge Me and lead Me to be crucified."
               }
+            },
+            {
+              "type": "prayer",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Pray, Father, a blessing."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "I have forsaken my house; I have left mine inheritance."
+                  },
+                  "r": {
+                    "en-US": "I have given my dear soul into the hands of sinners."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -248,31 +372,52 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Absolution"
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "May the Passion of our Lord Jesus Christ bring us to the joys of Paradise."
+                  },
+                  "r": {
+                    "en-US": "Amen."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
+              "speaker": "people",
               "inline": {
-                "en-US": "℣. May the Passion of our Lord Jesus Christ bring us to the joys of Paradise.\n℟. Amen.\n(℟. Pray, Father, a blessing.)"
+                "en-US": "Pray, Father, a blessing."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Blessing"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Through His holy Passion, may our Lord grant unto us His benediction.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Through His holy Passion, may our Lord grant unto us His benediction."
+                  },
+                  "r": {
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "First Lesson (S. John 19. 1-3)"
               }
@@ -280,29 +425,56 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Pilate took Jesus, and scourged Him. And the soldiers, platting a crown of thorns, put it upon His head: and they put on Him a purple garment. And they came to Him and said: Hail, King of the Jews. And they buffeted Him and, spitting upon Him, they took the reed and struck His Head.\n℣. But Thou, O Lord, have mercy upon us.\n℟. Thanks be to God."
+                "en-US": "Pilate took Jesus, and scourged Him. And the soldiers, platting a crown of thorns, put it upon His head: and they put on Him a purple garment. And they came to Him and said: Hail, King of the Jews. And they buffeted Him and, spitting upon Him, they took the reed and struck His Head."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "But Thou, O Lord, have mercy upon us."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. The ancients consulted together, that, by subtlety, they might apprehend Jesus and put Him to death. They went out, as it were to a robber, with swords and clubs.\n(℟. Pray, Father, a blessing.)"
+                "en-US": "The ancients consulted together, that, by subtlety, they might apprehend Jesus and put Him to death. They went out, as it were to a robber, with swords and clubs."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Pray, Father, a blessing."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Blessing"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Through the might of His Holy Cross, may our Lord bring us to the joys of light and truth.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Through the might of His Holy Cross, may our Lord bring us to the joys of light and truth."
+                  },
+                  "r": {
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Second Lesson (S. John 19. 16-18; S. Luke 23. 34)"
               }
@@ -310,29 +482,75 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "But the soldiers took Jesus and led Him forth, and, bearing His own cross, He went forth to that place which is called Calvary but, in Hebrew, Golgotha, where they crucified Him and, with Him, two others, one on each side, and Jesus in the midst. And Jesus said: Father, forgive them, for they know not what they do.\n℣. But Thou, Lord, have mercy upon us.\n℟. Thanks be to God."
+                "en-US": "But the soldiers took Jesus and led Him forth, and, bearing His own cross, He went forth to that place which is called Calvary but, in Hebrew, Golgotha, where they crucified Him and, with Him, two others, one on each side, and Jesus in the midst. And Jesus said: Father, forgive them, for they know not what they do."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "But Thou, Lord, have mercy upon us."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. You are come out, as it were, to a robber, with swords and clubs, to apprehend Me.\n℣. I was daily with you in the temple teaching, and you laid not hands on Me, and lo!, you scourge Me and lead Me to be crucified.\n℟. And when they had laid hands on Jesus and taken Him, He said to them:\n℣. I was daily with you in the temple teaching, and you laid not hands on Me, and lo!, you scourge Me and lead Me to be crucified.\n(℟. Pray, Father, a blessing.)"
+                "en-US": "You are come out, as it were, to a robber, with swords and clubs, to apprehend Me."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "I was daily with you in the temple teaching, and you laid not hands on Me, and lo!, you scourge Me and lead Me to be crucified."
+                  },
+                  "r": {
+                    "en-US": "And when they had laid hands on Jesus and taken Him, He said to them:"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "I was daily with you in the temple teaching, and you laid not hands on Me, and lo!, you scourge Me and lead Me to be crucified."
+              }
+            },
+            {
+              "type": "prayer",
+              "speaker": "people",
+              "inline": {
+                "en-US": "Pray, Father, a blessing."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Blessing"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. May the sprinkling of Christ's Blood be our everlasting health and protection.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "May the sprinkling of Christ's Blood be our everlasting health and protection."
+                  },
+                  "r": {
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Third Lesson (S. John 19. 28-30)"
               }
@@ -340,13 +558,58 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Afterwards, Jesus, knowing that all things were now accomplished, that the Scripture might be fulfilled, said: I thirst. Now there was a vessel set there full of vinegar. And they, putting a sponge full of vinegar about hyssop, put it to His mouth. Jesus, therefore, when He had taken the vinegar, said: It is consummated. And, bowing His head, He gave up the ghost.\n℣. But Thou, Lord, have mercy upon us.\n℟. Thanks be to God."
+                "en-US": "Afterwards, Jesus, knowing that all things were now accomplished, that the Scripture might be fulfilled, said: I thirst. Now there was a vessel set there full of vinegar. And they, putting a sponge full of vinegar about hyssop, put it to His mouth. Jesus, therefore, when He had taken the vinegar, said: It is consummated. And, bowing His head, He gave up the ghost."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "But Thou, Lord, have mercy upon us."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Darkness covered the earth, whilst the Jews crucified Jesus. And about the ninth hour, Jesus cried out with a loud voice:\n℣. My God, My God, why hast Thou forsaken Me? And, bowing down His head, He gave up the ghost.\n℟. Jesus, crying out with a loud voice, said: Father, into Thy hands I commend My Spirit.\n℣. And, bowing down His head, He gave up the ghost.\n℟. Glory be to the Father and to the Son and to the Holy Ghost,\n℣. And, bowing down His head, He gave up the ghost."
+                "en-US": "Darkness covered the earth, whilst the Jews crucified Jesus. And about the ninth hour, Jesus cried out with a loud voice:"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "My God, My God, why hast Thou forsaken Me? And, bowing down His head, He gave up the ghost."
+                  },
+                  "r": {
+                    "en-US": "Jesus, crying out with a loud voice, said: Father, into Thy hands I commend My Spirit."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "And, bowing down His head, He gave up the ghost."
+                  },
+                  "r": {
+                    "en-US": "Glory be to the Father and to the Son and to the Holy Ghost,"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "And, bowing down His head, He gave up the ghost."
               }
             }
           ]
@@ -359,13 +622,39 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto mine aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father and to the Son and to the Holy Ghost,"
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now and ever shall be, world without end."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Incline unto mine aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father and to the Son and to the Holy Ghost,\n℟. As it was in the beginning, is now and ever shall be, world without end.\nAmen. Praise be to Thee, O Lord, King of everlasting glory."
+                "en-US": "Amen. Praise be to Thee, O Lord, King of everlasting glory."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -377,7 +666,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm XII"
               }
@@ -389,7 +678,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -401,7 +690,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter (Lamentations 4. 20)"
               }
@@ -415,29 +704,36 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℟. Thanks be to God."
+                "en-US": "Thanks be to God."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "Now let us all with one accord\nTo Christ our Captain anthems raise,\nWhose conquering cross our life restored,\nLet Heaven resound with songs of praise.\nO, may Thy dreadful agony With true contrition rend our breast,\nAnd make us ever seek for Thee, O Jesus, our Redeemer blest.\nThose blissful scars which Jesus bore,\nThe scourging, spitting, buffeting, To us have won for evermore\nTh'eternal gifts of Christ our King.\nLet not Thy Blood be shed in vain\nBut to our hearts its power apply.\nAnd wash them clean from every stain,\nCreator of the starry sky.\nThe gifts from which Thy Passion flow\nGrant us, O Saviour, of Thy grace.\nAnd, in Thy faithfulness bestow,\nThe Heavenly vision of Thy Face.\nTo Christ, the Lord of Majesty, Betrayed and sold to set us free,\nWho suffered on the cruel tree, Be praise and honour endlessly.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. He gave His cheek to him that struck Him.\n℟. He was filled with reproaches."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "He gave His cheek to him that struck Him."
+                  },
+                  "r": {
+                    "en-US": "He was filled with reproaches."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -449,7 +745,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Canticle of Zachary (S. Luke 1. 68-80)"
               }
@@ -461,7 +757,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -473,15 +769,40 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Lord, have mercy."
+                  },
+                  "r": {
+                    "en-US": "Christ, have mercy."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Lord, have mercy.\n℟. Christ, have mercy.\n℣. Lord, have mercy."
+                "en-US": "Lord, have mercy."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nO Lord Jesus Christ, Who, at the hour of Matins, didst will to be betrayed, captured, bound, scourged, buffeted and spit upon for the salvation of mankind: make us, we beseech Thee, to receive reproaches and injuries with joy for the glory of Thy Name, and so to keep the memory of Thy most holy Passion ever in mind, that we may deserve to be made partakers in Thy Resurrection, Who livest and reignest, world without end.\n℟. Amen."
+                "en-US": "O Lord Jesus Christ, Who, at the hour of Matins, didst will to be betrayed, captured, bound, scourged, buffeted and spit upon for the salvation of mankind: make us, we beseech Thee, to receive reproaches and injuries with joy for the glory of Thy Name, and so to keep the memory of Thy most holy Passion ever in mind, that we may deserve to be made partakers in Thy Resurrection, Who livest and reignest, world without end."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Amen."
               }
             }
           ]
@@ -494,37 +815,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto mine aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father and to the Son and to the Holy Ghost,"
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now and ever shall be, world without end."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Incline unto mine aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father and to the Son and to the Holy Ghost,\n℟. As it was in the beginning, is now and ever shall be, world without end.\nAmen.\nPraise be to Thee, O Lord, King of everlasting glory."
+                "en-US": "Amen.\nPraise be to Thee, O Lord, King of everlasting glory."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "O Sun of Justice,\nThou Whose rays,\nBy sinful hands,\nwere veiled from gaze,\nO Thou Who,\nmocked on bended knee,\nWas scourged for us most piteously."
+                "en-US": "O Sun of Justice,\nThou Whose rays,\nBy sinful hands,\nwere veiled from gaze,\nO Thou Who,\nmocked on bended knee,\nWas scourged for us most piteously.\n\nWith fervent love,\nO Lord, we pray, Have mercy on our souls today;\nAnd lead us from this dark world's night\nTo see in Heaven Thy glorious light.\n\nTo Christ, the Lord of Majesty,\nBetrayed and sold to set us free,\nWho suffered on the cruel tree,\nBe praise and honour endlessly.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "With fervent love,\nO Lord, we pray, Have mercy on our souls today;\nAnd lead us from this dark world's night\nTo see in Heaven Thy glorious light."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "To Christ, the Lord of Majesty,\nBetrayed and sold to set us free,\nWho suffered on the cruel tree,\nBe praise and honour endlessly.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -536,7 +871,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm XLII"
               }
@@ -548,7 +883,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -560,7 +895,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter (Hebrews 12. 3)"
               }
@@ -568,25 +903,63 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Think diligently upon Him that endured such opposition from sinners against Himself, that you be not wearied, fainting in your minds.\n℟. Thanks be to God."
+                "en-US": "Think diligently upon Him that endured such opposition from sinners against Himself, that you be not wearied, fainting in your minds."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. When He was reviled, He did not revile.\n℟. And when He suffered, He threatened not."
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "When He was reviled, He did not revile."
+                  },
+                  "r": {
+                    "en-US": "And when He suffered, He threatened not."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Lord, have mercy."
+                  },
+                  "r": {
+                    "en-US": "Christ, have mercy."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Lord, have mercy."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Lord, have mercy.\n℟. Christ, have mercy.\n℣. Lord, have mercy."
+                "en-US": "O Lord Jesus Christ, Judge of all judges, Who, at the first hour of the day, wast brought before the governor Pilate for us sinners, and didst there receive a most severe sentence: we humbly beseech Thee to succour us when we shall be arraigned before Thee, that, in that Last Judgement, we may not be condemned to eternal punishment, but may be found worthy to have fellowship with Thy faithful in Heaven, Who livest and reignest, world without end."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nO Lord Jesus Christ, Judge of all judges, Who, at the first hour of the day, wast brought before the governor Pilate for us sinners, and didst there receive a most severe sentence: we humbly beseech Thee to succour us when we shall be arraigned before Thee, that, in that Last Judgement, we may not be condemned to eternal punishment, but may be found worthy to have fellowship with Thy faithful in Heaven, Who livest and reignest, world without end.\n℟. Amen."
+                "en-US": "Amen."
               }
             }
           ]
@@ -599,37 +972,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto mine aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father and to the Son and to the Holy Ghost,"
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now and ever shall be, world without end."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Incline unto mine aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father and to the Son and to the Holy Ghost,\n℟. As it was in the beginning, is now and ever shall be, world without end.\nAmen. Praise be to Thee, O Lord, King of everlasting glory."
+                "en-US": "Amen. Praise be to Thee, O Lord, King of everlasting glory."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "Thou, Who, at this third hour, wast led\nFor guilty man, Thy Blood to shed,\nBearing the cross they laid on Thee,\nThe weight of this world's misery."
+                "en-US": "Thou, Who, at this third hour, wast led\nFor guilty man, Thy Blood to shed,\nBearing the cross they laid on Thee,\nThe weight of this world's misery.\n\nO fill our hearts with love, and bless\nOur life, with fruits of holiness.\nUntil, when strife is o'er, we stand\nBefore Thee in the Heavenly land.\n\nTo Christ, the Lord of Majesty,\nBetrayed and sold to set us free,\nWho suffered on the cruel tree, Be praise and honour endlessly.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "O fill our hearts with love, and bless\nOur life, with fruits of holiness.\nUntil, when strife is o'er, we stand\nBefore Thee in the Heavenly land."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "To Christ, the Lord of Majesty,\nBetrayed and sold to set us free,\nWho suffered on the cruel tree, Be praise and honour endlessly.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -641,7 +1028,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm LXIII"
               }
@@ -653,7 +1040,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -665,7 +1052,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter (I Peter 2. 21-22)"
               }
@@ -673,25 +1060,63 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Christ suffered for us, leaving you an example that you should follow His steps, Who did no sin, neither was guile found in His mouth.\n℟. Thanks be to God."
+                "en-US": "Christ suffered for us, leaving you an example that you should follow His steps, Who did no sin, neither was guile found in His mouth."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. He was offered because it was His own will.\n℟. And He Himself bore our iniquities."
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "He was offered because it was His own will."
+                  },
+                  "r": {
+                    "en-US": "And He Himself bore our iniquities."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Lord, have mercy."
+                  },
+                  "r": {
+                    "en-US": "Christ, have mercy."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Lord, have mercy."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Lord, have mercy.\n℟. Christ, have mercy.\n℣. Lord, have mercy."
+                "en-US": "O Lord Jesus Christ, Son of the living God, Who, at the third hour of the day, wast led forth to the torment of the cross for the salvation of the whole world: we humbly beseech Thee that, by the power of Thy most holy Passion, Thou mayest blot out all our sins, and bring us, in Thy mercy, to the glory of Thine everlasting bliss, Who livest and reignest, world without end."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nO Lord Jesus Christ, Son of the living God, Who, at the third hour of the day, wast led forth to the torment of the cross for the salvation of the whole world: we humbly beseech Thee that, by the power of Thy most holy Passion, Thou mayest blot out all our sins, and bring us, in Thy mercy, to the glory of Thine everlasting bliss, Who livest and reignest, world without end.\n℟. Amen."
+                "en-US": "Amen."
               }
             }
           ]
@@ -704,37 +1129,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto mine aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father and to the Son and to the Holy Ghost,"
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now and ever shall be, world without end."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Incline unto mine aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father and to the Son and to the Holy Ghost,\n℟. As it was in the beginning, is now and ever shall be, world without end.\nAmen.\nPraise be to Thee, O Lord, King of everlasting glory."
+                "en-US": "Amen.\nPraise be to Thee, O Lord, King of everlasting glory."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "Jesus was hanged upon the tree, And thirsted in His agony, In hands and feet He deigned to bear The cruel nails that held Him there."
+                "en-US": "Jesus was hanged upon the tree, And thirsted in His agony, In hands and feet He deigned to bear The cruel nails that held Him there.\n\nHonour and blessing ever be, O Jesus crucified, to Thee, Who, by Thy death and bitter pain, Didst bring us exiles home again.\n\nTo Christ, the Lord of Majesty, Betrayed and sold to set us free, Who suffered on the cruel tree, Be praise and honour endlessly.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "Honour and blessing ever be, O Jesus crucified, to Thee, Who, by Thy death and bitter pain, Didst bring us exiles home again."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "To Christ, the Lord of Majesty, Betrayed and sold to set us free, Who suffered on the cruel tree, Be praise and honour endlessly.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -746,7 +1185,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm CXV"
               }
@@ -758,7 +1197,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -770,7 +1209,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter (I Peter 2. 23-24)"
               }
@@ -778,25 +1217,63 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "He delivered Himself to him that judged Him unjustly, Who His own Self bore our sins in His Body on the tree, that we, being dead to sins, should live to justice; by Whose stripes we were healed.\n℟. Thanks be to God."
+                "en-US": "He delivered Himself to him that judged Him unjustly, Who His own Self bore our sins in His Body on the tree, that we, being dead to sins, should live to justice; by Whose stripes we were healed."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. He was offered because it was His own will.\n℟. And He Himself bore our iniquities."
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "He was offered because it was His own will."
+                  },
+                  "r": {
+                    "en-US": "And He Himself bore our iniquities."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Lord, have mercy."
+                  },
+                  "r": {
+                    "en-US": "Christ, have mercy."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Lord, have mercy."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Lord, have mercy.\n℟. Christ, have mercy.\n℣. Lord, have mercy."
+                "en-US": "O Lord Jesus Christ, Who, at the sixth hour of the day, didst mount upon the gibbet of the cross and, thirsting for our salvation, didst suffer gall and vinegar to be given Thee to drink: we humbly beseech Thee to enkindle Thy fire in our hearts, and make us to thirst for the chalice of Thy Passion, Who livest and reignest, world without end."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nO Lord Jesus Christ, Who, at the sixth hour of the day, didst mount upon the gibbet of the cross and, thirsting for our salvation, didst suffer gall and vinegar to be given Thee to drink: we humbly beseech Thee to enkindle Thy fire in our hearts, and make us to thirst for the chalice of Thy Passion, Who livest and reignest, world without end.\n℟. Amen."
+                "en-US": "Amen."
               }
             }
           ]
@@ -809,37 +1286,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto mine aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father and to the Son and to the Holy Ghost,"
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now and ever shall be, world without end."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Incline unto mine aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father and to the Son and to the Holy Ghost,\n℟. As it was in the beginning, is now and ever shall be, world without end.\nAmen. Praise be to Thee, O Lord, King of everlasting glory."
+                "en-US": "Amen. Praise be to Thee, O Lord, King of everlasting glory."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "May Christ's most blessed Passion win\nDeliverance from death and sin,\nWhereby, to man, the hope is given Of everlasting joys in Heaven."
+                "en-US": "May Christ's most blessed Passion win\nDeliverance from death and sin,\nWhereby, to man, the hope is given Of everlasting joys in Heaven.\n\nGlory to Christ, our Lord on high,\nWho, with one last trumpet\ncry, Gave up His soul upon the cross And saved the world from endless loss.\n\nTo Christ, the Lord of Majesty,\nBetrayed and sold to set us free,\nWho suffered on the cruel tree, Be praise and honour endlessly.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "Glory to Christ, our Lord on high,\nWho, with one last trumpet\ncry, Gave up His soul upon the cross And saved the world from endless loss."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "To Christ, the Lord of Majesty,\nBetrayed and sold to set us free,\nWho suffered on the cruel tree, Be praise and honour endlessly.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -851,7 +1342,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm CXLI"
               }
@@ -863,7 +1354,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -875,7 +1366,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter (Hebrews 2. 10)"
               }
@@ -883,25 +1374,63 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "It became Him for Whom are all things and by Whom are all things, Who had brought many children into glory, to perfect the Author of their salvation by His Passion.\n℟. Thanks be to God."
+                "en-US": "It became Him for Whom are all things and by Whom are all things, Who had brought many children into glory, to perfect the Author of their salvation by His Passion."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. He hath delivered His Soul unto death.\n℟. And He was reputed with the wicked."
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "He hath delivered His Soul unto death."
+                  },
+                  "r": {
+                    "en-US": "And He was reputed with the wicked."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Lord, have mercy."
+                  },
+                  "r": {
+                    "en-US": "Christ, have mercy."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Lord, have mercy."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Lord, have mercy.\n℟. Christ, have mercy.\n℣. Lord, have mercy."
+                "en-US": "O Lord Jesus Christ, Who, with arms outstretched on the cross and head bowed down, didst, at the ninth hour of the day, yield up Thy Spirit to God Thy Father and, with the key of Thy death, didst vouchsafe to unlock the gates of Paradise, grant to us, Thy unworthy suppliants, that, in the hour of our death, our souls, through Thy mercy, may attain to Thee Who art the true Paradise, Who livest and reignest, world without end."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nO Lord Jesus Christ, Who, with arms outstretched on the cross and head bowed down, didst, at the ninth hour of the day, yield up Thy Spirit to God Thy Father and, with the key of Thy death, didst vouchsafe to unlock the gates of Paradise, grant to us, Thy unworthy suppliants, that, in the hour of our death, our souls, through Thy mercy, may attain to Thee Who art the true Paradise, Who livest and reignest, world without end.\n℟. Amen."
+                "en-US": "Amen."
               }
             }
           ]
@@ -914,13 +1443,39 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto mine aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father and to the Son and to the Holy Ghost,"
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now and ever shall be, world without end."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Incline unto mine aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father and to the Son and to the Holy Ghost,\n℟. As it was in the beginning, is now and ever shall be, world without end.\nAmen.\nPraise be to Thee, O Lord, King of everlasting glory."
+                "en-US": "Amen.\nPraise be to Thee, O Lord, King of everlasting glory."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -932,7 +1487,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm XXIX"
               }
@@ -944,7 +1499,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -956,7 +1511,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter (Hebrews 2. 9)"
               }
@@ -964,29 +1519,42 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "We see Jesus, for the suffering of death, crowned with glory and honour; that, through the grace of God, He might taste death for all.\n℟. Thanks be to God."
+                "en-US": "We see Jesus, for the suffering of death, crowned with glory and honour; that, through the grace of God, He might taste death for all."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "O Thou Who, through death's agony,\nFor man, didst break sin's barrier down,\nBring us to find true peace in Thee,\nJesus, Who art the virgin's crown.\nA bitter potion Thou didst drain\n'Mid cruel scorn and suffering Thou spotless\nLamb, for sinners slain, O Lord most High, eternal King.\nTo all Thy faithful, who, this day,\nThy Sacred Passion bear in mind:\nGive saving health and grace to pray,\nJesus, Redeemer of mankind.\nUpon the altar of the tree Flowed forth, in streams,\nThy Blood divine: O Jesus,\nKing of clemency, In Whom the Father's light doth shine.\nO Blood of Christ, Whose glorious might\nDid strike the demon with despair:\nGrant we may come in robes of white\nThe Lamb's great marriage feast to share.\nTo Christ, the Lord of Majesty,\nBetrayed and sold to set us free,\nWho suffered on the cruel tree,\nBe praise and honour endlessly.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. The chastisement of our sins was upon Him.\n℟. For, by His stripes, we were healed."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "The chastisement of our sins was upon Him."
+                  },
+                  "r": {
+                    "en-US": "For, by His stripes, we were healed."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -998,7 +1566,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "The Magnificat (S. Luke 1. 46-55)"
               }
@@ -1010,7 +1578,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -1022,15 +1590,40 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Lord, have mercy."
+                  },
+                  "r": {
+                    "en-US": "Christ, have mercy."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Lord, have mercy.\n℟. Christ, have mercy.\n℣. Lord, have mercy."
+                "en-US": "Lord, have mercy."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nO Lord Jesus Christ, Who, according to the pious belief of the faithful, didst, at the hour of Vespers, will to be taken down from the cross and laid dead in the arms of Thy mother: grant, we beseech Thee, that, laying aside the burden of our sins, we may be presented in the sight of Thy divine Majesty, Who livest and reignest, world without end.\n℟. Amen."
+                "en-US": "O Lord Jesus Christ, Who, according to the pious belief of the faithful, didst, at the hour of Vespers, will to be taken down from the cross and laid dead in the arms of Thy mother: grant, we beseech Thee, that, laying aside the burden of our sins, we may be presented in the sight of Thy divine Majesty, Who livest and reignest, world without end."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Amen."
               }
             }
           ]
@@ -1043,13 +1636,52 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Convert us, O God our Saviour."
+                  },
+                  "r": {
+                    "en-US": "And turn away Thine anger from us."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto mine aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father and to the Son and to the Holy Ghost,"
+                  },
+                  "r": {
+                    "en-US": "As it was in the beginning, is now and ever shall be, world without end."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Convert us, O God our Saviour.\n℟. And turn away Thine anger from us.\n℣. Incline unto mine aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father and to the Son and to the Holy Ghost,\n℟. As it was in the beginning, is now and ever shall be, world without end.\nAmen.\nPraise be to Thee, O Lord, King of everlasting glory."
+                "en-US": "Amen.\nPraise be to Thee, O Lord, King of everlasting glory."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -1061,7 +1693,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Psalm LXXXVII"
               }
@@ -1073,7 +1705,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -1085,31 +1717,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "O sinless King, Who, at the close\nOf day, didst in the rock repose:\nDo Thou our restless passions still\nAnd win our hearts to do Thy will."
+                "en-US": "O sinless King, Who, at the close\nOf day, didst in the rock repose:\nDo Thou our restless passions still\nAnd win our hearts to do Thy will.\n\nLord, succour in the conflict dread\nThe soul for whom Thy Blood was shed;\nAnd bring us when life's trials cease To rest in Thine eternal peace.\n\nTo Christ, the Lord of Majesty,\nBetrayed and sold to set us free,\nWho suffered on the cruel tree, Be praise and honour endlessly.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "Lord, succour in the conflict dread\nThe soul for whom Thy Blood was shed;\nAnd bring us when life's trials cease To rest in Thine eternal peace."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "To Christ, the Lord of Majesty,\nBetrayed and sold to set us free,\nWho suffered on the cruel tree, Be praise and honour endlessly.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter (I Peter 4. 1)"
               }
@@ -1117,17 +1737,30 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Christ, having suffered in the flesh, be you also armed with the same thought.\n℟. Thanks be to God."
+                "en-US": "Christ, having suffered in the flesh, be you also armed with the same thought."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. And His place is in peace.\n℟. And His abode in Sion."
+                "en-US": "Thanks be to God."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "And His place is in peace."
+                  },
+                  "r": {
+                    "en-US": "And His abode in Sion."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -1139,7 +1772,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "The Canticle of Simeon (S. Luke 2. 29-32)"
               }
@@ -1151,7 +1784,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -1163,15 +1796,40 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Lord, have mercy."
+                  },
+                  "r": {
+                    "en-US": "Christ, have mercy."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Lord, have mercy.\n℟. Christ, have mercy.\n℣. Lord, have mercy."
+                "en-US": "Lord, have mercy."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nO Lord Jesus Christ, Who, at the last hour of the day, didst repose in the tomb, and wast lamented by Thy sorrowful mother and the other holy women: grant, we beseech Thee, that we may mourn for Thee with all the devotion of our hearts, and, abounding with tears of compunction, we may, with ardent desire, ever meditate upon Thy most glorious Passion, Who livest and reignest, world without end.\n℟. Amen."
+                "en-US": "O Lord Jesus Christ, Who, at the last hour of the day, didst repose in the tomb, and wast lamented by Thy sorrowful mother and the other holy women: grant, we beseech Thee, that we may mourn for Thee with all the devotion of our hearts, and, abounding with tears of compunction, we may, with ardent desire, ever meditate upon Thy most glorious Passion, Who livest and reignest, world without end."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Amen."
               }
             }
           ]

--- a/content/practices/little-office-s-alexius/flow.json
+++ b/content/practices/little-office-s-alexius/flow.json
@@ -1,13 +1,13 @@
 {
   "sections": [
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Invitatory"
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Invit."
       }
@@ -44,25 +44,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Alexi, gentis unica,\nIn ortu spes Quirina,\nEuphemiani gloria,\nEt urbium Reginae.\nSalve o miles nobilis,\nQui novo bellas astu\nFugiendo sponsam, redderis\nVictor de mundi fastu."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -74,15 +100,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Mihi autem adhaerere Deo bonum est.\n℟. Et ponere in Jesu meo spem meam."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Mihi autem adhaerere Deo bonum est."
+                  },
+                  "r": {
+                    "la": "Et ponere in Jesu meo spem meam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui famulum tuum Sanctum Alexium\nmirabili modo docuisti mundum spernere,\nut relicta primum sponsa peregrinus,\npaternas etiam inter aedes ignotus omnibus\nseptendecim annos abjectus remaneret;\npraesta quaesumus:\nut, dum mirificam ejus constantiam veneramur in terris,\nejus etiam intercessione semper in te uno,\nmi Jesu, gaudeamus in caelis.\nAmen."
+                "la": "Deus, qui famulum tuum Sanctum Alexium\nmirabili modo docuisti mundum spernere,\nut relicta primum sponsa peregrinus,\npaternas etiam inter aedes ignotus omnibus\nseptendecim annos abjectus remaneret;\npraesta quaesumus:\nut, dum mirificam ejus constantiam veneramur in terris,\nejus etiam intercessione semper in te uno,\nmi Jesu, gaudeamus in caelis.\nAmen."
               }
             }
           ]
@@ -96,25 +135,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Tum apparatur nuptiae,\nPlus caeli crescit amor\nHinc rapitur, et prope\nSolum consedit aequor.\nEgestas sponsa sumitur;\nComes amor latendi:\nBeata mens, quae tangitur\nHoc studio vivendi."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -126,15 +191,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Oculi Domini super fideles terrae.\n℟. Et super timentes eum gratia ejus."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Oculi Domini super fideles terrae."
+                  },
+                  "r": {
+                    "la": "Et super timentes eum gratia ejus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui famulos tuos, etc. ut supra."
+                "la": "Deus, qui famulos tuos, etc. ut supra."
               }
             }
           ]
@@ -148,25 +226,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Amen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Elapsus fuga, tegitur\nMendiculi lacerna\nNec amplius distinguitur\nper famulos a Verna.\nO alta mens Alexii!\nQuae siscitate quaesieris\npro Christo velle despici,\nQuam rara res in terris!"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -178,15 +282,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Oculi Domini super fideles terrae.\n℟. Et super timentes eum gratia ejus."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Oculi Domini super fideles terrae."
+                  },
+                  "r": {
+                    "la": "Et super timentes eum gratia ejus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui famulos tuos, etc. ut supra."
+                "la": "Deus, qui famulos tuos, etc. ut supra."
               }
             }
           ]
@@ -200,25 +317,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Amen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Edesse tenet litora;\nPauper, mendicus, nudus:\nCujus non tangat viscera\nTam novus iste luctus?\nO nova res! ut senore\nVirtus pateat miro,\nDitissimus cum paupere\nMiseri gaudet in Iro."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -230,15 +373,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Justus quasi palma florebit:\n℟. Sicut cedrus Libani multiplicabitur."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Justus quasi palma florebit:"
+                  },
+                  "r": {
+                    "la": "Sicut cedrus Libani multiplicabitur."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui famulum tuum, etc. ut supra."
+                "la": "Deus, qui famulum tuum, etc. ut supra."
               }
             }
           ]
@@ -252,25 +408,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Amen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Sed postquam omni patuit\nTam clara virtus luci,\nCiliciam constituit\nTentare, Ponto duci,\nJam fugerat: cum vertitur\nAdversa vi ventorum,\nPortu Quirino sistitur\nHaec cymba tot annorum."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -282,15 +464,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Laetatus sum in his, quae dicta sunt mihi:\n℟. In domum Domini ibimus."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Laetatus sum in his, quae dicta sunt mihi:"
+                  },
+                  "r": {
+                    "la": "In domum Domini ibimus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui famulum tuum, etc. ut supra."
+                "la": "Deus, qui famulum tuum, etc. ut supra."
               }
             }
           ]
@@ -304,25 +499,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Amen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Ingressus urbem, queruli\nIgnotos Domo Patris\nAdmittitur, sed pauperi\nCubile sit sub scalis.\nGementem Sponsam adspicit,\nTristésque Matris vultus:\nDolorem tamen supprimit:\nDeo patent singulatus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -336,13 +557,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Pater meus, et mater mea dereliquerunt me."
+                "la": "Pater meus, et mater mea dereliquerunt me."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui famulum tuum, etc. ut supra."
+                "la": "Deus, qui famulum tuum, etc. ut supra."
               }
             }
           ]
@@ -356,25 +583,64 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus Salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos Deus Salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Amen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Septemdecim jam viderat\nHac egestate soles;\nQueis natum se celaverat\nToties quaesita proles.\nErgo, ut notescat Patria\nCalamo consignant vitam\nRecondit illam pectore,\nFideli loco fixam.\nHoc acto, Coelo spiritum\nCorpusque reddit terris!\nO verum Jesu Filium\nQui patriam sic quaesitis!"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -386,15 +652,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Quam bonus Deus Israel his.\n℟. Qui recto sunt corde."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Quam bonus Deus Israel his."
+                  },
+                  "r": {
+                    "la": "Qui recto sunt corde."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui famulum tuum, etc. ut supra."
+                "la": "Deus, qui famulum tuum, etc. ut supra."
               }
             }
           ]

--- a/content/practices/little-office-s-aloysius-gonzaga-of-the-society-of-jesus/flow.json
+++ b/content/practices/little-office-s-aloysius-gonzaga-of-the-society-of-jesus/flow.json
@@ -26,33 +26,65 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies,"
+                  },
+                  "r": {
+                    "la": "Et os meum annunciabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, labia mea aperies,\n℟. Et os meum annunciabit laudem tuam.\n℣. Deus in adjutorium meum intende.\nGloria Patri, et Filio; et Spiritui Sancto."
+                "la": "Deus in adjutorium meum intende."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, et Filio; et Spiritui Sancto."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Gonzaga, salve floscule\nFavore Virginali,\nPrognate flos tenellule\nDe stirpe Principali\nTe luna Martis edidit,\nTe Martiale sidus;\nOrbique te concredidit\nSol, cum teneret Idus."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Dominus ab utero vocavit me.\n℟. Ergo judicium meum cum Domino, et opus meum cum Deo meo."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus ab utero vocavit me."
+                  },
+                  "r": {
+                    "la": "Ergo judicium meum cum Domino, et opus meum cum Deo meo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui famulum tuum B. Aloysium ad majorem nominis tui gloriam in Societatem Filii tui vocare dignatus es: largiri quaesumus, ut, cujus angelicam puritatem veneramur in terris, ejus gloriae participes fieri mereamur in caelis. Per Dominum nostrum, etc."
+                "la": "Deus, qui famulum tuum B. Aloysium ad majorem nominis tui gloriam in Societatem Filii tui vocare dignatus es: largiri quaesumus, ut, cujus angelicam puritatem veneramur in terris, ejus gloriae participes fieri mereamur in caelis. Per Dominum nostrum, etc."
               }
             }
           ]
@@ -66,33 +98,59 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Quem te vocabo vernulam\nNum tulipam colore?\nViolamne, veris gemmula,\nCasto fragrantem odore?\nUterque flos est Virginis,\nFlos est uterque Flora\nGonzaga tu propaginis\nCujus flagras amore."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ecce tu pulcher es dilecte mi, et decorus.\n℟. Lectulus noster floridus."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ecce tu pulcher es dilecte mi, et decorus."
+                  },
+                  "r": {
+                    "la": "Lectulus noster floridus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui famulum tuum, etc. ut supra."
+                "la": "Deus, qui famulum tuum, etc. ut supra."
               }
             }
           ]
@@ -106,33 +164,59 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Gonzaga vix hunc hortulum\nOrbis subis, tenellis\nMox sanctiorem flosculum\nFers Numini labellis:\nQuando Mariam, et Jesulum\nSic nominas biennis,\nUt orbis in miraculum\nOraveris triennis."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Iste puer meus electus.\n℟. Posui super eum spiritum meum."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Iste puer meus electus."
+                  },
+                  "r": {
+                    "la": "Posui super eum spiritum meum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui famulum tuum, etc. ut supra."
+                "la": "Deus, qui famulum tuum, etc. ut supra."
               }
             }
           ]
@@ -146,33 +230,59 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Jesu, et Mariae literas\nDe more tuliparum\nIn cor tuum transmisseras:\nUt quinque litterarum\nMox syllabas adnecteres,\nIllisque sanctiores;\nOrationes plecteres,\nVersusque castiores."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ex ore infantium et lactentium.\n℟. Perfecisti laudem tuam."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ex ore infantium et lactentium."
+                  },
+                  "r": {
+                    "la": "Perfecisti laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui famulum tuum, etc. ut supra."
+                "la": "Deus, qui famulum tuum, etc. ut supra."
               }
             }
           ]
@@ -186,33 +296,59 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Undene major paulum\nHortum tuum colebas,\nEt suaviorum flosculum\nCor ut daret, volebas?\nQuare supremo Numini\nAudes, sacraque Virgini\nOfferre puritatem."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Cum adhuc esset puer, coepit quaerere Deum Patris sui David.\n℟. Et duodecimo anno mundavit Judam, et Jerusalem."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Cum adhuc esset puer, coepit quaerere Deum Patris sui David."
+                  },
+                  "r": {
+                    "la": "Et duodecimo anno mundavit Judam, et Jerusalem."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui famulum tuum, etc. ut supra."
+                "la": "Deus, qui famulum tuum, etc. ut supra."
               }
             }
           ]
@@ -226,33 +362,59 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "In serta vix haec planctula,\nIn corde seminatur\nGonzaga, et ore blandula\nRosa inde procreatur\nQuae blandientis Cypridis\nNe fraudibus pateret,\nSpernit jocos Adonidis,\nUt castior lateret.\nHinc tauricis, hinc funibus,\nCalcaribus, catenis\nSe se induit, ceu vepribus,\nUt obviat venenis.\nNec sat: cruore proprio\nApud Patrem perorat?\nJesuque sub tentorio\nLatere flos hic orat."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ex omnibus floribus orbis elegisti tibi lilium unum.\n℟. Lilium inter spinas."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ex omnibus floribus orbis elegisti tibi lilium unum."
+                  },
+                  "r": {
+                    "la": "Lilium inter spinas."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui famulum tuum, etc. ut supra."
+                "la": "Deus, qui famulum tuum, etc. ut supra."
               }
             }
           ]
@@ -266,33 +428,72 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Transfertur ergo patria\nGonzaga flos ab urbe,\nRomanae in Urbis atria:\nSed saeviente sede\nIn urbe pestilentia,\nDum gnaviter ministrat\nAegris, febris constantia\nVictus sub astra migrat."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Cum liber essem, omnium me servum feci.\n℟. Mihi vivere Christus, et mori lucrum."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Cum liber essem, omnium me servum feci."
+                  },
+                  "r": {
+                    "la": "Mihi vivere Christus, et mori lucrum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui famulum tuum, etc. ut supra."
+                "la": "Deus, qui famulum tuum, etc. ut supra."
               }
             }
           ]

--- a/content/practices/little-office-s-anastasia/flow.json
+++ b/content/practices/little-office-s-anastasia/flow.json
@@ -26,9 +26,35 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nAlleluia."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nAlleluia."
               }
             },
             {
@@ -38,19 +64,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Ex stirpe nata Consulum,\nAmor, decusque siderum,\nFausta Parentis unicum,\nNostraque, salve, gaudium.\nTe Roma mundo protulit,\nTe Mater astris nutriit."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -62,22 +88,87 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Specie tua et pulchritudine tua.\n℟. Intende, prospere procede, et regna.\n℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Specie tua et pulchritudine tua."
+                  },
+                  "r": {
+                    "la": "Intende, prospere procede, et regna."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede, quaesumus, omnipotens Deus, ut beata Anastasia, quae martyrii promuit palmam, intercessionibus suis et praesentis vitae nobis remedia conferat, et aeternam salutem.Per Christum Dominum nostrum.\n℟. Amen."
+                "la": "Concede, quaesumus, omnipotens Deus, ut beata Anastasia, quae martyrii promuit palmam, intercessionibus suis et praesentis vitae nobis remedia conferat, et aeternam salutem.Per Christum Dominum nostrum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Et fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -90,25 +181,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "O quam te memorem, diva,\nDei tui,\nDum fervens teneris parvula flammulis,\nEt spernens generis Romulei decus,\nAd altiora provolas.\nSuccendit docilem discipulae facem\nArdor Chrysogoni. Mens, radiis sacris\nLeges docta pias Christianismum sequi,\nRidet deorum inanias."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -120,22 +224,87 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Adjuvabit eam Deus vultu suo.\n℟. Deus in medio ejus non commovebitur.\n℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Adjuvabit eam Deus vultu suo."
+                  },
+                  "r": {
+                    "la": "Deus in medio ejus non commovebitur."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede, quaesumus, omnipotens Deus, ut beata Anastasia, quae martyrii promuit palmam, intercessionibus suis et praesentis vitae nobis remedia conferat, et aeternam salutem.Per Christum Dominum nostrum.\n℟. Amen."
+                "la": "Concede, quaesumus, omnipotens Deus, ut beata Anastasia, quae martyrii promuit palmam, intercessionibus suis et praesentis vitae nobis remedia conferat, et aeternam salutem.Per Christum Dominum nostrum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Et fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -148,25 +317,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "O diva, dives hortus es,\nTempesque gratarum,\nHic castitatis lilia,\nFlores benignitatis,\nLibertime progerminant,\nFidesque pesque intentae.\nSed una Christi caritas\nSpinae insita est merito."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -178,22 +360,87 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Flores apparuerunt in terra nostra.\n℟. Tempus putationis advenit.\n℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Flores apparuerunt in terra nostra."
+                  },
+                  "r": {
+                    "la": "Tempus putationis advenit."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede, quaesumus, omnipotens Deus, ut beata Anastasia, quae martyrii promuit palmam, intercessionibus suis et praesentis vitae nobis remedia conferat, et aeternam salutem. Per Christum Dominum nostrum.\n℟. Amen."
+                "la": "Concede, quaesumus, omnipotens Deus, ut beata Anastasia, quae martyrii promuit palmam, intercessionibus suis et praesentis vitae nobis remedia conferat, et aeternam salutem. Per Christum Dominum nostrum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Et fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
+                "la": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -206,25 +453,32 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium, etc.\n℟. Domine, etc."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium, etc."
+                  },
+                  "r": {
+                    "la": "Domine, etc."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Viro ligata conjugii\nLigata sacris artibus\nAstris adhaeres nexibus,\nViriquae amores respuis.\nHinc lora, carcer te manent,\nErgastulumque foetidum:\nSed altior mens libera\nQuiescit inter sidera."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -236,21 +490,59 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Cupio dissolvi."
+                  },
+                  "r": {
+                    "la": "Et esse cum Christo."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Cupio dissolvi.\n℟. Et esse cum Christo.\n℣. Domine exaudi, etc."
+                "la": "Domine exaudi, etc."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede, quaesumus, omnipotens Deus, ut beata Anastasia, quae Martyrii promuit palmam,\nintercessionibus suis et praesentis vitae nobis remedia conferat, et aeternam salutem.\nPer Christum Dominum nostrum.\n℟. Amen."
+                "la": "Concede, quaesumus, omnipotens Deus, ut beata Anastasia, quae Martyrii promuit palmam,\nintercessionibus suis et praesentis vitae nobis remedia conferat, et aeternam salutem.\nPer Christum Dominum nostrum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi.\n℟.Benedicamus.\n℣. Et Fidelium, etc."
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi."
+                  },
+                  "r": {
+                    "la": "Benedicamus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Et Fidelium, etc."
               }
             }
           ]
@@ -264,25 +556,32 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium, etc.\n℟. Domine. Gloria. ut supra."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium, etc."
+                  },
+                  "r": {
+                    "la": "Domine. Gloria. ut supra."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Non te deliciae, gaudia non trahunt,\nNon te divitiae, praemia non movent.\nNec triplex Veneris machina te rapit\nNec Ulpiani basia.\nCastis fixa Deo semper amoribus\nFulges aethereo lumine gratiae.\nSed perdit Cyprio cum Puero miser\nSua Ulpianus lumina."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -294,21 +593,59 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ancilla Christi nec terrore concutitur."
+                  },
+                  "r": {
+                    "la": "Nec blandimentis seducitur."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Ancilla Christi nec terrore concutitur.\n℟. Nec blandimentis seducitur.\n℣. Domine exaudi, etc."
+                "la": "Domine exaudi, etc."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede, quaesumus, omnipotens Deus, ut beata Anastasia, quae Martyrii promuit palmam,\nintercessionibus suis et praesentis vitae nobis remedia conferat, et aeternam salutem.\nPer Christum Dominum nostrum.\n℟. Amen."
+                "la": "Concede, quaesumus, omnipotens Deus, ut beata Anastasia, quae Martyrii promuit palmam,\nintercessionibus suis et praesentis vitae nobis remedia conferat, et aeternam salutem.\nPer Christum Dominum nostrum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi.\n℟. Benedicamus.\n℣. Et Fidelium, etc."
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi."
+                  },
+                  "r": {
+                    "la": "Benedicamus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Et Fidelium, etc."
               }
             }
           ]
@@ -322,25 +659,32 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium, etc.\n℟. Domine. Gloria. ut supra."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium, etc."
+                  },
+                  "r": {
+                    "la": "Domine. Gloria. ut supra."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Te, Diva, nullis casibus\nNullaque fraude victam\nFlorus perire naufraga\nPontus cupit furente,\nNavi sedes lacertimia\nCum Martyrum corona\nSed charitas susum trahit,\nNequitiae procul merita."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -352,21 +696,59 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In charitate perpetua dilexi te."
+                  },
+                  "r": {
+                    "la": "Ideo attraxi te."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. In charitate perpetua dilexi te.\n℟. Ideo attraxi te.\n℣. Domine exaudi, etc."
+                "la": "Domine exaudi, etc."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede, quaesumus, omnipotens Deus, ut beata Anastasia, quae Martyrii promuit palmam,\nintercessionibus suis et praesentis vitae nobis remedia conferat, et aeternam salutem.\nPer Christum Dominum nostrum.\n℟. Amen."
+                "la": "Concede, quaesumus, omnipotens Deus, ut beata Anastasia, quae Martyrii promuit palmam,\nintercessionibus suis et praesentis vitae nobis remedia conferat, et aeternam salutem.\nPer Christum Dominum nostrum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi.\n℟. Benedicamus.\n℣. Et Fidelium, etc."
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi."
+                  },
+                  "r": {
+                    "la": "Benedicamus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Et Fidelium, etc."
               }
             }
           ]
@@ -380,25 +762,45 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium, etc.\n℟. Domine. Gloria. ut supra."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium, etc."
+                  },
+                  "r": {
+                    "la": "Domine. Gloria. ut supra."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Qui palma stoter largior\nPalmariam per Insulam,\nHic Coelites Victoriam\nTuum videre gestiunt.\nAssita lentis ignibus\nMoras pati jam nescia,\nConquesta flammis languida,\nAmoris igne concidis."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -410,21 +812,59 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Elegit eam Deus, et praelegit eam."
+                  },
+                  "r": {
+                    "la": "In tabernaculo suo habitare facit eam."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Elegit eam Deus, et praelegit eam.\n℟. In tabernaculo suo habitare facit eam.\n℣. Domine exaudi, etc."
+                "la": "Domine exaudi, etc."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede, quaesumus, omnipotens Deus, ut beata Anastasia, quae Martyrii promuit palmam,\nintercessionibus suis et praesentis vitae nobis remedia conferat, et aeternam salutem.\nPer Christum Dominum nostrum.\n℟. Amen."
+                "la": "Concede, quaesumus, omnipotens Deus, ut beata Anastasia, quae Martyrii promuit palmam,\nintercessionibus suis et praesentis vitae nobis remedia conferat, et aeternam salutem.\nPer Christum Dominum nostrum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi.\n℟. Benedicamus.\n℣. Et Fidelium, etc."
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi."
+                  },
+                  "r": {
+                    "la": "Benedicamus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Et Fidelium, etc."
               }
             }
           ]

--- a/content/practices/little-office-s-anna/flow.json
+++ b/content/practices/little-office-s-anna/flow.json
@@ -28,23 +28,55 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Jesus, Maria, Anna.\n℣. Domine, labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus, in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Jesus, Maria, Anna."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "O gloriosa Domina,\nDe cujus Virgo genere\nCoeli Regem columen\nLaetavit sacro ubere.\n\nQuod Eva tristis abstulit,\nRedditur Patri Filiae,\nQuae sancta sanctis procreat,\nCoeli fenestra facta est.\n\nTu Regis alti gratiam\nDeposce, atque veniam,\nMemoriam colentibus\nTuae perennis gloriae.\n\nGloria tibi, Domine,\nEx Anna natae germine,\nCum Patre et Sancto Spiritu,\nIn saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -52,13 +84,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Coeleste beneficium introivit in Annam, ex qua nobis nata est B. V. Maria.\n℣. Ora pro nobis, sancta Anna.\n℟. Ut digni efficiamur promissionibus Christi."
+                "la": "Coeleste beneficium introivit in Annam, ex qua nobis nata est B. V. Maria."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Anna."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui beatae Annae tantam gratiam conferre dignatus es, ut Genetricis unigeniti Filii tui mater effici mereretur:\nconcede propitius, ut cujus memoriam veneramur in terris, ejus apud te patrociniis adjuvemur in coelis.\nPer eundem Dominum nostrum Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum.\nAmen."
+                "la": "Deus, qui beatae Annae tantam gratiam conferre dignatus es, ut Genetricis unigeniti Filii tui mater effici mereretur:\nconcede propitius, ut cujus memoriam veneramur in terris, ejus apud te patrociniis adjuvemur in coelis.\nPer eundem Dominum nostrum Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum.\nAmen."
               }
             }
           ]
@@ -78,25 +129,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Clara diei gaudia\nModulizat Ecclesia,\nIn Annae Christi famula\nPandens caeli miracula.\n\nGloria tibi, Domine,\nEx Anna natae germine,\nCum Patre et Sancto Spiritu,\nIn saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -104,13 +168,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Coeleste beneficium introivit in Annam, ex qua nobis nata est B. V. Maria.\n℣. Ora pro nobis, sancta Anna.\n℟. Ut digni efficiamur promissionibus Christi."
+                "la": "Coeleste beneficium introivit in Annam, ex qua nobis nata est B. V. Maria."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,"
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Anna."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
@@ -136,25 +213,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Alma Regum progenies,\nEt Sacerdotum soboles,\nStirpem illustrum Patribus\nSuis ornavit actibus.\n\nGloria tibi, Domine,\nEx Anna natae germine,\nCum Patre et Sancto Spiritu,\nIn saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -162,13 +252,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Coeleste beneficium introivit in Annam, ex qua nobis nata est B. V. Maria.\n℣. Ora pro nobis, sancta Anna.\n℟. Ut digni efficiamur promissionibus Christi."
+                "la": "Coeleste beneficium introivit in Annam, ex qua nobis nata est B. V. Maria."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,"
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Anna."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
@@ -188,25 +291,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Nupta, Dei judicio,\nFideli matrimonio,\nJuxta verbum angelicum\nFructum concepit coelicum.\n\nGloria tibi, Domine,\nEx Anna natae germine,\nCum Patre et Sancto Spiritu,\nIn saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -214,13 +330,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Coeleste beneficium introivit in Annam, ex qua nobis nata est B. V. Maria.\n℣. Ora pro nobis, sancta Anna.\n℟. Ut digni efficiamur promissionibus Christi."
+                "la": "Coeleste beneficium introivit in Annam, ex qua nobis nata est B. V. Maria."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,"
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Anna."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
@@ -246,25 +375,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "In saecula pro tempore,\nPrope marcescens corpore ;\nDecreto Patris luminum\nParit Reginam Virginum.\n\nGloria tibi, Domine,\nEx Anna natae germine,\nCum Patre et Sancto Spiritu,\nIn saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -272,13 +414,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Coeleste beneficium introivit in Annam, ex qua nobis nata est B. V. Maria.\n℣. Ora pro nobis, sancta Anna.\n℟. Ut digni efficiamur promissionibus Christi."
+                "la": "Coeleste beneficium introivit in Annam, ex qua nobis nata est B. V. Maria."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,"
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Anna."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
@@ -304,25 +459,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Anna pia mater ave,\nCujus nomen est suave:\nAnna sonat gratiam.\n\nAve Jesse radix florens,\nQuae coelestes das odores,\nPerenem fragrantiam.\n\nAve patens stella maris,\nQuam tu nuptam contemplaris\nRegis regum Filio.\n\nTu, quae sola meruisti\nParens esse matris Christi ;\nPreces nostras suscipe:\n\nTu nos Matri, atque Patri,\nEt Reginae Poli\nCommendare non desine."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -330,13 +498,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Coeleste beneficium introivit in Annam, ex qua nobis nata est B. V. Maria.\n℣. Ora pro nobis, sancta Anna.\n℟. Ut digni efficiamur promissionibus Christi."
+                "la": "Coeleste beneficium introivit in Annam, ex qua nobis nata est B. V. Maria."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,"
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Anna."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
@@ -362,31 +543,51 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos, Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Obtentu suae Filiae\nMariae plenae gratiae,\nNobis auctorem omnium\nReddat Anna propitium.\n\nGloria tibi, Domine,\nCum Patre et Sancto Spiritu,\nIn saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -394,13 +595,26 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Coeleste beneficium introivit in Annam, ex qua nobis nata est B. V. Maria.\n℣. Ora pro nobis, sancta Anna.\n℟. Ut digni efficiamur promissionibus Christi."
+                "la": "Coeleste beneficium introivit in Annam, ex qua nobis nata est B. V. Maria."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,"
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Anna."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {

--- a/content/practices/little-office-s-anthony-of-padua/flow.json
+++ b/content/practices/little-office-s-anthony-of-padua/flow.json
@@ -15,11 +15,19 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.",
-        "en-US": "℣. O Lord, open my lips.\n℟. And my mouth will announce Thy praise."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine labia mea aperies.",
+            "en-US": "O Lord, open my lips."
+          },
+          "r": {
+            "la": "Et os meum annuntiabit laudem tuam.",
+            "en-US": "And my mouth will announce Thy praise."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -29,11 +37,19 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis.",
-        "en-US": "℣. Convert us, O God our Saviour.\n℟. And turn away Thy wrath from us."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Converte nos, Deus salutaris noster.",
+            "en-US": "Convert us, O God our Saviour."
+          },
+          "r": {
+            "la": "Et averte iram tuam a nobis.",
+            "en-US": "And turn away Thy wrath from us."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -43,11 +59,34 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Deus in adiutorium meum intende.\n℟. Domine ad adiuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Alleluia.",
-        "en-US": "℣. O God, come to my aid.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Spirit.\n℟. As it was in the beginning, is now, and ever shall be, world without end. Alleluia."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Deus in adiutorium meum intende.",
+            "en-US": "O God, come to my aid."
+          },
+          "r": {
+            "la": "Domine ad adiuvandum me festina.",
+            "en-US": "O Lord, make haste to help me."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Gloria Patri, et Filio, et Spiritui Sancto.",
+            "en-US": "Glory be to the Father, and to the Son, and to the Holy Spirit."
+          },
+          "r": {
+            "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Alleluia.",
+            "en-US": "As it was in the beginning, is now, and ever shall be, world without end. Alleluia."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -202,7 +241,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Ant.",
         "en-US": "Ant."
@@ -216,17 +255,32 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Ora pro nobis, beate Antoni.\n℟. Ut digni efficiamur promissionibus Christi.",
-        "en-US": "℣. Pray for us, blessed Anthony.\n℟. That we may be made worthy of the promises of Christ."
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ora pro nobis, beate Antoni.",
+            "en-US": "Pray for us, blessed Anthony."
+          },
+          "r": {
+            "la": "Ut digni efficiamur promissionibus Christi.",
+            "en-US": "That we may be made worthy of the promises of Christ."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus.",
+        "en-US": "Let us pray."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nEcclesiam tuam, Deus, Beati Antonii Confessoris tui deprecatio votiva laetificet, ut spiritualibus semper muniatur auxiliis, et gaudiis perfrui mereatur aeternis. Per Dominum Iesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus per omnia saecula saeculorum.\nAmen.",
-        "en-US": "Let us pray,\nMay Thy Church, O God, be gladdened by the devout prayers of Blessed Anthony, Thy Confessor, so that it may always be protected by spiritual help and deserve to enjoy eternal joys. Through our Lord Jesus Christ, Thy Son, who lives and reigns with Thee in the unity of the Holy Spirit, God forever and ever.\nAmen."
+        "la": "Ecclesiam tuam, Deus, Beati Antonii Confessoris tui deprecatio votiva laetificet, ut spiritualibus semper muniatur auxiliis, et gaudiis perfrui mereatur aeternis. Per Dominum Iesum Christum Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti, Deus per omnia saecula saeculorum.\nAmen.",
+        "en-US": "May Thy Church, O God, be gladdened by the devout prayers of Blessed Anthony, Thy Confessor, so that it may always be protected by spiritual help and deserve to enjoy eternal joys. Through our Lord Jesus Christ, Thy Son, who lives and reigns with Thee in the unity of the Holy Spirit, God forever and ever.\nAmen."
       }
     }
   ]

--- a/content/practices/little-office-s-barbara/flow.json
+++ b/content/practices/little-office-s-barbara/flow.json
@@ -28,7 +28,39 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Diffusa est gratia in labiis tuis: propterea benedixit te Deus in aeternum.\n℣. Domine, labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri. Alleluia."
+                "la": "Diffusa est gratia in labiis tuis: propterea benedixit te Deus in aeternum."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
               }
             },
             {
@@ -38,19 +70,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Fatalis o agonis\nPatrona Barbara,\nCoelestibus coronis,\nGemmisque fulgida!\nMoerentis in novissimo\nMors certa spiculo\nSed, Virgo, te favente,\nSum par periculo."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Osee. 2. 19."
               }
@@ -58,20 +90,72 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sponsabo te mihi in sempiternum; et sponsabo te mihi in justitia et judicio, et in misericordia, et in miserationibus.\n℣. Ora pro nobis, sancta Virgo et Martyr Barbara.\n℟. Ut felix nobis sit mortis hora."
+                "la": "Sponsabo te mihi in sempiternum; et sponsabo te mihi in justitia et judicio, et in misericordia, et in miserationibus."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancta Virgo et Martyr Barbara."
+                  },
+                  "r": {
+                    "la": "Ut felix nobis sit mortis hora."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nIntercessio, quaesumus, Domine, sanctae virginis et martyris tuae Barbarae nos adjuvet: ut qui ejus patrocinio in angustiis et necessitatibus nostris imploramus, auxilium quoque in hora potissimum mortis experiarmur. Per Dominum nostrum."
+                "la": "Intercessio, quaesumus, Domine, sanctae virginis et martyris tuae Barbarae nos adjuvet: ut qui ejus patrocinio in angustiis et necessitatibus nostris imploramus, auxilium quoque in hora potissimum mortis experiarmur. Per Dominum nostrum."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -86,23 +170,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Diffusa est gratia in labiis tuis: propterea benedixit te Deus in aeternum.\n℣. Deus, in adjutorium meum intende.\n℣. Gloria Patri. Alleluia."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+                "la": "Diffusa est gratia in labiis tuis: propterea benedixit te Deus in aeternum."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Deus, in adjutorium meum intende."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Tu vincis innocenti\nCandore lilia,\nPer prata quae nitenti\nStant lacte turgida.\nDa candido nitore\nUt, Virgo, fulgeam,\nCastoque fac amore\nUt purus ardeam."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Cant. 8. 7."
               }
@@ -116,7 +212,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Ora pro nobis, etc.\ncum Oratione, ut supra."
+                "la": "versus Ora pro nobis, etc.\ncum Oratione, ut supra."
               }
             }
           ]
@@ -132,23 +228,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Diffusa est gratia in labiis tuis: propterea benedixit te Deus in aeternum.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+                "la": "Diffusa est gratia in labiis tuis: propterea benedixit te Deus in aeternum."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Dum proprio cruore\nAsperas pingeris,\nVincis rosas rubore,\nQuae stant in hortulis.\nO coelico vireto\nPlantatae flosculae!\nHoc orbis in vepreto,\nMe, quaeso, respice."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Sap. 3. 13."
               }
@@ -162,7 +270,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Ora pro nobis, etc.\ncum Oratione, ut supra."
+                "la": "versus Ora pro nobis, etc.\ncum Oratione, ut supra."
               }
             }
           ]
@@ -178,23 +286,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Diffusa est gratia in labiis tuis: propterea benedixit te Deus in aeternum.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+                "la": "Diffusa est gratia in labiis tuis: propterea benedixit te Deus in aeternum."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Ut axe sunt sereno\nNocturna sidera,\nUt vere sunt amoeno\nJucunda flumina;\nSic, Virgo, charitatis\nEs luce fulgida,\nSic, Virgo, puritatis\nEs rore limpida."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Sap. 4. 1."
               }
@@ -208,7 +328,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Ora pro nobis, etc.\ncum Oratione, ut supra."
+                "la": "versus Ora pro nobis, etc.\ncum Oratione, ut supra."
               }
             }
           ]
@@ -224,23 +344,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Diffusa est gratia in labiis tuis: propterea benedixit te Deus in aeternum.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+                "la": "Diffusa est gratia in labiis tuis: propterea benedixit te Deus in aeternum."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Te sentiunt patronam\nQuos morbus opprimit,\nTe sublevare pronam\nQuos cura deserit.\nAngore cum super me\nMe morbus opprimit;\nSuccurre, quando nemo\nLevamen adferet."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Eccli. 51. 4."
               }
@@ -254,7 +386,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Ora pro nobis, etc.\ncum Oratione, ut supra."
+                "la": "versus Ora pro nobis, etc.\ncum Oratione, ut supra."
               }
             }
           ]
@@ -270,23 +402,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Diffusa est gratia in labiis tuis: propterea benedixit te Deus in aeternum.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+                "la": "Diffusa est gratia in labiis tuis: propterea benedixit te Deus in aeternum."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Cum ferreo sopore\nMors membra vinciet,\nEt tartarus furore\nBacchante saeviet:\nDum Judicis severi\nTribunal horreo,\nTum, Virgo, me tuere\nNe differ, obsecro."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Matth. 25. 6."
               }
@@ -300,7 +444,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Ora pro nobis, etc.\ncum Oratione, ut supra."
+                "la": "versus Ora pro nobis, etc.\ncum Oratione, ut supra."
               }
             }
           ]
@@ -316,23 +460,48 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Diffusa est gratia in labiis tuis: propterea benedixit te Deus in aeternum.\n℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
+                "la": "Diffusa est gratia in labiis tuis: propterea benedixit te Deus in aeternum."
               }
             },
             {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos, Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in adjutorium."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Amabo te, sanabo,\nDum vita manserit,\nMagisque praedicabo,\nCum vita cessaverit:\nInterque liliata\nCum me receperis,\nQueis gaudiis repleta,\nO Virgo, pasceris."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Cant. 2. 11, 13."
               }
@@ -346,7 +515,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Ora pro nobis, etc.\ncum Oratione, ut supra."
+                "la": "versus Ora pro nobis, etc.\ncum Oratione, ut supra."
               }
             }
           ]

--- a/content/practices/little-office-s-benedict/flow.json
+++ b/content/practices/little-office-s-benedict/flow.json
@@ -29,21 +29,28 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater. Ave. Credo. (secreto).\n℣. Deus in adiutorium, etc., ut supra ad vesperas.",
-                "en-US": "Our Father. Hail Mary. I believe. (silently).\n℣. Incline unto mine aid, etc., as above at vespers."
+                "la": "Pater. Ave. Credo. (secreto).",
+                "en-US": "Our Father. Hail Mary. I believe. (silently)."
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Deus in adiutorium, etc., ut supra ad vesperas.",
+                "en-US": "Incline unto mine aid, etc., as above at vespers."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Coetus triumphant coelitum. Addatque terra jubilum,\nFruatur quod aethereis, en, Benedictus gaudiis.",
+                "la": "Coetus triumphant coelitum.\nAddatque terra jubilum,\nFruatur quod aethereis,\nen, Benedictus gaudiis.",
                 "en-US": "Let saints above and men below,\nTheir joy and triumph gladly show.\nThat Benedict, with glory crowned,\nEternal bliss in heaven has found."
               }
             },
@@ -62,7 +69,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Anthem."
@@ -76,7 +83,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Ieremiae xvij, 7, 8.",
                 "en-US": "Canticle of Jeremias xvij, 7 and 8."
@@ -90,7 +97,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Anthem."
@@ -104,21 +111,44 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, beate pater Benedicte. (T.P. Alleluia).\n℟. Et impetra nobis spiritum tuum. (T.P. Alleluia).",
-                "en-US": "℣. Pray for us, O blessed father Benedict. (In P.T. Alleluia).\n℟. And obtain for us thy spirit. (In P.T. Alleluia)."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, beate pater Benedicte. (T.P. Alleluia).",
+                    "en-US": "Pray for us, O blessed father Benedict. (In P.T. Alleluia)."
+                  },
+                  "r": {
+                    "la": "Et impetra nobis spiritum tuum. (T.P. Alleluia).",
+                    "en-US": "And obtain for us thy spirit. (In P.T. Alleluia)."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater noster (secreto).\n℣. Et ne nos inducas in tentationem.\n℟. Sed libera nos a malo.",
-                "en-US": "Our Father (silently).\n℣. And lead us not into temptation.\n℟. But deliver us from evil."
+                "la": "Pater noster (secreto).",
+                "en-US": "Our Father (silently)."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et ne nos inducas in tentationem.",
+                    "en-US": "And lead us not into temptation."
+                  },
+                  "r": {
+                    "la": "Sed libera nos a malo.",
+                    "en-US": "But deliver us from evil."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Absolutio.",
                 "en-US": "Prayer of conclusion."
@@ -127,12 +157,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Precibus et meritis beati patris nostri Benedicti et omnium sanctorum, perducat nos Dominus ad regna coelorum.\n℟. Amen. ℣.\nIube, Domine, benedicere.",
-                "en-US": "Through the prayers and merits of our holy father Benedict and of all the saints, may the Lord bring us safely to his heavenly kingdom.\n℟. Amen.\n℣. O Lord, give unto us thy blessing."
+                "la": "Precibus et meritis beati patris nostri Benedicti et omnium sanctorum, perducat nos Dominus ad regna coelorum.",
+                "en-US": "Through the prayers and merits of our holy father Benedict and of all the saints, may the Lord bring us safely to his heavenly kingdom."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "speaker": "all",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Iube, Domine, benedicere.",
+                "en-US": "O Lord, give unto us thy blessing."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Benedictio",
                 "en-US": "Blessing"
@@ -141,12 +186,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Cuius commemorationem facimus, ipse gloriosus pater noster intercedat pro nobis ad Dominum. ℟. Amen.",
-                "en-US": "May our father most renowned, whose memory we celebrate, himself intercede for us unto the Lord. ℟. Amen."
+                "la": "Cuius commemorationem facimus, ipse gloriosus pater noster intercedat pro nobis ad Dominum.",
+                "en-US": "May our father most renowned, whose memory we celebrate, himself intercede for us unto the Lord."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio.",
                 "en-US": "Lesson"
@@ -155,12 +207,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Incipit liber secundus dialogorum sancti Gregorii papae.\nFuit vir vitae venerabilis, gratia Benedictus et nomine, ab ipso pueritiae suae tempore cor gerens senile.\nAetatem quippe moribus transiens, nulli animum voluptati dedit: sed dum in hac terra adhuc esset, quo temporaliter libere uti potuisset, despexit iam quasi aridum mundum cum flore. Tu autem Domine, miserere nobis.\n℟. Deo gratias.",
-                "en-US": "The beginning of the second book of the dialogues of Pope St Gregory.\nThere was a man of venerable life, Benedict—that is, blessed—both by grace and by name, who even from his boyhood's days bore within his breast the wisdom of old age.\nFor, far outstripping his years by his behaviour, he gave himself up in no way to the pleasures of the senses;\nbut while still upon this earth, of whose passing bounty he might freely have made use, he chose rather to despise the world with its allurements as something already withered up. But do thou, O Lord, have mercy upon us.\n℟. Thanks be to God."
+                "la": "Incipit liber secundus dialogorum sancti Gregorii papae.\nFuit vir vitae venerabilis, gratia Benedictus et nomine, ab ipso pueritiae suae tempore cor gerens senile.\nAetatem quippe moribus transiens, nulli animum voluptati dedit: sed dum in hac terra adhuc esset, quo temporaliter libere uti potuisset, despexit iam quasi aridum mundum cum flore. Tu autem Domine, miserere nobis.",
+                "en-US": "The beginning of the second book of the dialogues of Pope St Gregory.\nThere was a man of venerable life, Benedict—that is, blessed—both by grace and by name, who even from his boyhood's days bore within his breast the wisdom of old age.\nFor, far outstripping his years by his behaviour, he gave himself up in no way to the pleasures of the senses;\nbut while still upon this earth, of whose passing bounty he might freely have made use, he chose rather to despise the world with its allurements as something already withered up. But do thou, O Lord, have mercy upon us."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsorium",
                 "en-US": "Responsorium"
@@ -168,31 +227,114 @@
             },
             {
               "type": "prayer",
+              "speaker": "people",
               "inline": {
-                "la": "℟. Admonemus te, sancte pater, illius dignitatis, qua te Dominus tuus tam glorioso fine dignatus est honorare ac beatificare:Tu itaque nobis in hora mortis nostrae fideliter velis adesse. (T.P. Alleluia, alleluia).\n℣. Ut tua praesentia laqueos inimicorum evadamur, ac coeli gaudia petamus sine fine beati. Tu itaque, etc. (Gloria Patri, etc. Tu itaque).\n\nTempore passionis omittitur: ℣. Gloria Patri et Tu itaque et eorum loco repetitur integrum ℟. Admonemus usque ad velis adesse.",
-                "en-US": "℟. We remind thee, O holy father, of that dignity, with which thy Lord, by thy most glorious end, didst deign to honour thee and make thee blessed:\nDo thou, therefore, in thy turn, vouchsafe to stand by us faithfully at the hour of our death. (In P.T. Alleluia, alleluia).\n℣. That strengthened and protected by thy presence, we may escape from the toils of the enemy and reach the joys of heaven, to be therein for ever blessed.\n(Glory be to the Father, etc., Do thou, therefore, etc.)\n\nIn passiontide the ℣. Glory be to the Father and Do thou, therefore are omitted, and in their place is repeated the whole of the ℟. We remind thee down to hour of our death."
+                "la": "Admonemus te, sancte pater, illius dignitatis, qua te Dominus tuus tam glorioso fine dignatus est honorare ac beatificare:Tu itaque nobis in hora mortis nostrae fideliter velis adesse. (T.P. Alleluia, alleluia).",
+                "en-US": "We remind thee, O holy father, of that dignity, with which thy Lord, by thy most glorious end, didst deign to honour thee and make thee blessed:\nDo thou, therefore, in thy turn, vouchsafe to stand by us faithfully at the hour of our death. (In P.T. Alleluia, alleluia)."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ut tua praesentia laqueos inimicorum evadamur, ac coeli gaudia petamus sine fine beati. Tu itaque, etc. (Gloria Patri, etc. Tu itaque).",
+                    "en-US": "That strengthened and protected by thy presence, we may escape from the toils of the enemy and reach the joys of heaven, to be therein for ever blessed.\n(Glory be to the Father, etc., Do thou, therefore, etc.)"
+                  },
+                  "r": {
+                    "la": "Admonemus te, sancte pater.",
+                    "en-US": "We remind thee, O holy father."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Tempore passionis omittitur: Gloria Patri et Tu itaque et eorum loco repetitur integrum Admonemus usque ad velis adesse.",
+                "en-US": "In passiontide the Glory be to the Father and Do thou, therefore are omitted, and in their place is repeated the whole of the We remind thee down to hour of our death."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto thee."
+                "la": "Deus, qui beatissimum patrem ac legislatorem nostrum Benedictum abstractum a mundi turbinibus tibi soli militare iussisti: tribue, quaesumus, nobis sub eius magisterio tibi servientibus, perseverandi constantiam et usque in finem victoriam. Per Christum Dominum nostrum.",
+                "en-US": "O God, who didst command our most blessed father and lawgiver, Benedict, to leave the turmoil of the world and fight for thee alone:\nwe, who are serving thee under his tutelage, beseech thee to grant us an unshakable constancy and victory unto the end.\nThrough Christ our Lord."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui beatissimum patrem ac legislatorem nostrum Benedictum abstractum a mundi turbinibus tibi soli militare iussisti: tribue, quaesumus, nobis sub eius magisterio tibi servientibus, perseverandi constantiam et usque in finem victoriam. Per Christum Dominum nostrum.\n℟. Amen.",
-                "en-US": "Let us pray,\nO God, who didst command our most blessed father and lawgiver, Benedict, to leave the turmoil of the world and fight for thee alone:\nwe, who are serving thee under his tutelage, beseech thee to grant us an unshakable constancy and victory unto the end.\nThrough Christ our Lord.\n℟. Amen."
+                "la": "Amen.",
+                "en-US": "Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed through the mercy of God rest in peace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+                    "en-US": "May the souls of the faithful departed through the mercy of God rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -207,12 +349,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater. Ave. (secreto).\n℣. Deus in adiutorium, etc., ut supra ad Vesperas.",
-                "en-US": "Our Father. Hail Mary (silently).\n℣. Incline unto mine aid, etc., as above at Vespers."
+                "la": "Pater. Ave. (secreto).",
+                "en-US": "Our Father. Hail Mary (silently)."
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Deus in adiutorium, etc., ut supra ad Vesperas.",
+                "en-US": "Incline unto mine aid, etc., as above at Vespers."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -226,7 +375,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus CL",
                 "en-US": "Psalm CL"
@@ -240,7 +389,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -254,7 +403,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum (Ecclus. 1:10–11, 13–14)",
                 "en-US": "Little Chapter (Ecclus. 1:10–11, 13–14)"
@@ -263,12 +412,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quasi vas auri solidum, ornatum omni lapide pretioso.\nQuasi oliva pullulans, et cypressus in altitudinem se extollens.\nEt circa illum corona fratrum:\nquasi plantatio cedri in monte Libano,\nsic circa illum steterunt quasi rami palmae,\net omnes filii Aaron in gloria sua.\n℟. Deo gratias.",
-                "en-US": "He was as a massy vessel of gold, adorned with every precious stone;\nas an olive tree budding forth, and a cypress tree rearing itself on high.\nAnd about him was the ring of his brethren:\nas the cedar planted on Mount Libanus, and as branches of palm trees,\nthey stood round about him, and all the sons of Aaron in their glory.\n℟. Thanks be to God."
+                "la": "Quasi vas auri solidum, ornatum omni lapide pretioso.\nQuasi oliva pullulans, et cypressus in altitudinem se extollens.\nEt circa illum corona fratrum:\nquasi plantatio cedri in monte Libano,\nsic circa illum steterunt quasi rami palmae,\net omnes filii Aaron in gloria sua.",
+                "en-US": "He was as a massy vessel of gold, adorned with every precious stone;\nas an olive tree budding forth, and a cypress tree rearing itself on high.\nAnd about him was the ring of his brethren:\nas the cedar planted on Mount Libanus, and as branches of palm trees,\nthey stood round about him, and all the sons of Aaron in their glory."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsorium Breve",
                 "en-US": "Short Responsory"
@@ -277,33 +433,113 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Sancte Pater Benedicte, intercede pro nobis.\nRep.: Sancte Pater, etc.\n℣. Et impetra nobis spiritum tuum. Intercede pro nobis.\n℣. Gloria Patri, etc.\n℟. Sancte Pater, etc.\n\nTempore Passionis omittitur ℣. Gloria Patri.\n\nTempore Paschali:\n℟. Sancte Pater Benedicte, intercede pro nobis, alleluia, alleluia.\nRep.: Sancte Pater, etc.\n℣. Et impetra nobis spiritum tuum. Alleluia, alleluia.\n℣. Gloria Patri, etc.\n℟. Sancte Pater, etc.",
-                "en-US": "℟. O holy Father Benedict, intercede for us.\nRepeat: O holy Father, etc.\n℣. And obtain for us thy spirit. Intercede for us.\n℣. Glory be to the Father, etc.\n℟. O holy Father, etc.\n\nIn Passiontide the ℣. Glory be to the Father is omitted.\n\nDuring Paschal Time:\n℟. O holy Father Benedict, intercede for us, alleluia, alleluia.\nRepeat: O holy Father, etc.\n℣. And obtain for us thy spirit. Alleluia, alleluia.\n℣. Glory be to the Father, etc.\n℟. O holy Father, etc."
+                "la": "Sancte Pater Benedicte, intercede pro nobis.",
+                "en-US": "O holy Father Benedict, intercede for us."
               }
             },
             {
+              "type": "prayer",
+              "inline": {
+                "la": "Rep.: Sancte Pater, etc.",
+                "en-US": "Repeat: O holy Father, etc."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Et impetra nobis spiritum tuum. Intercede pro nobis.",
+                "en-US": "And obtain for us thy spirit. Intercede for us."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, etc.",
+                    "en-US": "Glory be to the Father, etc."
+                  },
+                  "r": {
+                    "la": "Sancte Pater, etc.",
+                    "en-US": "O holy Father, etc."
+                  }
+                }
+              ]
+            },
+            {
               "type": "rubric",
+              "text": {
+                "la": "Tempore Passionis omittitur Gloria Patri.\n\nTempore Paschali:",
+                "en-US": "In Passiontide the Glory be to the Father is omitted.\n\nDuring Paschal Time:"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Sancte Pater Benedicte, intercede pro nobis, alleluia, alleluia.",
+                "en-US": "O holy Father Benedict, intercede for us, alleluia, alleluia."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Rep.: Sancte Pater, etc.",
+                "en-US": "Repeat: O holy Father, etc."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Et impetra nobis spiritum tuum. Alleluia, alleluia.",
+                "en-US": "And obtain for us thy spirit. Alleluia, alleluia."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, etc.",
+                    "en-US": "Glory be to the Father, etc."
+                  },
+                  "r": {
+                    "la": "Sancte Pater, etc.",
+                    "en-US": "O holy Father, etc."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Te, Pater alme, petimus\nUt sanctis tuis precibus\nA cunctis malis protegas,\nMentesque nostras dirigas.\n\nDum laudes Dei concinis,\nTerrenas omnes despicis:\nHoc nobis quoque obtine,\nHostisque a telo protege.\n\nO sacrosancta Trinitas,\nSit tibi laus et gloria!\nQua Benedictus fruitur\nPer infinita saecula. Amen.",
                 "en-US": "Father beloved, from day to day\nWith love untiring thee we pray\nFrom thoughts of sin and snare of hell\nTo keep our minds, and guard us well.\n\nWhilst thou dost e'er thy spirit sate\nWith praising God, teach us to hate,\nAs thou didst, all things here below,\nAnd shield us from our deadly foe.\n\nPraise, honour, glory, be to Thee,\nMost sacred, holy Trinity;\nWhose love, in everlasting rest,\nO'erflows our Saint's enraptured breast. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, beate Pater Benedicte. (T.P. Alleluia).\n℟. Ut digni efficiamur promissionibus Christi. (T.P. Alleluia).",
-                "en-US": "℣. Pray for us, O blessed Father Benedict. (In P.T. Alleluia).\n℟. That we may be made worthy of the promises of Christ. (In P.T. Alleluia)."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, beate Pater Benedicte. (T.P. Alleluia).",
+                    "en-US": "Pray for us, O blessed Father Benedict. (In P.T. Alleluia)."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi. (T.P. Alleluia).",
+                    "en-US": "That we may be made worthy of the promises of Christ. (In P.T. Alleluia)."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -317,7 +553,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum (Luc. 1:68–79)",
                 "en-US": "Canticle (Luke 1:68–79)"
@@ -331,7 +567,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -345,25 +581,85 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui beatum Patrem nostrum Benedictum Abbatem,\nde eius quae in mundo est concupiscentia corruptione ereptum,\nChristo fideliter adhaerere fecisti:\nquaesumus, ut contra saeculi huius illecebras tua virtute roborati,\nbravium supernae vocationis constanter persequi et feliciter assequi valeamus.\nPer eundem Christum Dominum nostrum.\n℟. Amen.",
-                "en-US": "Let us pray,\nO God, Who didst snatch our holy Father, the Abbot Benedict,\nfrom the corruption of that lust which pervadeth the world,\nand didst cause him to cleave faithfully unto Christ,\nwe beseech Thee to strengthen us also by Thy power\nagainst the allurements of this world,\nand to enable us both unflinchingly to pursue\nand successfully to lay hold on the reward of our heavenly calling.\nThrough the same Christ our Lord.\n℟. Amen."
+                "la": "Deus, qui beatum Patrem nostrum Benedictum Abbatem,\nde eius quae in mundo est concupiscentia corruptione ereptum,\nChristo fideliter adhaerere fecisti:\nquaesumus, ut contra saeculi huius illecebras tua virtute roborati,\nbravium supernae vocationis constanter persequi et feliciter assequi valeamus.\nPer eundem Christum Dominum nostrum.",
+                "en-US": "O God, Who didst snatch our holy Father, the Abbot Benedict,\nfrom the corruption of that lust which pervadeth the world,\nand didst cause him to cleave faithfully unto Christ,\nwe beseech Thee to strengthen us also by Thy power\nagainst the allurements of this world,\nand to enable us both unflinchingly to pursue\nand successfully to lay hold on the reward of our heavenly calling.\nThrough the same Christ our Lord."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed through the mercy of God rest in peace.\n℟. Amen."
+                "la": "Amen.",
+                "en-US": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+                    "en-US": "May the souls of the faithful departed through the mercy of God rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -378,26 +674,33 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater. Ave. Credo (secreto).\n℣. Deus in adiutorium, etc., ut supra ad Vesperas.",
-                "en-US": "Our Father. Hail Mary. I believe (silently).\n℣. Incline unto mine aid, etc., as above at Vespers."
+                "la": "Pater. Ave. Credo (secreto).",
+                "en-US": "Our Father. Hail Mary. I believe (silently)."
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Deus in adiutorium, etc., ut supra ad Vesperas.",
+                "en-US": "Incline unto mine aid, etc., as above at Vespers."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Athleta invictissime\nSacraeque dux militiae;\nNos, Benedicte, valido\nPrecum defende brachio.\n\nHis armis exsecrabilem\nLeonis vince rabiem:\nQuibus olim teterrimam\nPellis ab ore meruam.\n\nO sacrosancta Trinitas,\nSit tibi laus et gloria!\nQua Benedictus fruitur\nPer infinita saecula. Amen.",
                 "en-US": "Unconquered soldier, great in might,\nOur leader in the sacred fight:\nIn prayer to heaven lift up thine arms\nAnd save us from hell's fierce alarms.\n\nAs erst thou didst by prayer defeat\nThe unclean bird's most foul deceit,\nSo now the lion foil, who prowls\nWith raging thirst, to seize our souls.\n\nPraise, honour, glory, be to Thee,\nMost sacred, holy Trinity!\nWhose love, in everlasting rest,\nO'erflows our Saint's enraptured breast. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Anthem."
@@ -411,7 +714,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus I",
                 "en-US": "Psalm I"
@@ -425,7 +728,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Anthem."
@@ -439,31 +742,106 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, beate Pater Benedicte. (T.P. Alleluia).\n℟. Et impetra nobis spiritum tuum. (T.P. Alleluia).",
-                "en-US": "℣. Pray for us, O blessed Father Benedict. (In P.T. Alleluia).\n℟. And obtain for us thy spirit. (In P.T. Alleluia)."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, beate Pater Benedicte. (T.P. Alleluia).",
+                    "en-US": "Pray for us, O blessed Father Benedict. (In P.T. Alleluia)."
+                  },
+                  "r": {
+                    "la": "Et impetra nobis spiritum tuum. (T.P. Alleluia).",
+                    "en-US": "And obtain for us thy spirit. (In P.T. Alleluia)."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
+                "la": "Fac nos quaesumus Domine, beati Patris nostri Benedicti hic imitari labores:\nut illic eius gloriae participes esse mereamur.\nPer Christum Dominum nostrum.",
+                "en-US": "Make us, we beseech Thee, O Lord, so to imitate the labours of our holy Father Benedict here on earth,\nthat we may, in heaven, deserve to become partakers of his glory.\nThrough Christ our Lord."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nFac nos quaesumus Domine, beati Patris nostri Benedicti hic imitari labores:\nut illic eius gloriae participes esse mereamur.\nPer Christum Dominum nostrum.\n℟. Amen.",
-                "en-US": "Let us pray,\nMake us, we beseech Thee, O Lord, so to imitate the labours of our holy Father Benedict here on earth,\nthat we may, in heaven, deserve to become partakers of his glory.\nThrough Christ our Lord.\n℟. Amen."
+                "la": "Amen.",
+                "en-US": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+                    "en-US": "May the souls of the faithful departed through the mercy of God rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.\nPater. Ave. (secreto).",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed through the mercy of God rest in peace.\n℟. Amen.\nOur Father. Hail Mary. (silently)."
+                "la": "Pater. Ave. (secreto).",
+                "en-US": "Our Father. Hail Mary. (silently)."
               }
             }
           ]
@@ -479,26 +857,33 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater. Ave. (secreto).\n℣. Deus in adiutorium, etc., ut supra ad Vesperas.",
-                "en-US": "Our Father. Hail Mary (silently).\n℣. Incline unto mine aid, etc., as above at Vespers."
+                "la": "Pater. Ave. (secreto).",
+                "en-US": "Our Father. Hail Mary (silently)."
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Deus in adiutorium, etc., ut supra ad Vesperas.",
+                "en-US": "Incline unto mine aid, etc., as above at Vespers."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Urticae iunctae vepribus,\nVulnus curant vulneribus,\nFlammata mens divinitus\nIgnem exstinguit ignibus.\n\nCrucem mittens, ut lapidem,\nVeneni frangit calicem:\nNon valet mortis vasculum\nVitae ferre signaculum.\n\nO sacrosancta Trinitas,\nSit tibi laus et gloria!\nQua Benedictus fruitur\nPer infinita saecula. Amen.",
                 "en-US": "Whilst briers' wounds and nettles' sting\nHis flesh into subjection bring,\nHis soul, with love divine on fire,\nItself feels carnal love expire.\n\nThe Cross's saving sign he makes\nAnd lo! the poisoned chalice breaks;\nThe fatal cup with death full rife\nCannot withstand the sign of life.\n\nPraise, honour, glory, be to Thee,\nMost sacred, holy Trinity!\nWhose love, in everlasting rest,\nO'erflows our Saint's enraptured breast. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Anthem."
@@ -512,7 +897,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus CXIX",
                 "en-US": "Psalm CXIX"
@@ -526,7 +911,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Anthem."
@@ -540,31 +925,106 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, beate Pater Benedicte. (T.P. Alleluia).\n℟. Et impetra nobis spiritum tuum. (T.P. Alleluia).",
-                "en-US": "℣. Pray for us, O blessed Father Benedict. (In P.T. Alleluia).\n℟. And obtain for us thy spirit. (In P.T. Alleluia)."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, beate Pater Benedicte. (T.P. Alleluia).",
+                    "en-US": "Pray for us, O blessed Father Benedict. (In P.T. Alleluia)."
+                  },
+                  "r": {
+                    "la": "Et impetra nobis spiritum tuum. (T.P. Alleluia).",
+                    "en-US": "And obtain for us thy spirit. (In P.T. Alleluia)."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
+                "la": "Intercessio nos, quaesumus Domine, beati Patris nostri Benedicti Abbatis commendet:\nut quod nostris meritis non valemus, eius patrocinio assequamur.\nPer Christum Dominum nostrum.",
+                "en-US": "May the intercession, we beseech Thee, O Lord, of our holy Father, the Abbot Benedict,\nrecommend us: that that whereof our own merits fall short,\nwe may gain through his patronage.\nThrough Christ our Lord."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nIntercessio nos, quaesumus Domine, beati Patris nostri Benedicti Abbatis commendet:\nut quod nostris meritis non valemus, eius patrocinio assequamur.\nPer Christum Dominum nostrum.\n℟. Amen.",
-                "en-US": "Let us pray,\nMay the intercession, we beseech Thee, O Lord, of our holy Father, the Abbot Benedict,\nrecommend us: that that whereof our own merits fall short,\nwe may gain through his patronage.\nThrough Christ our Lord.\n℟. Amen."
+                "la": "Amen.",
+                "en-US": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+                    "en-US": "May the souls of the faithful departed through the mercy of God rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.\nPater. Ave. (secreto).",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed through the mercy of God rest in peace.\n℟. Amen.\nOur Father. Hail Mary. (silently)."
+                "la": "Pater. Ave. (secreto).",
+                "en-US": "Our Father. Hail Mary. (silently)."
               }
             }
           ]
@@ -580,26 +1040,33 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater. Ave (secreto).\n℣. Deus in adiutorium, etc., ut supra ad Vesperas.",
-                "en-US": "Our Father. Hail Mary (silently).\n℣. Incline unto mine aid, etc., as above at Vespers."
+                "la": "Pater. Ave (secreto).",
+                "en-US": "Our Father. Hail Mary (silently)."
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Deus in adiutorium, etc., ut supra ad Vesperas.",
+                "en-US": "Incline unto mine aid, etc., as above at Vespers."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Frater quem tunc nequissimus\nVagum rapbat spiritus,\nDum tua virga caeditur\nStabilitati redditur.\n\nTua, carentum gratia\nTellus vomit cadavera,\nDevotis unda liquida\nSicca lambit vestigia.\n\nO sacrosancta Trinitas,\nSit tibi laus et gloria!\nQua Benedictus fruitur\nPer infinita saecula. Amen.",
                 "en-US": "When by the devil led astray\nA restless brother drifts away,\nReproved by thy chastising rod\nHe gains new strength to serve his God.\n\nWhoe'er reject thy friendship, those\nThe earth from her cold bosom throws;\nWhile they who faithful to thee prove\nO'er waters wild securely move.\n\nPraise, honour, glory, be to Thee,\nMost sacred, holy Trinity!\nWhose love, in everlasting rest,\nO'erflows our Saint's enraptured breast. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona",
                 "en-US": "Anthem."
@@ -613,7 +1080,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus CXXII",
                 "en-US": "Psalm CXXII"
@@ -627,7 +1094,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona",
                 "en-US": "Anthem"
@@ -641,31 +1108,106 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, beate Pater Benedicte. (T. P. Alleluia).\n℟. Et impetra nobis spiritum tuum. (T. P. Alleluia).",
-                "en-US": "℣. Pray for us, O blessed Father Benedict. (T. P. Alleluia).\n℟. And obtain for us thy spirit. (T. P. Alleluia)."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, beate Pater Benedicte. (T. P. Alleluia).",
+                    "en-US": "Pray for us, O blessed Father Benedict. (T. P. Alleluia)."
+                  },
+                  "r": {
+                    "la": "Et impetra nobis spiritum tuum. (T. P. Alleluia).",
+                    "en-US": "And obtain for us thy spirit. (T. P. Alleluia)."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
+                "la": "Deus, in cuius virtute beatus Pater noster Benedictus exstincta fecit pueri membra reviviscere: praesta quaesumus eius meritis; per afflatum tui Spiritus a morte animae vivificari. Per Christum Dominum nostrum.",
+                "en-US": "O God, by Whose power our holy Father Benedict brought back a dead boy to life again, grant, we beseech Thee, through his merits, that by the breath of Thy Spirit our souls may be quickened and preserved from death. Through Christ our Lord."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, in cuius virtute beatus Pater noster Benedictus exstincta fecit pueri membra reviviscere: praesta quaesumus eius meritis; per afflatum tui Spiritus a morte animae vivificari. Per Christum Dominum nostrum.\n℟. Amen.",
-                "en-US": "Let us pray,\nO God, by Whose power our holy Father Benedict brought back a dead boy to life again, grant, we beseech Thee, through his merits, that by the breath of Thy Spirit our souls may be quickened and preserved from death. Through Christ our Lord.\n℟. Amen."
+                "la": "Amen.",
+                "en-US": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+                    "en-US": "May the souls of the faithful departed through the mercy of God rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.\nPater. Ave (secreto).",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed through the mercy of God rest in peace.\n℟. Amen.\nOur Father. Hail Mary (silently)."
+                "la": "Pater. Ave (secreto).",
+                "en-US": "Our Father. Hail Mary (silently)."
               }
             }
           ]
@@ -681,26 +1223,33 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater. Ave (secreto).\n℣. Deus in adiutorium, etc., ut supra ad Vesperas.",
-                "en-US": "Our Father. Hail Mary (silently).\n℣. Incline unto mine aid, etc., as above at Vespers."
+                "la": "Pater. Ave (secreto).",
+                "en-US": "Our Father. Hail Mary (silently)."
               }
             },
             {
               "type": "rubric",
+              "text": {
+                "la": "Deus in adiutorium, etc., ut supra ad Vesperas.",
+                "en-US": "Incline unto mine aid, etc., as above at Vespers."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Totius orbis ambitum\nPer solis videt radium,\nMens in Auctore posita\nSubiecta cernit omnia.\n\nO virum vere coelicum!\nO rerum Dei conscium!\nGermani videt animam\nLaetam ire ad coelestia.\n\nO sacrosancta Trinitas,\nSit tibi laus et gloria!\nQua Benedictus fruitur\nPer infinita saecula. Amen.",
-                "en-US": "The whole extent of this our sphere,\nOne ray of light to him makes clear,\nWhose mind, raised up to God on high\nSees all things with a keener eye.\n\nO heaven-blest mortal,\nin whose breast\nThe Deity's dread secrets rest:\nHe sees in glory to the skies\nThe soul of Saint Germanus rise.\n\nPraise, honour, glory, be to Thee\nMost sacred, holy Trinity!\nWhose love, in everlasting rest,\nO'erflows our Saint's enraptured breast. Amen."
+                "en-US": "The whole extent of this our sphere,\nOne ray of light to him makes clear,\nWhose mind, raised up to God on high\nSees all things with a keener eye.\n\nO heaven-blest mortal, in whose breast\nThe Deity's dread secrets rest:\nHe sees in glory to the skies\nThe soul of Saint Germanus rise.\n\nPraise, honour, glory, be to Thee\nMost sacred, holy Trinity!\nWhose love, in everlasting rest,\nO'erflows our Saint's enraptured breast. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona.",
                 "en-US": "Anthem."
@@ -714,7 +1263,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus CXXV",
                 "en-US": "Psalm CXXV"
@@ -728,7 +1277,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona",
                 "en-US": "Anthem"
@@ -742,31 +1291,106 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, beate Pater Benedicte. (T. P. Alleluia).\n℟. Et impetra nobis spiritum tuum. (T. P. Alleluia).",
-                "en-US": "℣. Pray for us, O blessed Father Benedict. (T. P. Alleluia).\n℟. And obtain for us thy spirit. (T. P. Alleluia)."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, beate Pater Benedicte. (T. P. Alleluia).",
+                    "en-US": "Pray for us, O blessed Father Benedict. (T. P. Alleluia)."
+                  },
+                  "r": {
+                    "la": "Et impetra nobis spiritum tuum. (T. P. Alleluia).",
+                    "en-US": "And obtain for us thy spirit. (T. P. Alleluia)."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
+                "la": "Concede nobis quaesumus Domine, alacris animis beati Patris nostri Benedicti commemorationem cotidie peragere: cuius diversis decorata miraculis tibi vita complacuit. Per Christum Dominum nostrum.",
+                "en-US": "Grant, we beseech Thee O Lord, that we may celebrate with blithe and cheerful hearts the daily memory of our holy Father Benedict, whose life, adorned with miracles of every sort, was pleasing in Thy sight. Through Christ our Lord."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede nobis quaesumus Domine, alacris animis beati Patris nostri Benedicti commemorationem cotidie peragere: cuius diversis decorata miraculis tibi vita complacuit. Per Christum Dominum nostrum.\n℟. Amen.",
-                "en-US": "Let us pray,\nGrant, we beseech Thee O Lord, that we may celebrate with blithe and cheerful hearts the daily memory of our holy Father Benedict, whose life, adorned with miracles of every sort, was pleasing in Thy sight. Through Christ our Lord.\n℟. Amen."
+                "la": "Amen.",
+                "en-US": "Amen."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+                    "en-US": "May the souls of the faithful departed through the mercy of God rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.\nPater. Ave (secreto).",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed through the mercy of God rest in peace.\n℟. Amen.\nOur Father. Hail Mary (silently)."
+                "la": "Pater. Ave (secreto).",
+                "en-US": "Our Father. Hail Mary (silently)."
               }
             }
           ]
@@ -782,8 +1406,45 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater. Ave. (secreto).\n℣. Deus in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia.",
-                "en-US": "Our Father. Hail Mary. (silently).\n℣. Incline unto mine aid, O God.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. As it was in the beginning, is now, and ever shall be, world without end.\nAmen. Alleluia."
+                "la": "Pater. Ave. (secreto).",
+                "en-US": "Our Father. Hail Mary. (silently)."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende.",
+                    "en-US": "Incline unto mine aid, O God."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina.",
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri et Filio, et Spiritui Sancto.",
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.",
+                    "en-US": "As it was in the beginning, is now, and ever shall be, world without end."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen. Alleluia.",
+                "en-US": "Amen. Alleluia."
               }
             },
             {
@@ -794,7 +1455,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Anthem."
@@ -808,7 +1469,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus CIX",
                 "en-US": "Psalm CIX"
@@ -822,7 +1483,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona",
                 "en-US": "Anthem"
@@ -836,7 +1497,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum. Ecclus. 1, 6, 7.",
                 "en-US": "Little Chapter Ecclus. 1, 6 and 7."
@@ -845,12 +1506,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ecce Confessor magnus: qui quasi stella matutina in medio nebulae, et quasi luna plena in diebus suis lucet; et quasi sol refulgens, sic ille effulsit in templo Dei.\n℟. Deo gratias.",
-                "en-US": "Behold a great Confessor: who shone in his days as the morning star in the midst of a cloud, and as the moon at the full; and as the sun when it shineth, so did he shine in the temple of God.\n℟. Thanks be to God."
+                "la": "Ecce Confessor magnus: qui quasi stella matutina in medio nebulae, et quasi luna plena in diebus suis lucet; et quasi sol refulgens, sic ille effulsit in templo Dei.",
+                "en-US": "Behold a great Confessor: who shone in his days as the morning star in the midst of a cloud, and as the moon at the full; and as the sun when it shineth, so did he shine in the temple of God."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsorium Breve",
                 "en-US": "Short Responsory"
@@ -858,34 +1526,91 @@
             },
             {
               "type": "prayer",
+              "lang": "la",
               "inline": {
-                "la": "℟. Sancte Pater Benedicte intercede pro nobis.\nRep. Sancte Pater Benedicte, intercede pro nobis.\n℣. Ut digni efficiamur promissionibus Christi.\nIntercede pro nobis.\n(Vel: Gloria Patri, et Filio, et Spiritui Sancto.)\n℟. Sancte Pater, etc.\n\nTempore Passionis omittitur: Gloria Patri.\n\nTempore paschali:\n℟. Sancte Pater Benedicte, intercede pro nobis, Alleluia, alleluia.\nRep. Sancte Pater Benedicte, intercede pro nobis, Alleluia, alleluia.\n℣. Ut digni efficiamur promissionibus Christi. Alleluia, alleluia.\n℣. Gloria Patri, etc. ℟. Sancte Pater, etc.",
-                "en-US": "℟. O holy Father Benedict, intercede for us.\nRep. O holy Father Benedict, intercede for us.\n℣. That we may be made worthy of the promises of Christ. Intercede for us.\n(Vel: Glory be to the Father, and to the Son, and to the Holy Ghost.)\n℟. O holy Father, etc.\n\nIn Passiontide the ℣. Gloria Patri is omitted.\n\nDuring Paschal Time:\n℟. O holy Father Benedict, intercede for us, Alleluia, alleluia.\nRep. O holy Father Benedict, intercede for us, Alleluia, alleluia.\n℣. That we may be made worthy of the promises of Christ. Alleluia, alleluia.\n℣. Glory be to the Father,\netc. ℟. O holy Father, etc."
+                "la": "Sancte Pater Benedicte intercede pro nobis.\nRep. Sancte Pater Benedicte, intercede pro nobis.\nUt digni efficiamur promissionibus Christi.\nIntercede pro nobis.\n(Vel: Gloria Patri, et Filio, et Spiritui Sancto.)\nSancte Pater, etc."
               }
             },
             {
               "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Tempore Passionis omittitur: Gloria Patri."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "la",
+              "text": {
+                "la": "Tempore paschali:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "la",
+              "inline": {
+                "la": "Sancte Pater Benedicte, intercede pro nobis, Alleluia, alleluia.\nRep. Sancte Pater Benedicte, intercede pro nobis, Alleluia, alleluia.\nUt digni efficiamur promissionibus Christi. Alleluia, alleluia.\nGloria Patri, etc. Sancte Pater, etc."
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O holy Father Benedict, intercede for us.\nRep. O holy Father Benedict, intercede for us.\nThat we may be made worthy of the promises of Christ. Intercede for us.\n(Vel: Glory be to the Father, and to the Son, and to the Holy Ghost.)\nO holy Father, etc."
+              }
+            },
+            {
+              "type": "rubric",
+              "lang": "en-US",
+              "text": {
+                "en-US": "In Passiontide the Gloria Patri is omitted."
+              }
+            },
+            {
+              "type": "subheading",
+              "lang": "en-US",
+              "text": {
+                "en-US": "During Paschal Time:"
+              }
+            },
+            {
+              "type": "prayer",
+              "lang": "en-US",
+              "inline": {
+                "en-US": "O holy Father Benedict, intercede for us, Alleluia, alleluia.\nRep. O holy Father Benedict, intercede for us, Alleluia, alleluia.\nThat we may be made worthy of the promises of Christ. Alleluia, alleluia.\nGlory be to the Father,\netc. O holy Father, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Sanctae sororis spiritum\nOmni labe purissimum,\nInstar columbae candidae,\nCoelum videt ascendere.\n\nBeata demum corpora\nUnum claudit sarcophagum;\nMens quibus una fuerat\nPar coelo servat gloria.\n\nO sacrosancta Trinitas,\nSit tibi laus et gloria!\nQua Benedictus fruitur\nPer infinita saecula. Amen.",
                 "en-US": "He sees his sainted sister's soul,\nAll pure, and free from sin's control,\nLike some fair, white, and spotless dove,\nTake wing, and mount to bliss above.\n\nAt last their bodily remains\nOne hallowed tomb in peace contains;\nTheir souls, which here were linked in love,\nIn glory now are joined above.\n\nPraise, honour, glory, be to Thee,\nMost sacred, holy Trinity!\nWhose love, in everlasting rest,\nO'erflows our Saint's enraptured breast. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, beate Pater Benedicte. (T. P. Alleluia).\n℟. Et impetra nobis spiritum tuum. (T. P. Alleluia).",
-                "en-US": "℣. Pray for us, O blessed Father Benedict. (In P.T. Alleluia).\n℟. And obtain for us Thy spirit. (In P.T. Alleluia)."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, beate Pater Benedicte. (T. P. Alleluia).",
+                    "en-US": "Pray for us, O blessed Father Benedict. (In P.T. Alleluia)."
+                  },
+                  "r": {
+                    "la": "Et impetra nobis spiritum tuum. (T. P. Alleluia).",
+                    "en-US": "And obtain for us Thy spirit. (In P.T. Alleluia)."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Anthem."
@@ -899,7 +1624,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum (Luc. 1, 46–55)",
                 "en-US": "Canticle. S. Luke 1, 46 to 55."
@@ -913,7 +1638,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona",
                 "en-US": "Anthem"
@@ -927,24 +1652,91 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nExcita, Domine, in Ecclesia tua Spiritum, cui beatus Pater noster Benedictus Abbas secutus est, ut eodem nos repleti studeamus amare quod amavit, et opere exercere quod docuit. Per Christum Dominum nostrum.\n℟. Amen.",
-                "en-US": "Let us pray,\nStir up, O Lord, in Thy Church that Spirit, to Whose service our Holy Father the Abbot Benedict was wholly devoted, that we being filled with the Same may strive to love what he loved and to practise what he taught. Through Christ our Lord.\n℟. Amen."
+                "la": "Excita, Domine, in Ecclesia tua Spiritum, cui beatus Pater noster Benedictus Abbas secutus est, ut eodem nos repleti studeamus amare quod amavit, et opere exercere quod docuit. Per Christum Dominum nostrum.",
+                "en-US": "Stir up, O Lord, in Thy Church that Spirit, to Whose service our Holy Father the Abbot Benedict was wholly devoted, that we being filled with the Same may strive to love what he loved and to practise what he taught. Through Christ our Lord."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.\nPater. Ave. (secreto).",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed through the mercy of God rest in peace.\n℟. Amen.\nOur Father. Hail Mary. (silently)."
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+                    "en-US": "May the souls of the faithful departed through the mercy of God rest in peace."
+                  },
+                  "r": {
+                    "la": "Amen.",
+                    "en-US": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Pater. Ave. (secreto).",
+                "en-US": "Our Father. Hail Mary. (silently)."
               }
             }
           ]
@@ -960,12 +1752,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Incipit, qui Officium dicit, absolute:\n℣. Iube, Domine, benedicere.",
-                "en-US": "The Office begins straightway as follows:\n℣. O Lord, give unto us Thy blessing."
+                "la": "Incipit, qui Officium dicit, absolute:",
+                "en-US": "The Office begins straightway as follows:"
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Iube, Domine, benedicere.",
+                "en-US": "O Lord, give unto us Thy blessing."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Benedictio",
                 "en-US": "Blessing"
@@ -974,12 +1773,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Noctem quietam et finem perfectum concedat nobis Dominus omnipotens.\n℟. Amen.",
-                "en-US": "May the Lord Almighty grant us a quiet night and a perfect end.\n℟. Amen."
+                "la": "Noctem quietam et finem perfectum concedat nobis Dominus omnipotens.",
+                "en-US": "May the Lord Almighty grant us a quiet night and a perfect end."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio Brevis",
                 "en-US": "Short Lesson"
@@ -988,12 +1794,41 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Incipit Prologo sanctissimi Patris nostri Benedicti in Regulam suam.\nObsculta, o fili, praecepta magistri, et inclina aurem cordis tui; et admonitionem pii patris libenter excipe, et efficaciter comple.\nTu autem, Domine, miserere nobis.\n℟. Deo gratias.\n℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adiutorium, etc., ut supra ad Vesperas.",
-                "en-US": "The beginning of the Prologue of our most holy Father Benedict to his Rule.\nAttend, O my son, to the precepts of thy master, and open the ear of thy heart; willingly receive the admonitions of thy loving father, and efficaciously fulfil them.\nBut do Thou, O Lord, have mercy upon us.\n℟. Thanks be to God.\n℣. Transform our hearts, O God our Saviour.\n℟. And turn away Thy wrath from us.\n℣. Incline unto mine aid, etc. as above at Vespers."
+                "la": "Incipit Prologo sanctissimi Patris nostri Benedicti in Regulam suam.\nObsculta, o fili, praecepta magistri, et inclina aurem cordis tui; et admonitionem pii patris libenter excipe, et efficaciter comple.\nTu autem, Domine, miserere nobis.",
+                "en-US": "The beginning of the Prologue of our most holy Father Benedict to his Rule.\nAttend, O my son, to the precepts of thy master, and open the ear of thy heart; willingly receive the admonitions of thy loving father, and efficaciously fulfil them.\nBut do Thou, O Lord, have mercy upon us."
               }
             },
             {
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias.",
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos, Deus salutaris noster.",
+                    "en-US": "Transform our hearts, O God our Saviour."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis.",
+                    "en-US": "And turn away Thy wrath from us."
+                  }
+                }
+              ]
+            },
+            {
               "type": "rubric",
+              "text": {
+                "la": "Deus in adiutorium, etc., ut supra ad Vesperas.",
+                "en-US": "Incline unto mine aid, etc. as above at Vespers."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Psalmus CXXXIII",
                 "en-US": "Psalm CXXXIII."
@@ -1007,56 +1842,109 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus",
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Te, Pater alme, petimus,\nPronis mentis visceribus,\nUt coelum das ascendere\nQuos doces terram spernere.\n\nQuae sursum sunt da quaerere,\nSanctam servare regulam:\nChristi foveri gratia,\nDemumque frui gloria.\n\nO sacrosancta Trinitas,\nSit tibi laus et gloria!\nQua Benedictus fruitur\nPer infinita saecula. Amen.",
                 "en-US": "Blest Father, thee we humbly pray,\nWith lowly hearts, both night and day,\nThat, taught by thee earth's joys to spurn,\nWe may eternal glory earn.\n\nLet not our thoughts from heaven stray,\nMay we the Holy Rule obey;\nBe succoured here by Christ's sweet grace,\nIn heaven enjoy Him face to face.\n\nPraise, honour, glory, be to Thee,\nMost sacred, holy Trinity!\nWhose love, in everlasting rest,\nO'erflows our Saint's enraptured breast. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, beate Pater Benedicte. (T.P. Alleluia).\n℟. Ut digni efficiamur promissionibus Christi. (T.P. Alleluia).",
-                "en-US": "℣. Pray for us, O blessed Father Benedict. (In P.T. Alleluia).\n℟. That we may be made worthy of the promises of Christ. (In P.T. Alleluia)."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, beate Pater Benedicte. (T.P. Alleluia).",
+                    "en-US": "Pray for us, O blessed Father Benedict. (In P.T. Alleluia)."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi. (T.P. Alleluia).",
+                    "en-US": "That we may be made worthy of the promises of Christ. (In P.T. Alleluia)."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nPer intercessionem sanctissimi Patris nostri Benedicti custodi nos, Domine, ab omni diabolico incursu: et sanctorum Angelorum protectione defende; ut ad te pervenire feliciter valeamus. Per Christum Dominum nostrum.\n℟. Amen.",
-                "en-US": "Let us pray,\nThrough the intercession of our most holy Father Benedict defend us, O Lord, from all the onslaughts of the devil; and guard us with the protection of the holy angels; that we may at length happily come home to Thee. Through Christ our Lord.\n℟. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.",
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
               "text": {
-                "la": "Non dicitur ℣. Fidelium animae, sed loco eius:",
-                "en-US": "The ℣. \"May the souls\" is not said, but in its place is recited:"
+                "la": "Oremus.",
+                "en-US": "Let us pray."
               }
             },
             {
+              "type": "prayer",
+              "inline": {
+                "la": "Per intercessionem sanctissimi Patris nostri Benedicti custodi nos, Domine, ab omni diabolico incursu: et sanctorum Angelorum protectione defende; ut ad te pervenire feliciter valeamus. Per Christum Dominum nostrum.",
+                "en-US": "Through the intercession of our most holy Father Benedict defend us, O Lord, from all the onslaughts of the devil; and guard us with the protection of the holy angels; that we may at length happily come home to Thee. Through Christ our Lord."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam.",
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat.",
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino.",
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "la": "Deo gratias.",
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
               "type": "rubric",
+              "text": {
+                "la": "Non dicitur versus Fidelium animae, sed loco eius:",
+                "en-US": "The versicle \"May the souls\" is not said, but in its place is recited:"
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Benedictio",
                 "en-US": "The Blessing"
@@ -1065,8 +1953,15 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Intercessio sanctissimi Patris nostri Benedicti protegat nos: et praesidium beatae Mariae Virginis praeservet nos: et benedictio Dei omnipotentis, Patris, et Filii ✠ et Spiritus Sancti, descendat super nos et maneat semper.\n℟. Amen.",
-                "en-US": "May the intercession of our most holy Father Benedict defend us; and the protection of the Blessed Virgin Mary preserve us; and may the blessing of Almighty God, Father, Son ✠, and Holy Ghost, come down upon us and abide with us for ever.\n℟. Amen."
+                "la": "Intercessio sanctissimi Patris nostri Benedicti protegat nos: et praesidium beatae Mariae Virginis praeservet nos: et benedictio Dei omnipotentis, Patris, et Filii ✠ et Spiritus Sancti, descendat super nos et maneat semper.",
+                "en-US": "May the intercession of our most holy Father Benedict defend us; and the protection of the Blessed Virgin Mary preserve us; and may the blessing of Almighty God, Father, Son ✠, and Holy Ghost, come down upon us and abide with us for ever."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen.",
+                "en-US": "Amen."
               }
             },
             {

--- a/content/practices/little-office-s-bruno/flow.json
+++ b/content/practices/little-office-s-bruno/flow.json
@@ -32,25 +32,51 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Coloniae progenitus,\nQuam vocant Agrippinam,\nEx inclyt is Parentibus,\nSub juventutem primam\nInferiora studia\nBruno puellus adit,\nQuaeis omnibus industria\nJam potior evadit,\nSophiae post Parisius,\nNec non Theologiae,\nSet totum sacris literis\nImpedit Bruno pie;\nTanarquicidem studio,\nUt palam respondere,\nToroque in Palladio\nDoctrina emineret."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -62,15 +88,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis sancte Bruno,\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis sancte Bruno,"
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nSancti Brunonis Confessoris tui, quaesumus, Domine, intercessionibus adjuvemur: ut qui majestatem tuam graviter delinquendo offendimus, ejus meritis et precibus nostrorum delictorum veniam consequamur. Per Dominum nostrum etc."
+                "la": "Sancti Brunonis Confessoris tui, quaesumus, Domine, intercessionibus adjuvemur: ut qui majestatem tuam graviter delinquendo offendimus, ejus meritis et precibus nostrorum delictorum veniam consequamur. Per Dominum nostrum etc."
               }
             }
           ]
@@ -84,25 +123,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Theosophiae scrupulos\nSolvens abstrusiores,\nDoctrinae modestissimos\nConsociat et mores,\nSacra et naturalia\nArte tractans aequali,\nSuprema tandem laurea,\nOrnatur doctorali;\nPosthac, et post epomidem,\nSacrum assumens statum,\nPinguen capit propediem\nRhemis Canonicatum;\nStatuì dies absitris\nSed antequam illuxit,\nHorrendum drama coelitus\nHunc saeculo subduxit."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -130,25 +182,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Doctorum Vir primarius\nTum temporis obibat:\nJustus (ut vulgi publicus\nTunc rumor circumibat)\nSed huic cum officio\nDum missa decantatur,\nTer corpore exserto\nSe erigens, sic fatur:\nJusto Dei judicio\nSum rite accusatus,\nEodem sum et merito,\nJusque judicatus,\nAequa Dei sententia\nSum condemnatus! quare\nScitote, piis suffragiis,\nNil sacra me juvare."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -176,25 +241,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Haec territus tragedia\nAttonitus discedit,\nDei pavens judicia\nDum Noster domum redit,\nCharos cohortans socios\nLanduinum et Hugonem,\nAndream, duos Stephanos,\nGuarinum, se Brunonem\nMox ut sequantur: Stygias\nVitentque ut Harpyas,\nPer antra, per et latebras\nScrutentur Coeli vias,\nStricte servent silentia,\nSemperque meditentur\nAlta Dei judicia,\nQuois olim judicentur?"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -222,25 +300,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Posthaec Gratianopolis\nAntistitem accedunt,\nSibi que Solitudinis\nSignari locum petunt,\nDilato quo in crastinum\nDumtentum exstirpari\nIs noctu videt solitum\nCarthusiam vocari,\nUt Domus ibi fieret\nSeptena micans luce;\nQuo somno dum exsurgere,\nMox Deo struit duce\nTemplum, cuius cellulas\nSuamque hic disponit,\nSilentioque Regulam\nRogantibus imponit."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -268,25 +359,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Hic orant, texunt, sepiunt,\nJejunant, meditantur,\nTentamina si ingerunt,\nPro ope se precantur;\nAt integro septennio\nDum sic continuatur,\nEn! Bruno Romam illico\nAd Papam evocatur,\nMox Archipraesul Rhegii\nAb Hoc denominatus:\nSed apex hic officii\nHaud nostro fuit gratus;\nLinqut is cito moenia,\nEt cum quibusdam denuo\nTurena petit nemora\nCalabriae Eremuum."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -314,25 +418,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Convertere nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Convertere nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Sed neque hic delituit\nDivi virtus Brunonis,\nDum canibus subvoluit\nRogeri Marchionis,\nQui virum ut conspexerat,\nPleno favoris igne\nSic mox in hunc exarserat\nAmoris ad insignae\nFestivam huc ecclesiam\nUt hic aedificaret,\nJesum et Familiam\nOppiare dotaret,\nLimosa prius casulas\nEx latere condendo,\nPiscinas, hortos, vinas,\nSylvasque largiendo."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -366,7 +496,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Ant."
       }
@@ -378,15 +508,28 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Ora pro nobis sancte Bruno,\n℟. Ut digni efficiamur promissionibus Christi."
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ora pro nobis sancte Bruno,"
+          },
+          "r": {
+            "la": "Ut digni efficiamur promissionibus Christi."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nO praeclarum ac lucidissimum sydus Ecclesiae, beate Bruno! qui a prima infantia, admirabili morum gravitate haud obscura futurae sanctitatis indicia prodidisti, artibus et divinis studiis tam profunde imbutus, et reportato in praemium virtutis et scientiae tuo doctorali honore, et Rhemensi canonicatu, tandemque ad Rhegiensem Archiepiscopatum sponte oblato, speciali divinae providentiae ductu eremitici eremitam tamen vitae amans propositi, sacrum Chartusiensem ordinem adserto silentii, solitudinis et jejunii fundavisti instituto; tanta quidem effectu, ut tam ceteris omnibus, quam praesertim Ecclesiae rebus, per sanum hanc regulam, ac singularem Divini sermonis methodum plurimum accommodatam, atque spiritualis accelerim incrementi. Fac igitur venerande Pater! ut per tua merita et suffragia sua, jugemque novissimi morum emendationem, ab omnibus peccatis nos solidos caveamus, de peccatis doleamus maxime, atque per assidua increscentis mortis meditationem vitam aeternam securam nobis, et certis consequamur.\nAmen."
+        "la": "O praeclarum ac lucidissimum sydus Ecclesiae, beate Bruno! qui a prima infantia, admirabili morum gravitate haud obscura futurae sanctitatis indicia prodidisti, artibus et divinis studiis tam profunde imbutus, et reportato in praemium virtutis et scientiae tuo doctorali honore, et Rhemensi canonicatu, tandemque ad Rhegiensem Archiepiscopatum sponte oblato, speciali divinae providentiae ductu eremitici eremitam tamen vitae amans propositi, sacrum Chartusiensem ordinem adserto silentii, solitudinis et jejunii fundavisti instituto; tanta quidem effectu, ut tam ceteris omnibus, quam praesertim Ecclesiae rebus, per sanum hanc regulam, ac singularem Divini sermonis methodum plurimum accommodatam, atque spiritualis accelerim incrementi. Fac igitur venerande Pater! ut per tua merita et suffragia sua, jugemque novissimi morum emendationem, ab omnibus peccatis nos solidos caveamus, de peccatis doleamus maxime, atque per assidua increscentis mortis meditationem vitam aeternam securam nobis, et certis consequamur.\nAmen."
       }
     }
   ]

--- a/content/practices/little-office-s-dismas/flow.json
+++ b/content/practices/little-office-s-dismas/flow.json
@@ -13,7 +13,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Ant."
       }
@@ -25,10 +25,17 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. In quacunque die conversus fuerit ab impietate sua\n℟. Impietas impii non nocebit ei."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "In quacunque die conversus fuerit ab impietate sua"
+          },
+          "r": {
+            "la": "Impietas impii non nocebit ei."
+          }
+        }
+      ]
     },
     {
       "type": "select",
@@ -57,25 +64,64 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sis Disma memor omnium"
+                  },
+                  "r": {
+                    "la": "Cum morte confligantium."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Sis Disma memor omnium\n℟. Cum morte confligantium.\n℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Non Aegyptus thura dabat\nTot Idolis: abundabat\nSaevis quot latronibus;\nInter quales et fuisse,\nDisma! datur, te legisse,\nHuc dum fugit Jesulus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -87,15 +133,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Lucernas accendit illis,\n℟. Ne a latronibus exspolientur."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Lucernas accendit illis,"
+                  },
+                  "r": {
+                    "la": "Ne a latronibus exspolientur."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nMisericordissime Jesu, qui pendens in Cruce, ineffabile infinitae misericordiae tuae specimen in conversione sancti Dismas latronis ostendisti: per sanguinem tuum pretiosum in Cruce effusum, obsecro te, concede mihi ingratissimo peccatori efficacem tuam gratiam, ut peccata mea deplorare, te toto corde amare, et in hora mortis meae audire a te merear: Hodie mecum eris in Paradiso. Qui vivis et regnas cum Deo Patre etc."
+                "la": "Misericordissime Jesu, qui pendens in Cruce, ineffabile infinitae misericordiae tuae specimen in conversione sancti Dismas latronis ostendisti: per sanguinem tuum pretiosum in Cruce effusum, obsecro te, concede mihi ingratissimo peccatori efficacem tuam gratiam, ut peccata mea deplorare, te toto corde amare, et in hora mortis meae audire a te merear: Hodie mecum eris in Paradiso. Qui vivis et regnas cum Deo Patre etc."
               }
             }
           ]
@@ -109,25 +168,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sis Disma memor omnium"
+                  },
+                  "r": {
+                    "la": "Cum morte confligantium."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Sis Disma memor omnium\n℟. Cum morte confligantium.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Dum sub palma Joseph pater\nSedet, atque nato mater\nJesulo advigilat,\nTu cum assectis prorumpis,\nSupplex vero mox procumbis,\nPupus te dum advocat."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -139,10 +224,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ego cum exaltatus fuero de terra,\n℟. Omnia traham ad meipsum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ego cum exaltatus fuero de terra,"
+                  },
+                  "r": {
+                    "la": "Omnia traham ad meipsum."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -161,25 +253,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sis Disma memor omnium"
+                  },
+                  "r": {
+                    "la": "Cum morte confligantium."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Sis Disma memor omnium\n℟. Cum morte confligantium.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Quin jam sociis relictis,\nHospitem te das afflictis,\nDucem et itineris;\nAt non diu! nam reversus\nAd sodales, mox immersus\nPriscis es flagitiis."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -191,10 +309,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Cum electo electus eris,\n℟. Et cum perverso perverteris."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Cum electo electus eris,"
+                  },
+                  "r": {
+                    "la": "Et cum perverso perverteris."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -213,25 +338,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sis Disma memor omnium"
+                  },
+                  "r": {
+                    "la": "Cum morte confligantium."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Sis Disma memor omnium\n℟. Cum morte confligantium.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "En! jam Christus, instar Ducis,\nPer virtutes viam Crucis\nIntrat et miracula,\nNum et tu ad Crucem perges?\nImo certe! sed huc verges\nProbra per et scelera."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -243,10 +394,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Justum autem deducet Dominus per vias rectas,\n℟. Et impii in circuitu ambulabunt."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Justum autem deducet Dominus per vias rectas,"
+                  },
+                  "r": {
+                    "la": "Et impii in circuitu ambulabunt."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -265,25 +423,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sis Disma memor omnium"
+                  },
+                  "r": {
+                    "la": "Cum morte confligantium."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Sis Disma memor omnium\n℟. Cum morte confligantium.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "At, quam multum obliquabas\nIter Dismae, et distabas\nRecta Christi semita,\nTamen hi, per pares mortes,\nViae sancti sunt consortes\nRursum in Calvaria."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -295,10 +479,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ducebantur autem et alii duo nequam cum eo,\n℟. Ut interficerentur."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ducebantur autem et alii duo nequam cum eo,"
+                  },
+                  "r": {
+                    "la": "Ut interficerentur."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -317,25 +508,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sis Disma memor omnium"
+                  },
+                  "r": {
+                    "la": "Cum morte confligantium."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Sis Disma memor omnium\n℟. Cum morte confligantium.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Disma, quae haec paradoxa?\nPar est poena, dispar noxa,\nTu sons, Christus innocens:\nPorro nec vercundaris,\nSons insolens, criminari,\nProbrum terrae, summum Ens."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -347,10 +564,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Si tu es Christus, salvum fac temetipsum et nos,\n℟. Alios salvos facis, te ipsum non potes salvum facere."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Si tu es Christus, salvum fac temetipsum et nos,"
+                  },
+                  "r": {
+                    "la": "Alios salvos facis, te ipsum non potes salvum facere."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -369,25 +593,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sis Disma memor omnium"
+                  },
+                  "r": {
+                    "la": "Cum morte confligantium."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Sis Disma memor omnium\n℟. Cum morte confligantium.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Unus Christi sed aspectus\nSic contudit tibi pectus\nAlta missus arbore,\nMox ut totus indoleres,\nCaedes, spolia defleres,\nNoxas et blasphemiae."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -399,10 +649,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Et nos quidem digna factis recipimus,\n℟. Hic vero nihil mali gessit."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et nos quidem digna factis recipimus,"
+                  },
+                  "r": {
+                    "la": "Hic vero nihil mali gessit."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -421,25 +678,64 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sis Disma memor omnium"
+                  },
+                  "r": {
+                    "la": "Cum morte confligantium."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Convertere nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Sis Disma memor omnium\n℟. Cum morte confligantium.\n℣. Convertere nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Venia sic impetrata,\nDismae Paradisi grata\nJam et regna exspectat;\nCui et Jesus prompto ore,\nHodie se adhuc fore\nIbi secum, innuit."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -451,10 +747,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, memento mei, cum veneris in regnum tuum.\n℟. Amen. dico tibi: hodie mecum eris in Paradiso."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, memento mei, cum veneris in regnum tuum."
+                  },
+                  "r": {
+                    "la": "Amen. dico tibi: hodie mecum eris in Paradiso."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -479,7 +782,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Ant."
       }
@@ -491,19 +794,33 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Sacrificium Deo spiritus contribulatus,\n℟. Cor contritum et humiliatum Deus non despicies."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Sacrificium Deo spiritus contribulatus,"
+          },
+          "r": {
+            "la": "Cor contritum et humiliatum Deus non despicies."
+          }
+        }
+      ]
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Ora pro nobis beate Disma,\n℟. Ut digni efficiamur promissionibus Christi."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ora pro nobis beate Disma,"
+          },
+          "r": {
+            "la": "Ut digni efficiamur promissionibus Christi."
+          }
+        }
+      ]
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Oratio"
       }

--- a/content/practices/little-office-s-dominic/flow.json
+++ b/content/practices/little-office-s-dominic/flow.json
@@ -32,22 +32,43 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Grant his prayer, sweet Lord, that we\n℟. May still be pleasing unto Thee."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Grant his prayer, sweet Lord, that we"
+                  },
+                  "r": {
+                    "en-US": "May still be pleasing unto Thee."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lord, open Thou my lips,\n℟. And my mouth shall declare Thy praise."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, open Thou my lips,"
+                  },
+                  "r": {
+                    "en-US": "And my mouth shall declare Thy praise."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto my aid, O God,\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God,"
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -68,7 +89,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Invitatory."
               }
@@ -88,31 +109,43 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "O come, let us be glad in the Lord, let us joyfully sing to the God of our salvation:\nlet us come before His presence with thanksgiving, and make a joyful noise to Him with psalms.\n℟. The King and Lord of confessors: O come, let us adore.\nGlory be to the Father, and to the Son, and to the Holy Ghost, etc.\n℟. O come let us adore.\nThe King and Lord of confessors: O come, let us adore."
+                "en-US": "O come, let us be glad in the Lord, let us joyfully sing to the God of our salvation:\nlet us come before His presence with thanksgiving, and make a joyful noise to Him with psalms."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "en-US": "The King and Lord of confessors: O come, let us adore."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost, etc."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "O come let us adore."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "The King and Lord of confessors: O come, let us adore."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn - Gaude Mater Ecclesia"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "Rejoice, sweet Mother Church, to whom\nThis happy festal day is given,\nIn mind of him who from thy womb\nIs born a saint this day to heaven."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "Our mighty father, who led forth\nAnd marshalled his great preacher host,\nWith glory crowned now leaves this earth\nTo dwell on heaven's blissful coast."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "To God, the Three and One, be praise\nAnd honour, strength and glory given;\nAnd may He deign our souls to raise\nThrough our sweet father's prayers to heaven."
+                "en-US": "Rejoice, sweet Mother Church, to whom\nThis happy festal day is given,\nIn mind of him who from thy womb\nIs born a saint this day to heaven.\n\nOur mighty father, who led forth\nAnd marshalled his great preacher host,\nWith glory crowned now leaves this earth\nTo dwell on heaven's blissful coast.\n\nTo God, the Three and One, be praise\nAnd honour, strength and glory given;\nAnd may He deign our souls to raise\nThrough our sweet father's prayers to heaven."
               }
             },
             {
@@ -146,7 +179,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Anthem"
               }
@@ -158,10 +191,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. The Lord loved him and adorned him.\n℟. He clad him in a robe of glory."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "The Lord loved him and adorned him."
+                  },
+                  "r": {
+                    "en-US": "He clad him in a robe of glory."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -176,7 +216,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Blessing"
               }
@@ -184,11 +224,17 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "May our blessed father, Saint Dominic, make loving intercession for us.\n℟. Amen."
+                "en-US": "May our blessed father, Saint Dominic, make loving intercession for us."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Lesson I"
               }
@@ -202,13 +248,37 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℟. Sworn to Christ a virgin knight,\nVirtue's pattern pure and bright,\nThou with burning words of grace\nSeek'st thy heavenly dwelling-place.\nSweetest odors fill the air,\nAngel hosts thy praise declare."
+                "en-US": "Sworn to Christ a virgin knight,"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. To thy sons, O blessed guide,\nHeaven's high portals open wide.\n℟. Sweetest odors fill the air,\nAngel hosts thy praise declare."
+                "en-US": "Virtue's pattern pure and bright,\nThou with burning words of grace\nSeek'st thy heavenly dwelling-place.\nSweetest odors fill the air,\nAngel hosts thy praise declare."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "To thy sons, O blessed guide,"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Heaven's high portals open wide."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Sweetest odors fill the air,"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Angel hosts thy praise declare."
               }
             },
             {
@@ -218,7 +288,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Blessing"
               }
@@ -230,7 +300,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Lesson II"
               }
@@ -238,19 +308,37 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "O Dominic, most holy father, rise and embrace our Saviour's feet; reconcile us to Christ by thy holy and compassionate prayers, for thou seest how we have offended the eyes of our Creator. Obtain for us the pardon of our sins, rest for our souls, and the joys of heaven. But do Thou, O Lord, etc.\n℟. Thanks be to God."
+                "en-US": "O Dominic, most holy father, rise and embrace our Saviour's feet; reconcile us to Christ by thy holy and compassionate prayers, for thou seest how we have offended the eyes of our Creator. Obtain for us the pardon of our sins, rest for our souls, and the joys of heaven. But do Thou, O Lord, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Rising from this vale of earth,\nChoirs of angels hymn his worth.\nGrant his prayer, sweet Lord, that we\nMay still be pleasing unto Thee."
+                "en-US": "Thanks be to God."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℟. Oft-times at his prayer of faith\nThou didst loose the bonds of death;\nMay his pleadings now obtain\nFreedom from our debt of pain."
+                "en-US": "Rising from this vale of earth,"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Choirs of angels hymn his worth.\nGrant his prayer, sweet Lord, that we\nMay still be pleasing unto Thee."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Oft-times at his prayer of faith"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Thou didst loose the bonds of death;\nMay his pleadings now obtain\nFreedom from our debt of pain."
               }
             },
             {
@@ -260,7 +348,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Blessing"
               }
@@ -268,11 +356,17 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "May blessed Dominic, the father and guide of the Order of Preachers, conduct us to the society of the heavenly citizens.\n℟. Amen."
+                "en-US": "May blessed Dominic, the father and guide of the Order of Preachers, conduct us to the society of the heavenly citizens."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "en-US": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Lesson III"
               }
@@ -286,37 +380,61 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℟. Thanks be to God."
+                "en-US": "Thanks be to God."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℟. Sweet the hope thy fainting breath\nGave to those who wept thy death,\nPromising, though life were flown,\nThou wouldst still protect thine own.\nFather, keep thy gracious word,\nPleading for us with our Lord."
+                "en-US": "Sweet the hope thy fainting breath"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Who so oft was wont to shine\n'Midst the sick with powers divine,\nTo our languid souls apply\nChrist's restoring remedy."
+                "en-US": "Gave to those who wept thy death,\nPromising, though life were flown,\nThou wouldst still protect thine own.\nFather, keep thy gracious word,\nPleading for us with our Lord."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℟. Father, keep thy gracious word,\nPleading for us with our Lord."
+                "en-US": "Who so oft was wont to shine"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Glory be to the Father and to the Son and to the Holy Ghost."
+                "en-US": "'Midst the sick with powers divine,\nTo our languid souls apply\nChrist's restoring remedy."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℟. Father, keep thy gracious word,\nPleading for us with our Lord."
+                "en-US": "Father, keep thy gracious word,"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Pleading for us with our Lord."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Glory be to the Father and to the Son and to the Holy Ghost."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Father, keep thy gracious word,"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Pleading for us with our Lord."
               }
             },
             {
@@ -332,10 +450,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Pray for us, O blessed father Dominic,\n℟. That we may be made worthy of the promises of Christ."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Pray for us, O blessed father Dominic,"
+                  },
+                  "r": {
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -347,10 +472,17 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -371,7 +503,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Anthem - Pie Pater"
               }
@@ -383,7 +515,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter Ecclus. L, 6, 7"
               }
@@ -391,38 +523,39 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "As the morning star in the midst of a cloud, and as the moon in the days of her fullness, and as the sun when it shineth, so shone he in the temple of God.\n℟. Thanks be to God."
+                "en-US": "As the morning star in the midst of a cloud, and as the moon in the days of her fullness, and as the sun when it shineth, so shone he in the temple of God."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn - Carnis liber ergastulo"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "From prison of the flesh set free,\nSee how he shines with beams from heaven!\nAnd for his garb of poverty\nA robe of royalty is given."
+                "en-US": "From prison of the flesh set free,\nSee how he shines with beams from heaven!\nAnd for his garb of poverty\nA robe of royalty is given.\n\nThe fragrant tomb, the frequent sign,\nClear proof to all mankind afford\nHow much of grace and power divine,\nChrist's servant shareth with his Lord.\n\nTo God, the Three and One, be praise\nAnd honour, strength and glory given;\nAnd may He deign our souls to raise,\nThrough our sweet father's prayers to heaven. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "The fragrant tomb, the frequent sign,\nClear proof to all mankind afford\nHow much of grace and power divine,\nChrist's servant shareth with his Lord."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "To God, the Three and One, be praise\nAnd honour, strength and glory given;\nAnd may He deign our souls to raise,\nThrough our sweet father's prayers to heaven. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Thou didst appear glorious in the sight of the Lord.\n℟. Therefore the Lord hath clothed thee with beauty."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Thou didst appear glorious in the sight of the Lord."
+                  },
+                  "r": {
+                    "en-US": "Therefore the Lord hath clothed thee with beauty."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -437,7 +570,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Anthem - Carnis viror"
               }
@@ -449,19 +582,32 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "Let us pray,\nO God, who didst vouchsafe to enlighten Thy Church by the merits and teaching of our blessed father Dominic, Thy confessor, grant that through his intercession we may be provided against all temporal necessities, and ever increase in spiritual good. Through our Lord Jesus Christ, Thy Son, Who liveth and reigneth with Thee, in the unity of the Holy Ghost, for ever and ever. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "O God, who didst vouchsafe to enlighten Thy Church by the merits and teaching of our blessed father Dominic, Thy confessor, grant that through his intercession we may be provided against all temporal necessities, and ever increase in spiritual good. Through our Lord Jesus Christ, Thy Son, Who liveth and reigneth with Thee, in the unity of the Holy Ghost, for ever and ever. Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Commemoration of S. Augustine"
               }
@@ -473,21 +619,66 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. The just man shall spring up like the lily,\n℟. And shall flourish for ever before the Lord."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "The just man shall spring up like the lily,"
+                  },
+                  "r": {
+                    "en-US": "And shall flourish for ever before the Lord."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nGive ear to our supplications, Almighty God, and through the intercession of blessed Augustine, Thy confessor and bishop, graciously show forth unto us the effect of Thine accustomed mercy, whom Thou indulgest in the confident hope of Thy loving kindness. Through our Lord Jesus Christ Thy Son, Who liveth and reigneth with Thee in the unity of the Holy Ghost, world without end. Amen."
+                "en-US": "Give ear to our supplications, Almighty God, and through the intercession of blessed Augustine, Thy confessor and bishop, graciously show forth unto us the effect of Thine accustomed mercy, whom Thou indulgest in the confident hope of Thy loving kindness. Through our Lord Jesus Christ Thy Son, Who liveth and reigneth with Thee in the unity of the Holy Ghost, world without end. Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Father, keep thy gracious word,"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. Father, keep thy gracious word,\nPleading for us with our Lord."
+                "en-US": "Pleading for us with our Lord."
               }
             }
           ]
@@ -500,16 +691,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Grant his prayer, sweet Lord, that we\n℟. May still be pleasing unto Thee."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Grant his prayer, sweet Lord, that we"
+                  },
+                  "r": {
+                    "en-US": "May still be pleasing unto Thee."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -518,27 +723,15 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn - Novus athleta Domini"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "Raise to the champion of our Lord,\nGreat Dominic, our loud acclaim,\nWhose lordly work, the Gospel-word,\nSo well doth suit his lordly name."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "With watchful eye and careful hand\nHe kept the lily all unstained;\nHis zeal burned like a flaming brand,\nFor souls that Satan else had gained."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "To God, the Three and One, be praise,\nAnd honour, strength and glory given;\nAnd may He deign our souls to raise\nThrough our sweet father's prayers to heaven. Amen."
+                "en-US": "Raise to the champion of our Lord,\nGreat Dominic, our loud acclaim,\nWhose lordly work, the Gospel-word,\nSo well doth suit his lordly name.\n\nWith watchful eye and careful hand\nHe kept the lily all unstained;\nHis zeal burned like a flaming brand,\nFor souls that Satan else had gained.\n\nTo God, the Three and One, be praise,\nAnd honour, strength and glory given;\nAnd may He deign our souls to raise\nThrough our sweet father's prayers to heaven. Amen."
               }
             },
             {
@@ -554,7 +747,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Anthem - Gemma"
               }
@@ -566,7 +759,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter Ecclus. XXXIX 6"
               }
@@ -574,26 +767,117 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "The just man will give his heart to watch early to the God that made him, and he will pray in the sight of the Most High.\n℟. Thanks be to God."
+                "en-US": "The just man will give his heart to watch early to the God that made him, and he will pray in the sight of the Most High."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Make us pleasing unto Thee,\n℟. At the prayer of S. Dominic.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. O Jesus Christ, Son of the living God, at the prayer of S. Dominic,\n℣. Arise, O Lord, and help us.\n℟. And deliver us for Thy Name's sake.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Make us pleasing unto Thee,"
+                  },
+                  "r": {
+                    "en-US": "At the prayer of S. Dominic."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "O Jesus Christ, Son of the living God, at the prayer of S. Dominic,"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Arise, O Lord, and help us."
+                  },
+                  "r": {
+                    "en-US": "And deliver us for Thy Name's sake."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nGive ear to our supplications, Almighty God, and direct all the actions of Thy servants to the prosperous attainment of Thy salvation; and grant through the intercession of Thy blessed confessor, our most holy father, Saint Dominic, that we may ever be defended by Thine assistance amidst all the changes of this our life and pilgrimage. Through our Lord Jesus Christ, Thy Son, Who liveth, etc."
+                "en-US": "Give ear to our supplications, Almighty God, and direct all the actions of Thy servants to the prosperous attainment of Thy salvation; and grant through the intercession of Thy blessed confessor, our most holy father, Saint Dominic, that we may ever be defended by Thine assistance amidst all the changes of this our life and pilgrimage. Through our Lord Jesus Christ, Thy Son, Who liveth, etc."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. Father, keep thy gracious word,\n℟. Pleading for us with our Lord."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Father, keep thy gracious word,"
+                  },
+                  "r": {
+                    "en-US": "Pleading for us with our Lord."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -605,16 +889,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Grant his prayer, sweet Lord, that we\n℟. May still be pleasing unto Thee."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Grant his prayer, sweet Lord, that we"
+                  },
+                  "r": {
+                    "en-US": "May still be pleasing unto Thee."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -623,27 +921,15 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn - Mundum calcans"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "He trod the world beneath his feet,\nForward to strenuous toil he pressed,\nAnd stripped himself the foe to meet,\nBy Christ's strong grace upheld and blessed."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "He still fights on with ceaseless prayer,\nWith tears, and words, and signs of power;\nAnd sends his children forth to bear\nThe glorious war from shore to shore."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "To God, the Three and One, be praise,\nAnd honour, strength and glory given;\nAnd may He deign our souls to raise\nThrough our sweet father's prayers to heaven."
+                "en-US": "He trod the world beneath his feet,\nForward to strenuous toil he pressed,\nAnd stripped himself the foe to meet,\nBy Christ's strong grace upheld and blessed.\n\nHe still fights on with ceaseless prayer,\nWith tears, and words, and signs of power;\nAnd sends his children forth to bear\nThe glorious war from shore to shore.\n\nTo God, the Three and One, be praise,\nAnd honour, strength and glory given;\nAnd may He deign our souls to raise\nThrough our sweet father's prayers to heaven."
               }
             },
             {
@@ -659,7 +945,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Anthem - Corpus sanctum"
               }
@@ -671,7 +957,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter Ecclus. L, 6, 7"
               }
@@ -679,26 +965,115 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "As the morning star in the midst of a cloud,\nand as the moon in the days of her fullness,\nand as the sun when it shineth, so shone he\nin the temple of God.\n℟. Thanks be to God."
+                "en-US": "As the morning star in the midst of a cloud,\nand as the moon in the days of her fullness,\nand as the sun when it shineth, so shone he\nin the temple of God."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Loving father Dominic, hear thy servants who pray to thee.\n℟. Loving father Dominic, hear thy servants who pray to thee.\n℣. And bring us remission from above.\n℟. Hear thy servants who pray to thee.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. Loving father Dominic, hear thy servants who pray to thee.\n℣. Holy father, cast thy mind\nOn the work thy hands designed,\n℟. In the Judge's presence stand\nFor thy poor and lowly band.\n℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Loving father Dominic, hear thy servants who pray to thee."
+                  },
+                  "r": {
+                    "en-US": "Loving father Dominic, hear thy servants who pray to thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "And bring us remission from above."
+                  },
+                  "r": {
+                    "en-US": "Hear thy servants who pray to thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "Loving father Dominic, hear thy servants who pray to thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Holy father, cast thy mind"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nO God, who didst vouchsafe to enlighten Thy Church by the merits and teaching of our blessed father Dominic, Thy confessor, grant that through his intercession we may be provided against all temporal necessities, and ever increase in spiritual good. Through our Lord Jesus Christ, Thy Son, Who liveth, etc."
+                "en-US": "On the work thy hands designed,"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Father, keep thy gracious word,\n℟. Pleading for us with our Lord."
+                "en-US": "In the Judge's presence stand"
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "For thy poor and lowly band."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "O God, who didst vouchsafe to enlighten Thy Church by the merits and teaching of our blessed father Dominic, Thy confessor, grant that through his intercession we may be provided against all temporal necessities, and ever increase in spiritual good. Through our Lord Jesus Christ, Thy Son, Who liveth, etc."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Father, keep thy gracious word,"
+                  },
+                  "r": {
+                    "en-US": "Pleading for us with our Lord."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -710,16 +1085,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Jesu sweet, at Dominic's prayer,\n℟. Let his sons Thy power share."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Jesu sweet, at Dominic's prayer,"
+                  },
+                  "r": {
+                    "en-US": "Let his sons Thy power share."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -728,27 +1117,15 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn - Hymnum novae laetitiae"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "Come, let our choir, this happy day,\nProlong its sweet melodious lay;\nAnd hymns of new-felt joy proclaim\nThe praise of Dominic's great name."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "The world at its grim vesper-tide\nThis brightly glittering star descried,\nHerald of freedom's light up-risen\nTo souls detained in sin's dark prison."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "Unto the sacred One and Three\nPraise, honour, strength and glory be;\nAnd may He grant our souls to rise\nThrough Dominic's pleading to the skies. Amen."
+                "en-US": "Come, let our choir, this happy day,\nProlong its sweet melodious lay;\nAnd hymns of new-felt joy proclaim\nThe praise of Dominic's great name.\n\nThe world at its grim vesper-tide\nThis brightly glittering star descried,\nHerald of freedom's light up-risen\nTo souls detained in sin's dark prison.\n\nUnto the sacred One and Three\nPraise, honour, strength and glory be;\nAnd may He grant our souls to rise\nThrough Dominic's pleading to the skies. Amen."
               }
             },
             {
@@ -764,7 +1141,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Anthem - Scala caelo"
               }
@@ -776,7 +1153,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter Isa. LIX, 21"
               }
@@ -784,26 +1161,175 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "My spirit which is in thee, and My words which I have put into thy mouth, shall not depart out of thy mouth, nor out of the mouth of thy seed, nor out of the mouth of thy seed's seed, saith the Lord, from henceforth now and for ever.\n℟. Thanks be to God."
+                "en-US": "My spirit which is in thee, and My words which I have put into thy mouth, shall not depart out of thy mouth, nor out of the mouth of thy seed, nor out of the mouth of thy seed's seed, saith the Lord, from henceforth now and for ever."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Holy father cast thy mind\nOn the work thy hands designed.\n℟. Holy father cast thy mind\nOn the work thy hands designed.\n℣. In the Judge's presence stand\nFor thy poor and lowly band.\n℟. On the work thy hands designed.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. Holy father cast thy mind\nOn the work thy hands designed.\n℣. When touched by death\nWe yield our breath,\n℟. O come and take us to the sky.\n℣. And even now,\nGreat father, show\n℟. We walk beneath thy watchful eye.\n℣. O Lord hear my prayer.\n℟. And let my cry come unto Thee."
+                "en-US": "Thanks be to God."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nGrant, we beseech Thee, O Lord, that we may be assisted by the prayers of blessed Dominic, Thy confessor, that what we ourselves are not able to obtain, may be vouchsafed us through his intercession. Through our Lord Jesus Christ, Thy Son, Who liveth, etc."
+                "en-US": "Holy father cast thy mind"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. Father keep thy gracious word,\n℟. Pleading for us with our Lord."
+                "en-US": "On the work thy hands designed."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Holy father cast thy mind"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "On the work thy hands designed."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "In the Judge's presence stand"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "For thy poor and lowly band."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "On the work thy hands designed."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "Holy father cast thy mind"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "On the work thy hands designed."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "When touched by death"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "We yield our breath,"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "O come and take us to the sky."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "And even now,"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Great father, show"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "We walk beneath thy watchful eye."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Grant, we beseech Thee, O Lord, that we may be assisted by the prayers of blessed Dominic, Thy confessor, that what we ourselves are not able to obtain, may be vouchsafed us through his intercession. Through our Lord Jesus Christ, Thy Son, Who liveth, etc."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Father keep thy gracious word,"
+                  },
+                  "r": {
+                    "en-US": "Pleading for us with our Lord."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -815,16 +1341,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Grant his prayer, sweet Lord, that we\n℟. May still be pleasing unto Thee."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Grant his prayer, sweet Lord, that we"
+                  },
+                  "r": {
+                    "en-US": "May still be pleasing unto Thee."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -833,27 +1373,15 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn - Doctrinam Evangelicam"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "He spread abroad the Gospel sound\nEven to earth's remotest bound,\nAnd with his new-formed ranks subdued\nAnd banished heresy's false brood."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "He was the well-spring from whose tide\nSwelled the rich river, deep and wide,\nA living flood still rolling forth\nIts healing waters through the earth."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "Unto the sacred One and Three\nPraise, honour, strength and glory be\nAnd may He grant our souls to rise\nThrough Dominic's pleading to the skies. Amen."
+                "en-US": "He spread abroad the Gospel sound\nEven to earth's remotest bound,\nAnd with his new-formed ranks subdued\nAnd banished heresy's false brood.\n\nHe was the well-spring from whose tide\nSwelled the rich river, deep and wide,\nA living flood still rolling forth\nIts healing waters through the earth.\n\nUnto the sacred One and Three\nPraise, honour, strength and glory be\nAnd may He grant our souls to rise\nThrough Dominic's pleading to the skies. Amen."
               }
             },
             {
@@ -869,7 +1397,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Anthem - Fulgent in choro"
               }
@@ -881,7 +1409,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter Mal. II, 6"
               }
@@ -889,32 +1417,120 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "The law of truth was in his mouth, and iniquity was not found on his lips; he walked with Me in peace and justice, and turned many from iniquity.\n℟. Thanks be to God."
+                "en-US": "The law of truth was in his mouth, and iniquity was not found on his lips; he walked with Me in peace and justice, and turned many from iniquity."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. When touched by death\nWe yield our breath,\n℟. O come and take us to the sky.\n℣. And even now,\nGreat father, show\n℟. We walk beneath thy watchful eye.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. When touched by death\nWe yield our breath,\nO come and take us to the sky."
+                "en-US": "Thanks be to God."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. The mouth of the just man shall speak wisdom.\n℟. And his tongue shall utter judgment."
+                "en-US": "When touched by death"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nGrant, we beseech Thee, Almighty God, that we who are weighed down with the burden of our sins may be relieved by the intercession of our blessed father Dominic, Thy confessor. Through our Lord Jesus Christ, Thy Son, Who liveth, etc."
+                "en-US": "We yield our breath,"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. O Lord hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Father, keep thy gracious word.\n℟. Pleading for us with our Lord."
+                "en-US": "O come and take us to the sky."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "And even now,"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Great father, show"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "We walk beneath thy watchful eye."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "When touched by death"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "We yield our breath,\nO come and take us to the sky."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "The mouth of the just man shall speak wisdom."
+                  },
+                  "r": {
+                    "en-US": "And his tongue shall utter judgment."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "Grant, we beseech Thee, Almighty God, that we who are weighed down with the burden of our sins may be relieved by the intercession of our blessed father Dominic, Thy confessor. Through our Lord Jesus Christ, Thy Son, Who liveth, etc."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Father, keep thy gracious word."
+                  },
+                  "r": {
+                    "en-US": "Pleading for us with our Lord."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -926,16 +1542,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Grant his prayer, sweet Lord, that we\n℟. May still be pleasing unto Thee."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Grant his prayer, sweet Lord, that we"
+                  },
+                  "r": {
+                    "en-US": "May still be pleasing unto Thee."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -956,7 +1586,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Anthem - Transit pauper"
               }
@@ -974,7 +1604,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter Ecclus. L, 6, 7"
               }
@@ -982,38 +1612,39 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "As the morning star in the midst of a cloud,\nand as the moon in the days of her fullness,\nand as the sun when it shineth, so shone he in the temple of God.\n℟. Thanks be to God."
+                "en-US": "As the morning star in the midst of a cloud,\nand as the moon in the days of her fullness,\nand as the sun when it shineth, so shone he in the temple of God."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "en-US": "Thanks be to God."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn - Gaude Mater"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "Rejoice, sweet Mother Church, to whom\nThis happy festal day is given\nIn mind of him who from thy womb\nIs born a saint this day to heaven."
+                "en-US": "Rejoice, sweet Mother Church, to whom\nThis happy festal day is given\nIn mind of him who from thy womb\nIs born a saint this day to heaven.\n\nOur mighty father, who led forth\nAnd marshalled his great preacher-host,\nWith glory crowned now leaves this earth\nTo dwell on heaven's blissful coast.\n\nTo God, the Three and One, be praise\nAnd honour, strength and glory given;\nAnd may He deign our souls to raise\nThrough our sweet father's prayers to heaven. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "Our mighty father, who led forth\nAnd marshalled his great preacher-host,\nWith glory crowned now leaves this earth\nTo dwell on heaven's blissful coast."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "To God, the Three and One, be praise\nAnd honour, strength and glory given;\nAnd may He deign our souls to raise\nThrough our sweet father's prayers to heaven. Amen."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Pray for us, O Holy Father, Dominic.\n℟. That we may be made worthy of the promises of Christ."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Pray for us, O Holy Father, Dominic."
+                  },
+                  "r": {
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -1028,7 +1659,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Anthem - O Lumen"
               }
@@ -1046,19 +1677,32 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lord hear my prayer.\n℟. And let my cry come unto Thee."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "Let us pray,\nO God, who didst vouchsafe to enlighten Thy Church by the merits and teaching of our blessed Father Dominic, Thy confessor, grant that through his intercession we may be provided against all temporal necessities, and ever increase in spiritual good. Through our Lord Jesus Christ, Thy Son, Who liveth, etc."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "en-US": "O God, who didst vouchsafe to enlighten Thy Church by the merits and teaching of our blessed Father Dominic, Thy confessor, grant that through his intercession we may be provided against all temporal necessities, and ever increase in spiritual good. Through our Lord Jesus Christ, Thy Son, Who liveth, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Commemoration of St Augustine"
               }
@@ -1070,22 +1714,68 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. The Lord loved him and adorned him.\n℟. He clad him with a robe of glory."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "The Lord loved him and adorned him."
+                  },
+                  "r": {
+                    "en-US": "He clad him with a robe of glory."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nGive ear to our supplications, Almighty God, and through the intercession of Blessed Augustine, Thy confessor and bishop, graciously show forth unto us the effect of Thine accustomed mercy, whom Thou indulgest in the confident hope of Thy loving kindness. Through our Lord Jesus Christ, Thy Son, Who liveth, etc."
+                "en-US": "Give ear to our supplications, Almighty God, and through the intercession of Blessed Augustine, Thy confessor and bishop, graciously show forth unto us the effect of Thine accustomed mercy, whom Thou indulgest in the confident hope of Thy loving kindness. Through our Lord Jesus Christ, Thy Son, Who liveth, etc."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. Father, keep thy gracious word.\n℟. Pleading for us with our Lord."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Father, keep thy gracious word."
+                  },
+                  "r": {
+                    "en-US": "Pleading for us with our Lord."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -1097,22 +1787,43 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Grant his prayer, sweet Lord, that we\n℟. May still be pleasing unto Thee."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Grant his prayer, sweet Lord, that we"
+                  },
+                  "r": {
+                    "en-US": "May still be pleasing unto Thee."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Convert us, O Lord, our Saviour.\n℟. And turn away Thy wrath from us."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Convert us, O Lord, our Saviour."
+                  },
+                  "r": {
+                    "en-US": "And turn away Thy wrath from us."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help us."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help us."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -1133,7 +1844,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Anthem - Agonizans"
               }
@@ -1145,7 +1856,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Little Chapter Ecclus. XV, 5"
               }
@@ -1153,23 +1864,62 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "In the midst of the Church, the Lord opened his mouth and filled him with the spirit of wisdom and understanding, and clothed him with a robe of glory.\n℟. Thanks be to God."
+                "en-US": "In the midst of the Church, the Lord opened his mouth and filled him with the spirit of wisdom and understanding, and clothed him with a robe of glory."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Intercede for us, O blessed father Dominic.\n℟. Intercede for us, O blessed father Dominic.\n℣. That we may be made worthy of the promises of Christ.\n℟. O blessed father Dominic.\n℣. Glory be to the Father, and to the Son, and to the Holy Ghost.\n℟. Intercede for us, O blessed father Dominic."
+                "en-US": "Thanks be to God."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Intercede for us, O blessed father Dominic."
+                  },
+                  "r": {
+                    "en-US": "Intercede for us, O blessed father Dominic."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  },
+                  "r": {
+                    "en-US": "O blessed father Dominic."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Glory be to the Father, and to the Son, and to the Holy Ghost."
+                  },
+                  "r": {
+                    "en-US": "Intercede for us, O blessed father Dominic."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn - Carnis liber ergastulo"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "From prison of the flesh set free,\nSee how he shines with beams from heaven!\nAnd for his garb of poverty\nA robe of royalty is given.\nThe fragrant tomb, the frequent sign,\nClear proof to all mankind afford\nHow much of grace and power divine\nChrist's servant shareth with his Lord.\nTo God, the Three and One, be praise\nAnd honour, strength and glory given;\nAnd may He deign our souls to raise\nThrough our sweet father's prayers to heaven. Amen."
               }
@@ -1187,7 +1937,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Anthem - O Speculum"
               }
@@ -1199,22 +1949,81 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nHave mercy upon us, Thy servants, we beseech Thee, O Lord, and whatsoever sins we have committed in this our life and pilgrimage, by the sight of evil things, or the hearing of unprofitable discourse, do Thou of Thine unspeakable kindness, and through the intercession of Thy confessor, our most blessed and sweet father Dominic, wholly blot out and forgive. Through our Lord, etc."
+                "en-US": "Have mercy upon us, Thy servants, we beseech Thee, O Lord, and whatsoever sins we have committed in this our life and pilgrimage, by the sight of evil things, or the hearing of unprofitable discourse, do Thou of Thine unspeakable kindness, and through the intercession of Thy confessor, our most blessed and sweet father Dominic, wholly blot out and forgive. Through our Lord, etc."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. O Lord, hear my prayer.\n℟. And let my cry come unto Thee.\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n℣. May the souls of the faithful departed through the mercy of God rest in peace.\n℟. Amen.\n℣. Father, keep thy gracious word,\n℟. Pleading for us with our Lord."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, hear my prayer."
+                  },
+                  "r": {
+                    "en-US": "And let my cry come unto Thee."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Let us bless the Lord."
+                  },
+                  "r": {
+                    "en-US": "Thanks be to God."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "May the souls of the faithful departed through the mercy of God rest in peace."
+                  },
+                  "r": {
+                    "en-US": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Father, keep thy gracious word,"
+                  },
+                  "r": {
+                    "en-US": "Pleading for us with our Lord."
+                  }
+                }
+              ]
             }
           ]
         }

--- a/content/practices/little-office-s-francis-borgia-of-the-society-of-jesus/flow.json
+++ b/content/practices/little-office-s-francis-borgia-of-the-society-of-jesus/flow.json
@@ -32,31 +32,51 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus, in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Illustre sidus Principum,\nFrancisce salve maxime;\nQui foetido cadavere\nViso, horruisti saeculum."
+                "la": "Illustre sidus Principum,\nFrancisce salve maxime;\nQui foetido cadavere\nViso, horruisti saeculum.\n\nAverte nostra lumina,\nNe vanitates hauriant,\nSed in supernam caelitum\nSint fixa saeculum jugiter."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Averte nostra lumina,\nNe vanitates hauriant,\nSed in supernam caelitum\nSint fixa saeculum jugiter."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -68,15 +88,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Non aspiciam hominem ultra, et habitatorum quietis.\n℟. Haec requies mea in saeculum saeculi: quoniam elegi eam."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Non aspiciam hominem ultra, et habitatorum quietis."
+                  },
+                  "r": {
+                    "la": "Haec requies mea in saeculum saeculi: quoniam elegi eam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nOmnipotens, sempiterne Deus,\nqui spreta vanitate, beatum Franciscum Borgiam\net Societatem Filii tui vocare dignatus es:\npraesta, quaesumus, ut, quem eximia sanctimoniae exempla\npar habuimus in terris,\nejus coronae participes fieri mereamur in caelis.\nPer Christum Dominum nostrum. Amen."
+                "la": "Omnipotens, sempiterne Deus,\nqui spreta vanitate, beatum Franciscum Borgiam\net Societatem Filii tui vocare dignatus es:\npraesta, quaesumus, ut, quem eximia sanctimoniae exempla\npar habuimus in terris,\nejus coronae participes fieri mereamur in caelis.\nPer Christum Dominum nostrum. Amen."
               }
             }
           ]
@@ -90,31 +123,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Salve columna Gandiae,\nEt Religionis gloria:\nQui aula relicta Principis,\nAulam petisti Numinis."
+                "la": "Salve columna Gandiae,\nEt Religionis gloria:\nQui aula relicta Principis,\nAulam petisti Numinis.\n\nServos fideles caelitum\nServire fac nos Principi,\nUt tecum eodem praemio\nPerfruamur perpetuo."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Servos fideles caelitum\nServire fac nos Principi,\nUt tecum eodem praemio\nPerfruamur perpetuo."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -126,10 +166,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Beatus vir, qui timet Dominum:\n℟. Et non respexit in vanitates, et insanias falsas."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Beatus vir, qui timet Dominum:"
+                  },
+                  "r": {
+                    "la": "Et non respexit in vanitates, et insanias falsas."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -148,31 +195,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Salve, o speculum pauperum,\nOpumque spretor inclite,\nFelicitatem divitum\nQui vanitatem duxeras:"
+                "la": "Salve, o speculum pauperum,\nOpumque spretor inclite,\nFelicitatem divitum\nQui vanitatem duxeras:\n\nFac spiritu nos pauperes,\nVirtute vero divites,\nGazas caducas spernere,\nSolumque Christum quaerere."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Fac spiritu nos pauperes,\nVirtute vero divites,\nGazas caducas spernere,\nSolumque Christum quaerere."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -184,10 +238,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Beatus vir, cujus est nomen Domini spes ejus.\n℟. Et non respexit in vanitates, et insanias falsas."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Beatus vir, cujus est nomen Domini spes ejus."
+                  },
+                  "r": {
+                    "la": "Et non respexit in vanitates, et insanias falsas."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -206,31 +267,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Salve polaris flammula,\nCaeli voluptas, Borgia,\nDevotionis lachryma\nCui madebant lumina:"
+                "la": "Salve polaris flammula,\nCaeli voluptas, Borgia,\nDevotionis lachryma\nCui madebant lumina:\n\nRores supernos gratiae\nDevotionis depule,\nCor incalescat frigidum,\nFlammis amoris affluat."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Rores supernos gratiae\nDevotionis depule,\nCor incalescat frigidum,\nFlammis amoris affluat."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -242,10 +310,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Tanquam imbres mittet eloquia sapientiae tuae.\n℟. Et in oratione constituitur Domino."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Tanquam imbres mittet eloquia sapientiae tuae."
+                  },
+                  "r": {
+                    "la": "Et in oratione constituitur Domino."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -264,31 +339,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Salve pudicitiae rosa,\nEt castitatis lilium:\nHostis voluptae maxime,\nCarnisque victor hostium:"
+                "la": "Salve pudicitiae rosa,\nEt castitatis lilium:\nHostis voluptae maxime,\nCarnisque victor hostium:\n\nTu puritatem corporis,\nMentisque serves integram:\nCor munda ab omni crimine,\nDignus thorus sit Numine."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Tu puritatem corporis,\nMentisque serves integram:\nCor munda ab omni crimine,\nDignus thorus sit Numine."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -300,10 +382,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Retribuet mihi Dominus secundum justitiam meam.\n℟. Et secundum puritatem manuum mearum in conspectu oculorum ejus."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Retribuet mihi Dominus secundum justitiam meam."
+                  },
+                  "r": {
+                    "la": "Et secundum puritatem manuum mearum in conspectu oculorum ejus."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -322,31 +411,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Salve culmen humilium,\nExemplum obedientiae,\nCalcata honoris purpura,\nDemissionis gratia."
+                "la": "Salve culmen humilium,\nExemplum obedientiae,\nCalcata honoris purpura,\nDemissionis gratia.\n\nQui claruit maxima,\nMotus superbos comprime,\nMentes rebelles doma,\nHumilesque veros effice."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Qui claruit maxima,\nMotus superbos comprime,\nMentes rebelles doma,\nHumilesque veros effice."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -358,10 +454,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Memoriam superborum perdidit Deus.\n℟. Reliquit memoriam humilium sensu."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Memoriam superborum perdidit Deus."
+                  },
+                  "r": {
+                    "la": "Reliquit memoriam humilium sensu."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -380,31 +483,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Salve potestas daemonum,\nBellator invincibilis,\nQui nobilis victoriae\nPlaudens migrasti e corpore."
+                "la": "Salve potestas daemonum,\nBellator invincibilis,\nQui nobilis victoriae\nPlaudens migrasti e corpore.\n\nAdversus infernalium\nTentationes hostium,\nNobis adis fortissimum\nIn morte propugnaculum."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Adversus infernalium\nTentationes hostium,\nNobis adis fortissimum\nIn morte propugnaculum."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -416,10 +539,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Gloriosa in conspectu Domini.\n℟. Mors Sanctorum ejus."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloriosa in conspectu Domini."
+                  },
+                  "r": {
+                    "la": "Mors Sanctorum ejus."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",

--- a/content/practices/little-office-s-francis-of-assisi/flow.json
+++ b/content/practices/little-office-s-francis-of-assisi/flow.json
@@ -33,25 +33,64 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Amor Seraphicus accendat sensus, et corda nostra."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Amor Seraphicus accendat sensus, et corda nostra.\n℟. Amen.\n℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Venite omnes pie mentes,\nVenite sinceri clientes,\nFranciscum Filii laudemus,\nEique nunc honorem demus.\n\nQuem humilitas exaltavit,\nVeraque sanctitas beavit,\nQui in angeli altam sedem\nLectus per luciferi caedem.\n\nLucifer enim superbiit,\nFranciscus se exinanivit."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -63,15 +102,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis S. Francisce Seraphice.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis S. Francisce Seraphice."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui ad demonstrandam tuam potestatem servum tuum Franciscum,\nob profundam ejusdem humilitatem in thronum luciferi collocasti,\ndejectum vero angelum ob superbiam humiliasti:\nconcede propitius, ut ejusdem exemplo hic in terris semper humiles,\nin aeterna dein gloria exaltari mereamur.\nPer Christum Dominum nostrum. Amen."
+                "la": "Deus, qui ad demonstrandam tuam potestatem servum tuum Franciscum,\nob profundam ejusdem humilitatem in thronum luciferi collocasti,\ndejectum vero angelum ob superbiam humiliasti:\nconcede propitius, ut ejusdem exemplo hic in terris semper humiles,\nin aeterna dein gloria exaltari mereamur.\nPer Christum Dominum nostrum. Amen."
               }
             }
           ]
@@ -85,25 +137,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Amor Seraphicus accendat sensus, et corda nostra."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Amor Seraphicus accendat sensus, et corda nostra.\n℟. Amen.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "A Deo eras confirmatus,\nTu ut Seraphim inflammatus;\nVotum insuper emisisti,\nUt qui petunt amore Christi,\n\nOmnia per Christum dabis,\nNihil illis denegabis.\nLicet petant vestimenta,\nCorporisque lenimenta,\n\nOpem nemini negabis,\nCuncta nobis impetrabis."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -115,15 +193,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis Sancte Francisce Seraphice.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis Sancte Francisce Seraphice."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui cor sinceri tui servi Francisci in tuo amore ita inflammasti,\nut se votis obstrinxerit nulli quidquam amore tui petenti denegandi:\nfac ut pariter in nomine Christi postulantibus nihil denegemus.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui tecum vivit et regnat in saecula saeculorum. Amen."
+                "la": "Deus, qui cor sinceri tui servi Francisci in tuo amore ita inflammasti,\nut se votis obstrinxerit nulli quidquam amore tui petenti denegandi:\nfac ut pariter in nomine Christi postulantibus nihil denegemus.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui tecum vivit et regnat in saecula saeculorum. Amen."
               }
             }
           ]
@@ -137,25 +228,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Amor Seraphicus accendat sensus, et corda nostra."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Amor Seraphicus accendat sensus, et corda nostra.\n℟. Amen.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Patris e domo ejectus,\nDei filius adlectus,\nPatrem nostrum invocasti,\nEs expertus, quod optasti.\n\nDulci eundem amplexu,\nColuisti novo nexu;\nInquiebas: Pater mi!\nAudiebas: Fili mi!\n\nDeus meus, et omnia,\nCaetera mundi somnia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -167,15 +284,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis S. Francisce Seraphice.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis S. Francisce Seraphice."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui desertum a parente Franciscum,\net teque sincere et filiali invocantem\nin patronum tuum praesidium recipere dignatus es:\nconcede nobis filiis tuis, tibi filiali confidentia semper adhaerere,\natque sub paterno tuo praesidio secure vivere.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui tecum vivit et regnat in saecula saeculorum. Amen."
+                "la": "Deus, qui desertum a parente Franciscum,\net teque sincere et filiali invocantem\nin patronum tuum praesidium recipere dignatus es:\nconcede nobis filiis tuis, tibi filiali confidentia semper adhaerere,\natque sub paterno tuo praesidio secure vivere.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui tecum vivit et regnat in saecula saeculorum. Amen."
               }
             }
           ]
@@ -189,25 +319,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Amor Seraphicus accendat sensus, et corda nostra."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Amor Seraphicus accendat sensus, et corda nostra.\n℟. Amen.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Te Deo plene dedicasti,\nAnimam totam consecrasti,\nPostquam corpus cruciasti,\nSanguineque sauciasti.\n\nOrdinis novi fundator\nFactus es, et propagator,\nE coelis qui mundo natus,\nSeraphicus appellatus.\n\nTu quas leges praescripsisti,\nIpse ad unguem implevisti."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -219,15 +375,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis S. Francisce Seraphice.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis S. Francisce Seraphice."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede nobis Omnipotens ac Benigne Deus,\nper austeram vivendi normam et magnamque zelosi servi tui Francisci poenitentiam,\nauxilium ac gratiam,\nut hic in terris nostrae conformiter vocationi in mortificatione corporis constanter nos exerceamus.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui tecum vivit et regnat in saecula saeculorum. Amen."
+                "la": "Concede nobis Omnipotens ac Benigne Deus,\nper austeram vivendi normam et magnamque zelosi servi tui Francisci poenitentiam,\nauxilium ac gratiam,\nut hic in terris nostrae conformiter vocationi in mortificatione corporis constanter nos exerceamus.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui tecum vivit et regnat in saecula saeculorum. Amen."
               }
             }
           ]
@@ -241,25 +410,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Amor Seraphicus accendat sensus, et corda nostra."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Amor Seraphicus accendat sensus, et corda nostra.\n℟. Amen.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Paupertati desponsatus,\nEt inopia dotatus,\nHanc reginam nominasti,\nFactis tuis decorasti.\n\nDei opes solas veras,\nPraeter illas nugas meras,\nAgnovisti, et dixisti,\nDives, pauper dum vixisti.\n\nTe virtutes adornarunt,\nCaeli cives honorarunt."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -271,15 +466,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis S. Francisce Seraphice.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis S. Francisce Seraphice."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Sancto Francisco Seraphico\npauperi quidem in hoc mundo,\ndiviti vero in gratia tua thesaurum verae evangelicae paupertatis indicasti:\ntribue nobis veram heroicam spiritus paupertatem,\nut cujus terrena omnia despicamus,\net non aliam quam in coelis haereditatem devote suspiremus,\natque glorioso obtineamus.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui tecum vivit et regnat in saecula saeculorum. Amen."
+                "la": "Deus, qui Sancto Francisco Seraphico\npauperi quidem in hoc mundo,\ndiviti vero in gratia tua thesaurum verae evangelicae paupertatis indicasti:\ntribue nobis veram heroicam spiritus paupertatem,\nut cujus terrena omnia despicamus,\net non aliam quam in coelis haereditatem devote suspiremus,\natque glorioso obtineamus.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui tecum vivit et regnat in saecula saeculorum. Amen."
               }
             }
           ]
@@ -293,25 +501,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Amor Seraphicus accendat sensus, et corda nostra."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Amor Seraphicus accendat sensus, et corda nostra.\n℟. Amen.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Orans noctes consumebas,\nOrto sole mox legebas,\nSacra Patrum volumina,\nDelapsa coelo lumina.\n\nDeo laudes decantabas,\nEt canendo plus amabas;\nExclamabas: O mi Deus!\nEt omnia totus meus.\n\nEn te cor meum diligit,\nTeque in patrem eligit."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -323,15 +557,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis Sancte Francisce Seraphice.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis Sancte Francisce Seraphice."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, immensum mare omnium gratiarum et perfectionum,\nqui electo tuo servo Francisco omnia in omnibus fuisti,\ndum amore succensus exclamaret:\nDeus meus, et omnia!\nconcede etiam servis tuis, ut in te unicum nostrum cordis lenimen reperiamus.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui tecum vivit et regnat in saecula saeculorum. Amen."
+                "la": "Deus, immensum mare omnium gratiarum et perfectionum,\nqui electo tuo servo Francisco omnia in omnibus fuisti,\ndum amore succensus exclamaret:\nDeus meus, et omnia!\nconcede etiam servis tuis, ut in te unicum nostrum cordis lenimen reperiamus.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui tecum vivit et regnat in saecula saeculorum. Amen."
               }
             }
           ]
@@ -345,25 +592,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Amor Seraphicus accendat sensus, et corda nostra."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Amor Seraphicus accendat sensus, et corda nostra.\n℟. Amen.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Seraphicae mentis ardor,\nPuritatis vitae candor,\nDeo semper eras gratus,\nEt ab angelis amatus.\n\nTe calefasti parvum mundum,\nAbjecisti in profundum;\nNosti quod sit caro coenum,\nQuo delectat, sit venenum.\n\nMundum ergo debellasti,\nFelix victor triumphasti."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -375,15 +648,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis Sancte Francisce Seraphice.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis Sancte Francisce Seraphice."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede nobis Domine per merita et intercessionem tui maxime\nin angelica puritate excellentis servi tui Francisci\nillibatam animae et corporis puritatem,\nut mundo corde Agnum Immaculatum aeternum aspicere mereamur.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui tecum vivit et regnat in saecula saeculorum. Amen."
+                "la": "Concede nobis Domine per merita et intercessionem tui maxime\nin angelica puritate excellentis servi tui Francisci\nillibatam animae et corporis puritatem,\nut mundo corde Agnum Immaculatum aeternum aspicere mereamur.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui tecum vivit et regnat in saecula saeculorum. Amen."
               }
             }
           ]
@@ -397,25 +683,64 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Amor Seraphicus accendat sensus, et corda nostra."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Amor Seraphicus accendat sensus, et corda nostra.\n℟. Amen.\n℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Tibi Jesus vult uniri,\nCor amore vult muniri,\nIn dulce amoris signum\nMiat tibi crucis lignum.\n\nSigna imprimit doloris,\nMutui testes amoris;\nUt capias coeli bona,\nPurpurea confert dona.\n\nTe sibi facit similem,\nQuem novit esse humilem."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -427,15 +752,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis Sancte Francisce Seraphice.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis Sancte Francisce Seraphice."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDomine Jesu Christe, qui frigescente mundo\nad inflammandum corda nostra tui amoris igne,\nin carne Beatissimi Patris Francisci passionis tuae sacra stigmata renovasti:\nconcede propitius, ut ejus meritis et precibus crucem jugiter feramus,\net dignos fructus poenitentiae faciamus.\nQui vivis et regnas cum Deo Patre\nin unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum. Amen."
+                "la": "Domine Jesu Christe, qui frigescente mundo\nad inflammandum corda nostra tui amoris igne,\nin carne Beatissimi Patris Francisci passionis tuae sacra stigmata renovasti:\nconcede propitius, ut ejus meritis et precibus crucem jugiter feramus,\net dignos fructus poenitentiae faciamus.\nQui vivis et regnas cum Deo Patre\nin unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum. Amen."
               }
             }
           ]
@@ -455,27 +793,40 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Hymnus"
       }
     },
     {
-      "type": "prayer",
+      "type": "hymn",
       "inline": {
         "la": "Iste confessor Domini, relicto\nOrbe terrarum meruit beatos\nExinde laetus penetrare portus\nAtrium coeli.\n\nNam pius, prudens, humilis, pudicus,\nNobilem duxit sine labe vitam,\nEt Dei mansit pietate plenus\nSemper amicus.\n\nInter electos sine fine gaudet,\nOsculum sanctae recipitque pacis,\nSortis aeternae meruitque salutis\nExsultat in aevum.\n\nPropter ingentis meriti valorem,\nHactenus multi potitiuntur aegri\nViribus morbi domitis, salute\nSuppeditata.\n\nReddit hinc illi chorus iste noster\nOmne per vitae viridantis aevum\nMaximas laudes celebresque palmas\nExhilaratus.\n\nRector immensi Dominusque coeli,\nSpiritus Sanctus, Pater atque Natus,\nTrinus ac unus tibi sint honores,\nGloria, virtus."
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Ora pro nobis Sancte Francisce Seraphice.\n℟. Ut digni efficiamur promissionibus Christi."
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ora pro nobis Sancte Francisce Seraphice."
+          },
+          "r": {
+            "la": "Ut digni efficiamur promissionibus Christi."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nDeus, qui Ecclesiam tuam\nBeati Francisci meritis foetu novae prolis amplificas:\ntribue nobis ex ejus imitatione terrena despicere,\net coelestium donorum semper participatione gaudere.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui tecum vivit et regnat in saecula saeculorum. Amen."
+        "la": "Deus, qui Ecclesiam tuam\nBeati Francisci meritis foetu novae prolis amplificas:\ntribue nobis ex ejus imitatione terrena despicere,\net coelestium donorum semper participatione gaudere.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui tecum vivit et regnat in saecula saeculorum. Amen."
       }
     },
     {

--- a/content/practices/little-office-s-francis-of-paola/flow.json
+++ b/content/practices/little-office-s-francis-of-paola/flow.json
@@ -29,23 +29,55 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Sancto Francisco de Paula nascente lux miraculosa in domo resplenduit.\n℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Sancto Francisco de Paula nascente lux miraculosa in domo resplenduit."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Paulae nascentis claritas\nNoctis illustrat nubila,\nCanoras fert laetitias\nQui docuit silentia,\n\nAdam etiam intemperans\nNoctem tulit nepotibus,\nReduxit lucem imperans\nCarnes caret carinibus;\n\nPulsis dapum vaporibus\nNam ut serenat cerebra,\nLucidor sic spiritus\nPer carnis fit jejunia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -57,15 +89,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis sancte Francisce de Paula,\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis sancte Francisce de Paula,"
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus humilium celsitudo, qui beatum Franciscum confessorem tuum sanctorum gloria sublimasti: tribue, quaesumus, ut ejus meritis et imitatione, promissa humilibus praemia feliciter consequamur. Per Dominum nostrum etc."
+                "la": "Deus humilium celsitudo, qui beatum Franciscum confessorem tuum sanctorum gloria sublimasti: tribue, quaesumus, ut ejus meritis et imitatione, promissa humilibus praemia feliciter consequamur. Per Dominum nostrum etc."
               }
             }
           ]
@@ -85,25 +130,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Preces fundit et cantica\nPios incurvans poplites\nTam grata Deo musices,\nIpsi gaudent coelites;\n\nOra veretur spiritu\nSublimis inter sydera,\nClaro virtutum ambitu\nJam forte dignus coelis.\n\nNam sub carnis pondere\nRecusat corpus deprimi,\nAstra volavit scandere\nMens valet haud difficili."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -137,25 +195,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Primo juventae tempore\nHaerere nugis renuit,\nVirili mentis robore\nCircen repulsam conspexit;\n\nVirgo notatus candido\nLapillo castimoniae\nJam tutus est a sordido\nCupidinis tentamine,\n\nBlandis rebellis motibus\nCarnis terit potentiam,\nCastis puelli moribus\nViri jungens prudentiam."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -189,25 +260,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Agenti cum triennio\nBilustrum nostro juveni\nFit sylva pro palatio\nSacri doctrix silentii,\n\nEremus, quaeque spernitur\nA vanis mundi affectibus,\nHuic coelum et creditur\nSupernis plenum gaudiis:\n\nNec tangitur molestia\nRemotus a sodalibus,\nDei dat suam praesentiam\nAbstrusus latens specubus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -241,25 +325,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Sylvae relictens fructices,\nSub Charitatis exercitu\nAd bella Christi milites\nManu producit strenua,\n\nQuem manuevit Charitas,\nPraedignus hic et signifer,\nQuo conteratur vanitas,\nQuam fallax sufflat Lucifer.\n\nAmor tumorem dejicit,\nSuperbiam humilitas,\nTurgentes vidit ductiles\nCalore Phoebus nebulas."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -293,25 +390,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Ignas domat, et aequora,\nTerras, flatusque aetheris,\nDat lingua mutis organa,\nEt caecis usum luminis;\n\nBinis amorum nexibus\nTum Numini, tum Proximi\nMiraclis claret pluribus\nAeterno plenus Principi;\n\nNec diligenti potuit\nUt Deus quidquam denegat,\nQuin, quo se plus abjicit,\nHoc gratia plus eminet."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -345,25 +455,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Die, qua fudit spiritum\nChristus in Crucis cathedra\nFranciscus hoc exilium\nPerennis intrat gloria,\n\nCrucem dum tenens, coelici\nAmoris ictus spiculis,\nPendens Jesu vertici\nJungi meretur oculis,\n\nAssuetus Christo vivere,\nDux vitae postquam mortuus,\nCum hoc et vitam cedere\nEadem die cupidus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -397,25 +520,51 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Convertere nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Convertere nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Hunc, in quem tumba conditum\nFormidat marcor furere,\nAgmen audet haereticum\nIn cineres comburere,\n\nUt, qui tot vivus aspera\nAbs laurea martyrii\nTulit, athletae viscera\nJam concrementur mortui,\n\nQuo rosae, tectae antea\nSub castitatis frigore,\nAmoris tinctae purpura\nFlagrante furgant corpore."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -449,7 +598,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Ant."
       }
@@ -461,15 +610,28 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Ora pro nobis sancte Francisce de Paula,\n℟. Ut digni efficiamur promissionibus Christi."
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ora pro nobis sancte Francisce de Paula,"
+          },
+          "r": {
+            "la": "Ut digni efficiamur promissionibus Christi."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nO sancte Francisce de Paula! mitissimi Jesu humilime imitator, in quo manifeste apparet, humilia Deum respicere, et esse mirabilem in sanctis suis, quique quem paternis intercessionibus beati Francisci Stephani consequum in filium, divina vero providentia in tenera adhuc aetate eduxit, ut humilitationis ac coarctationis solitudinem sponte ingressus, inter asperrimas corporis, animique mortificationes, sexenio ibidem delapseceres, donec adduce divino spiritu progressus faciam, plenamque humilitate Fratrum Minimorum originem fundas; etiam omnibus qua pluries, in summo ignis injectus, sicut nec pedem transgrediens mare, nec amnem innatans, incolumis evasisti, nec innumera illustratus prodigiis; quaesumus, benigne Pater, gloriosae coelorum laetitia! efficaciter apud Deum, ut et nos devoti clientes tui, ab infimo humilitatis gradu ad summum divini amoris culmen pertingere, unaque tecum atque omnibus sanctis, aeternis recreari gaudiis mereamur. Per Christum Dominum nostrum.\nAmen."
+        "la": "O sancte Francisce de Paula! mitissimi Jesu humilime imitator, in quo manifeste apparet, humilia Deum respicere, et esse mirabilem in sanctis suis, quique quem paternis intercessionibus beati Francisci Stephani consequum in filium, divina vero providentia in tenera adhuc aetate eduxit, ut humilitationis ac coarctationis solitudinem sponte ingressus, inter asperrimas corporis, animique mortificationes, sexenio ibidem delapseceres, donec adduce divino spiritu progressus faciam, plenamque humilitate Fratrum Minimorum originem fundas; etiam omnibus qua pluries, in summo ignis injectus, sicut nec pedem transgrediens mare, nec amnem innatans, incolumis evasisti, nec innumera illustratus prodigiis; quaesumus, benigne Pater, gloriosae coelorum laetitia! efficaciter apud Deum, ut et nos devoti clientes tui, ab infimo humilitatis gradu ad summum divini amoris culmen pertingere, unaque tecum atque omnibus sanctis, aeternis recreari gaudiis mereamur. Per Christum Dominum nostrum.\nAmen."
       }
     }
   ]

--- a/content/practices/little-office-s-francis-xavier-of-the-society-of-jesus/flow.json
+++ b/content/practices/little-office-s-francis-xavier-of-the-society-of-jesus/flow.json
@@ -26,25 +26,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies"
+                  },
+                  "r": {
+                    "la": "Et os meum annunciabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies\n℟. Et os meum annunciabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Salve, domus Xaverii\nAugustior corona,\nFrancisce, quem tot gloria,\nCoeloque tanta dona\nInsigniunt, quem Trinitas,\nQuem Japon, Indus orbis,\nQuem Trina adornat Unitas,\nPulsis tot orbe morbis."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -56,15 +82,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Mihi autem nimis honorificati sunt amici tui Deus.\n℟. Nimis confortatus est principatus eorum."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Mihi autem nimis honorificati sunt amici tui Deus."
+                  },
+                  "r": {
+                    "la": "Nimis confortatus est principatus eorum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Evangelium regni tui per barbaras gentes,\net reconditas nationes Sancti Francisci tui Xaverii praedicatione fideminasti,\net ejus sanctitatem purissimi corporis incorruptione declarasti:\nconcede quaesumus: ut, qui ejus memoriam agimus,\ncum morum imitatione sequamur.\nPer Dominum nostrum Jesum Christum, etc."
+                "la": "Deus, qui Evangelium regni tui per barbaras gentes,\net reconditas nationes Sancti Francisci tui Xaverii praedicatione fideminasti,\net ejus sanctitatem purissimi corporis incorruptione declarasti:\nconcede quaesumus: ut, qui ejus memoriam agimus,\ncum morum imitatione sequamur.\nPer Dominum nostrum Jesum Christum, etc."
               }
             }
           ]
@@ -78,25 +117,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Salve, salus Travancoris,\nDoctorque parvulorum\nExorta Lampas Brasilis,\nDuctorque barbarorum:\nIllis legebas Virgine\nDe Matre lectiones,\nHis de Deo, in corpore\nCruento fectiones."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -108,15 +160,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Omnibus omnia factus sum.\n℟. Ut omnes facerem salvos."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Omnibus omnia factus sum."
+                  },
+                  "r": {
+                    "la": "Ut omnes facerem salvos."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui, etc."
+                "la": "Deus, qui, etc."
               }
             }
           ]
@@ -130,25 +195,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Salve, cui nec barbarus\nHostis, superbus armis,\nNec ipse par est Tartarus.\nClarus tot orbe Palmis.\nTe namque Bungus praedicat,\nMalaca te parentem\nAgnoscit, et depraedicat\nXaverium potentem."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Gen. 22."
               }
@@ -160,15 +238,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Cumque levaret Moyses manus.\n℟. Vincebat Israel."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Cumque levaret Moyses manus."
+                  },
+                  "r": {
+                    "la": "Vincebat Israel."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Evangelium, etc."
+                "la": "Deus, qui Evangelium, etc."
               }
             }
           ]
@@ -182,25 +273,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Salve, sacri Baptismatis,\nQui sic lavas ab undis Maures:\nUt atri stigmatis\nHos liberes ab umbris.\nDecies centena millia,\nFrancisce, te sequuntur,\nQuae si putantur vilia\nMajora subsequuntur."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Ezech. 36."
               }
@@ -212,15 +316,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Millia millium ministrabant ei.\n℟. Et decies centena millia assistebant ei. Daniel. 7."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Millia millium ministrabant ei."
+                  },
+                  "r": {
+                    "la": "Et decies centena millia assistebant ei. Daniel. 7."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui, etc."
+                "la": "Deus, qui, etc."
               }
             }
           ]
@@ -234,25 +351,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Salve, cui mors horrida\nNon ante fata struxit,\nQuam, quos in antra torrida\nAbduxerat, reduxit.\nVicena namque funera\nEt quinque suscitasti,\nMortemque post tot vulnera\nIn temet incitasti."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -264,15 +394,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Dii facti similes hominibus descenderunt ad nos. Actor. 14.\n℟. Et resurrectione mortuorum, lumen annunciantes populo, et gentibus. Actor. 26."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dii facti similes hominibus descenderunt ad nos. Actor. 14."
+                  },
+                  "r": {
+                    "la": "Et resurrectione mortuorum, lumen annunciantes populo, et gentibus. Actor. 26."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Evangelium, etc."
+                "la": "Deus, qui Evangelium, etc."
               }
             }
           ]
@@ -286,25 +429,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Francisce, magne Nominis,\nEt proximorum amator,\nFrancisce, veri luminis\nIn orbe seminator:\nSalve, cui dum patria\nAngustiora castra\nDescriberet, tunc atria\nDat Numen inter astra."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona 2 Cor. 5."
               }
@@ -316,15 +472,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Pretiosa in conspectu Domini.\n℟. Mors Sanctorum ejus."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Pretiosa in conspectu Domini."
+                  },
+                  "r": {
+                    "la": "Mors Sanctorum ejus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Evangelium, etc."
+                "la": "Deus, qui Evangelium, etc."
               }
             }
           ]
@@ -338,25 +507,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Francisce, nec labecula\nPutredinis notate,\nPost fata nec nubecula\nPalloris inquinate,\nSalve, tuoque lumine\nSic Indias ferena,\nEuropa vero Numine\nUt sit, Deoque plena."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Dan. 3."
               }
@@ -368,15 +563,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Quoniam non derelinques animam meam in inferno.\n℟. Nec dabis, Sanctum tuum videre corruptionem."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Quoniam non derelinques animam meam in inferno."
+                  },
+                  "r": {
+                    "la": "Nec dabis, Sanctum tuum videre corruptionem."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Evangelium, etc."
+                "la": "Deus, qui Evangelium, etc."
               }
             }
           ]

--- a/content/practices/little-office-s-gertrude/flow.json
+++ b/content/practices/little-office-s-gertrude/flow.json
@@ -26,37 +26,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "O Lord, open Thou my lips."
+                  },
+                  "r": {
+                    "en-US": "And my mouth shall declare Thy praise."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. O Lord, open Thou my lips.\n℟. And my mouth shall declare Thy praise.\n℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me.\nGlory be to the Father, etc."
+                "en-US": "Glory be to the Father, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "Dear Spouse of Virgins, hear us sing\nWith joy a virgin's praise,\nWhom Thou didst in Thy love prepare\nTo join angelic lays."
+                "en-US": "Dear Spouse of Virgins, hear us sing\nWith joy a virgin's praise,\nWhom Thou didst in Thy love prepare\nTo join angelic lays.\n\nAnd hear us, too, O Gertrude, now,\nWhile we thy joys proclaim,\nChanting this office with sweet voice,\nIn honour of thy name.\n\nPraise be to Father, and to Son,\nAnd to the Paraclete,\nBy whom this spouse unto her Lord\nWas joined in union sweet."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "And hear us, too, O Gertrude, now,\nWhile we thy joys proclaim,\nChanting this office with sweet voice,\nIn honour of thy name."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "Praise be to Father, and to Son,\nAnd to the Paraclete,\nBy whom this spouse unto her Lord\nWas joined in union sweet."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Prayer"
               }
@@ -77,31 +91,32 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "Before all ages thou wert chosen,\nO Gertrude, to obtain\nThe richest treasures which the love\nOf Christ thy Spouse can gain."
+                "en-US": "Before all ages thou wert chosen,\nO Gertrude, to obtain\nThe richest treasures which the love\nOf Christ thy Spouse can gain.\n\nFor this be praise to God on high,\nAnd unto Christ thy love,\nWith holy and eternal laud\nTo the co-equal Dove."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "For this be praise to God on high,\nAnd unto Christ thy love,\nWith holy and eternal laud\nTo the co-equal Dove."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Prayer"
               }
@@ -122,31 +137,32 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "Thy early dawn of life was filled\nWith equal love and light,\nWhich sweetly drew thy heart and soul\nTo realms of pure delight."
+                "en-US": "Thy early dawn of life was filled\nWith equal love and light,\nWhich sweetly drew thy heart and soul\nTo realms of pure delight.\n\nFor this be praise to God on high,\nAnd unto Christ thy love,\nWith holy and eternal laud\nTo the co-equal Dove."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "For this be praise to God on high,\nAnd unto Christ thy love,\nWith holy and eternal laud\nTo the co-equal Dove."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Prayer"
               }
@@ -167,31 +183,32 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "Thou hast no other spouse but Christ,\nTo Him thy pure soul turns;\nAnd every thought of other love\nFor love of Him is spurned."
+                "en-US": "Thou hast no other spouse but Christ,\nTo Him thy pure soul turns;\nAnd every thought of other love\nFor love of Him is spurned.\n\nFor this be praise to God on high,\nAnd unto Christ thy love,\nWith holy and eternal laud\nTo the co-equal Dove."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "For this be praise to God on high,\nAnd unto Christ thy love,\nWith holy and eternal laud\nTo the co-equal Dove."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Prayer"
               }
@@ -212,31 +229,32 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "Thy Spouse, within thy heart enthroned,\nKeeps regal state, and finds His rest;\nWhile others scorn His gentle rule,\nOr drive away the heavenly Guest."
+                "en-US": "Thy Spouse, within thy heart enthroned,\nKeeps regal state, and finds His rest;\nWhile others scorn His gentle rule,\nOr drive away the heavenly Guest.\n\nFor this be praise to God on high,\nAnd unto Christ thy love,\nWith holy and eternal laud\nTo the co-equal Dove."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "For this be praise to God on high,\nAnd unto Christ thy love,\nWith holy and eternal laud\nTo the co-equal Dove."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Prayer"
               }
@@ -257,31 +275,32 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "Stronger than death is that strong love\nWhich burns within thy virgin breast,\nMourning thy Jesus slain for thee,\nIn whom alone thy heart can rest."
+                "en-US": "Stronger than death is that strong love\nWhich burns within thy virgin breast,\nMourning thy Jesus slain for thee,\nIn whom alone thy heart can rest.\n\nFor this be praise to God on high,\nAnd unto Christ thy love,\nWith holy and eternal laud\nTo the co-equal Dove."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "For this be praise to God on high,\nAnd unto Christ thy love,\nWith holy and eternal laud\nTo the co-equal Dove."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Prayer"
               }
@@ -302,31 +321,32 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "With the right Hand of love He wounds,\nWith the right Hand He victory gains;\nFor love's own victim, who with Him,\nIn everlasting triumph reigns."
+                "en-US": "With the right Hand of love He wounds,\nWith the right Hand He victory gains;\nFor love's own victim, who with Him,\nIn everlasting triumph reigns.\n\nFor this be praise to God on high,\nAnd unto Christ thy love,\nWith holy and eternal laud\nTo the co-equal Dove."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "For this be praise to God on high,\nAnd unto Christ thy love,\nWith holy and eternal laud\nTo the co-equal Dove."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Prayer"
               }
@@ -347,31 +367,32 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto my aid, O God.\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto my aid, O God."
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "en-US": "And now thy earthly race is o'er,\nThe conqueror's crown and palm is won,\nAnd thou wilt rest for evermore\nUpon the Heart of God's dear Son."
+                "en-US": "And now thy earthly race is o'er,\nThe conqueror's crown and palm is won,\nAnd thou wilt rest for evermore\nUpon the Heart of God's dear Son.\n\nFor this be praise to God on high,\nAnd unto Christ thy love,\nWith holy and eternal laud\nTo the co-equal Dove."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "For this be praise to God on high,\nAnd unto Christ thy love,\nWith holy and eternal laud\nTo the co-equal Dove."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Prayer"
               }

--- a/content/practices/little-office-s-igantius/flow.json
+++ b/content/practices/little-office-s-igantius/flow.json
@@ -26,25 +26,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies,"
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, labia mea aperies,\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, etc."
+                "la": "Gloria Patri, et Filio, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Cum mundus in caligine reatum jacet\nEt haeresisum fuligine\nSuffusis indoleret:\nRerum supremus arbiter\n\nMiseritum ingementis,\nMovit cor, et graviter\nInnondodo emendicis.\n\nFuit vir hic Ignatius,\nMissus medela morbis,\nVirtute cujus latius\nLate viteret orbis."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Jerem. 1."
               }
@@ -56,15 +82,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Inveni filium Jesse virum secundum cor meum.\n℟. Qui faciet omnes voluntates meas. Actor. 13."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Inveni filium Jesse virum secundum cor meum."
+                  },
+                  "r": {
+                    "la": "Qui faciet omnes voluntates meas. Actor. 13."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui ad majorem Nominis tui gloriam,\npropagandam novo per B. Ignatium subsidium militantem Ecclesiam roborasti;\nconcede, ut ejus auxilio, et imitatione certantes in terris,\ncoronari cum ipso mereamur in caelis.\nQui vivis et regnas, etc."
+                "la": "Deus, qui ad majorem Nominis tui gloriam,\npropagandam novo per B. Ignatium subsidium militantem Ecclesiam roborasti;\nconcede, ut ejus auxilio, et imitatione certantes in terris,\ncoronari cum ipso mereamur in caelis.\nQui vivis et regnas, etc."
               }
             }
           ]
@@ -78,25 +117,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, etc."
+                "la": "Gloria Patri, et Filio, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Ignatius Mavortiae se consecrat coronae\nSpem fregit hujus gratiae Bellona Pampellonae:\nCuratus aegre cogitat vias inire vitae,\nQuasi rite Divos, lecitavit, renuncians avitae.\nLares Paternos deserit, plensuque charitatis,\nUbique semen inserit salubrae sanctitatis."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Gen. 12."
               }
@@ -108,15 +160,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ambula coram me, et esto perfectus.\n℟. Et multiplicabo te vehementer nimis."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ambula coram me, et esto perfectus."
+                  },
+                  "r": {
+                    "la": "Et multiplicabo te vehementer nimis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui ad majorem, etc. ut supra."
+                "la": "Deus, qui ad majorem, etc. ut supra."
               }
             }
           ]
@@ -130,25 +195,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Amen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Ad Matris aram Virginis, pernoct precando durat.\nOmnique labe criminis cor expiando curat.\nCarnem domat jejuniis, austeritatibusque\nInsensu, et cupidis et laetitiis quibusque.\nIdem frequenter extimos expertus est labores.\nIdem frequenter intimos expertus est dolores."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Isai. 43."
               }
@@ -160,15 +251,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Honestavit illum in laboribus.\n℟. Et complevit labores illius."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Honestavit illum in laboribus."
+                  },
+                  "r": {
+                    "la": "Et complevit labores illius."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui ad majorem, etc. ut supra."
+                "la": "Deus, qui ad majorem, etc. ut supra."
               }
             }
           ]
@@ -182,25 +286,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Amen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Tricennis, imaestatis est Tiro latinitatis:\nHuc insolenti adactus est ardore charitatis.\nEt actus inde nobis sodalium sequella,\nRebus vacaret, fertili mortalium medela.\nCalumnias, et verba, saenasque, et carceresque\nTulit, et sustinet vulnera libentius, necque."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -212,15 +342,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Custodivit illum ab inimicis.\n℟. Et a seductoribus tutavit illum."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Custodivit illum ab inimicis."
+                  },
+                  "r": {
+                    "la": "Et a seductoribus tutavit illum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui ad majorem, etc. ut supra."
+                "la": "Deus, qui ad majorem, etc. ut supra."
               }
             }
           ]
@@ -234,25 +377,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Amen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Sublimis inter aera Ignatius tenetur:\nQuando te ulgens sidera precando conatur\nApostolos in judicium ab legat hinc vereptum:\nCum caeteris exotiicum hic, excolit rosetum.\nAufert suorum cordibus sodalium pavorem\nCum Christus ipsis omnibus proponit et favorem."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Isai. 18."
               }
@@ -264,15 +433,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. In doctrinis glorificate Dominum. Eccli. 14.\n℟. Et docete homines legem Dei. 4 Reg."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In doctrinis glorificate Dominum. Eccli. 14."
+                  },
+                  "r": {
+                    "la": "Et docete homines legem Dei. 4 Reg."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui, etc. ut supra."
+                "la": "Deus, qui, etc. ut supra."
               }
             }
           ]
@@ -286,25 +468,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Amen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Mox Ordo Jesu nomine vocatus, inchoatur\nFausto deinceps, omine firmatus approbatur.\nSacco jubetur caetui Ignatius praeesse,\nPastoris hujus mutui grex gessit subsellere.\nCutam suorum sodalium fructu ferace gessit,\nEt Coelique juxta regulam res cuncta vitae cessit."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Agg. 2."
               }
@@ -318,13 +526,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Caput in tribubus Israel factus est."
+                "la": "Caput in tribubus Israel factus est."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui, etc. ut supra."
+                "la": "Deus, qui, etc. ut supra."
               }
             }
           ]
@@ -338,25 +552,64 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Convertere nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Convertere nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Amen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Jam vitis illicae sersperat Ignatio fatore,\nOrbemque ferme sersperat coelestium favore.\nCum strenui mens militis post haec relicta castra\nInepta nomen coelitis poli subivit astra.\nO Patriarcha, lumine dignare nos paterno!\nOpemque natis, lumine transmittente de superno."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -368,15 +621,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Respexit in orationem humilium.\n℟. Et non sprevit precem eorum. Psalm 101."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Respexit in orationem humilium."
+                  },
+                  "r": {
+                    "la": "Et non sprevit precem eorum. Psalm 101."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui, etc."
+                "la": "Deus, qui, etc."
               }
             }
           ]
@@ -396,7 +662,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Oratio recitanda ante Imaginem S. Ignatii"
       }
@@ -408,7 +674,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Antiphona"
       }
@@ -420,19 +686,32 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Annunciate inter gentes gloriam ejus.\n℟. In omnibus populis mirabilia ejus."
-      }
-    },
-    {
-      "type": "prayer",
-      "inline": {
-        "la": "Oremus,\nDeus, qui servum tuum S. Ignatium de mundi caesis\nad spiritualis militiae triumphos evocasti;\npraesta quaesumus: ut eum sequamur lucem morum,\net protectorem consequamur.\nPer Christum Dominum nostrum."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Annunciate inter gentes gloriam ejus."
+          },
+          "r": {
+            "la": "In omnibus populis mirabilia ejus."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
+      "text": {
+        "la": "Oremus."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Deus, qui servum tuum S. Ignatium de mundi caesis\nad spiritualis militiae triumphos evocasti;\npraesta quaesumus: ut eum sequamur lucem morum,\net protectorem consequamur.\nPer Christum Dominum nostrum."
+      }
+    },
+    {
+      "type": "subheading",
       "text": {
         "la": "Antiphona"
       }
@@ -444,15 +723,34 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Ora pro nobis, Sancte Pater Ignati.\n℟. Ut digni efficiamur promissionibus Christi."
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ora pro nobis, Sancte Pater Ignati."
+          },
+          "r": {
+            "la": "Ut digni efficiamur promissionibus Christi."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nDeus, qui glorificantes te, glorificas,\net in Sanctorum tuorum honoribus honoraris;\nconcede propitius: ut, qui sancti tui Ignatii gloriosa merita colimus\nejus apud te pia patrocinia sentiamus.\nPer Christum Dominum nostrum.\n℟. Amen."
+        "la": "Deus, qui glorificantes te, glorificas,\net in Sanctorum tuorum honoribus honoraris;\nconcede propitius: ut, qui sancti tui Ignatii gloriosa merita colimus\nejus apud te pia patrocinia sentiamus.\nPer Christum Dominum nostrum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Amen."
       }
     }
   ]

--- a/content/practices/little-office-s-ignatius/flow.json
+++ b/content/practices/little-office-s-ignatius/flow.json
@@ -38,9 +38,35 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri. Alleluia."
+                "la": "Gloria Patri. Alleluia."
               }
             },
             {
@@ -50,19 +76,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "O Ignati, militantis\nClara fax Ecclesiae!\nO Xaveri, daventis\nSidus et lux Indiae!\nVos honorent, quotquot ambit\nPhoebus orbis climata,\nQuaqua pontum sero lambit,\nQuaqua tollit lumina."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -70,20 +96,72 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sapientiam ipsorum narrent populi, et laudem eorum nuntiet Ecclesia. Eccli. 44. 15.\n℣. In omnem terram exivit sonus eorum.\n℟. Et in fines orbis terrae verba eorum."
+                "la": "Sapientiam ipsorum narrent populi, et laudem eorum nuntiet Ecclesia. Eccli. 44. 15."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In omnem terram exivit sonus eorum."
+                  },
+                  "r": {
+                    "la": "Et in fines orbis terrae verba eorum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui glorificantes te glorificas, et in Sanctorum tuorum honoribus honoraris: concede propitius, ut qui beatorum Ignatii et Xaverii Confessorum tuorum merita veneramur, eorum pia apud te patrocinia sentiamus. Per Dominum nostrum."
+                "la": "Deus, qui glorificantes te glorificas, et in Sanctorum tuorum honoribus honoraris: concede propitius, ut qui beatorum Ignatii et Xaverii Confessorum tuorum merita veneramur, eorum pia apud te patrocinia sentiamus. Per Dominum nostrum."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -98,23 +176,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudemus viros gloriosos, et parentes nostros in generatione sua.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+                "la": "Laudemus viros gloriosos, et parentes nostros in generatione sua."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Vera virtus cum ruebat\nPressa pravo dogmate,\nHanc Loyola fulciebat\nNixus uno Numine.\nSic, Xaveri, te docente,\nCredit orbis Indicus:\nInde natum cum parente\nTollit aether laudibus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -122,7 +212,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sit memoria illorum in benedictione: et ossa eorum pullulent de loco suo, et nomen eorum permaneat in aeternum. Eccli. 46.\n℣. In omnem terram, etc."
+                "la": "Sit memoria illorum in benedictione: et ossa eorum pullulent de loco suo, et nomen eorum permaneat in aeternum. Eccli. 46."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "In omnem terram, etc."
               }
             },
             {
@@ -144,23 +240,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudemus viros gloriosos, et parentes nostros in generatione sua.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+                "la": "Laudemus viros gloriosos, et parentes nostros in generatione sua."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Vos cubile solis orti\nEt cadentis respicit;\nVestra dura cura sorti\nQuot clientes eripit!\nNos fovete, nos tenete,\nNe cadamus noxii,\nTramitemque nos docete,\nQuem premamus integri."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -168,7 +276,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Quasi stella matutina in medio nebulae, et quasi luna plena in diebus suis lucet, et quasi sol refulgens: sic illi effulserunt in templo Dei. Eccli. 50. 6.\n℣. In omnem terram, etc."
+                "la": "Quasi stella matutina in medio nebulae, et quasi luna plena in diebus suis lucet, et quasi sol refulgens: sic illi effulserunt in templo Dei. Eccli. 50. 6."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "In omnem terram, etc."
               }
             },
             {
@@ -190,23 +304,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudemus viros gloriosos, et parentes nostros in generatione sua.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+                "la": "Laudemus viros gloriosos, et parentes nostros in generatione sua."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Sol nitente cum sorore\nJungat etsi lumina,\nAureoque clarus ore\nVibret axe spicula;\nCedit illi, quo sedetis\nInclyti subsellio,\nRegique, quem tenetis\nAxis in palatio."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -214,7 +340,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Qui docti fuerunt, fulgebunt quasi splendor firmamenti; et qui ad justitiam erudiunt multos, quasi stellae in perpetuas aeternitates. Dan. 12. 3.\n℣. In omnem terram, etc."
+                "la": "Qui docti fuerunt, fulgebunt quasi splendor firmamenti; et qui ad justitiam erudiunt multos, quasi stellae in perpetuas aeternitates. Dan. 12. 3."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "In omnem terram, etc."
               }
             },
             {
@@ -236,23 +368,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudemus viros gloriosos, et parentes nostros in generatione sua.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+                "la": "Laudemus viros gloriosos, et parentes nostros in generatione sua."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Nulla dura tela sortis,\nNulla fati vulnera,\nIpsa nec pericula mortis,\nNulla mundi munera,\nVos amore separarunt\nProximi vel Numinis,\nVos beatis advocarunt\nCoelitum commerciis."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -260,7 +404,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "In pace vis vexati, in multis bene disponentur; quoniam Deus tentavit eos, et invenit illos dignos se. Sap. 3. 5.\n℣. In omnem terram, etc."
+                "la": "In pace vis vexati, in multis bene disponentur; quoniam Deus tentavit eos, et invenit illos dignos se. Sap. 3. 5."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "In omnem terram, etc."
               }
             },
             {
@@ -282,23 +432,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudemus viros gloriosos, et parentes nostros in generatione sua.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+                "la": "Laudemus viros gloriosos, et parentes nostros in generatione sua."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Quot nefandis explicastis\nCriminum exemplibus!\nQuot beatis aligastis\nSanctitatis nexibus!\nTrado hostes me regendum,\nAd salutem ducite\nCorpus et corda tuendum,\nOro, me defende."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -306,7 +468,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Illi viri misericordiae sunt, quorum pietates non defuerunt: cum semine eorum permanent bona. Eccli. 44. 10. 11.\n℣. In omnem terram, etc."
+                "la": "Illi viri misericordiae sunt, quorum pietates non defuerunt: cum semine eorum permanent bona. Eccli. 44. 10. 11."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "In omnem terram, etc."
               }
             },
             {
@@ -328,23 +496,48 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudemus viros gloriosos, et parentes nostros in generatione sua.\n℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
+                "la": "Laudemus viros gloriosos, et parentes nostros in generatione sua."
               }
             },
             {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos, Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in adjutorium."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Vos polique, vos solique\nBina luminaria,\nInfinique, maximique\nSicut exemplaria\nLutuentur obstruptentes:\nLumen, oro, spargite;\nNe premantur forte mentes\nCriminum caligine."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -352,7 +545,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Corpora eorum in pace sepulta sunt, et nomen eorum vivit in generationem et generationem. Eccli. 44. 14.\n℣. In omnem terram, etc."
+                "la": "Corpora eorum in pace sepulta sunt, et nomen eorum vivit in generationem et generationem. Eccli. 44. 14."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "In omnem terram, etc."
               }
             },
             {

--- a/content/practices/little-office-s-john-nepomucene/flow.json
+++ b/content/practices/little-office-s-john-nepomucene/flow.json
@@ -26,16 +26,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -44,37 +58,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Sidus orbis, et decori\nFax Joannes Aetheris;\nQui Bohemis es favori,\nEt Patronus singulis!"
+                "la": "Sidus orbis, et decori\nFax Joannes Aetheris;\nQui Bohemis es favori,\nEt Patronus singulis!\n\nTua felix Nepomucium\nVidit incunabula;\nTeque tota gens Amicum\nCredit ab que fabula.\n\nMagna Proles Zachariae\nNascitur miraculo:\nPrecibusque Tu Mariae\nImpetraris saeculo.\n\nMox futuram claritatem\nRutilantes flammulae;\nAtque vitae sanctitatem\nPraenotarunt stellulae."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Tua felix Nepomucium\nVidit incunabula;\nTeque tota gens Amicum\nCredit ab que fabula."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Magna Proles Zachariae\nNascitur miraculo:\nPrecibusque Tu Mariae\nImpetraris saeculo."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mox futuram claritatem\nRutilantes flammulae;\nAtque vitae sanctitatem\nPraenotarunt stellulae."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Isaiae 49)"
               }
@@ -86,28 +82,81 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ad te levavi animam meam.\n℟. Deus meus in Te confido, non erubescam."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ad te levavi animam meam."
+                  },
+                  "r": {
+                    "la": "Deus meus in Te confido, non erubescam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad Te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad Te veniat."
+                "la": "Omnipotens sempiterne Deus,\ncui soli omnis honor et gloria debetur;\nper gloriosa Sancti Tui Martyris Joannis Nepomuceni merita,\nTe supplices exoramus,\nut omnem a nobis publicam infamiam et ignominiam clementer avertas,\nconcedasque, ut cum honore sic transeamus per bona temporalia,\nut non amittamus aeterna.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui Tecum vivit et regnat in unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nOmnipotens sempiterne Deus,\ncui soli omnis honor et gloria debetur;\nper gloriosa Sancti Tui Martyris Joannis Nepomuceni merita,\nTe supplices exoramus,\nut omnem a nobis publicam infamiam et ignominiam clementer avertas,\nconcedasque, ut cum honore sic transeamus per bona temporalia,\nut non amittamus aeterna.\nPer Dominum nostrum Jesum Christum Filium tuum,\nqui Tecum vivit et regnat in unitate Spiritus Sancti Deus,\nper omnia saecula saeculorum.\nAmen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad Te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad Te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -120,10 +169,17 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -132,37 +188,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Tua primum cum juventa\nConsecratur literis,\nDocta stillant mox fluenta\nSuada prodit fertilis."
+                "la": "Tua primum cum juventa\nConsecratur literis,\nDocta stillant mox fluenta\nSuada prodit fertilis.\n\nIn Palaestris praedicari\nJus bibisse Canonum;\nDoctor ergo nominaris,\nNova lux fidelium.\n\nPresbyter post haec es unctus,\nPraeco sacris pulpitis:\nHoc honore rite functus,\nSacra promis dogmata.\n\nFactus Aulae castigatur,\nLuxus et licentia,\nStolidique reprobatur,\nSaeculi dementia."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "In Palaestris praedicari\nJus bibisse Canonum;\nDoctor ergo nominaris,\nNova lux fidelium."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Presbyter post haec es unctus,\nPraeco sacris pulpitis:\nHoc honore rite functus,\nSacra promis dogmata."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Factus Aulae castigatur,\nLuxus et licentia,\nStolidique reprobatur,\nSaeculi dementia."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Jerem. 1)"
               }
@@ -174,22 +212,68 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus ne elongeris a me.\n℟. Deus meus in auxilium meum respice."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus ne elongeris a me."
+                  },
+                  "r": {
+                    "la": "Deus meus in auxilium meum respice."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nOmnipotens sempiterne Deus, ut supra."
+                "la": "Omnipotens sempiterne Deus, ut supra."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad Te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad Te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -202,10 +286,17 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -214,37 +305,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Imperator ipse morum\nIractus innocentia,\nMinor hostis tunc proborum,\nTibi spondet ardua."
+                "la": "Imperator ipse morum\nIractus innocentia,\nMinor hostis tunc proborum,\nTibi spondet ardua.\n\nSed ad alta cur vocatus\nPromoveri respuis?\nInsulae cur deputatus\nViliora respicis?\n\nNempe totus ad superna\nSpiritus cum vertitur:\nTerra mundus ut caverna\nMerito contemnitur:\n\nHinc in Aula dividebas\nPauperum stipendia,\nEt egenis conferrebas\nDeputata munera."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sed ad alta cur vocatus\nPromoveri respuis?\nInsulae cur deputatus\nViliora respicis?"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Nempe totus ad superna\nSpiritus cum vertitur:\nTerra mundus ut caverna\nMerito contemnitur:"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Hinc in Aula dividebas\nPauperum stipendia,\nEt egenis conferrebas\nDeputata munera."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Galat. 6)"
               }
@@ -256,22 +329,68 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Suscipe me Domine secundum eloquium tuum et vivam.\n℟. Et non confundas me ab expectatione mea."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Suscipe me Domine secundum eloquium tuum et vivam."
+                  },
+                  "r": {
+                    "la": "Et non confundas me ab expectatione mea."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nOmnipotens sempiterne Deus, etc."
+                "la": "Omnipotens sempiterne Deus, etc."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -284,10 +403,17 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -296,37 +422,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Interim flagitiorum\nPestis Aulam polluit:\nQuando Wenceslaus, horum\nFautor, ipsis adstruit."
+                "la": "Interim flagitiorum\nPestis Aulam polluit:\nQuando Wenceslaus, horum\nFautor, ipsis adstruit.\n\nImperatrix ast Mariti\nIntuens licentiam:\nVana spernens, corde miti\nServat innocentiam.\n\nCui jactae tot procellis\nMontis adstas Arbiter;\nAnimique moesta pellis\nCeu coruscus Lucifer.\n\nSed Tribunal cum verendum\nPia saepe visiteret:\nCrescit ardor ad ascendium,\nToties quid proderet?"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Imperatrix ast Mariti\nIntuens licentiam:\nVana spernens, corde miti\nServat innocentiam."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Cui jactae tot procellis\nMontis adstas Arbiter;\nAnimique moesta pellis\nCeu coruscus Lucifer."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sed Tribunal cum verendum\nPia saepe visiteret:\nCrescit ardor ad ascendium,\nToties quid proderet?"
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Act. 20)"
               }
@@ -338,22 +446,68 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Adjuva me Domine Deus meus.\n℟. Salvum me fac secundum misericordiam tuam."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Adjuva me Domine Deus meus."
+                  },
+                  "r": {
+                    "la": "Salvum me fac secundum misericordiam tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nOmnipotens sempiterne Deus, etc."
+                "la": "Omnipotens sempiterne Deus, etc."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -366,10 +520,17 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -378,37 +539,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ampla spes est dignitatum,\nMunerandus diceris,\nCaesari si vis reatum\nAperire Conjugis."
+                "la": "Ampla spes est dignitatum,\nMunerandus diceris,\nCaesari si vis reatum\nAperire Conjugis.\n\nSed nefanda postulantis\nCum favorem despicis:\nAestuantis et minantis\nTonat ira Caesaris.\n\nFacibus perusta squallent\nIn Catasta viscera:\nAt secari tota mallent,\nQuam fateri credita.\n\nInde liber et solutus\nRursus adstas publico:\nMira post haec elocutus\nSpiritu prophetico."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sed nefanda postulantis\nCum favorem despicis:\nAestuantis et minantis\nTonat ira Caesaris."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Facibus perusta squallent\nIn Catasta viscera:\nAt secari tota mallent,\nQuam fateri credita."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Inde liber et solutus\nRursus adstas publico:\nMira post haec elocutus\nSpiritu prophetico."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Rom. 8"
               }
@@ -420,22 +563,68 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Intende anima mea, et libera eam.\n℟. Propter inimicos meos eripe me."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Intende anima mea, et libera eam."
+                  },
+                  "r": {
+                    "la": "Propter inimicos meos eripe me."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nOmnipotens sempiterne Deus, etc."
+                "la": "Omnipotens sempiterne Deus, etc."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -448,10 +637,17 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -460,37 +656,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Trux Tyrannus rursus ira\nFuris, instat, aestuat;\nComminatus quaeque dira,\nNisi jussis annuat."
+                "la": "Trux Tyrannus rursus ira\nFuris, instat, aestuat;\nComminatus quaeque dira,\nNisi jussis annuat.\n\nSolito stat firma mentis\nMore virtus jugiter:\nErgo vinctus clam fluentis\nMergitur crudeliter.\n\nNocte Caesar cogitabat\nFacinus latescere;\nSed serena lux natabat\nMartyris cum corpore.\n\nUnde tota, copioso\nPraga viso lumine,\nConcitatur, et vadoso\nCorpus effert flumine."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Solito stat firma mentis\nMore virtus jugiter:\nErgo vinctus clam fluentis\nMergitur crudeliter."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Nocte Caesar cogitabat\nFacinus latescere;\nSed serena lux natabat\nMartyris cum corpore."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Unde tota, copioso\nPraga viso lumine,\nConcitatur, et vadoso\nCorpus effert flumine."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Rom. 8)"
               }
@@ -502,22 +680,68 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. In te Domine speravi.\n℟. Non confundar in aeternum."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In te Domine speravi."
+                  },
+                  "r": {
+                    "la": "Non confundar in aeternum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nOmnipotens sempiterne Deus, etc."
+                "la": "Omnipotens sempiterne Deus, etc."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad Te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad Te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -530,10 +754,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -542,49 +786,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Cathedrali collocatus\nAede, Martyr plurimis\nUndequeque visitatus\nRutilat miraculis."
+                "la": "Cathedrali collocatus\nAede, Martyr plurimis\nUndequeque visitatus\nRutilat miraculis.\n\nHocce rarum praedicabit\nPosteris Religio:\nMansit expers lingua tabis,\nMaximo prodigio.\n\nNempe viva quae tacendo\nDelictere voluit:\nMira Caeli nunc loquendo\nEmitere meruit.\n\nQui reatus crubescunt\nConsistendo prodere:\nQui per acta pertimescunt\nGravem famam perdere:\n\nHuc recurrunt; ac honoris\nConstat his integritas:\nAnxiique mox pudoris\nDesinit perplexitas.\n\nLaus perennis, et sonora\nTriadi sit gloria:\nMartyri per quam decora\nObtigit victoria."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Hocce rarum praedicabit\nPosteris Religio:\nMansit expers lingua tabis,\nMaximo prodigio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Nempe viva quae tacendo\nDelictere voluit:\nMira Caeli nunc loquendo\nEmitere meruit."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Qui reatus crubescunt\nConsistendo prodere:\nQui per acta pertimescunt\nGravem famam perdere:"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Huc recurrunt; ac honoris\nConstat his integritas:\nAnxiique mox pudoris\nDesinit perplexitas."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus perennis, et sonora\nTriadi sit gloria:\nMartyri per quam decora\nObtigit victoria."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Ps. 20)"
               }
@@ -596,22 +810,68 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Confitemini Domino, quoniam bonus.\n℟. Quoniam in saeculum misericordia ejus."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Confitemini Domino, quoniam bonus."
+                  },
+                  "r": {
+                    "la": "Quoniam in saeculum misericordia ejus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nOmnipotens sempiterne Deus, etc."
+                "la": "Omnipotens sempiterne Deus, etc."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         }

--- a/content/practices/little-office-s-john-of-god/flow.json
+++ b/content/practices/little-office-s-john-of-god/flow.json
@@ -26,37 +26,64 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Amen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Laus Joanni sit, qui Patrum\nPosuit primordia,\nSacri Ordinis, et Fratrum\nde misericordia,"
+                "la": "Laus Joanni sit, qui Patrum\nPosuit primordia,\nSacri Ordinis, et Fratrum\nde misericordia,\n\nCujus ortu glorioso\nGaudet Lusitania\nFato sit hic ominoso\nMiles in Hispania,\n\nApparente sed mutavit\nDivae Deiparae,\nEt ad pia applicavit\nCharitatis opera."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Cujus ortu glorioso\nGaudet Lusitania\nFato sit hic ominoso\nMiles in Hispania,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Apparente sed mutavit\nDivae Deiparae,\nEt ad pia applicavit\nCharitatis opera."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -68,15 +95,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, sancte Joannes Dei.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancte Joannes Dei."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui per caritatem beati Joannis Dei infirmis, pauperibus, et afflictis clementer subvenisti:\nconcede propitius, ut ejus meritis et precibus ab omni semper infirmitate, periculo, et adversitate misericorditer protegamur et liberemur.\nPer Dominum nostrum Jesum Christum, etc."
+                "la": "Deus, qui per caritatem beati Joannis Dei infirmis, pauperibus, et afflictis clementer subvenisti:\nconcede propitius, ut ejus meritis et precibus ab omni semper infirmitate, periculo, et adversitate misericorditer protegamur et liberemur.\nPer Dominum nostrum Jesum Christum, etc."
               }
             }
           ]
@@ -90,31 +130,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ut vitaret mundi viam,\nLubrica carnalia,\nAd agendam vitam piam\nFundat hospitalia."
+                "la": "Ut vitaret mundi viam,\nLubrica carnalia,\nAd agendam vitam piam\nFundat hospitalia.\n\nEt infirmos derelictos\nExcipit hospitio,\nConsolatur et afflictos,\nPauperes servitio."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Et infirmos derelictos\nExcipit hospitio,\nConsolatur et afflictos,\nPauperes servitio."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -126,13 +173,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, sancte Joannes Dei.\n℟. Ut digni efficiamur promissionibus Christi."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancte Joannes Dei."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -154,31 +208,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Aegros curat, fovet, sanat,\nEt dementes recipit,\nMoribundis viam planat\nEt defunctos sepelit."
+                "la": "Aegros curat, fovet, sanat,\nEt dementes recipit,\nMoribundis viam planat\nEt defunctos sepelit.\n\nSpiritualem corporalem\nCaritatem habuit,\nEsse semper hospitalem\nOmnibus exhibuit."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Spiritualem corporalem\nCaritatem habuit,\nEsse semper hospitalem\nOmnibus exhibuit."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -190,13 +251,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, sancte Joannes Dei.\n℟. Ut digni efficiamur promissionibus Christi."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancte Joannes Dei."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -218,31 +286,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Verus hinc Samaritanus,\nEt fundator Ordinis,\nPius fuit Lusitanus,\nClarus et miraculis."
+                "la": "Verus hinc Samaritanus,\nEt fundator Ordinis,\nPius fuit Lusitanus,\nClarus et miraculis.\n\nVitam duxit rigorosam\nFlagris et jejunio,\nVigilando gloriosam\nLuctam cum diabolo."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Vitam duxit rigorosam\nFlagris et jejunio,\nVigilando gloriosam\nLuctam cum diabolo."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -254,13 +329,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, sancte Joannes Dei.\n℟. Ut digni efficiamur promissionibus Christi."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancte Joannes Dei."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -282,31 +364,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Sitam animam afflictam\nDedit patientiae,\nNullam voluit vindictam"
+                "la": "Sitam animam afflictam\nDedit patientiae,\nNullam voluit vindictam\n\nPatiens injuriae.\nHunc Maria coronavit\nSpinis in Ecclesia."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Patiens injuriae.\nHunc Maria coronavit\nSpinis in Ecclesia."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -318,13 +407,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, sancte Joannes Dei.\n℟. Ut digni efficiamur promissionibus Christi."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancte Joannes Dei."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -346,31 +442,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Jesum cum ignotum foris\nUt aegrotum suscipit,\nProximum ab hoc amoris\nNomen Dei recipit."
+                "la": "Jesum cum ignotum foris\nUt aegrotum suscipit,\nProximum ab hoc amoris\nNomen Dei recipit.\n\nAb Octavo est relatus\nAlexandro civibus,\nCoeli atque declaratus\nSanctus Dei famulus."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Ab Octavo est relatus\nAlexandro civibus,\nCoeli atque declaratus\nSanctus Dei famulus."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -382,13 +485,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, sancte Joannes Dei.\n℟. Ut digni efficiamur promissionibus Christi."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancte Joannes Dei."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -410,31 +520,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos, Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O Joannes, pro me ora,\nEt a Deo impetra,\nFaciam ut omni hora\nCaritatis opera."
+                "la": "O Joannes, pro me ora,\nEt a Deo impetra,\nFaciam ut omni hora\nCaritatis opera.\n\nUt ex orbis hospitali\nTecum ire merear,\nEt in vita aeterna\nTua sorte perfruar."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Ut ex orbis hospitali\nTecum ire merear,\nEt in vita aeterna\nTua sorte perfruar."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -446,13 +576,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, sancte Joannes Dei.\n℟. Ut digni efficiamur promissionibus Christi."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, sancte Joannes Dei."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -486,7 +623,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Antiphona"
       }
@@ -498,15 +635,34 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Ora pro nobis, sancte Joannes Dei.\n℟. Ut digni efficiamur promissionibus Christi."
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ora pro nobis, sancte Joannes Dei."
+          },
+          "r": {
+            "la": "Ut digni efficiamur promissionibus Christi."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nOmnipotens sempiterne Deus, Pater pauperum, humilium celsitudo et caritatis amator:\nte humiliter deprecamur, ut sicut Ecclesia tua beati Joannis Dei paupertate, humilitate et caritate coruscata, ita et nos ejus meritis et exemplis eadem sectantes, cum ipso in aeterna gloria feliciter coronari mereamur.\nPer Dominum nostrum Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\n℟. Amen."
+        "la": "Omnipotens sempiterne Deus, Pater pauperum, humilium celsitudo et caritatis amator:\nte humiliter deprecamur, ut sicut Ecclesia tua beati Joannis Dei paupertate, humilitate et caritate coruscata, ita et nos ejus meritis et exemplis eadem sectantes, cum ipso in aeterna gloria feliciter coronari mereamur.\nPer Dominum nostrum Jesum Christum, Filium tuum, qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Amen."
       }
     }
   ]

--- a/content/practices/little-office-s-john-the-baptist/flow.json
+++ b/content/practices/little-office-s-john-the-baptist/flow.json
@@ -33,37 +33,51 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Praecursorem summi Regis\nEt Praeconem novae legis\nCoeli ornat gloria;\nSed et ortus gratiosa,\nNec non mortis pretiosa\nTerris est memoria."
+                "la": "Praecursorem summi Regis\nEt Praeconem novae legis\nCoeli ornat gloria;\nSed et ortus gratiosa,\nNec non mortis pretiosa\nTerris est memoria.\n\nPater senex novum natum\nDandum stupet; dum legatum\nAudit missum coelitus;\nNam aetatem et naturam\nSpectans, aegre rem futuram\nCredit jam decrepitus.\n\nSed quod negat, quod infirmat,\nHoc attestans mox confirmat\nLinguae destitutio;\nDum non paret verbo parens,\nJam ex perdita apparens\nVoce fit punitio."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Pater senex novum natum\nDandum stupet; dum legatum\nAudit missum coelitus;\nNam aetatem et naturam\nSpectans, aegre rem futuram\nCredit jam decrepitus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sed quod negat, quod infirmat,\nHoc attestans mox confirmat\nLinguae destitutio;\nDum non paret verbo parens,\nJam ex perdita apparens\nVoce fit punitio."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -75,22 +89,42 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Tu puer Propheta altissimi vocaberis.\n℟. Praeibis enim ante faciem Domini parare vias ejus."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Tu puer Propheta altissimi vocaberis."
+                  },
+                  "r": {
+                    "la": "Praeibis enim ante faciem Domini parare vias ejus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui praesentem commemorationem honorabilem nobis in beati Joannis nativitate fecisti: da populis tuis spiritualium gratiam gaudiorum, et omnium fidelium mentes dirige in viam salutis aeternae. Per Dominum nostrum Jesum Christum. Amen."
+                "la": "Deus, qui praesentem commemorationem honorabilem nobis in beati Joannis nativitate fecisti: da populis tuis spiritualium gratiam gaudiorum, et omnium fidelium mentes dirige in viam salutis aeternae. Per Dominum nostrum Jesum Christum. Amen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi, etc. Benedicamus, etc.\n℟. Et Fidelium, etc."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi, etc. Benedicamus, etc."
+                  },
+                  "r": {
+                    "la": "Et Fidelium, etc."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -103,37 +137,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Praecursore nondum nato,\nNedum partu referato,\nDona clarent coelica,\nNostro sole tunc exclusus,\nVerioris est perfusus,\nLuce solis mystica."
+                "la": "Praecursore nondum nato,\nNedum partu referato,\nDona clarent coelica,\nNostro sole tunc exclusus,\nVerioris est perfusus,\nLuce solis mystica.\n\nPrius novit diem verum,\nQuam nostrorum sit dierum\nUsus beneficio;\nIlle notus nondum natus,\nNondum nascens est renatus\nChristi ex commercio.\n\nAlvo Deum Virgo claudit,\nClauso clausus hic applaudid,\nVentris ex custodia;\nLinguae gestus obsequuntur,\nDum infantum colloquuntur\nMuta jam prodigia."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Prius novit diem verum,\nQuam nostrorum sit dierum\nUsus beneficio;\nIlle notus nondum natus,\nNondum nascens est renatus\nChristi ex commercio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Alvo Deum Virgo claudit,\nClauso clausus hic applaudid,\nVentris ex custodia;\nLinguae gestus obsequuntur,\nDum infantum colloquuntur\nMuta jam prodigia."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -145,14 +180,21 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Beata quae credidisti, quoniam perficientur.\n℟. Quae dicta sunt tibi a Domino."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Beata quae credidisti, quoniam perficientur."
+                  },
+                  "r": {
+                    "la": "Quae dicta sunt tibi a Domino."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oratio ut supra."
               }
             }
@@ -167,37 +209,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Mater parit; Pater credit;\nReduente fide, redit\nLinguae beneficium.\nEja felix partus Matris,\nQuo soluta lingua Patris\nCelebrat mysterium."
+                "la": "Mater parit; Pater credit;\nReduente fide, redit\nLinguae beneficium.\nEja felix partus Matris,\nQuo soluta lingua Patris\nCelebrat mysterium.\n\nThori fructus Matri dantur;\nEjam Matris expiantur\nSterilis opprobria;\nOrtu tanti praecursoris\nMulti timent, sed timoris\nComes est laetitia.\n\nSe de munde servans mundum,\nMunde vivit intra mundum\nIn aetate tenera,\nSed e mundi mox convictu\nCedens, loco, veste, vietu\nMera perfert aspera!"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Thori fructus Matri dantur;\nEjam Matris expiantur\nSterilis opprobria;\nOrtu tanti praecursoris\nMulti timent, sed timoris\nComes est laetitia."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Se de munde servans mundum,\nMunde vivit intra mundum\nIn aetate tenera,\nSed e mundi mox convictu\nCedens, loco, veste, vietu\nMera perfert aspera!"
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -209,14 +252,21 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Erit magnus coram Domino.\n℟. Et vinum et siceram non bibet."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Erit magnus coram Domino."
+                  },
+                  "r": {
+                    "la": "Et vinum et siceram non bibet."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oratio ut supra."
               }
             }
@@ -231,37 +281,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Lege vitae sub angusta\nMel sylvestre cum locusta,\nCibum non abhorruit;\nCamelorum tectus pilis,\nPer desertum mundo vilis,\nCoelo magnus claruit."
+                "la": "Lege vitae sub angusta\nMel sylvestre cum locusta,\nCibum non abhorruit;\nCamelorum tectus pilis,\nPer desertum mundo vilis,\nCoelo magnus claruit.\n\nQuem dum replet lux superna,\nVerae lucis fit lucerna:\nVeri solis Lucifer.\nNovus novae praecone legis,\nImo novus novi Regis\nPugnatur signifer.\n\nSingulari Prophetia\nProphetarum Monarchia\nSublimatur omnium:\nHi venturum, hic praesentem,\nHi promissum, hic viventem\nMonstrat orbis Dominum."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Quem dum replet lux superna,\nVerae lucis fit lucerna:\nVeri solis Lucifer.\nNovus novae praecone legis,\nImo novus novi Regis\nPugnatur signifer."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Singulari Prophetia\nProphetarum Monarchia\nSublimatur omnium:\nHi venturum, hic praesentem,\nHi promissum, hic viventem\nMonstrat orbis Dominum."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -273,14 +324,21 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Et audierunt eum discipuli.\n℟. Et secuti sunt Jesum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et audierunt eum discipuli."
+                  },
+                  "r": {
+                    "la": "Et secuti sunt Jesum."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oratio ut supra."
               }
             }
@@ -295,37 +353,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ardens vita, verbo lucens;\nEt ad veram lucem ducens\nMulta docet milia,\nO quam clarus mos docendi,\nCum doctoris dant vivendi\nFormulam vestigia!"
+                "la": "Ardens vita, verbo lucens;\nEt ad veram lucem ducens\nMulta docet milia,\nO quam clarus mos docendi,\nCum doctoris dant vivendi\nFormulam vestigia!\n\nNon lux quidem fuit iste,\nSed ut daret tibi, Christe,\nLuci testimonium.\nNon lux erat, sed lucerna:\nVerbum Christus luc aeterma,\nLucem cerans omnium.\n\nDum baptizat Christum soris,\nReddit Christus dignioris\nAquae beneficium;\nEn! ut ambos curat Numen!\nIsti Flamen, illi flumen\nAddidit praeconium."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Non lux quidem fuit iste,\nSed ut daret tibi, Christe,\nLuci testimonium.\nNon lux erat, sed lucerna:\nVerbum Christus luc aeterma,\nLucem cerans omnium."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Dum baptizat Christum soris,\nReddit Christus dignioris\nAquae beneficium;\nEn! ut ambos curat Numen!\nIsti Flamen, illi flumen\nAddidit praeconium."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -337,14 +396,21 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ego baptizo vos aqua.\n℟. Ille vero baptizabit vos Spiritu Sancto."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ego baptizo vos aqua."
+                  },
+                  "r": {
+                    "la": "Ille vero baptizabit vos Spiritu Sancto."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oratio ut supra."
               }
             }
@@ -359,37 +425,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Qui baptizat, elevatur,\nBaptizatus non lavatur,\nIn quo nulla macula,\nAquae lavant, quin lavantur,\nQuaeis lavandi vires dantur,\nVi mundantis omnia."
+                "la": "Qui baptizat, elevatur,\nBaptizatus non lavatur,\nIn quo nulla macula,\nAquae lavant, quin lavantur,\nQuaeis lavandi vires dantur,\nVi mundantis omnia.\n\nContemplatur omnes istum,\nQuem putabat turba Christum,\nStupens ad prodigia,\nQui cervicem non erexit,\nSed Dominum se despexit,\nDomini corrigia.\n\nAttestante palam Christo:\nNon surrexit major isto\nNatus de muliere,\nSolum Christus se excepit,\nQui de carne carnem cept.\nSine carnis opere."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Contemplatur omnes istum,\nQuem putabat turba Christum,\nStupens ad prodigia,\nQui cervicem non erexit,\nSed Dominum se despexit,\nDomini corrigia."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Attestante palam Christo:\nNon surrexit major isto\nNatus de muliere,\nSolum Christus se excepit,\nQui de carne carnem cept.\nSine carnis opere."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -401,14 +468,21 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Quid existis videre Prophetam?\n℟. Ego dico vobis, etiam plusquam Prophetam."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Quid existis videre Prophetam?"
+                  },
+                  "r": {
+                    "la": "Ego dico vobis, etiam plusquam Prophetam."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oratio ut supra."
               }
             }
@@ -423,37 +497,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Non hic Praeco veritatis,\nUt arundo levitatis,\nQuaevis laudat placita;\nSed et scribas, et Doctores,\nVocat legis et ruptores,\nViperae genimina."
+                "la": "Non hic Praeco veritatis,\nUt arundo levitatis,\nQuaevis laudat placita;\nSed et scribas, et Doctores,\nVocat legis et ruptores,\nViperae genimina.\n\nQuin et arguit Herodem,\nUnde vinctus ab eodem,\nSed nec victus carcere;\nFert injustam justus poenam,\nRem detestans, vah! obscenam\nRegis et adulterae.\n\nInde saevit vis Tyranni,\nSed ut crevite laus Joanni,\nRegi sic supplicium,\nServit stultus nam prudenti,\nDum probatur in persenti\nInnocens per impium."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Quin et arguit Herodem,\nUnde vinctus ab eodem,\nSed nec victus carcere;\nFert injustam justus poenam,\nRem detestans, vah! obscenam\nRegis et adulterae."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Inde saevit vis Tyranni,\nSed ut crevite laus Joanni,\nRegi sic supplicium,\nServit stultus nam prudenti,\nDum probatur in persenti\nInnocens per impium."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -465,14 +540,21 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Volens illum occidere timuit populum.\n℟. Quia sicut Prophetam habebant eum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Volens illum occidere timuit populum."
+                  },
+                  "r": {
+                    "la": "Quia sicut Prophetam habebant eum."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oratio ut supra."
               }
             }
@@ -487,37 +569,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "In natalis sui coena,\nCapitali plecti poena\nRex Joannem jusserat,\nSpiculator saltatrici,\nLaena desert Genitrici\nCaput quod petierat;"
+                "la": "In natalis sui coena,\nCapitali plecti poena\nRex Joannem jusserat,\nSpiculator saltatrici,\nLaena desert Genitrici\nCaput quod petierat;\n\nCrux designat sublimari\nChristum, sed hunc minorari\nCapitis abscissio.\nO mors vere pretiosa\nPrae quoa est tam gloriosa\nVitae conversatio!\n\nAtque haec in laudem, Christe!\nTu reddimus Baptistae\nVota, et encomia,\nNos ad vitam recto calle\nEx hac mortis ducas valle\nEjus ut per merita."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Crux designat sublimari\nChristum, sed hunc minorari\nCapitis abscissio.\nO mors vere pretiosa\nPrae quoa est tam gloriosa\nVitae conversatio!"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Atque haec in laudem, Christe!\nTu reddimus Baptistae\nVota, et encomia,\nNos ad vitam recto calle\nEx hac mortis ducas valle\nEjus ut per merita."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -529,20 +625,27 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Venerunt discipuli ejus, et tulerunt corpus ejus.\n℟. Et posuerunt illud in monumento."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Venerunt discipuli ejus, et tulerunt corpus ejus."
+                  },
+                  "r": {
+                    "la": "Et posuerunt illud in monumento."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Prayer"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "ut supra."
               }
             }
@@ -557,22 +660,29 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Hymn"
       }
     },
     {
-      "type": "prayer",
+      "type": "hymn",
       "inline": {
         "la": "Caput sacrum dum truncatur,\nEt Herodi praesentatur\nIn fatali phiala,\nAures claudis atque ora,\nCassa vultus et aurora,\nDive claudis lumina,\nSed quid nobis denum erit,\nCaput nostrum si mors ferit!\nUrget ira Judicis?\nNi tu audias clamantes,\nNi respicias peccantes,\nReos mi defenderis!\nAudi ergo, interpella,\nUt gehennae ex procella\nCaput nostrum eruas,\nChristus sed benigne donet,\nNe in illud dira tonet,\nSedes nobis coelicas."
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Ora pro nobis Sancte Joannes Baptista.\n℟. Ut digni efficiamur promissionibus Christi."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ora pro nobis Sancte Joannes Baptista."
+          },
+          "r": {
+            "la": "Ut digni efficiamur promissionibus Christi."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",

--- a/content/practices/little-office-s-joseph/flow.json
+++ b/content/practices/little-office-s-joseph/flow.json
@@ -22,11 +22,19 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.",
-        "en-US": "℣. O Lord, open my lips.\n℟. And my mouth will announce Thy praise."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine labia mea aperies.",
+            "en-US": "O Lord, open my lips."
+          },
+          "r": {
+            "la": "Et os meum annuntiabit laudem tuam.",
+            "en-US": "And my mouth will announce Thy praise."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -36,11 +44,19 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis.",
-        "en-US": "℣. Convert us, O God our Saviour.\n℟. And turn away Thy wrath from us."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Converte nos, Deus salutaris noster.",
+            "en-US": "Convert us, O God our Saviour."
+          },
+          "r": {
+            "la": "Et averte iram tuam a nobis.",
+            "en-US": "And turn away Thy wrath from us."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -50,11 +66,34 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Deus in adiutorium meum intende.\n℟. Domine ad adiuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Alleluia.",
-        "en-US": "℣. O God, come to my aid.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Spirit.\n℟. As it was in the beginning, is now, and ever shall be, world without end. Alleluia."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Deus in adiutorium meum intende.",
+            "en-US": "O God, come to my aid."
+          },
+          "r": {
+            "la": "Domine ad adiuvandum me festina.",
+            "en-US": "O Lord, make haste to help me."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Gloria Patri, et Filio, et Spiritui Sancto.",
+            "en-US": "Glory be to the Father, and to the Son, and to the Holy Spirit."
+          },
+          "r": {
+            "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Alleluia.",
+            "en-US": "As it was in the beginning, is now, and ever shall be, world without end. Alleluia."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -96,7 +135,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. (Psalmus 104)",
                 "en-US": "Ant. (Psalm 104)"
@@ -127,7 +166,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. (Mt 1:20)",
                 "en-US": "Ant. (Mt 1:20)"
@@ -158,7 +197,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. (Lc 2:4)",
                 "en-US": "Ant. (Lk 2:4)"
@@ -189,7 +228,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. (Mt 2:13)",
                 "en-US": "Ant. (Mt 2:13)"
@@ -220,7 +259,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. (Mt 2:23)",
                 "en-US": "Ant. (Mt 2:23)"
@@ -251,7 +290,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. (Lc 2:48)",
                 "en-US": "Ant. (Lk 2:48)"
@@ -282,7 +321,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. (Psalmus 4:9)",
                 "en-US": "Ant. (Psalms 4:9)"
@@ -307,11 +346,85 @@
       }
     },
     {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ora pro nobis beatissime Ioseph.",
+            "en-US": "Pray for us, most blessed Joseph."
+          },
+          "r": {
+            "la": "Ut digni efficiamur promissionibus Christi.",
+            "en-US": "That we may be made worthy of the promises of Christ."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus.",
+        "en-US": "Let us pray."
+      }
+    },
+    {
       "type": "prayer",
       "inline": {
-        "la": "℣. Ora pro nobis beatissime Ioseph.\n℟. Ut digni efficiamur promissionibus Christi.\n\nOremus,\nSanctissimae Genetricis tuae sponsi, quaesumus, Domine, meritis adiuvemur, ut quod possibilitas nostra non obtinet, eius nobis intercessione donetur. Qui vivis et regnas Deus per omnia saecula saeculorum.\n℟. Amen.\n\n℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n\n℣. Benedicamus Domino.\n℟. Deo gratias.\n\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen.",
-        "en-US": "℣. Pray for us, most blessed Joseph.\n℟. That we may be made worthy of the promises of Christ.\n\nLet us pray,\nO Lord, we beseech Thee, may we be assisted by the merits of the Spouse of thy most holy Mother, that what of ourselves we cannot possibly obtain, may through his intercession be granted to us by Thee, who livest and reignest God for ever and ever.\n℟. Amen.\n\n℣. Lord, hear my prayer,\n℟. And let my cry come unto Thee.\n\n℣. Let us bless the Lord.\n℟. Thanks be to God.\n\n℣. May the souls of the faithful, through the mercy of God, rest in peace.\n℟. Amen."
+        "la": "Sanctissimae Genetricis tuae sponsi, quaesumus, Domine, meritis adiuvemur, ut quod possibilitas nostra non obtinet, eius nobis intercessione donetur. Qui vivis et regnas Deus per omnia saecula saeculorum.",
+        "en-US": "O Lord, we beseech Thee, may we be assisted by the merits of the Spouse of thy most holy Mother, that what of ourselves we cannot possibly obtain, may through his intercession be granted to us by Thee, who livest and reignest God for ever and ever."
       }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Amen.",
+        "en-US": "Amen."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine, exaudi orationem meam.",
+            "en-US": "Lord, hear my prayer,"
+          },
+          "r": {
+            "la": "Et clamor meus ad te veniat.",
+            "en-US": "And let my cry come unto Thee."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Benedicamus Domino.",
+            "en-US": "Let us bless the Lord."
+          },
+          "r": {
+            "la": "Deo gratias.",
+            "en-US": "Thanks be to God."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Fidelium animae per misericordiam Dei requiescant in pace.",
+            "en-US": "May the souls of the faithful, through the mercy of God, rest in peace."
+          },
+          "r": {
+            "la": "Amen.",
+            "en-US": "Amen."
+          }
+        }
+      ]
     },
     {
       "type": "subheading",

--- a/content/practices/little-office-s-lawrence/flow.json
+++ b/content/practices/little-office-s-lawrence/flow.json
@@ -25,43 +25,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Laureato per agonem\nLaudis gestit mens sermonem\nPromere Laurentio."
+                "la": "Laureato per agonem\nLaudis gestit mens sermonem\nPromere Laurentio.\n\nO si puras ex amore\nCorde laudes dem et ore\nMartyum Delitio!\n\nSixtus quidem jam ad mortem\nRapitur: sed faustam sortem\nPatri ne invideas;\n\nTe supplicia plus dura,\nEt adversa manent plura,\nMartyr quae sustineas."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "O si puras ex amore\nCorde laudes dem et ore\nMartyum Delitio!"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sixtus quidem jam ad mortem\nRapitur: sed faustam sortem\nPatri ne invideas;"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Te supplicia plus dura,\nEt adversa manent plura,\nMartyr quae sustineas."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -69,13 +77,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Mundus gaudebit, vos autem contristabimini, sed tristitia vestra vertetur in gaudium.\n℣. Per S. Laurentii preces et merita\n℟. Libera nos Deus a flamma perpetua."
+                "la": "Mundus gaudebit, vos autem contristabimini, sed tristitia vestra vertetur in gaudium."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per S. Laurentii preces et merita"
+                  },
+                  "r": {
+                    "la": "Libera nos Deus a flamma perpetua."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDa nobis quaesumus Omnipotens Deus vitiorum nostrorum flammas extinguere, qui Beato Laurentio tribuisti tormentorum suorum incendia superare. Per Dominum nostrum Jesum Christum etc."
+                "la": "Da nobis quaesumus Omnipotens Deus vitiorum nostrorum flammas extinguere, qui Beato Laurentio tribuisti tormentorum suorum incendia superare. Per Dominum nostrum Jesum Christum etc."
               }
             }
           ]
@@ -88,43 +115,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Jussus hinc dispensat aurum,\nEt Ecclesiae thesaurum\nIndigis Laurentius;"
+                "la": "Jussus hinc dispensat aurum,\nEt Ecclesiae thesaurum\nIndigis Laurentius;\n\nQua de re cum vocaretur\nAd Tribunal, nil movetur\nCaesaris insultibus,\n\nPyram licet hic minatur,\nGenerosus rem effatur\nFlammas spernens rabidas,\n\nEcquid, rogat, his turbari,\nVera magis num probari\nAuri potest puritas?"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Qua de re cum vocaretur\nAd Tribunal, nil movetur\nCaesaris insultibus,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Pyram licet hic minatur,\nGenerosus rem effatur\nFlammas spernens rabidas,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Ecquid, rogat, his turbari,\nVera magis num probari\nAuri potest puritas?"
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -151,43 +173,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Sicut chorda musicorum\nTensa sonum dat canorum\nPlectri ministerio:"
+                "la": "Sicut chorda musicorum\nTensa sonum dat canorum\nPlectri ministerio:\n\nSic in cheli tormentorum\nChristi resonat servorum\nFidei confessio;\n\nInter ignium conflictus\nStat Laurentius invictus\nAssa versans latera,\n\nSpes interna consolatur,\nDum superna vis hortatur\nVirum de constantia."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sic in cheli tormentorum\nChristi resonat servorum\nFidei confessio;"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Inter ignium conflictus\nStat Laurentius invictus\nAssa versans latera,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Spes interna consolatur,\nDum superna vis hortatur\nVirum de constantia."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -214,43 +231,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Post thesauros dum inquiris\nVane tortor, nil acquiris\nTibi; sed Laurentio"
+                "la": "Post thesauros dum inquiris\nVane tortor, nil acquiris\nTibi; sed Laurentio\n\nHosce Christo coacervat,\nQuos hic in coronam servat\nSuo Dux armigero.\n\nEt ut flamma cum calore\nJuncto unitat splendore,\nSic et iste promicat,\n\nFlammis undique obsessus,\nChristum jugiter confessus\nArdet et illuminat."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Hosce Christo coacervat,\nQuos hic in coronam servat\nSuo Dux armigero."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Et ut flamma cum calore\nJuncto unitat splendore,\nSic et iste promicat,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Flammis undique obsessus,\nChristum jugiter confessus\nArdet et illuminat."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -277,43 +289,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Non formidat prunis volvi,\nQui de carne cupit solvi,\nEt cum Christo vivere,"
+                "la": "Non formidat prunis volvi,\nQui de carne cupit solvi,\nEt cum Christo vivere,\n\nNeque corpus occidentes\nTimet, quia non valentes\nMentem scit perimere;\n\nAc ut vasa figulorum\nFornax firmat, et illorum\nSolidat substantiam.\n\nSic Laurentium assatum\nIgnis facit plus firmatum\nMentis per constantiam."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Neque corpus occidentes\nTimet, quia non valentes\nMentem scit perimere;"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Ac ut vasa figulorum\nFornax firmat, et illorum\nSolidat substantiam."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sic Laurentium assatum\nIgnis facit plus firmatum\nMentis per constantiam."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -340,43 +347,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Vetus homo cum vastatur,\nAlter novus solidatur\nVeteris exitio;"
+                "la": "Vetus homo cum vastatur,\nAlter novus solidatur\nVeteris exitio;\n\nUnde nimis confortatus\nEst Athletae principatus\nCoeli in palatio;\n\nUdos flammas credit rores,\nPrunas Amor putat flores,\nLecatulum Craticulum:\n\nUrit Amor: Vis favillae\nCorpus urit, mentem ille\nSalamandrae aemulam."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Unde nimis confortatus\nEst Athletae principatus\nCoeli in palatio;"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Udos flammas credit rores,\nPrunas Amor putat flores,\nLecatulum Craticulum:"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Urit Amor: Vis favillae\nCorpus urit, mentem ille\nSalamandrae aemulam."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -403,43 +405,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Convertere nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Convertere nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymn"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Parum olet, parum fragrata,\nSi non ardet, si non flagrat\nThus injectum ignibus;"
+                "la": "Parum olet, parum fragrata,\nSi non ardet, si non flagrat\nThus injectum ignibus;\n\nSic per poenas, per ardorem\nPleniorem dat odorem\nMartyr de Virtutibus,\n\nEt quam odor iste nimis\nDulcis modoque et sublimis\nAlta petit sidera:\n\nThuris instar Cherubini\nSumma Principis divini\nPergens ad Altaria."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sic per poenas, per ardorem\nPleniorem dat odorem\nMartyr de Virtutibus,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Et quam odor iste nimis\nDulcis modoque et sublimis\nAlta petit sidera:"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Thuris instar Cherubini\nSumma Principis divini\nPergens ad Altaria."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphon"
               }
@@ -492,7 +502,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Antiphon"
       }
@@ -500,13 +510,32 @@
     {
       "type": "prayer",
       "inline": {
-        "la": "Ambulate in dilectione, sicut et Christus dilexit nos, et tradidit semetipsum pro nobis oblationem et hostiam Deo in odorem suavitatis.\n℣. Ora pro nobis B. Martyr Laurenti,\n℟. Ut digni efficiamur promissionibus Christi."
+        "la": "Ambulate in dilectione, sicut et Christus dilexit nos, et tradidit semetipsum pro nobis oblationem et hostiam Deo in odorem suavitatis."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ora pro nobis B. Martyr Laurenti,"
+          },
+          "r": {
+            "la": "Ut digni efficiamur promissionibus Christi."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nDeus cujus charitatis ardore B. Laurentius edaces incendii flammas contempto persecutore devicit; Concede, ut omnes, qui Martyrii Ejus merita invocamus, protectionis tuae auxilio muniamur. Per Dominum nostrum etc."
+        "la": "Deus cujus charitatis ardore B. Laurentius edaces incendii flammas contempto persecutore devicit; Concede, ut omnes, qui Martyrii Ejus merita invocamus, protectionis tuae auxilio muniamur. Per Dominum nostrum etc."
       }
     }
   ]

--- a/content/practices/little-office-s-liborius/flow.json
+++ b/content/practices/little-office-s-liborius/flow.json
@@ -33,9 +33,35 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies,"
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende,"
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies,\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende,\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen. Alleluia."
               }
             },
             {
@@ -45,25 +71,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "O Libori! Praesul bone,\nAdvocate, et Patrone\nQuovis in discrimine:\nNostra spes in rebus duris,\nConsolator in pressuris\nCorporis et animae!"
+                "la": "O Libori! Praesul bone,\nAdvocate, et Patrone\nQuovis in discrimine:\nNostra spes in rebus duris,\nConsolator in pressuris\nCorporis et animae!\n\nDe caelorum celsa aede,\nBeatorum laeta sede,\nMe dicentem respice:\nGratiose preces audi,\nQuas dicabo tuae laudi;\nNec orantem despice!"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "De caelorum celsa aede,\nBeatorum laeta sede,\nMe dicentem respice:\nGratiose preces audi,\nQuas dicabo tuae laudi;\nNec orantem despice!"
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona 2 Mach. 15:14."
               }
@@ -75,15 +95,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam,\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam,"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Sanctum Liborium Pontificem tuum, aliis innumeris gloriosum miraculis, speciali in medendis arenarum et calculi passionibus privilegio decorasti: praesta, quaesumus, ut ipsius meritis et intercessione his aliis malis eruti, gaudiis perfrui mereamur aeternis. Per Dominum nostrum Jesum Christum Filium tuum: qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\nAmen."
+                "la": "Deus, qui Sanctum Liborium Pontificem tuum, aliis innumeris gloriosum miraculis, speciali in medendis arenarum et calculi passionibus privilegio decorasti: praesta, quaesumus, ut ipsius meritis et intercessione his aliis malis eruti, gaudiis perfrui mereamur aeternis. Per Dominum nostrum Jesum Christum Filium tuum: qui tecum vivit et regnat in unitate Spiritus Sancti Deus, per omnia saecula saeculorum.\nAmen."
               }
             }
           ]
@@ -97,31 +130,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende,"
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende,\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto, etc."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ab ingressu juventutis\nCor et mentem ad virtutis\nContulisti studium:\nHaec deinceps in te crevit,\nEt constanter adolevit\nAd stuporem omnium."
+                "la": "Ab ingressu juventutis\nCor et mentem ad virtutis\nContulisti studium:\nHaec deinceps in te crevit,\nEt constanter adolevit\nAd stuporem omnium.\n\nFac, et ego sic intendam\nRebus sacris, et impendam\nMe virtutum cultui:\nFac, in fide, spe, amore,\nProbe crescam te Doctore,\nUti semper debui."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Fac, et ego sic intendam\nRebus sacris, et impendam\nMe virtutum cultui:\nFac, in fide, spe, amore,\nProbe crescam te Doctore,\nUti semper debui."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Eccles. 51:18."
               }
@@ -133,14 +173,21 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam,\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam,"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oremus, Deus, qui S. Liborium, etc. ut supra."
               }
             }
@@ -155,31 +202,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende,"
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende,\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto, etc."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "In doctrina mandatorum,\nOre Christi traditorum,\nPerstitisti gnaviter:\nNemo vidit te peccantem,\nVel a recto deviantem,\nAc prolapsum graviter."
+                "la": "In doctrina mandatorum,\nOre Christi traditorum,\nPerstitisti gnaviter:\nNemo vidit te peccantem,\nVel a recto deviantem,\nAc prolapsum graviter.\n\nOra Deum, ut et ego,\nDum in fluxa carne dego,\nSine lapsu maneam:\nUtque semper castam vitam,\nEt a noxis custoditam,\nHic in orbe peragam!"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Ora Deum, ut et ego,\nDum in fluxa carne dego,\nSine lapsu maneam:\nUtque semper castam vitam,\nEt a noxis custoditam,\nHic in orbe peragam!"
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Ps. 118:33."
               }
@@ -191,14 +245,21 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam,\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam,"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oremus, Deus, qui S. Liborium, etc. ut supra."
               }
             }
@@ -213,31 +274,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende,"
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende,\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Tuae mentis lenitudo,\nHumilissima mansuetudo\nProbabatur omnibus.\nPlenus eras caritate,\nPlenus omni suavitate,\nPlacidissimis moribus."
+                "la": "Tuae mentis lenitudo,\nHumilissima mansuetudo\nProbabatur omnibus.\nPlenus eras caritate,\nPlenus omni suavitate,\nPlacidissimis moribus.\n\nFac, ut ego quoque vitem\nIras omnes, nec ad litem\nSim et rixas facilis:\nOra Jesum et Mariam,\nUt exemplo horum fiam\nMitis, blandus, humilis!"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Fac, ut ego quoque vitem\nIras omnes, nec ad litem\nSim et rixas facilis:\nOra Jesum et Mariam,\nUt exemplo horum fiam\nMitis, blandus, humilis!"
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona 2 Reg. 6:21."
               }
@@ -249,14 +317,21 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam,\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam,"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oremus, Deus, qui Sanctum Liborium, etc. ut supra."
               }
             }
@@ -271,31 +346,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende,"
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende,\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto, etc."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Omnem plausum et honorem\nMundi hujus, ut vaporem,\nDespexisti penitus:\nSoli Deo inhaesisti;\nIn hoc solo quievisti\nPrae creatis omnibus."
+                "la": "Omnem plausum et honorem\nMundi hujus, ut vaporem,\nDespexisti penitus:\nSoli Deo inhaesisti;\nIn hoc solo quievisti\nPrae creatis omnibus.\n\nSancte Praesul! pro me ora,\nUt et ego sine mora\nMundi pompas negligam:\nSoli Deo sim innixus,\nHuic mente sim infixus,\nEt hunc solum diligam!"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sancte Praesul! pro me ora,\nUt et ego sine mora\nMundi pompas negligam:\nSoli Deo sim innixus,\nHuic mente sim infixus,\nEt hunc solum diligam!"
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona 1 Joan. 2:15."
               }
@@ -307,14 +389,21 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam,\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam,"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oremus, Deus, qui Sanctum Liborium, etc. ut supra."
               }
             }
@@ -329,31 +418,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende,"
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende,\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto, etc."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Sanctus Praesul te Martinus,\nMorti esses cum vicinus,\nAegrotantem adiit.\nO! quam pios cordis motus,\nCum arderes Deo totus,\nTecum is eliciuit?"
+                "la": "Sanctus Praesul te Martinus,\nMorti esses cum vicinus,\nAegrotantem adiit.\nO! quam pios cordis motus,\nCum arderes Deo totus,\nTecum is eliciuit?\n\nAh! et mihi, o Libori,\nQuando fata jubent mori,\nSacerdotem advoca:\nDum supremus urget angor,\nAtque mortis falce tangor,\nAd solandum advola!"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Ah! et mihi, o Libori,\nQuando fata jubent mori,\nSacerdotem advoca:\nDum supremus urget angor,\nAtque mortis falce tangor,\nAd solandum advola!"
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Numb. 23:10."
               }
@@ -365,14 +461,21 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam,\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam,"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oremus, Deus, qui Sanctum Liborium, etc. ut supra."
               }
             }
@@ -387,31 +490,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende,"
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende,\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Contra morbos oculorum,\nPedum quoque, et lumborum,\nTe fideles invocant:\nAt praesertim acriore\nCalculorum in dolore\nTe Patronum praedicant."
+                "la": "Contra morbos oculorum,\nPedum quoque, et lumborum,\nTe fideles invocant:\nAt praesertim acriore\nCalculorum in dolore\nTe Patronum praedicant.\n\nFac, me morbis expediri,\nNec urentis experiri\nCalculi saevitiem:\nAc, ne frustra istud orem,\nA me aufer graviorem\nPeccatorum silicem!"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Fac, me morbis expediri,\nNec urentis experiri\nCalculi saevitiem:\nAc, ne frustra istud orem,\nA me aufer graviorem\nPeccatorum silicem!"
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Eccli. 48:4."
               }
@@ -423,14 +533,21 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam,\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam,"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oremus, Deus, qui Sanctum Liborium, etc. ut supra."
               }
             }
@@ -445,31 +562,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster,"
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende,"
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos Deus salutaris noster,\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende,\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto, etc."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Contra morbos oculorum,\nPedum quoque, et lumborum,\nTe fideles invocant:\nAt praesertim acriore\nCalculorum in dolore\nTe Patronum praedicant."
+                "la": "Contra morbos oculorum,\nPedum quoque, et lumborum,\nTe fideles invocant:\nAt praesertim acriore\nCalculorum in dolore\nTe Patronum praedicant.\n\nFac, me morbis expediri,\nNec urentis experiri\nCalculi saevitiem:\nAc, ne frustra istud orem,\nA me aufer graviorem\nPeccatorum silicem!"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Fac, me morbis expediri,\nNec urentis experiri\nCalculi saevitiem:\nAc, ne frustra istud orem,\nA me aufer graviorem\nPeccatorum silicem!"
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Eccli. 48:4."
               }
@@ -481,14 +618,21 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi orationem meam,\n℟. Et clamor meus ad te veniat."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi orationem meam,"
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oremus, Deus, qui Sanctum Liborium, etc. ut supra."
               }
             }

--- a/content/practices/little-office-s-ludger/flow.json
+++ b/content/practices/little-office-s-ludger/flow.json
@@ -27,9 +27,35 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annunciabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annunciabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri et Filio et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nAlleluia."
+                "la": "Gloria Patri et Filio et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen.\nAlleluia."
               }
             },
             {
@@ -39,37 +65,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Huc adeste Seraphini\nIgneique Cherubini,\nCorda sursum sublevate,\nTepidumque excitate,\nCorde totus ardeam."
+                "la": "Huc adeste Seraphini\nIgneique Cherubini,\nCorda sursum sublevate,\nTepidumque excitate,\nCorde totus ardeam.\n\nDeum meum adorabo,\nEt in Sanctis praedicabo:\nAh quam vellem! aestuaret,\nEt amore cor flagraret;\nDum Ludgerum praedico.\n\nLiasburga dum gerebat,\nEt Ludgerum continebat\nSinu, cadens fauciata,\nAtque dire vulnerata,\nServat hunc incolumem.\n\nMille Jesu perennanti,\nMille grates sint Tonanti,\nFlaminique tot honores,\nSempiternum quot amores\nFovet alma Trinitas."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Deum meum adorabo,\nEt in Sanctis praedicabo:\nAh quam vellem! aestuaret,\nEt amore cor flagraret;\nDum Ludgerum praedico."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Liasburga dum gerebat,\nEt Ludgerum continebat\nSinu, cadens fauciata,\nAtque dire vulnerata,\nServat hunc incolumem."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mille Jesu perennanti,\nMille grates sint Tonanti,\nFlaminique tot honores,\nSempiternum quot amores\nFovet alma Trinitas."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Isai. 49)"
               }
@@ -81,15 +89,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis beate Ludgere.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis beate Ludgere."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui conspicis, quia nos undique mala nostra perturbant,\npraesta, quaesumus, ut beati Ludgeri Confessoris tui atque Pontificis\nintercessio gloriosa nos protegat.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum. Amen."
+                "la": "Deus, qui conspicis, quia nos undique mala nostra perturbant,\npraesta, quaesumus, ut beati Ludgeri Confessoris tui atque Pontificis\nintercessio gloriosa nos protegat.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum. Amen."
               }
             }
           ]
@@ -103,43 +124,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri et Filio et Spiritui Sancto."
+                "la": "Gloria Patri et Filio et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Puer mirae sanctitatis,\nAtque vitae probitatis,\nAdolescens expeditus,\nSub Gregorio nutritus\nUltrajecti Praesule."
+                "la": "Puer mirae sanctitatis,\nAtque vitae probitatis,\nAdolescens expeditus,\nSub Gregorio nutritus\nUltrajecti Praesule.\n\nCumque fama late plaudit,\nAlcuinus haec subaudit;\nQui deinde vitae forma\nStudiique sacri norma\nInstruct in Anglia.\n\nLiterarum jam thesauro,\nEt amoris dives auro;\nQuae Ludgere quaesivisti,\nHoc Doctore consecrasti\nSanctitatis culmina.\n\nMille Jesu perennanti,\nMille grates sint Tonanti,\nFlaminique tot honores,\nSempiternum quot amores\nFovet alma Trinitas."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Cumque fama late plaudit,\nAlcuinus haec subaudit;\nQui deinde vitae forma\nStudiique sacri norma\nInstruct in Anglia."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Literarum jam thesauro,\nEt amoris dives auro;\nQuae Ludgere quaesivisti,\nHoc Doctore consecrasti\nSanctitatis culmina."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mille Jesu perennanti,\nMille grates sint Tonanti,\nFlaminique tot honores,\nSempiternum quot amores\nFovet alma Trinitas."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Eccli. 50)"
               }
@@ -151,15 +167,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis beate Ludgere.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis beate Ludgere."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui conspicis, quia nos undique mala nostra perturbant,\npraesta, quaesumus, ut beati Ludgeri Confessoris tui atque Pontificis\nintercessio gloriosa nos protegat.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum. Amen."
+                "la": "Deus, qui conspicis, quia nos undique mala nostra perturbant,\npraesta, quaesumus, ut beati Ludgeri Confessoris tui atque Pontificis\nintercessio gloriosa nos protegat.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum. Amen."
               }
             }
           ]
@@ -173,43 +202,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri et Filio et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri et Filio et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Sanctitate jam maturus,\nPar Apostolis futurus,\nAd Idola confringenda,\nAtque Fana destruenda\nMitteris in Angliam."
+                "la": "Sanctitate jam maturus,\nPar Apostolis futurus,\nAd Idola confringenda,\nAtque Fana destruenda\nMitteris in Angliam.\n\nSed cum turba concitata\nDesaeviret efferata,\nEt vastaret armis gentes\nWidikindus Dux credentes\nMysta Romam confugis.\n\nTer beata pergis fuga\nAd Cassini tendis juga;\nSub Abbate didicisti\nTheotmaro, quam legisti\nBenedicti Regulam.\n\nMille Jesu perennanti,\nMille grates sint Tonanti,\nFlaminique tot honores,\nSempiternum quot amores\nFovet alma Trinitas."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sed cum turba concitata\nDesaeviret efferata,\nEt vastaret armis gentes\nWidikindus Dux credentes\nMysta Romam confugis."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Ter beata pergis fuga\nAd Cassini tendis juga;\nSub Abbate didicisti\nTheotmaro, quam legisti\nBenedicti Regulam."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mille Jesu perennanti,\nMille grates sint Tonanti,\nFlaminique tot honores,\nSempiternum quot amores\nFovet alma Trinitas."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Matth. 5)"
               }
@@ -221,15 +245,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis beate Ludgere.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis beate Ludgere."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui conspicis, quia nos undique mala nostra perturbant,\npraesta, quaesumus, ut beati Ludgeri Confessoris tui atque Pontificis\nintercessio gloriosa nos protegat.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum. Amen."
+                "la": "Deus, qui conspicis, quia nos undique mala nostra perturbant,\npraesta, quaesumus, ut beati Ludgeri Confessoris tui atque Pontificis\nintercessio gloriosa nos protegat.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum. Amen."
               }
             }
           ]
@@ -243,43 +280,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri et Filio et Spiritui Sancto."
+                "la": "Gloria Patri et Filio et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Inde redux eras fortis,\nNulla pavens fata mortis;\nMente semper gaudiosus,\nOre blando gratiosus\nVerbum Dei praedicas."
+                "la": "Inde redux eras fortis,\nNulla pavens fata mortis;\nMente semper gaudiosus,\nOre blando gratiosus\nVerbum Dei praedicas.\n\nTurba Stygis expavescit,\nFides vera dum clarescit;\nManu tenens signa Crucis\nPellis atra monstra lucis\nDaniae ex finibus.\n\nMitram virtus recusabat,\nSed invito virtus dabat.\nMimigarda bellicosas,\nEt in pugnas animosa\nTe quiescit Praesule.\n\nMille Jesu perennanti,\nMille grates sint Tonanti,\nFlaminique tot honores,\nSempiternum quot amores\nFovet alma Trinitas."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Turba Stygis expavescit,\nFides vera dum clarescit;\nManu tenens signa Crucis\nPellis atra monstra lucis\nDaniae ex finibus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mitram virtus recusabat,\nSed invito virtus dabat.\nMimigarda bellicosas,\nEt in pugnas animosa\nTe quiescit Praesule."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mille Jesu perennanti,\nMille grates sint Tonanti,\nFlaminique tot honores,\nSempiternum quot amores\nFovet alma Trinitas."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Eccli. 44)"
               }
@@ -291,15 +323,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis beate Ludgere.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis beate Ludgere."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui conspicis, quia nos undique mala nostra perturbant,\npraesta, quaesumus, ut beati Ludgeri Confessoris tui atque Pontificis\nintercessio gloriosa nos protegat.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum. Amen."
+                "la": "Deus, qui conspicis, quia nos undique mala nostra perturbant,\npraesta, quaesumus, ut beati Ludgeri Confessoris tui atque Pontificis\nintercessio gloriosa nos protegat.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum. Amen."
               }
             }
           ]
@@ -313,43 +358,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri et Filio et Spiritui Sancto."
+                "la": "Gloria Patri et Filio et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Depascentes hinc agrestes,\nPellis anseres sylvestres.\nNulla posthac damna pratis,\nInferenda neque satis\nSunt ab his anseribus."
+                "la": "Depascentes hinc agrestes,\nPellis anseres sylvestres.\nNulla posthac damna pratis,\nInferenda neque satis\nSunt ab his anseribus.\n\nAbbatiam Werdenensem\nFundas, et Helmsladensem;\nSylva quamvis tenebrosa\nObstat, quae prodigiosa\nPrece noctu sternitur.\n\nAd Nortmannos subjugandos,\nChristo Jesu sociandos,\nTe accingens, morbo pressus\nPersequentum graves laesus\nNuntias Ecclesiae.\n\nMille Jesu perennanti,\nMille grates sint Tonanti,\nFlaminique tot honores,\nSempiternum quot amores\nFovet alma Trinitas."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Abbatiam Werdenensem\nFundas, et Helmsladensem;\nSylva quamvis tenebrosa\nObstat, quae prodigiosa\nPrece noctu sternitur."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Ad Nortmannos subjugandos,\nChristo Jesu sociandos,\nTe accingens, morbo pressus\nPersequentum graves laesus\nNuntias Ecclesiae."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mille Jesu perennanti,\nMille grates sint Tonanti,\nFlaminique tot honores,\nSempiternum quot amores\nFovet alma Trinitas."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Eccli. 50)"
               }
@@ -361,15 +401,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis beate Ludgere.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis beate Ludgere."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui conspicis, quia nos undique mala nostra perturbant,\npraesta, quaesumus, ut beati Ludgeri Confessoris tui atque Pontificis\nintercessio gloriosa nos protegat.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum. Amen."
+                "la": "Deus, qui conspicis, quia nos undique mala nostra perturbant,\npraesta, quaesumus, ut beati Ludgeri Confessoris tui atque Pontificis\nintercessio gloriosa nos protegat.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum. Amen."
               }
             }
           ]
@@ -383,43 +436,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri et Filio et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
+                "la": "Gloria Patri et Filio et Spiritui Sancto.\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum. Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Morbo licet premereris,\nEt dolore torquereris;\nChristum tamen praedicabas\nIndiesque consecrabas,\nGratam Deo victimam."
+                "la": "Morbo licet premereris,\nEt dolore torquereris;\nChristum tamen praedicabas\nIndiesque consecrabas,\nGratam Deo victimam.\n\nPostquam Missam auscultaras,\nPopuloque praedicaras;\nTe ad mortem praeparabas,\nAtque Deo commendabas\nEgressurum spiritum.\n\nPost haec clausa est suprema\nBillerbeccae vitae scena:\nMors per lucem demonstratur,\nEt Gerfrido nuntiatur\nPer hos lucis radios.\n\nMille Jesu perennanti,\nMille grates sint Tonanti,\nFlaminique tot honores,\nSempiternum quot amores\nFovet alma Trinitas."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Postquam Missam auscultaras,\nPopuloque praedicaras;\nTe ad mortem praeparabas,\nAtque Deo commendabas\nEgressurum spiritum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Post haec clausa est suprema\nBillerbeccae vitae scena:\nMors per lucem demonstratur,\nEt Gerfrido nuntiatur\nPer hos lucis radios."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mille Jesu perennanti,\nMille grates sint Tonanti,\nFlaminique tot honores,\nSempiternum quot amores\nFovet alma Trinitas."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -431,15 +479,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis beate Ludgere.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis beate Ludgere."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui conspicis, quia nos undique mala nostra perturbant,\npraesta, quaesumus, ut beati Ludgeri Confessoris tui atque Pontificis\nintercessio gloriosa nos protegat.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum. Amen."
+                "la": "Deus, qui conspicis, quia nos undique mala nostra perturbant,\npraesta, quaesumus, ut beati Ludgeri Confessoris tui atque Pontificis\nintercessio gloriosa nos protegat.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum. Amen."
               }
             }
           ]
@@ -453,43 +514,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri et Filio et Spiritui Sancto."
+                "la": "Gloria Patri et Filio et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Mox defunctum deferebant\nMimigardam, quo vovebant;\nPignus sacrum primo mense\nIn Mariae Transaquenſe\nPonitur Ecclesia."
+                "la": "Mox defunctum deferebant\nMimigardam, quo vovebant;\nPignus sacrum primo mense\nIn Mariae Transaquenſe\nPonitur Ecclesia.\n\nHinc efferri nolunt vota\nQuae depromit plebs devota;\nAegre sinit transportari\nPraesulemque tumulari\nAlienis finibus.\n\nMimigarda reluctante,\nPopuloque reclamante,\nAquisgrani consignantur\nJussa, queis coercentur\nImperante Carolo.\n\nMille Jesu perennanti,\nMille grates sint Tonanti,\nFlaminique tot honores,\nSempiternum quot amores\nFovet alma Trinitas."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Hinc efferri nolunt vota\nQuae depromit plebs devota;\nAegre sinit transportari\nPraesulemque tumulari\nAlienis finibus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mimigarda reluctante,\nPopuloque reclamante,\nAquisgrani consignantur\nJussa, queis coercentur\nImperante Carolo."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mille Jesu perennanti,\nMille grates sint Tonanti,\nFlaminique tot honores,\nSempiternum quot amores\nFovet alma Trinitas."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Eccli. 24)"
               }
@@ -501,15 +557,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis beate Ludgere.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis beate Ludgere."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui conspicis, quia nos undique mala nostra perturbant,\npraesta, quaesumus, ut beati Ludgeri Confessoris tui atque Pontificis\nintercessio gloriosa nos protegat.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum. Amen."
+                "la": "Deus, qui conspicis, quia nos undique mala nostra perturbant,\npraesta, quaesumus, ut beati Ludgeri Confessoris tui atque Pontificis\nintercessio gloriosa nos protegat.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum. Amen."
               }
             }
           ]
@@ -523,43 +592,45 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "A Ludgero quod relatum,\nVaticinium probatum,\nExhalantes dum cruorem\nNares stillant velut rorem\nIn die trigesimo."
+                "la": "A Ludgero quod relatum,\nVaticinium probatum,\nExhalantes dum cruorem\nNares stillant velut rorem\nIn die trigesimo.\n\nPlebs hoc signo erudita\nFiat, clamat, fiat ita:\nIn Werdina tumuletur,\nIn Werdina honoretur,\nPraesul beatissimus.\n\nErgo te depraedicabo,\nTe Ludgere invocabo;\nMe defende, me guberna,\nEt post vitam in superna\nDuc me tabernacula.\n\nMille Jesu perennanti,\nMille grates sint Tonanti,\nFlaminique tot honores,\nSempiternum quot amores\nFovet alma Trinitas."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Plebs hoc signo erudita\nFiat, clamat, fiat ita:\nIn Werdina tumuletur,\nIn Werdina honoretur,\nPraesul beatissimus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Ergo te depraedicabo,\nTe Ludgere invocabo;\nMe defende, me guberna,\nEt post vitam in superna\nDuc me tabernacula."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Mille Jesu perennanti,\nMille grates sint Tonanti,\nFlaminique tot honores,\nSempiternum quot amores\nFovet alma Trinitas."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona (Eccli. 46)"
               }
@@ -571,15 +642,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis beate Ludgere.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis beate Ludgere."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui conspicis, quia nos undique mala nostra perturbant,\npraesta, quaesumus, ut beati Ludgeri Confessoris tui atque Pontificis\nintercessio gloriosa nos protegat.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum. Amen."
+                "la": "Deus, qui conspicis, quia nos undique mala nostra perturbant,\npraesta, quaesumus, ut beati Ludgeri Confessoris tui atque Pontificis\nintercessio gloriosa nos protegat.\nPer Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit et regnat\nin unitate Spiritus Sancti Deus, per omnia saecula saeculorum. Amen."
               }
             }
           ]

--- a/content/practices/little-office-s-michael-the-archangel/flow.json
+++ b/content/practices/little-office-s-michael-the-archangel/flow.json
@@ -29,7 +29,39 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancte Michael Archangele, defende me in praelio, ut non peream in tremendo judicio.\nAmen.\n℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri et Filio etc. Alleluia."
+                "la": "Sancte Michael Archangele, defende me in praelio, ut non peream in tremendo judicio.\nAmen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri et Filio etc. Alleluia."
               }
             },
             {
@@ -39,19 +71,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Invicte princeps Michael,\nexercitus caelestis;\nquae magna facta gesseris,\nlaudum canamus hymnis."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -59,13 +91,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Michael praeposite paradisi, quem honorificant Angelorum cives, intercede pro nobis ad Dominum.\n℣. Gloriosus apparuisti in conspectu Domini.\n℟. Propterea decorem induit te Dominus."
+                "la": "Michael praeposite paradisi, quem honorificant Angelorum cives, intercede pro nobis ad Dominum."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloriosus apparuisti in conspectu Domini."
+                  },
+                  "r": {
+                    "la": "Propterea decorem induit te Dominus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus cujus claritatis fulgore, beatus Michael praecellit agmina Angelorum; praesta quaesumus, ut sicut ille dono tuo principatum meruit habere coelestem, ita et nos ejus precibus vitam obtineamus aeternam. Per Christum Dominum nostrum.\nAmen."
+                "la": "Deus cujus claritatis fulgore, beatus Michael praecellit agmina Angelorum; praesta quaesumus, ut sicut ille dono tuo principatum meruit habere coelestem, ita et nos ejus precibus vitam obtineamus aeternam. Per Christum Dominum nostrum.\nAmen."
               }
             }
           ]
@@ -81,23 +132,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancte Michael Archangele, defende me in praelio, ut non peream in tremendo judicio.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc. Alleluia."
+                "la": "Sancte Michael Archangele, defende me in praelio, ut non peream in tremendo judicio."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Primo rebelles Angelos,\napostatas superbos,\nvictor tremendo praelio\nad tartarum trusisti."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Apoc. 12"
               }
@@ -109,15 +179,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Sub umbra alarum tuarum sancte Michael protege me.\n℟. A facie inimicorum meorum."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sub umbra alarum tuarum sancte Michael protege me."
+                  },
+                  "r": {
+                    "la": "A facie inimicorum meorum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus qui per gloriosum Archangelum tuum Michaelem, apostatam ac superbum luciferum, cum Angelis suis de coelo dejecisti; mitte quaeso in adjutorium meum, eundem Angelum, ut me adversus diabolicos insultus in vita et in morte mea protegat, et ad vitam aeternam perducat.\nAmen."
+                "la": "Deus qui per gloriosum Archangelum tuum Michaelem, apostatam ac superbum luciferum, cum Angelis suis de coelo dejecisti; mitte quaeso in adjutorium meum, eundem Angelum, ut me adversus diabolicos insultus in vita et in morte mea protegat, et ad vitam aeternam perducat.\nAmen."
               }
             }
           ]
@@ -133,23 +216,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancte Michael Archangele, defende me in praelio, ut non peream in tremendo judicio.\nAmen.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc. Alleluia."
+                "la": "Sancte Michael Archangele, defende me in praelio, ut non peream in tremendo judicio.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Primos parentes flebiles\nsolatus es post lapsum;\ndicens, eos a Filio\nDei, futuros salvos."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Ex Daniel"
               }
@@ -157,13 +259,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Princeps regni Persarum restitit mihi viginti et uno diebus, veruntamen Michael Archangelus, Princeps magnus, qui stat pro filiis populi tui, erit adjutor meus.\n℣. Sancte Michael Archangele,\n℟. Ora pro nobis Deum."
+                "la": "Princeps regni Persarum restitit mihi viginti et uno diebus, veruntamen Michael Archangelus, Princeps magnus, qui stat pro filiis populi tui, erit adjutor meus."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sancte Michael Archangele,"
+                  },
+                  "r": {
+                    "la": "Ora pro nobis Deum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui ex tua ineffabili bonitate, sanctum Michaelem Archangelum tuum ad nostra defensionem mittere dignaris: te suppliciter deprecamur, ut eodem pro nobis intercedente Angelico suffragio, a subitanea morte et aeterna damnatione nos eripias, et in regno tuo collocare facias, in quo cum eodem Principe et Archangelo, atque omnibus Sanctis in perpetuum te laudemus et glorificemus.\nAmen."
+                "la": "Deus, qui ex tua ineffabili bonitate, sanctum Michaelem Archangelum tuum ad nostra defensionem mittere dignaris: te suppliciter deprecamur, ut eodem pro nobis intercedente Angelico suffragio, a subitanea morte et aeterna damnatione nos eripias, et in regno tuo collocare facias, in quo cum eodem Principe et Archangelo, atque omnibus Sanctis in perpetuum te laudemus et glorificemus.\nAmen."
               }
             }
           ]
@@ -179,23 +300,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancte Michael Archangele, defende me in praelio, ut non peream in tremendo judicio.\nAmen.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc. Alleluia."
+                "la": "Sancte Michael Archangele, defende me in praelio, ut non peream in tremendo judicio.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Ducente te grex Israel\nolim per annos multos\ndefensus est, et attigit\npromissionis terram."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Exodi 23"
               }
@@ -207,15 +347,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Apprehende arma et scutum sancte Michael.\n℟. Et exurge in adjutorium mihi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Apprehende arma et scutum sancte Michael."
+                  },
+                  "r": {
+                    "la": "Et exurge in adjutorium mihi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO Invicte Dux, et Princeps militiae Domini, sancte Michael, veni quaeso in auxilium animae meae, quae continenter in tanto periculo a suis inimicis carne, mundo, daemone impugnatur; et sicut dux fuisti populo Israel per desertum, sic quoque velis esse dux et comes meus per desertum hujus mundi, donec secure me perduxeris ad felicem terram viventium.\nAmen."
+                "la": "O Invicte Dux, et Princeps militiae Domini, sancte Michael, veni quaeso in auxilium animae meae, quae continenter in tanto periculo a suis inimicis carne, mundo, daemone impugnatur; et sicut dux fuisti populo Israel per desertum, sic quoque velis esse dux et comes meus per desertum hujus mundi, donec secure me perduxeris ad felicem terram viventium.\nAmen."
               }
             }
           ]
@@ -231,23 +384,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancte Michael Archangele, defende me in praelio, ut non peream in tremendo judicio.\nAmen.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc. Alleluia."
+                "la": "Sancte Michael Archangele, defende me in praelio, ut non peream in tremendo judicio.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Tu, sicut olim jussus es\npraeesse Synagogae;\nnunc factus es Ecclesiae\nProtector universae."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -255,13 +427,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Princeps gloriosissime Michael, Dux coelestium exercituum, susceptor animarum debellator malorum spirituum, Ecclesiae Dei post Christum admirabilis et grandis excellentiae et virtutis, rector, omnes nos reclamantes ad te ab omni libera adversitate, et in omni cultu Dei facias proficere, tuo preciosissimo officio et dignissima prece.\n℣. Ora pro nobis S Michael.\n℟. Ut digni efficiamur promissionibus Christi."
+                "la": "Princeps gloriosissime Michael, Dux coelestium exercituum, susceptor animarum debellator malorum spirituum, Ecclesiae Dei post Christum admirabilis et grandis excellentiae et virtutis, rector, omnes nos reclamantes ad te ab omni libera adversitate, et in omni cultu Dei facias proficere, tuo preciosissimo officio et dignissima prece."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis S Michael."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nOmnipotens sempiterne Deus qui saluti humanae naturae ex summa clementia tua, gloriosum Principem Ecclesiae tuae Michaelem Archangelum mirabiliter deputasti: concede propitius, ut ejus salutari subsidio hic mereamur ab omnibus hostibus tueri efficacissime, et in obitu nostro ab omni tentatione liberari, tuaeque excelsae majestati beatifice per eum praesentari. Per Christum Dominum nostrum.\nAmen."
+                "la": "Omnipotens sempiterne Deus qui saluti humanae naturae ex summa clementia tua, gloriosum Principem Ecclesiae tuae Michaelem Archangelum mirabiliter deputasti: concede propitius, ut ejus salutari subsidio hic mereamur ab omnibus hostibus tueri efficacissime, et in obitu nostro ab omni tentatione liberari, tuaeque excelsae majestati beatifice per eum praesentari. Per Christum Dominum nostrum.\nAmen."
               }
             }
           ]
@@ -277,23 +468,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancte Michael Archangele, defende me in praelio, ut non peream in tremendo judicio.\nAmen.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc. Alleluia."
+                "la": "Sancte Michael Archangele, defende me in praelio, ut non peream in tremendo judicio.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Mentes solutas corpore\ntu suscipis benigne\nbeatus est quicumque te\ntunc senserit patronum."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Josue 5"
               }
@@ -305,15 +515,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Exurge in occursum meum sancte Michael.\n℟. Et suscipe animam meam."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Exurge in occursum meum sancte Michael."
+                  },
+                  "r": {
+                    "la": "Et suscipe animam meam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO Victoriose triumphator Archangele sancte Michael, te humiliter deprecor, ut in die exitus animae meae, uti semper promptus fuisti in omni periculo animarum fidelium, maximeque earum, quae te specialius amaverunt, et tibi devote servierunt; mihi quoque, cum Angelis tuis tuoque exercitu personaliter adesse, mihi subvenire, pro me pugnare, et animam meam in benedictas manus tuas suscipere, et ad coeleste regnum deferre digneris.\nAmen."
+                "la": "O Victoriose triumphator Archangele sancte Michael, te humiliter deprecor, ut in die exitus animae meae, uti semper promptus fuisti in omni periculo animarum fidelium, maximeque earum, quae te specialius amaverunt, et tibi devote servierunt; mihi quoque, cum Angelis tuis tuoque exercitu personaliter adesse, mihi subvenire, pro me pugnare, et animam meam in benedictas manus tuas suscipere, et ad coeleste regnum deferre digneris.\nAmen."
               }
             }
           ]
@@ -329,23 +552,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancte Michael Archangele, defende me in praelio, ut non peream in tremendo judicio.\nAmen.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc. Alleluia."
+                "la": "Sancte Michael Archangele, defende me in praelio, ut non peream in tremendo judicio.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Per te cadet fidelibus\nInfensus Antichristus:\nTuba citabis mortuos\nCum judicabit Christus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Daniel 12"
               }
@@ -357,15 +599,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ipse Dominus in jussu et voce Archangeli.\n℟. Descendet de coelo."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ipse Dominus in jussu et voce Archangeli."
+                  },
+                  "r": {
+                    "la": "Descendet de coelo."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO gloriose Princeps Archangele sancte Michael, qui tot pugnis interfusisti, per te divina virtus multa praeclara praestitit, atque praestata est; quoties mire virtutis aliquid agendum fuit, Deus semper misit, teque super alios Angelos suos, non tantum in coelis, sed et in terris amari, venerari, praedicari, et memoria tua haberi voluit, tibi denique jam ab exordio creationis tuae prima et ultima tot et tam honorifica officia demandavit; humiliter te rogo, ut impetres mihi mortem bonam et sanctam, ita ut pleno sensu, fide recta, et firma, spe bona et charitate perfecta letus ad Caelestem Hierusalem ascenda.\nAmen."
+                "la": "O gloriose Princeps Archangele sancte Michael, qui tot pugnis interfusisti, per te divina virtus multa praeclara praestitit, atque praestata est; quoties mire virtutis aliquid agendum fuit, Deus semper misit, teque super alios Angelos suos, non tantum in coelis, sed et in terris amari, venerari, praedicari, et memoria tua haberi voluit, tibi denique jam ab exordio creationis tuae prima et ultima tot et tam honorifica officia demandavit; humiliter te rogo, ut impetres mihi mortem bonam et sanctam, ita ut pleno sensu, fide recta, et firma, spe bona et charitate perfecta letus ad Caelestem Hierusalem ascenda.\nAmen."
               }
             }
           ]
@@ -381,23 +636,55 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sancte Michael Archangele, defende me in praelio, ut non peream in tremendo judicio.\nAmen.\n℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc. Alleluia."
+                "la": "Sancte Michael Archangele, defende me in praelio, ut non peream in tremendo judicio.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Christi crucem tunc praefers\nIn gloria triumphans:\nCoelo beatos infers,\nEt tartaro malignos."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona Matth 13"
               }
@@ -409,15 +696,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Tropaeum crucis feret Archangelus Michael.\n℟. Cum Dominus ad judicandum venerit."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Tropaeum crucis feret Archangelus Michael."
+                  },
+                  "r": {
+                    "la": "Cum Dominus ad judicandum venerit."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nSummae sedis minister, Princeps militiae coelestis, et signifer celsorum supernorum sancte Michael Angele piissime, Archangele placidissime tibi corpus et animam meam tota intentione tuendam commito, tibi specialiter post Deum et Deiparentem vitae et mortis meae curam commendo, te hodie et quotidie in praesentia totius coelestis curiae pro singulari Patrono, Protectore et Advocato meo eligo, obsecro igitur te per gloriam illam, quam in coelo jam frueris, ut hoc propositum meum, et gravem habeas sincerum hunc affectum erga te meum. O serve Dei excelse sancte Michael, ego te saluto millies et millies, ego te veneror et invoco, ego in argumentum gaudii ac gloriae tibi offero totius boni, totiusque beatitudinis gazophylacium, cor Jesu Christi dulcissimum. Gratias ago ipsi Domino Deo nostro pro beatitudine, quam tibi contulit, et pro eo, quod te sic super alios Angelos suos, nominari, praedicari, et honorari, et exaltari voluit. Adesto mihi nunc et semper, at maxime in fine vitae meae, ipsum obitum meum attenuis tibi commendo, benigne me tu consolare, conforta et protege. Impetra mihi augmentum fidei, spei, et charitatis, non permittas me sancte Michael, nec in vita, nec in morte a sancta fide Catholica declinare, nec in foveam desperationis deduci, neque de operibus meis bonis, quae cum divina gratia operatus sum, praesumere. Impetra mihi plena omnium peccatorum meorum veniam, et spiritum bonum, ac sanctam gratiam, et ut illi perfecte reconcilier, illique jugiter placeam, et ut sim homo secundum cor Dei, et illum amplius non offend. Impetra mihi veram et profundam humilitatem, et alias virtutes omnes, effice tuis gloriosis precibus et meritis ut anima mea tota munda hinc exeat, ad vitam aeternam perveniat. Insuper rogo te praeclarum atque decorum summe Divinitatis ministrum, ut in novissimo die benigne suscipias animam meam in sinu tuo sanctissimo, et eam comitantibus Angelo custode meo, et Angelis tuis, ad requiem sempiternam cum exultatione perducas.\nAmen."
+                "la": "Summae sedis minister, Princeps militiae coelestis, et signifer celsorum supernorum sancte Michael Angele piissime, Archangele placidissime tibi corpus et animam meam tota intentione tuendam commito, tibi specialiter post Deum et Deiparentem vitae et mortis meae curam commendo, te hodie et quotidie in praesentia totius coelestis curiae pro singulari Patrono, Protectore et Advocato meo eligo, obsecro igitur te per gloriam illam, quam in coelo jam frueris, ut hoc propositum meum, et gravem habeas sincerum hunc affectum erga te meum. O serve Dei excelse sancte Michael, ego te saluto millies et millies, ego te veneror et invoco, ego in argumentum gaudii ac gloriae tibi offero totius boni, totiusque beatitudinis gazophylacium, cor Jesu Christi dulcissimum. Gratias ago ipsi Domino Deo nostro pro beatitudine, quam tibi contulit, et pro eo, quod te sic super alios Angelos suos, nominari, praedicari, et honorari, et exaltari voluit. Adesto mihi nunc et semper, at maxime in fine vitae meae, ipsum obitum meum attenuis tibi commendo, benigne me tu consolare, conforta et protege. Impetra mihi augmentum fidei, spei, et charitatis, non permittas me sancte Michael, nec in vita, nec in morte a sancta fide Catholica declinare, nec in foveam desperationis deduci, neque de operibus meis bonis, quae cum divina gratia operatus sum, praesumere. Impetra mihi plena omnium peccatorum meorum veniam, et spiritum bonum, ac sanctam gratiam, et ut illi perfecte reconcilier, illique jugiter placeam, et ut sim homo secundum cor Dei, et illum amplius non offend. Impetra mihi veram et profundam humilitatem, et alias virtutes omnes, effice tuis gloriosis precibus et meritis ut anima mea tota munda hinc exeat, ad vitam aeternam perveniat. Insuper rogo te praeclarum atque decorum summe Divinitatis ministrum, ut in novissimo die benigne suscipias animam meam in sinu tuo sanctissimo, et eam comitantibus Angelo custode meo, et Angelis tuis, ad requiem sempiternam cum exultatione perducas.\nAmen."
               }
             }
           ]

--- a/content/practices/little-office-s-norbert/flow.json
+++ b/content/practices/little-office-s-norbert/flow.json
@@ -25,16 +25,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Thou, O Lord, wilt open my lips;\n℟. And my tongue shall announce Thy praise."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Thou, O Lord, wilt open my lips;"
+                  },
+                  "r": {
+                    "en-US": "And my tongue shall announce Thy praise."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto mine aid, O God,\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto mine aid, O God,"
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -43,19 +57,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn - The Conversion of S. Norbert"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "O blessed Saint! While yet unborn,\nA voice Divine decreed for thee;\n\"Thou'lt bear, through many a life-long storm,\nThe priest's and bishop's dignity\".\nYet worldly glory wooed thy heart,\nAnd thou, of noble race, didst turn\nAway from thine eternal part\nTo seek the fair, false lights that burn\nIn royal halls of earth. But lo!\nThese halls are trembling 'neath the power\nOf Him Who stoops to thee, to show\nThou shalt be His. Alas! That hour\nThou'rt faltering still. The voice of fame,\nIts flattery, in thine ear is sweet.\nAgain thy God thy heart must claim\nAnd sweetly stay thy wand'ring feet.\nMay we, like thee, shun worldly praise,\nIn worldly paths no longer roam,\nBut tread the peaceful, heavenward ways,\nTill angels come to lead us home."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -67,15 +81,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Pray for us, O S. Norbert,\n℟. That we may be made worthy of the promises of Christ."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Pray for us, O S. Norbert,"
+                  },
+                  "r": {
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nAwake, O Lord, in Thy Church the Spirit by Whom S. Norbert,\nThy Confessor and Bishop, was guided, in order that,\nfilled with the same Spirit, we may love what he loved,\nand live as he taught us. Through Christ, Our Lord.\nAmen."
+                "en-US": "Awake, O Lord, in Thy Church the Spirit by Whom S. Norbert,\nThy Confessor and Bishop, was guided, in order that,\nfilled with the same Spirit, we may love what he loved,\nand live as he taught us. Through Christ, Our Lord.\nAmen."
               }
             }
           ]
@@ -88,16 +115,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Thou, O Lord, wilt open my lips;\n℟. And my tongue shall announce Thy praise."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Thou, O Lord, wilt open my lips;"
+                  },
+                  "r": {
+                    "en-US": "And my tongue shall announce Thy praise."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto mine aid, O God,\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto mine aid, O God,"
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -106,19 +147,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn - Norbert's Penance"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "With deep affliction thou hast mourned\nThe failings of thy former life;\nThy robes of princely state are spurned;\nThe court, its pomps, its gilded strife,\nAre thine no more, for higher love\nHas fortified thy glowing heart,\nAnd, barefoot, through the snow thou'lt move\nAs one all heedless of the smart\nOf scorn and insult. Then with fasts,\nWith scourges, and with iron chain,\nThou'lt seek to expiate the past,\nAnd heal, with care, the former pain\nThy pride inflicted. May we now\nRich fruit of penance daily bear,\nAnd in the hour of death do thou\nObtain our pardon by thy prayer."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -130,15 +171,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Pray for us, O S. Norbert,\n℟. That we may be made worthy of the promises of Christ."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Pray for us, O S. Norbert,"
+                  },
+                  "r": {
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nAwake, O Lord, in Thy Church the Spirit by Whom S. Norbert,\nThy Confessor and Bishop, was guided, in order that,\nfilled with the same Spirit, we may love what he loved,\nand live as he taught us. Through Christ, Our Lord.\nAmen."
+                "en-US": "Awake, O Lord, in Thy Church the Spirit by Whom S. Norbert,\nThy Confessor and Bishop, was guided, in order that,\nfilled with the same Spirit, we may love what he loved,\nand live as he taught us. Through Christ, Our Lord.\nAmen."
               }
             }
           ]
@@ -151,16 +205,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Thou, O Lord, wilt open my lips;\n℟. And my tongue shall announce Thy praise."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Thou, O Lord, wilt open my lips;"
+                  },
+                  "r": {
+                    "en-US": "And my tongue shall announce Thy praise."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto mine aid, O God,\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto mine aid, O God,"
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -169,19 +237,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn - The Foundation of Norbert's Order"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "In token of her constant love\nThe glorious Queen of Heaven above\nClothes thee in white, that thou may'st be\nA witness to her purity.\nS. Austin gives his hallowed Rule\nTo train thy followers in that school\nOf holy life. And robed in light,\nThe Saviour meets the raptured sight,\nTo show, by seven-fold rays, the place\nWhere Norbert's band – a chosen race,\nShall dwell, as oft by Heaven foretold,\nIn lone Prémontré's blessed fold.\nS. Norbert, who the world disdained,\nPray that we may, with hearts unstained,\nWalk in the light of purity,\nAnd thus the heavenly nuptials see."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -193,15 +261,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Pray for us, O S. Norbert,\n℟. That we may be made worthy of the promises of Christ."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Pray for us, O S. Norbert,"
+                  },
+                  "r": {
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nAwake, O Lord, in Thy Church the Spirit by Whom S. Norbert,\nThy Confessor and Bishop, was guided, in order that,\nfilled with the same Spirit, we may love what he loved,\nand live as he taught us. Through Christ, Our Lord.\nAmen."
+                "en-US": "Awake, O Lord, in Thy Church the Spirit by Whom S. Norbert,\nThy Confessor and Bishop, was guided, in order that,\nfilled with the same Spirit, we may love what he loved,\nand live as he taught us. Through Christ, Our Lord.\nAmen."
               }
             }
           ]
@@ -214,16 +295,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Thou, O Lord, wilt open my lips;\n℟. And my tongue shall announce Thy praise."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Thou, O Lord, wilt open my lips;"
+                  },
+                  "r": {
+                    "en-US": "And my tongue shall announce Thy praise."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto mine aid, O God,\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto mine aid, O God,"
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -232,19 +327,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn - Norbert's Preaching"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "In cloistered hearts thou didst awake\nThe love of Him, Who for our sake\nDwells on our altars, closely veiled.\nWhen Tanchelin's profane touch assailed\nThat sacred Mystery, thou didst raise\nThy trumpet voice. And with amaze\nThe Gallic nation stood to hear\nThy matchless accents, rich and clear;\nS. Bernard, too, proclaiming thee\nA lute of heavenly melody.\nAngels of peace, at thy command\nFierce discord vanished from the land,\nAnd hearts by thee to Jesus given\nBrought forth abundant fruit for Heaven.\nWhen comes, at last, the harvest hour,\nOh! garner us, with saintly power."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -256,15 +351,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Pray for us, O S. Norbert,\n℟. That we may be made worthy of the promises of Christ."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Pray for us, O S. Norbert,"
+                  },
+                  "r": {
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nAwake, O Lord, in Thy Church the Spirit by Whom S. Norbert,\nThy Confessor and Bishop, was guided, in order that,\nfilled with the same Spirit, we may love what he loved,\nand live as he taught us. Through Christ, Our Lord.\nAmen."
+                "en-US": "Awake, O Lord, in Thy Church the Spirit by Whom S. Norbert,\nThy Confessor and Bishop, was guided, in order that,\nfilled with the same Spirit, we may love what he loved,\nand live as he taught us. Through Christ, Our Lord.\nAmen."
               }
             }
           ]
@@ -277,16 +385,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Thou, O Lord, wilt open my lips;\n℟. And my tongue shall announce Thy praise."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Thou, O Lord, wilt open my lips;"
+                  },
+                  "r": {
+                    "en-US": "And my tongue shall announce Thy praise."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto mine aid, O God,\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto mine aid, O God,"
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -295,19 +417,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn - Norbert's Miracles"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "Filled with Faith's spirit, miracles were thine,\nAnd thy skilled lips interpreted each sign\nOf heavenly dealings. Thou didst banish far\nThe phantoms of hell's spiritual war.\nNor from the nauseous insect didst thou shrink\nBut calmly dared the chalice still to drink.\nDiseases fled thy touch; the famished came\nAnd all were soothed by thee in Jesus' name.\nMore wondrous still, a wolf thou didst compel\nTo guard the trembling sheep, and guard them well.\nThy prophecies resounded loudly. Then\nThe demon fled the tortured souls of men\nAt thy desire. And when the raging flood\nBore all away, at thy command they stood\nBeside thee, saved. Thou, too, didst call to life\nThree breathless forms that sank in mortal strife.\nTo us, thy clients, teach the heavenly art\nTo live and yet to die to evil's part."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -319,15 +441,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Pray for us, O S. Norbert,\n℟. That we may be made worthy of the promises of Christ."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Pray for us, O S. Norbert,"
+                  },
+                  "r": {
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nAwake, O Lord, in Thy Church the Spirit by Whom S. Norbert,\nThy Confessor and Bishop, was guided, in order that,\nfilled with the same Spirit, we may love what he loved,\nand live as he taught us. Through Christ, Our Lord.\nAmen."
+                "en-US": "Awake, O Lord, in Thy Church the Spirit by Whom S. Norbert,\nThy Confessor and Bishop, was guided, in order that,\nfilled with the same Spirit, we may love what he loved,\nand live as he taught us. Through Christ, Our Lord.\nAmen."
               }
             }
           ]
@@ -340,16 +475,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Thou, O Lord, wilt open my lips;\n℟. And my tongue shall announce Thy praise."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Thou, O Lord, wilt open my lips;"
+                  },
+                  "r": {
+                    "en-US": "And my tongue shall announce Thy praise."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto mine aid, O God,\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto mine aid, O God,"
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -358,19 +507,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn - Norbert's Persecution"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "Great Pastor! Model of thy flock! Thy mind,\nFixed on eternal interests, entwined\nRound God's unchanging Church thy constant care;\nNor didst thou then her reckless plunderers spare.\nThey struck thee with the sword and with the tongue;\nThey exiled thee; vainly their darts were flung\nAround thy tranquil soul. Thy zeal untamed,\nNew merits and new recompenses claimed.\nPray for us now that trials ne'er may be,\nTriumphant o'er our faith and constancy;\nRather that heavenly pity, bending down,\nMay add new rays of glory to our crown."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -382,15 +531,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Pray for us, O S. Norbert,\n℟. That we may be made worthy of the promises of Christ."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Pray for us, O S. Norbert,"
+                  },
+                  "r": {
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Let us pray,\nAwake, O Lord, in Thy Church the Spirit by Whom S. Norbert,\nThy Confessor and Bishop, was guided, in order that,\nfilled with the same Spirit, we may love what he loved,\nand live as he taught us. Through Christ, Our Lord.\nAmen."
+                "en-US": "Awake, O Lord, in Thy Church the Spirit by Whom S. Norbert,\nThy Confessor and Bishop, was guided, in order that,\nfilled with the same Spirit, we may love what he loved,\nand live as he taught us. Through Christ, Our Lord.\nAmen."
               }
             }
           ]
@@ -403,16 +565,30 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Convert us, O God, our Salvation\n℟. And turn away Thy anger from us."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Convert us, O God, our Salvation"
+                  },
+                  "r": {
+                    "en-US": "And turn away Thy anger from us."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "en-US": "℣. Incline unto mine aid, O God,\n℟. O Lord, make haste to help me."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Incline unto mine aid, O God,"
+                  },
+                  "r": {
+                    "en-US": "O Lord, make haste to help me."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -421,19 +597,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Hymn - Norbert's Death and Translation"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "en-US": "Death summons thee, but do not fear,\nThe voice of Jesus soundeth near;\n\"Come, my beloved, take thy rest,\nCome, for thou shalt be crowned and blessed\".\nThy combat o'er, thy work is done.\nThe arms of Mary and her Son\nAre clasped around thee. Thou dost bear\nThe olive and the lily fair,\nAnd thus, beyond the distant star,\nThou'rt borne to heavenly courts afar,\nOh! may we win that peaceful rest,\nWe pray, who in thy joy are blest."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "en-US": "Antiphon"
               }
@@ -441,19 +617,38 @@
             {
               "type": "prayer",
               "inline": {
-                "en-US": "Having given his support to the Holy Church of Rome in her affliction,\nblessing his brethren, he happily fell asleep in Christ."
+                "en-US": "Having given his support to the Holy Church of Rome in her affliction,"
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "en-US": "blessing his brethren, he happily fell asleep in Christ."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "en-US": "Pray for us, O S. Norbert,"
+                  },
+                  "r": {
+                    "en-US": "That we may be made worthy of the promises of Christ."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "en-US": "Let us pray."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "en-US": "℣. Pray for us, O S. Norbert,\n℟. That we may be made worthy of the promises of Christ."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "en-US": "Let us pray,\nAwake, O Lord, in Thy Church the Spirit by Whom S. Norbert,\nThy Confessor and Bishop, was guided, in order that,\nfilled with the same Spirit, we may love what he loved,\nand live as he taught us. Through Christ, Our Lord.\nAmen."
+                "en-US": "Awake, O Lord, in Thy Church the Spirit by Whom S. Norbert,\nThy Confessor and Bishop, was guided, in order that,\nfilled with the same Spirit, we may love what he loved,\nand live as he taught us. Through Christ, Our Lord.\nAmen."
               }
             }
           ]

--- a/content/practices/little-office-s-paul-the-apostle/flow.json
+++ b/content/practices/little-office-s-paul-the-apostle/flow.json
@@ -39,31 +39,57 @@
           },
           "sections": [
             {
-              "type": "rubric",
-              "text": {
+              "type": "prayer",
+              "inline": {
                 "la": "Vas electionis est mihi iste, ut portet Nomen meum coram Gentibus, et Regibus, et Filiis Israel."
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies,"
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies,\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Saulus adhuc dum vocaris,\nPaulus donec fueras,\nUnice delectabaris\nPerdere Christicolas;\nAdolescens impiorum\nCuram geris vestium,\nLapidat dum Judaeorum\nGens proterva Stephanum."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -75,15 +101,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis S. Paule Apostole.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis S. Paule Apostole."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui multitudinem Gentium Beati\nPauli Apostoli praedicatione docuisti:\nDa nobis, quaesumus, ut cujus merita colimus,\nejus apud te patrocinia sentiamus.\nPer Dominum nostrum etc. Amen."
+                "la": "Deus, qui multitudinem Gentium Beati\nPauli Apostoli praedicatione docuisti:\nDa nobis, quaesumus, ut cujus merita colimus,\nejus apud te patrocinia sentiamus.\nPer Dominum nostrum etc. Amen."
               }
             }
           ]
@@ -97,31 +136,44 @@
           },
           "sections": [
             {
-              "type": "rubric",
-              "text": {
+              "type": "prayer",
+              "inline": {
                 "la": "Vas electionis est mihi iste etc."
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Sed Damascum ut tendenti\nChristus occlamaverat;\nSaule dic, me persequendi\nQuae te causa agitat?\nEquo lapsus mox respondes:\nDic, quid me vis facere!\nJugo Christi te despondes,\nSacro lotus flumine."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -149,31 +201,44 @@
           },
           "sections": [
             {
-              "type": "rubric",
-              "text": {
+              "type": "prayer",
+              "inline": {
                 "la": "Vas electionis est mihi iste etc."
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Dum in synagoga Christum\nPosthac palam praedicas,\nHunc convertis, jam et istum\nSanas, et resuscitas,\nStygem pellis, idolorum\nExcutis daemonia,\nPro mercede tot laborum,\nDura fers et aspera."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -201,31 +266,44 @@
           },
           "sections": [
             {
-              "type": "rubric",
-              "text": {
+              "type": "prayer",
+              "inline": {
                 "la": "Vas electionis est mihi iste etc."
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Isthoc tamen nil morante,\nScandis Jerosolymam,\nUt Jacobus velut ante\nIbi fudit animam,\nTuque Christo immoleris,\nNoctis sub concubium\nSed doceris, ut testes\nRomae quoque Dominum."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -253,31 +331,44 @@
           },
           "sections": [
             {
-              "type": "rubric",
-              "text": {
+              "type": "prayer",
+              "inline": {
                 "la": "Vas electionis est mihi iste etc."
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Inter haec ad Dithalassium,\nLongum post circuitum,\nPaule te Melita passum\nSuscipit naufragium:\nAt, quam Insula humana,\nAtrox tam est vipera,\nMordet haec: sed ira vana,\nViru quasi vacua."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -305,31 +396,44 @@
           },
           "sections": [
             {
-              "type": "rubric",
-              "text": {
+              "type": "prayer",
+              "inline": {
                 "la": "Vas electionis est mihi iste etc."
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Jugitaliter labore\nDum desudas strenue,\nAtque Christi pro amore\nDira suffers undique,\nUsque tertium in coelum\nRaperis; nec protinus\nLiber tamen, quin anhelum\nCarnis turbet stimulus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -357,31 +461,44 @@
           },
           "sections": [
             {
-              "type": "rubric",
-              "text": {
+              "type": "prayer",
+              "inline": {
                 "la": "Vas electionis est mihi iste etc."
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Tandem Romam dum venisti,\nPublice de ritibus,\nDeque nova lege Christi,\nPraedicas Quiritibus,\nPars auscultat, pars irridet,\nSed Neronis Pellicem\nGens, ut Christianam videt,\nFertur res ad Caesarem."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -409,31 +526,57 @@
           },
           "sections": [
             {
-              "type": "rubric",
-              "text": {
+              "type": "prayer",
+              "inline": {
                 "la": "Vas electionis est mihi iste etc."
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Jamque Paulus per lictotes\nMancipatur vinculis:\nFlagellato per tortores\nSed mandato Caesaris\nPostquam caput detruncatur,\nLac cruorque profluit,\nFonsque salva dum levatur\nTertus terno profluit."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -467,7 +610,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Ant."
       }
@@ -479,13 +622,20 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Ora pro nobis S. Paule Apostole.\n℟. Ut digni efficiamur promissionibus Christi."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ora pro nobis S. Paule Apostole."
+          },
+          "r": {
+            "la": "Ut digni efficiamur promissionibus Christi."
+          }
+        }
+      ]
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Oratio"
       }

--- a/content/practices/little-office-s-peter/flow.json
+++ b/content/practices/little-office-s-peter/flow.json
@@ -26,81 +26,85 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Petri laudes extollamus,\nNos romanae quotquot stamus\nCastris sub ecclesiae,"
+                "la": "Petri laudes extollamus,\nNos romanae quotquot stamus\nCastris sub ecclesiae,\n\nAlme claviger coelorum,\nRudem ne despexeris chorum\nRhytmo textum simplice!\n\nNam sic belle concordantes\nQui virtutes tam praestantes\nSat laudari valeant!\n\nAmor, timor, mens sincera,\nZelus, fides, spesque vera\nPari melo consonant;\n\nEst in Petro, quam addidicit\nPrinceps, quae in servo gliscat,\nAdest et humilitas,\n\nChristum sequi hic cunctator,\nAb hoc fundere peccator\nJustas discet lachrymas.\n\nIllic proximum juvare,\nDeum unice amare:\nEt, quos mundus detinet,\n\nFluxa quaevís aspernari,\nNudos Christum insectari\nPetrus nos erudit."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Simon Joannis, diligis me? etiam."
+                  },
+                  "r": {
+                    "la": "Domine, tu scis, quia amo te."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis s. Petre apostole,"
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Alme claviger coelorum,\nRudem ne despexeris chorum\nRhytmo textum simplice!"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Nam sic belle concordantes\nQui virtutes tam praestantes\nSat laudari valeant!"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Amor, timor, mens sincera,\nZelus, fides, spesque vera\nPari melo consonant;"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Est in Petro, quam addidicit\nPrinceps, quae in servo gliscat,\nAdest et humilitas,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Christum sequi hic cunctator,\nAb hoc fundere peccator\nJustas discet lachrymas."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Illic proximum juvare,\nDeum unice amare:\nEt, quos mundus detinet,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Fluxa quaevís aspernari,\nNudos Christum insectari\nPetrus nos erudit."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Simon Joannis, diligis me? etiam.\n℟. Domine, tu scis, quia amo te."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis s. Petre apostole,\n℟. Ut digni efficiamur promissionibus Christi."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus qui b. Petro apostolo tuo, collatis clavibus regni coelestis, ligandi atque solvendi pontificium tradidisti:\nconcede, ut intercessionis ejus auxilio a peccatorum nostrorum nexibus liberemur.\nQui vivis et regnas cum Deo Patre etc."
+                "la": "Deus qui b. Petro apostolo tuo, collatis clavibus regni coelestis, ligandi atque solvendi pontificium tradidisti:\nconcede, ut intercessionis ejus auxilio a peccatorum nostrorum nexibus liberemur.\nQui vivis et regnas cum Deo Patre etc."
               }
             }
           ]
@@ -120,67 +124,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Hunc piscantem, Piscatoris\nAd capturae dignioris\nOpus traxit Gratia;"
+                "la": "Hunc piscantem, Piscatoris\nAd capturae dignioris\nOpus traxit Gratia;\n\nNam qui iubet sic piscari,\nPisces vitae vult servari,\nQuos prehendant retia,\n\nUnde Petrus se vocantis\nNullum Christi tunc patrantis\nSignum vel prodigium,\n\nVoci cedit, verbo credit,\nSequi iussus, mox obedit,\nQuo vocaret servulum,\n\nVanis praefert veritatem,\nLinquit rete, linquit ratem,\nQuin relinquit omnia;\n\nEt, o felix Bar-Jona\nPro his Christus tibi bona,\nRegna spondet supera:\n\nDumque calcas undas maris,\nTe nutantem, ne mergaris,\nFida manu detinet,\n\nFidem quatit dum tempestas\nEjus alma vim potestas\nProcellarum cohibet."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Nam qui iubet sic piscari,\nPisces vitae vult servari,\nQuos prehendant retia,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Unde Petrus se vocantis\nNullum Christi tunc patrantis\nSignum vel prodigium,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Voci cedit, verbo credit,\nSequi iussus, mox obedit,\nQuo vocaret servulum,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Vanis praefert veritatem,\nLinquit rete, linquit ratem,\nQuin relinquit omnia;"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Et, o felix Bar-Jona\nPro his Christus tibi bona,\nRegna spondet supera:"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Dumque calcas undas maris,\nTe nutantem, ne mergaris,\nFida manu detinet,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Fidem quatit dum tempestas\nEjus alma vim potestas\nProcellarum cohibet."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -214,67 +189,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Mota Christi quaestione,\nBrevi claudit sub sermone\nFidem necessariam;"
+                "la": "Mota Christi quaestione,\nBrevi claudit sub sermone\nFidem necessariam;\n\nHunc personam dicit unam,\nSed naturae opportunam\nSimul dat distantiam,\n\nCarni scire, quod negatum,\nSibi Cephas revelatum\nDia profert diphthera\n\nSuper quo, perennatura,\nPetra tanquam super dura\nConditur Ecclesia,\n\nQuin et sorte, ut miranda\nPetre liges, quae liganda,\nRata sint, quae solveris\n\nChristus claves tibi credit,\nQuibus Coeli porta cedit,\nPandas, vel occluseris,\n\nQuodque hic est implicatum,\nSummus Judex et ligatum\nSuper astra voluit;\n\nQuae haec dignitas dicenda?\nAlta plane et tremenda,\nQuam vix sensus percipit."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Hunc personam dicit unam,\nSed naturae opportunam\nSimul dat distantiam,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Carni scire, quod negatum,\nSibi Cephas revelatum\nDia profert diphthera"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Super quo, perennatura,\nPetra tanquam super dura\nConditur Ecclesia,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Quin et sorte, ut miranda\nPetre liges, quae liganda,\nRata sint, quae solveris"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Christus claves tibi credit,\nQuibus Coeli porta cedit,\nPandas, vel occluseris,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Quodque hic est implicatum,\nSummus Judex et ligatum\nSuper astra voluit;"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Quae haec dignitas dicenda?\nAlta plane et tremenda,\nQuam vix sensus percipit."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -308,67 +254,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Transformantis se Messiae,\nMoysis simul, et Eliae\nFrueris colloquio,"
+                "la": "Transformantis se Messiae,\nMoysis simul, et Eliae\nFrueris colloquio,\n\nCensens hic manere gratum,\nSemper hoc si foret datum\nEsse in consortio;\n\nAt, quid erit, Majestatem,\nQuid aeternis Deitatem\nContemplari gaudiis?\n\nUbi, junctis tot Beatis,\nUna dies claritatis\nMille praestat saeculis,\n\nPetrus posthac Salvatori\nFidus comes, optat mori\nPariter cum Domino;\n\nZelus calcar est amoris,\nSed et casus est timoris\nJugis admonitio,\n\nTibi Christus eventurum\nQuem praedixit, ne securum\nObruat fiducia,\n\nSed prostratum Patientis\nAnxiumque Resurgentis\nErigat memoria."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Censens hic manere gratum,\nSemper hoc si foret datum\nEsse in consortio;"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "At, quid erit, Majestatem,\nQuid aeternis Deitatem\nContemplari gaudiis?"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Ubi, junctis tot Beatis,\nUna dies claritatis\nMille praestat saeculis,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Petrus posthac Salvatori\nFidus comes, optat mori\nPariter cum Domino;"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Zelus calcar est amoris,\nSed et casus est timoris\nJugis admonitio,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Tibi Christus eventurum\nQuem praedixit, ne securum\nObruat fiducia,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sed prostratum Patientis\nAnxiumque Resurgentis\nErigat memoria."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -402,67 +319,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ter negavit quod peccavit,\nKursus Amor expiavit,\nTriplex et Confessio:"
+                "la": "Ter negavit quod peccavit,\nKursus Amor expiavit,\nTriplex et Confessio:\n\nHinc sequutos delinquentem\nIam et Petrum poenitentem\nSequi iubet ratio.\n\nSed quam Christus carum gregem\nDet pascendum, prius legem\nCharitatis ponderat,\n\nAmat Petrus, contestatur,\nAmat: Sed haec tremens satur,\nGalli dum meminerat,\n\nAuro carens et argento,\nPosthac claudum in momento\nMembris donat validis,\n\nDat Aeneae sanitatem,\nHinc et inde sospitatem\nAegis fert, et miseris,\n\nQuin ad funus dum Tabithae\nVenit, suis reddit vitae\nPrecibus officia.\n\nSola umbra decumbentes\nPorro sanat, et languentes\nOpe curat coelica."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Hinc sequutos delinquentem\nIam et Petrum poenitentem\nSequi iubet ratio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sed quam Christus carum gregem\nDet pascendum, prius legem\nCharitatis ponderat,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Amat Petrus, contestatur,\nAmat: Sed haec tremens satur,\nGalli dum meminerat,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Auro carens et argento,\nPosthac claudum in momento\nMembris donat validis,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Dat Aeneae sanitatem,\nHinc et inde sospitatem\nAegis fert, et miseris,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Quin ad funus dum Tabithae\nVenit, suis reddit vitae\nPrecibus officia."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sola umbra decumbentes\nPorro sanat, et languentes\nOpe curat coelica."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -496,67 +384,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Strictam gregis curam gerit,\nDefraudantes gravi ferit\nConiuges supplicio,"
+                "la": "Strictam gregis curam gerit,\nDefraudantes gravi ferit\nConiuges supplicio,\n\nFraudes damnant et fallaces,\nQuo Divina in mendaces\nMox descendit ultio.\n\nSed et capto dans custodes\nIners fallitur Herodes\nSuo cum satellite,\n\nQuippe vincis relaxatus,\nJam it Petrus liberatus,\nFido cinctus Comite,\n\nMagus utque Petrum odit,\nSic Simonem Petrus prodit\nTurpi de flagitio;\n\nNam volare hic dum quaerit,\nGravi palam lapsu perit\nAsfectante Populo;\n\nUnde Nero insfendescens,\nMagi lapsum miserescens\nPetro fert judicium,\n\nUt in Crucem sublevetur,\nQuo Magistrum imitetur\nPari trabe pendulum."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Fraudes damnant et fallaces,\nQuo Divina in mendaces\nMox descendit ultio."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sed et capto dans custodes\nIners fallitur Herodes\nSuo cum satellite,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Quippe vincis relaxatus,\nJam it Petrus liberatus,\nFido cinctus Comite,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Magus utque Petrum odit,\nSic Simonem Petrus prodit\nTurpi de flagitio;"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Nam volare hic dum quaerit,\nGravi palam lapsu perit\nAsfectante Populo;"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Unde Nero insfendescens,\nMagi lapsum miserescens\nPetro fert judicium,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Ut in Crucem sublevetur,\nQuo Magistrum imitetur\nPari trabe pendulum."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -590,67 +449,51 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Dumque Petro Crux paratur,\nCrucifigi hic laetatur\nEquidem cum Domino,"
+                "la": "Dumque Petro Crux paratur,\nCrucifigi hic laetatur\nEquidem cum Domino,\n\nSed eodem situ lignum\nHaud subire censens dignum\nNisu rogat ultimo:\n\nPedibus ut elevatis,\nInque terram declinatis\nVertice et manibus\n\nCruci suae alligetur,\nNe Magistro par tractetur\nServus et Discipulus,\n\nSic mi Petre! versa cruce\nCoelum scandis; Isthac duce\nFac et nos id scandere,\n\nTuo gregi fores pande\nGnaro, clavium hoc grande\nTibi jus competere,\n\nOves, tuo quas ovili\nHic in terris haud exili\nCura enutviveras,\n\nChristo tandem Redemptori\nPrimo redditas Pastori,\nDuc ad Agni nuptias,"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Sed eodem situ lignum\nHaud subire censens dignum\nNisu rogat ultimo:"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Pedibus ut elevatis,\nInque terram declinatis\nVertice et manibus"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Cruci suae alligetur,\nNe Magistro par tractetur\nServus et Discipulus,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sic mi Petre! versa cruce\nCoelum scandis; Isthac duce\nFac et nos id scandere,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Tuo gregi fores pande\nGnaro, clavium hoc grande\nTibi jus competere,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oves, tuo quas ovili\nHic in terris haud exili\nCura enutviveras,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Christo tandem Redemptori\nPrimo redditas Pastori,\nDuc ad Agni nuptias,"
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -662,15 +505,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis S. Petre Apostole.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis S. Petre Apostole."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nMitissime ac Clementissime Deus, qui S. Petrum ex pauperculo piscatore, tuum in terris Vicarium, atque Apostolorum Principem constitutisti, eumque post grave negationis peccatum propitiis tamen respexisti oculis, et ad amarissimam poenitentiam commovisti. Oro te per intimum ejus amorem, et ferventissimas lachrymas, concede mihi gratiam tuam exuberantem, ut voluntati tuae me totum subternens, vocationi meae semper satisfaciam, et in petra Catholicae fidei immote persistere, Te summum Bonum meum in prosperis et adversis, super omnia amem, atque peccata mea contra Divinam Majestatem tuam commissa, vero, et profundissimo dolore plangam, donec tandem in coelis gaudio petrui merear sempiterna; Qui vivis et regnas Deus in saecula saeculorum, Amen."
+                "la": "Mitissime ac Clementissime Deus, qui S. Petrum ex pauperculo piscatore, tuum in terris Vicarium, atque Apostolorum Principem constitutisti, eumque post grave negationis peccatum propitiis tamen respexisti oculis, et ad amarissimam poenitentiam commovisti. Oro te per intimum ejus amorem, et ferventissimas lachrymas, concede mihi gratiam tuam exuberantem, ut voluntati tuae me totum subternens, vocationi meae semper satisfaciam, et in petra Catholicae fidei immote persistere, Te summum Bonum meum in prosperis et adversis, super omnia amem, atque peccata mea contra Divinam Majestatem tuam commissa, vero, et profundissimo dolore plangam, donec tandem in coelis gaudio petrui merear sempiterna; Qui vivis et regnas Deus in saecula saeculorum, Amen."
               }
             }
           ]

--- a/content/practices/little-office-s-philip-neri/flow.json
+++ b/content/practices/little-office-s-philip-neri/flow.json
@@ -26,25 +26,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Te Philippe quam amavit\nDei providentia!\nQuam te Numen exornavit\nSingulari gratia!\nA juventae pietatis,\nMirae jam sanctitatis\nDederas specimina."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -56,15 +82,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis sancte Philippe Neri,\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis sancte Philippe Neri,"
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO clementissime Deus, qui dilectum famulum tuum Philippum Nerium jam tenera in aetate multis sanctitatis tuae signis decorasti: oramus te igitur per insignia sancti tui merita, ut nos ad illum virtutis tramitem dirigere digneris, qui nos ad te, tanquam ad finem, unicamque animae nostrae metam perducat. Per Dominum nostrum Jesum Christum Filium tuum, qui tecum etc.\nAmen."
+                "la": "O clementissime Deus, qui dilectum famulum tuum Philippum Nerium jam tenera in aetate multis sanctitatis tuae signis decorasti: oramus te igitur per insignia sancti tui merita, ut nos ad illum virtutis tramitem dirigere digneris, qui nos ad te, tanquam ad finem, unicamque animae nostrae metam perducat. Per Dominum nostrum Jesum Christum Filium tuum, qui tecum etc.\nAmen."
               }
             }
           ]
@@ -78,25 +117,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Iter Romam subiit,\nCharam linquens patriam,\nRaram ubi ostendit\nIndolis praestantiam,\nTotum Christo te sacrando,\nLibertatem resignando,\nVitam et substantiam."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -108,15 +160,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis sancte Philippe Neri,\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis sancte Philippe Neri,"
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO benignissime Deus, qui dilectum famulum tuum Philippum Nerium ad singularem tui notitiam eveheti; adeo, ut sanctissimae tuae totum sese voluntati transcriberit: dignare, o Deus, et nos per sancti tui merita, ad talem tui notitiam perducere, ut nihil, quam tui soli fovere cupiamus. Per Dominum nostrum etc."
+                "la": "O benignissime Deus, qui dilectum famulum tuum Philippum Nerium ad singularem tui notitiam eveheti; adeo, ut sanctissimae tuae totum sese voluntati transcriberit: dignare, o Deus, et nos per sancti tui merita, ad talem tui notitiam perducere, ut nihil, quam tui soli fovere cupiamus. Per Dominum nostrum etc."
               }
             }
           ]
@@ -130,25 +195,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Totum Dei dum amore\nPectus suum aestuat,\nTota proximi ardore\nMensque incaluerat,\n\nDic! quot fervor animarum\nIste fontes lachrymarum\nTibi non extorserat?"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -160,15 +238,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis sancte Philippe Neri,\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis sancte Philippe Neri,"
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO amantissime Deus, qui famulum tuum Philippum Nerium tanto tui amoris incendio inflammasti, ut saepius igneae ex oculis erumperent scintillae viderentur, tantoque hic etiam proximi ardore flagraret, ut persaepe copiosissimos lachrymarum imbres effunderet: rogamus te igitur, o fons veri amoris, per merita famuli tui, ut tantum tui proximique amorem cordibus nostris infundas, quo nihil aliud quam te, et proximum diligere cogitemus. Per Dominum nostrum etc."
+                "la": "O amantissime Deus, qui famulum tuum Philippum Nerium tanto tui amoris incendio inflammasti, ut saepius igneae ex oculis erumperent scintillae viderentur, tantoque hic etiam proximi ardore flagraret, ut persaepe copiosissimos lachrymarum imbres effunderet: rogamus te igitur, o fons veri amoris, per merita famuli tui, ut tantum tui proximique amorem cordibus nostris infundas, quo nihil aliud quam te, et proximum diligere cogitemus. Per Dominum nostrum etc."
               }
             }
           ]
@@ -182,25 +273,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Tu parabas afflictorum\nCordibus solatia,\nIndurata peccatorum\nMolliens praecordia;\nQuotquot ad te proflugebant,\nOpem inter pericula\nCuras et pericula."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -212,15 +316,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis sancte Philippe Neri,\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis sancte Philippe Neri,"
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nMisericordissime Domine, qui sanctum Philippum Nerium tantis gratiarum cumulasti divitiis, ut omnes quibuscunque angustiarum afflictionibus pressi, solamen apud ipsum quaerentes, securissime illud invenerint: da igitur, o Pater misericordiarum, ut beati hujus famuli tui meritis, et nos a gravioribus animi anxietatibus atque periculis liberemur. Per Dominum etc."
+                "la": "Misericordissime Domine, qui sanctum Philippum Nerium tantis gratiarum cumulasti divitiis, ut omnes quibuscunque angustiarum afflictionibus pressi, solamen apud ipsum quaerentes, securissime illud invenerint: da igitur, o Pater misericordiarum, ut beati hujus famuli tui meritis, et nos a gravioribus animi anxietatibus atque periculis liberemur. Per Dominum etc."
               }
             }
           ]
@@ -234,25 +351,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Illium Virginitatis\nCustodivit sedulo,\nUt in flore puritatis\nViveret perpetuo,\nTela Cypridis vicit,\nEt illius vim fregit\nForti precum gladio."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -264,15 +394,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis sancte Philippe Neri,\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis sancte Philippe Neri,"
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO purissime Domine, et tenerime Virginis castitatis amator, qui sanctum Philippum Nerium speciali hoc gratiae dono exornasti, quod ejusdem corpus tam amabilem castitatis odorem reddidit, ut omnes, qui illud adstarent, mirabiliter suavi recrearet: oramus te igitur, per insignem hanc famuli tui castimoniam, ut nos ad candidam puritatis lilium donare digneris, et aliquando digni habeamur, te purissimum et divinissimum Sponsum a facie ad faciem intueri. Per Dominum nostrum Jesum etc."
+                "la": "O purissime Domine, et tenerime Virginis castitatis amator, qui sanctum Philippum Nerium speciali hoc gratiae dono exornasti, quod ejusdem corpus tam amabilem castitatis odorem reddidit, ut omnes, qui illud adstarent, mirabiliter suavi recrearet: oramus te igitur, per insignem hanc famuli tui castimoniam, ut nos ad candidam puritatis lilium donare digneris, et aliquando digni habeamur, te purissimum et divinissimum Sponsum a facie ad faciem intueri. Per Dominum nostrum Jesum etc."
               }
             }
           ]
@@ -286,25 +429,38 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Diu postquam praeluxit\nMira patientia,\nEt virtutum coluit\nFerrea constantia,\nQua te per sanctam mortem\nChristus, o beatam sortem,\nVocat ad convivia."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -316,15 +472,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis sancte Philippe Neri,\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis sancte Philippe Neri,"
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO patientissime Domine, et virtutis praemiator, qui miram beati famuli tui Philippi Neri in adversis patientiam, et eximiam virtutis constantiam aeterni in coelo gloria remunerasti: quaesumus Domine, ut nos quoque, per gloriosa sancti tui suffragia, fortes in rebus omnibus adversis patientiam, et heroicam in virtutis tramite constantiam usque ad vitae nostrae exitum mereamur servare. Per Dominum nostrum Jesum etc."
+                "la": "O patientissime Domine, et virtutis praemiator, qui miram beati famuli tui Philippi Neri in adversis patientiam, et eximiam virtutis constantiam aeterni in coelo gloria remunerasti: quaesumus Domine, ut nos quoque, per gloriosa sancti tui suffragia, fortes in rebus omnibus adversis patientiam, et heroicam in virtutis tramite constantiam usque ad vitae nostrae exitum mereamur servare. Per Dominum nostrum Jesum etc."
               }
             }
           ]
@@ -338,25 +507,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Convertere nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Convertere nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "O Philippe coeli lumen,\nClericorum gloria,\nPer quem maxima jam Numen\nExhibet miracula;\nEsto nobis semper pronus,\nDux fidelis et patronus,\nQuavis in miseria."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -368,15 +563,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis sancte Philippe Neri,\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis sancte Philippe Neri,"
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nO patientissime Domine, qui insignem sancti Philippi Nerii sanctitatem plurimis illustrasti miraculis, adeo, ut gloriosum illius nomen omnium extollatur linguis, ac celebretur encomiis: oramus te igitur, ut nos beati hujus famuli tui meritorum facere digneris participes. Per Dominum nostrum Jesum Christum etc."
+                "la": "O patientissime Domine, qui insignem sancti Philippi Nerii sanctitatem plurimis illustrasti miraculis, adeo, ut gloriosum illius nomen omnium extollatur linguis, ac celebretur encomiis: oramus te igitur, ut nos beati hujus famuli tui meritorum facere digneris participes. Per Dominum nostrum Jesum Christum etc."
               }
             }
           ]
@@ -396,7 +604,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Ant."
       }
@@ -408,15 +616,28 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Ora pro nobis sancte Philippe Neri,\n℟. Ut digni efficiamur promissionibus Christi."
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ora pro nobis sancte Philippe Neri,"
+          },
+          "r": {
+            "la": "Ut digni efficiamur promissionibus Christi."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nDeus, qui beatum Philippum confessorem tuum sanctorum gloria sublimasti: concede, propitius, ut ejus solemnitate laetamur, ejus virtutem prosequamur exemplis. Per Dominum nostrum Jesum Christum etc."
+        "la": "Deus, qui beatum Philippum confessorem tuum sanctorum gloria sublimasti: concede, propitius, ut ejus solemnitate laetamur, ejus virtutem prosequamur exemplis. Per Dominum nostrum Jesum Christum etc."
       }
     }
   ]

--- a/content/practices/little-office-s-stanislaus-kostka/flow.json
+++ b/content/practices/little-office-s-stanislaus-kostka/flow.json
@@ -26,15 +26,35 @@
           },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
@@ -44,13 +64,26 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Propter servum meum Jacob et Israel electum meum."
+                  },
+                  "r": {
+                    "la": "Ego ante te ibo ;"
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Propter servum meum Jacob et Israel electum meum.\n℟. Ego ante te ibo ;\net gloriosos terrae humiliabo ;\nportas aereas conteram,\net vectes ferreos confringam."
+                "la": "et gloriosos terrae humiliabo ;\nportas aereas conteram,\net vectes ferreos confringam."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -72,31 +105,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Salve, cui dum Tartara\nEmissa per latebras\nIlluderent, huc Barbara\nAbegit in tenebras,\nEt Angelicum ferculum,\nMissum, mente pia panem,\nIn pace Jesu corculum\nMox debit levamen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Cibavit eum ex adipe frumenti,\n℟. Et de Petra melle saturavit eum. (Ps. 80)"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Cibavit eum ex adipe frumenti,"
+                  },
+                  "r": {
+                    "la": "Et de Petra melle saturavit eum. (Ps. 80)"
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -118,31 +171,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Salve, cui dum clini\nAffixa membra lecto\nHaerent, resurgunt illico\nOmni malo retecto:\nCum nempe Kostkae Jesulum\nIn lectulo locavit,\nSuumque Virgo servulum\nA morte liberavit."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. In lectulo meo per noctes quaesivi, quem diligit anima mea.\n℟. Tenebo illum, et non dimittam."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In lectulo meo per noctes quaesivi, quem diligit anima mea."
+                  },
+                  "r": {
+                    "la": "Tenebo illum, et non dimittam."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -164,31 +237,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Salve, cui post redditam\nMaria sanitatem\nHaec verba fert, ut debitam\nSequar sanctitatem.\nVis Kostka Jesum sedibus\nCaelestibus videre?\nIgnatii fac aedibus,\nSignisque te tuere."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Euge dilecte mi, fuge super montes aromatum.\n℟. Et obliviscere populum tuum et domum Patris tui."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Euge dilecte mi, fuge super montes aromatum."
+                  },
+                  "r": {
+                    "la": "Et obliviscere populum tuum et domum Patris tui."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -210,31 +303,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Audit fidelis servulus\nMatrem Dei docentem,\nAudit, nec ultra sedulus\nDiffert sequi monentem:\nSed purpuram pro vilibus\nPermutat inde pannis,\nSeseque vulgi risibus\nExponit atque sannis."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Auditu auris audivi te,\n℟. Et egressus factus sum, cum essem dives."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Auditu auris audivi te,"
+                  },
+                  "r": {
+                    "la": "Et egressus factus sum, cum essem dives."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -256,31 +369,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Salve, cui nec lachrymae\nPatris fugam retardant,\nNec patriae spes maximae,\nAssumpta vota tardant ;\nNam Jesu stipenditis\nEt usque militasti.\nIgnatii compendiis\nDum sidera involasti."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Extraneus factus sum fratribus meis.\n℟. Et peregrinus filiis Matris meae. (Ps. 61)"
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Extraneus factus sum fratribus meis."
+                  },
+                  "r": {
+                    "la": "Et peregrinus filiis Matris meae. (Ps. 61)"
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -302,31 +435,64 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos, Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus, in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto,\nSicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Salve supernae patriae\nTandem receptae civis:\nQui sempiternae gloriae\nFelicitate vivis.\nSalve, tuumque caelitus\nSic protegeis clientem:\nUt sortiar divinitus,\nQuam quaero, habere mentem."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Trahe me post te.\n℟. Et currem in odorem unguentorum tuorum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Trahe me post te."
+                  },
+                  "r": {
+                    "la": "Et currem in odorem unguentorum tuorum."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio"
               }
@@ -354,31 +520,57 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Hymnus ad S. Stanislaum Kostkam"
       }
     },
     {
-      "type": "prayer",
+      "type": "hymn",
       "inline": {
         "la": "Salve, o caste Candor puritatis,\nIntemerate flos Virginitatis!\nTuum dum corpus purum conservatur,\nVultusque caeli luce illustratur,\nLumina ista monstrant radiorum,\nNon cinctam mente beato peccatorum.\nDecuit corpus ita illustrari,\nNescium noxa mortali gravari."
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Quasi flos rosarum in diebus vernis.\n℟. Et quasi lilium, sic fuit in transitu aquae.\n℣. Ora pro nobis, beatissime Kostka.\n℟. Ut digni efficiamur promissionibus Christi."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Quasi flos rosarum in diebus vernis."
+          },
+          "r": {
+            "la": "Et quasi lilium, sic fuit in transitu aquae."
+          }
+        }
+      ]
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "Oremus,\nJesu virgineae castitatis Amator et Auctor,\nqui B. Stanislaum Kostkam immaculatam in hoc saeculo custodisti ;\nconcede propitius,\nut qui ejus memoriam propter te et inter spiritualia lilia libenter pascere recolimus,\nejus precibus ac meritis intactam a mundi illecebris animam,\nac corpus pro tuo domicilio semper teneamus.\nQui vivis et regnas in saecula saeculorum.\nAmen."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ora pro nobis, beatissime Kostka."
+          },
+          "r": {
+            "la": "Ut digni efficiamur promissionibus Christi."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
+      "text": {
+        "la": "Oremus."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Jesu virgineae castitatis Amator et Auctor,\nqui B. Stanislaum Kostkam immaculatam in hoc saeculo custodisti ;\nconcede propitius,\nut qui ejus memoriam propter te et inter spiritualia lilia libenter pascere recolimus,\nejus precibus ac meritis intactam a mundi illecebris animam,\nac corpus pro tuo domicilio semper teneamus.\nQui vivis et regnas in saecula saeculorum.\nAmen."
+      }
+    },
+    {
+      "type": "subheading",
       "text": {
         "la": "Oratio de B. Joanne Francisco Regis."
       }

--- a/content/practices/little-office-s-thomas-aquinas/flow.json
+++ b/content/practices/little-office-s-thomas-aquinas/flow.json
@@ -27,13 +27,39 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adiutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adiuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus, in adiutorium meum intende.\n℟. Domine, ad adiuvandum me festina.\n℣. Gloria Patri."
+                "la": "Gloria Patri."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Invitatorium"
               }
@@ -63,31 +89,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Exultet mentis jubilo\nLaudans turba fidelium,\nErrorum pulso nubilo\nPer novi solis radium."
+                "la": "Exultet mentis jubilo\nLaudans turba fidelium,\nErrorum pulso nubilo\nPer novi solis radium.\n\nThomas in mundi vespere\nFundit thesauros gratiae,\nDonis plenus ex aethere\nMorum, et sapientiae.\n\nLaus Patri sit ac Genito,\nSimulque Sancto Flamini,\nQui Sancti Thomae merito\nNos coeli jungat agmini.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Thomas in mundi vespere\nFundit thesauros gratiae,\nDonis plenus ex aethere\nMorum, et sapientiae."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus Patri sit ac Genito,\nSimulque Sancto Flamini,\nQui Sancti Thomae merito\nNos coeli jungat agmini.\nAmen."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 1"
               }
@@ -99,7 +113,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -111,10 +125,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Amavit eum Dominus et ornavit eum.\n℟. Stolam gloriae induit eum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Amavit eum Dominus et ornavit eum."
+                  },
+                  "r": {
+                    "la": "Stolam gloriae induit eum."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
@@ -125,11 +146,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Et ne nos etc.\nIube, Domine, benedicere.\nOret piis precibus pro nobis Doctor Angelicus.\n℟. Amen."
+                "la": "Et ne nos etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Iube, Domine, benedicere.\nOret piis precibus pro nobis Doctor Angelicus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio I"
               }
@@ -143,23 +176,47 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Tu autem, Domine, miserere nostri.\n℟. Deo gratias."
+                "la": "Tu autem, Domine, miserere nostri."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. De excelsis fons sapientiae sancto Thomae infudit copiam, tamquam flumen clarae scientiae, qui susceptam refudit gratiam, dum fluentis summae peritiae. Rigat totam sanctam Ecclesiam.\n℣. Stylus brevis, grata facundia; celsa, clara, firma sententia. Rigat, etc."
+                "la": "Deo gratias."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Iube, Domine, benedicere.\nIn omni periculo et angustia sit nobis pius Thomas custodia.\n℟. Amen."
+                "la": "De excelsis fons sapientiae sancto Thomae infudit copiam, tamquam flumen clarae scientiae, qui susceptam refudit gratiam, dum fluentis summae peritiae. Rigat totam sanctam Ecclesiam."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Stylus brevis, grata facundia; celsa, clara, firma sententia. Rigat, etc."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Iube, Domine, benedicere."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "In omni periculo et angustia sit nobis pius Thomas custodia."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio II"
               }
@@ -173,23 +230,47 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Tu autem, etc.\n℟. Deo gratias."
+                "la": "Tu autem, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. O anima sanctissima, qua contemplante dulciter, corpus liquebat infirma, stans sursum mirabiliter.\n℣. Nullo prorsus fultus subsidio, levabatur in raptus gaudio. Stans, etc."
+                "la": "Deo gratias."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Iube, Domine, benedicere.\nAd societatem civium supernorum perducat nos Doctor Angelicus.\n℟. Amen."
+                "la": "O anima sanctissima, qua contemplante dulciter, corpus liquebat infirma, stans sursum mirabiliter."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Nullo prorsus fultus subsidio, levabatur in raptus gaudio. Stans, etc."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Iube, Domine, benedicere."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Ad societatem civium supernorum perducat nos Doctor Angelicus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Lectio III"
               }
@@ -203,17 +284,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Tu autem, etc.\n℟. Deo gratias."
+                "la": "Tu autem, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Sertum gestans cum torque duplici, cappa gemmis ornata cernitur, ex monili fulgoris caelici lux emissa mundo diffunditur. Augustinus fratri sic loquitur:\n℣. Thomas mihi par est in gloria: virginali praestans munditia. Augustinus, etc. Gloria Patri etc.\nAugustinus, etc."
+                "la": "Deo gratias."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Sertum gestans cum torque duplici, cappa gemmis ornata cernitur, ex monili fulgoris caelici lux emissa mundo diffunditur. Augustinus fratri sic loquitur:"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Thomas mihi par est in gloria: virginali praestans munditia. Augustinus, etc. Gloria Patri etc."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Augustinus, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Canticum SS. Ambrosii et Augustini"
               }
@@ -225,10 +324,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, beate Thoma.\n℟. Ut digni efficiamur promissionibus Christi."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, beate Thoma."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -237,16 +343,42 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui Ecclesiam tuam beati Thomae, confessoris tui atque doctoris, mira eruditione clarificas, et sancta operatione foecundas: da nobis, quaesumus, et quae docuit, intellectu conspicere, et quae egit, imitatione complere. Per Christum, etc."
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias."
+                "la": "Deus, qui Ecclesiam tuam beati Thomae, confessoris tui atque doctoris, mira eruditione clarificas, et sancta operatione foecundas: da nobis, quaesumus, et quae docuit, intellectu conspicere, et quae egit, imitatione complere. Per Christum, etc."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -259,13 +391,39 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adiutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adiuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adiutorium meum intende.\n℟. Domine, ad adiuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 116"
               }
@@ -277,7 +435,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -289,7 +447,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum. Eccli. 45"
               }
@@ -297,41 +455,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Elegit eum Dominus ex omni carne, et dedit illi coram praecepta et legem vitae et disciplinae, docere Iacob testamentum suum et iudicia sua Israel.\n℟. Deo gratias."
+                "la": "Elegit eum Dominus ex omni carne, et dedit illi coram praecepta et legem vitae et disciplinae, docere Iacob testamentum suum et iudicia sua Israel."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "De cuius fonte luminis\nVerbi coruscant faculae,\nScripturae sacrae numinis,\nEt veritatis regulae."
+                "la": "De cuius fonte luminis\nVerbi coruscant faculae,\nScripturae sacrae numinis,\nEt veritatis regulae.\n\nFulgens doctrinae radiis\nClarus vitae munditia,\nSplendens miris prodigiis,\nDat toti mundo gaudia.\n\nLaus Patri, etc., ut supra."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Fulgens doctrinae radiis\nClarus vitae munditia,\nSplendens miris prodigiis,\nDat toti mundo gaudia."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sapientia requiescit in corde suo."
+                  },
+                  "r": {
+                    "la": "Et prudentia in sermone oris illius."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus Patri, etc., ut supra."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Sapientia requiescit in corde suo.\n℟. Et prudentia in sermone oris illius."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Zachariae"
               }
@@ -343,7 +502,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -355,22 +514,55 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Ecclesiam tuam beati Thomae, confessoris tui atque doctoris, mira eruditione clarificas, et sancta operatione foecundas:\nda nobis, quaesumus, et quae docuit, intellectu conspicere, et quae egit, imitatione complere. Per Christum Dominum nostrum.\nAmen."
+                "la": "Deus, qui Ecclesiam tuam beati Thomae, confessoris tui atque doctoris, mira eruditione clarificas, et sancta operatione foecundas:\nda nobis, quaesumus, et quae docuit, intellectu conspicere, et quae egit, imitatione complere. Per Christum Dominum nostrum.\nAmen."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -383,31 +575,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adiutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adiuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adiutorium meum intende.\n℟. Domine, ad adiuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Thomas insignis genere,\nClaram ducens originem,\nSubit aetatis tenerae\nPraedicatorum Ordinem."
+                "la": "Thomas insignis genere,\nClaram ducens originem,\nSubit aetatis tenerae\nPraedicatorum Ordinem.\n\nLaus Patri, etc., ut supra."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus Patri, etc., ut supra."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 53"
               }
@@ -419,13 +631,26 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -445,31 +670,75 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Beatus vir, qui suffert tentationem, quoniam, cum probatus fuerit, accipiet coronam vitae, quam repromisit Deus diligentibus se.\n℟. Deo gratias."
+                "la": "Beatus vir, qui suffert tentationem, quoniam, cum probatus fuerit, accipiet coronam vitae, quam repromisit Deus diligentibus se."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Iesu Christe, Fili Dei vivi,\nPrece Doctoris caelici. Iesu, etc.\n℣. Tibi praesta nos gratos effici.\nPrece, etc. Gloria Patri, etc. Iesu, etc."
+                "la": "Deo gratias."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Exurge Domine, adiuva nos.\n℟. Et libera nos propter nomen tuum."
+                "la": "Iesu Christe, Fili Dei vivi,"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+                "la": "Prece Doctoris caelici. Iesu, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Ecclesiam tuam beati Thomae, confessoris tui atque doctoris, mira eruditione clarificas, et sancta operatione foecundas:\nda nobis, quaesumus, et quae docuit, intellectu conspicere, et quae egit, imitatione complere. Per Christum Dominum nostrum.\nAmen."
+                "la": "Tibi praesta nos gratos effici."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Prece, etc. Gloria Patri, etc. Iesu, etc."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Exurge Domine, adiuva nos."
+                  },
+                  "r": {
+                    "la": "Et libera nos propter nomen tuum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui Ecclesiam tuam beati Thomae, confessoris tui atque doctoris, mira eruditione clarificas, et sancta operatione foecundas:\nda nobis, quaesumus, et quae docuit, intellectu conspicere, et quae egit, imitatione complere. Per Christum Dominum nostrum.\nAmen."
               }
             }
           ]
@@ -483,31 +752,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adiutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adiuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adiutorium meum intende.\n℟. Domine, ad adiuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Typum gessit luciferi\nSplendens in coetu nubium,\nPlusquam doctores caeteri\nPurgans dogma Gentilium."
+                "la": "Typum gessit luciferi\nSplendens in coetu nubium,\nPlusquam doctores caeteri\nPurgans dogma Gentilium.\n\nLaus Patri, etc."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus Patri, etc."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 14"
               }
@@ -519,13 +808,26 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -537,7 +839,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum"
               }
@@ -545,31 +847,69 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Elegit eum Dominus ex omni carne, et dedit illi coram praecepta et legem vitae et disciplinae, docere Iacob testamentum suum et iudicia sua Israel.\n℟. Deo gratias."
+                "la": "Elegit eum Dominus ex omni carne, et dedit illi coram praecepta et legem vitae et disciplinae, docere Iacob testamentum suum et iudicia sua Israel."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Sancte Thoma, audi rogantes servulos. Sancte, etc.\n℣. Et impetratam nobis caelitus tu defer indulgentiam. Audi, etc.\nGloria Patri, etc. Sancte Thoma, etc."
+                "la": "Deo gratias."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Pie scholarum Patrone, tuorum memor operum.\n℟. Sta coram summo iudice pro tuo coetu pauperum."
+                "la": "Sancte Thoma, audi rogantes servulos. Sancte, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+                "la": "Et impetratam nobis caelitus tu defer indulgentiam. Audi, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Ecclesiam tuam beati Thomae, confessoris tui atque doctoris, mira eruditione clarificas, et sancta operatione foecundas:\nda nobis, quaesumus, et quae docuit, intellectu conspicere, et quae egit, imitatione complere. Per Christum Dominum nostrum.\nAmen."
+                "la": "Gloria Patri, etc. Sancte Thoma, etc."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Pie scholarum Patrone, tuorum memor operum."
+                  },
+                  "r": {
+                    "la": "Sta coram summo iudice pro tuo coetu pauperum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui Ecclesiam tuam beati Thomae, confessoris tui atque doctoris, mira eruditione clarificas, et sancta operatione foecundas:\nda nobis, quaesumus, et quae docuit, intellectu conspicere, et quae egit, imitatione complere. Per Christum Dominum nostrum.\nAmen."
               }
             }
           ]
@@ -583,31 +923,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adiutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adiuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adiutorium meum intende.\n℟. Domine, ad adiuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Profunda scrutans fluminum\nIn lucem pandit abdita,\nDum supra sensus hominum\nObscura facit cognita."
+                "la": "Profunda scrutans fluminum\nIn lucem pandit abdita,\nDum supra sensus hominum\nObscura facit cognita.\n\nLaus Patri, etc., ut supra."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus Patri, etc., ut supra."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 130"
               }
@@ -619,13 +979,26 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -637,7 +1010,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum. Eccli. 39"
               }
@@ -645,31 +1018,69 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ipse tanquam imbres mittet eloquia sapientiae suae,\net palam faciet disciplinam doctrinae eius,\ncollaudabunt multi sapientiam eius,\net usque in saeculo non delebitur.\n℟. Deo gratias."
+                "la": "Ipse tanquam imbres mittet eloquia sapientiae suae,\net palam faciet disciplinam doctrinae eius,\ncollaudabunt multi sapientiam eius,\net usque in saeculo non delebitur."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Pie scholarum Patrone, tuorum memor operum. Pie, etc.\n℣. Sta coram summo iudice pro tuo coetu pauperum. Tuorum, etc.\nGloria Patri, etc. Pie, etc."
+                "la": "Deo gratias."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Magne Pater, sancte Thoma, mortis hora nos tecum suscipe.\n℟. Et hic semper nos pie respice."
+                "la": "Pie scholarum Patrone, tuorum memor operum. Pie, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+                "la": "Sta coram summo iudice pro tuo coetu pauperum. Tuorum, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Ecclesiam tuam beati Thomae, confessoris tui atque doctoris, mira eruditione clarificas,\net sancta operatione foecundas:\nda nobis, quaesumus, et quae docuit, intellectu conspicere,\net quae egit, imitatione complere.\nPer Christum Dominum nostrum.\nAmen."
+                "la": "Gloria Patri, etc. Pie, etc."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Magne Pater, sancte Thoma, mortis hora nos tecum suscipe."
+                  },
+                  "r": {
+                    "la": "Et hic semper nos pie respice."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui Ecclesiam tuam beati Thomae, confessoris tui atque doctoris, mira eruditione clarificas,\net sancta operatione foecundas:\nda nobis, quaesumus, et quae docuit, intellectu conspicere,\net quae egit, imitatione complere.\nPer Christum Dominum nostrum.\nAmen."
               }
             }
           ]
@@ -683,31 +1094,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adiutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adiuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adiutorium meum intende.\n℟. Domine, ad adiuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Fit Paradisi fluvius\nQuadripartite pervius;\nFit Gedeonis gladius,\nTuba, lagena, radius."
+                "la": "Fit Paradisi fluvius\nQuadripartite pervius;\nFit Gedeonis gladius,\nTuba, lagena, radius.\n\nLaus Patri, etc., ut supra."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus Patri, etc., ut supra."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 126"
               }
@@ -719,13 +1150,26 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -737,7 +1181,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum. Sap. 7"
               }
@@ -745,31 +1189,68 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laetatus sum, quoniam antecedebat me ista sapientia,\nquam sine fictione didici, et sine invidia communico,\net honestatem illius non abscondo.\n℟. Deo gratias."
+                "la": "Laetatus sum, quoniam antecedebat me ista sapientia,\nquam sine fictione didici, et sine invidia communico,\net honestatem illius non abscondo."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Magne Pater, sancte Thoma, mortis hora nos tecum suscipe. Magne, etc.\n℣. Et hic semper nos pie respice. Mortis, etc.\nGloria Patri, etc. Magne, etc."
+                "la": "Deo gratias."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℟. Sancte Thoma, lumen Ecclesiae.\n℟. Intercede pro nobis ad Dominum Deum nostrum."
+                "la": "Magne Pater, sancte Thoma, mortis hora nos tecum suscipe. Magne, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+                "la": "Et hic semper nos pie respice. Mortis, etc."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Ecclesiam tuam beati Thomae, confessoris tui atque doctoris, mira eruditione clarificas, et sancta operatione foecundas: da nobis, quaesumus, et quae docuit, intellectu conspicere, et quae egit, imitatione complere.\nPer Christum Dominum nostrum.\nAmen."
+                "la": "Gloria Patri, etc. Magne, etc."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Sancte Thoma, lumen Ecclesiae."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Intercede pro nobis ad Dominum Deum nostrum."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui Ecclesiam tuam beati Thomae, confessoris tui atque doctoris, mira eruditione clarificas, et sancta operatione foecundas: da nobis, quaesumus, et quae docuit, intellectu conspicere, et quae egit, imitatione complere.\nPer Christum Dominum nostrum.\nAmen."
               }
             }
           ]
@@ -783,13 +1264,39 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adiutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adiuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adiutorium meum intende.\n℟. Domine, ad adiuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 111"
               }
@@ -801,13 +1308,26 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -819,49 +1339,44 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Elegit eum, etc., ut supra ad Laudes."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Lauda, mater Ecclesia,\nThomae felicem exitum,\nQui pervenit ad gaudia,\nPer Verbi vitae meritum."
+                "la": "Lauda, mater Ecclesia,\nThomae felicem exitum,\nQui pervenit ad gaudia,\nPer Verbi vitae meritum.\n\nFossa Nova tunc suscipit\nThecam thesauri gratiae,\nCum Christus Thomam efficit\nHaeredem regni gloriae.\n\nLaus Patri, etc., ut supra."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Fossa Nova tunc suscipit\nThecam thesauri gratiae,\nCum Christus Thomam efficit\nHaeredem regni gloriae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis, beate Thoma."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus Patri, etc., ut supra."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis, beate Thoma.\n℟. Ut digni efficiamur promissionibus Christi."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Beatae Virginis"
               }
@@ -873,7 +1388,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -885,15 +1400,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Ecclesiam tuam beati Thomae, confessoris tui atque doctoris, mira eruditione clarificas,\net sancta operatione foecundas:\nda nobis, quaesumus, et quae docuit, intellectu conspicere,\net quae egit, imitatione complere.\nPer Christum Dominum nostrum.\nAmen."
+                "la": "Deus, qui Ecclesiam tuam beati Thomae, confessoris tui atque doctoris, mira eruditione clarificas,\net sancta operatione foecundas:\nda nobis, quaesumus, et quae docuit, intellectu conspicere,\net quae egit, imitatione complere.\nPer Christum Dominum nostrum.\nAmen."
               }
             }
           ]
@@ -907,13 +1435,39 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adiutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adiuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus, in adiutorium meum intende.\n℟. Domine, ad adiuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus 133"
               }
@@ -925,13 +1479,26 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria Patri, et Filio, et Spiritui Sancto."
+                  },
+                  "r": {
+                    "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum.\nAmen."
+                "la": "Amen."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -943,7 +1510,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Capitulum (Eccli. 15)"
               }
@@ -951,35 +1518,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "In medio Ecclesiae aperuit os eius;\net implevit eum Dominus spiritu sapientiae et intellectus;\nstolam gloriae induit eum.\n℟. Deo gratias."
+                "la": "In medio Ecclesiae aperuit os eius;\net implevit eum Dominus spiritu sapientiae et intellectus;\nstolam gloriae induit eum."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Manens doctrinae veritas,\nEt funeris integritas,\nMira fragrans suavitas,\nAegris collata sanitas.\nMonstrat hunc dignum laudibus\nTerrae, ponto, et superis:\nNos iuvet suis precibus,\nDeo commendet meritis."
+                "la": "Manens doctrinae veritas,\nEt funeris integritas,\nMira fragrans suavitas,\nAegris collata sanitas.\nMonstrat hunc dignum laudibus\nTerrae, ponto, et superis:\nNos iuvet suis precibus,\nDeo commendet meritis.\n\nLaus Patri, etc., ut supra."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus Patri, etc., ut supra."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Custodi nos, beate Thoma, ut pupillam oculi."
+                  },
+                  "r": {
+                    "la": "Sub umbra alarum tuarum protege nos."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Custodi nos, beate Thoma, ut pupillam oculi.\n℟. Sub umbra alarum tuarum protege nos."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Simeonis"
               }
@@ -991,7 +1565,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -1003,15 +1577,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Ecclesiam tuam beati Thomae, confessoris tui atque doctoris, mira eruditione clarificas,\net sancta operatione foecundas:\nda nobis, quaesumus, et quae docuit, intellectu conspicere,\net quae egit, imitatione complere.\nPer Christum Dominum nostrum.\nAmen."
+                "la": "Deus, qui Ecclesiam tuam beati Thomae, confessoris tui atque doctoris, mira eruditione clarificas,\net sancta operatione foecundas:\nda nobis, quaesumus, et quae docuit, intellectu conspicere,\net quae egit, imitatione complere.\nPer Christum Dominum nostrum.\nAmen."
               }
             }
           ]

--- a/content/practices/little-office-sacred-heart-of-jesus/flow.json
+++ b/content/practices/little-office-sacred-heart-of-jesus/flow.json
@@ -15,11 +15,19 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.",
-        "en-US": "℣. O Lord, open my lips.\n℟. And my mouth will announce Thy praise."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Domine labia mea aperies.",
+            "en-US": "O Lord, open my lips."
+          },
+          "r": {
+            "la": "Et os meum annuntiabit laudem tuam.",
+            "en-US": "And my mouth will announce Thy praise."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -29,11 +37,34 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Deus in adiutorium meum intende.\n℟. Domine ad adiuvandum me festina.\n℣. Gloria Patri, et Filio, et Spiritui Sancto.\n℟. Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Alleluia.",
-        "en-US": "℣. O God, come to my aid.\n℟. O Lord, make haste to help me.\n℣. Glory be to the Father, and to the Son, and to the Holy Spirit.\n℟. As it was in the beginning, is now, and ever shall be, world without end. Alleluia."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Deus in adiutorium meum intende.",
+            "en-US": "O God, come to my aid."
+          },
+          "r": {
+            "la": "Domine ad adiuvandum me festina.",
+            "en-US": "O Lord, make haste to help me."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Gloria Patri, et Filio, et Spiritui Sancto.",
+            "en-US": "Glory be to the Father, and to the Son, and to the Holy Spirit."
+          },
+          "r": {
+            "la": "Sicut erat in principio, et nunc, et semper, et in saecula saeculorum. Alleluia.",
+            "en-US": "As it was in the beginning, is now, and ever shall be, world without end. Alleluia."
+          }
+        }
+      ]
     },
     {
       "type": "rubric",
@@ -43,11 +74,19 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Cor Iesu, flagrans amore nostri.\n℟. Inflamma cor nostrum amore tui.",
-        "en-US": "℣. Heart of Jesus, flaming with love of us.\n℟. Inflame our hearts with love of Thee."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Cor Iesu, flagrans amore nostri.",
+            "en-US": "Heart of Jesus, flaming with love of us."
+          },
+          "r": {
+            "la": "Inflamma cor nostrum amore tui.",
+            "en-US": "Inflame our hearts with love of Thee."
+          }
+        }
+      ]
     },
     {
       "type": "select",
@@ -83,7 +122,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -114,7 +153,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -145,7 +184,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -176,7 +215,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -207,7 +246,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -238,7 +277,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -269,7 +308,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -300,7 +339,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant.",
                 "en-US": "Ant."
@@ -325,10 +364,32 @@
       }
     },
     {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Paratum cor meum, Deus cordis mei, ut faciam voluntatem tuam.",
+            "en-US": "My heart is ready, O God of my heart, that I may do Thy will."
+          },
+          "r": {
+            "la": "Deus meus, volui, et legem tuam in medio cordis mei.",
+            "en-US": "My God, I have desired Thy Law in the depths of my heart."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus.",
+        "en-US": "Let us pray."
+      }
+    },
+    {
       "type": "prayer",
       "inline": {
-        "la": "℣. Paratum cor meum, Deus cordis mei, ut faciam voluntatem tuam.\n℟. Deus meus, volui, et legem tuam in medio cordis mei.\nOremus,\nDomine Iesu, qui ineffabiles Cordis tui dulcedines ac divitias Ecclesiae, Sponsae tuae, singulari dilectione aperire dignatus es: concede nobis famulis tuis, ut gratiis caelestibus ex hoc dulcissimo fonte manantibus ditari et recreari mereamur. Qui vivis et regnas in saecula saeculorum.\nAmen.",
-        "en-US": "℣. My heart is ready, O God of my heart, that I may do Thy will.\n℟. My God, I have desired Thy Law in the depths of my heart.\nLet us pray,\nLord Jesus, Who hast deigned to open by Thy special love the unutterable goodness and riches of Thy Heart to Thy Bride, the Church: grant to us, Thy servants, that we may merit to be enriched and refreshed by Thy heavenly graces, flowing from this sweetest of fountains. Thou who livest and reignest forever and ever.\nAmen."
+        "la": "Domine Iesu, qui ineffabiles Cordis tui dulcedines ac divitias Ecclesiae, Sponsae tuae, singulari dilectione aperire dignatus es: concede nobis famulis tuis, ut gratiis caelestibus ex hoc dulcissimo fonte manantibus ditari et recreari mereamur. Qui vivis et regnas in saecula saeculorum.\nAmen.",
+        "en-US": "Lord Jesus, Who hast deigned to open by Thy special love the unutterable goodness and riches of Thy Heart to Thy Bride, the Church: grant to us, Thy servants, that we may merit to be enriched and refreshed by Thy heavenly graces, flowing from this sweetest of fountains. Thou who livest and reignest forever and ever.\nAmen."
       }
     }
   ]

--- a/content/practices/little-office-saint-augustine/flow.json
+++ b/content/practices/little-office-saint-augustine/flow.json
@@ -44,25 +44,51 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Aurora veris tenera\nPrimo aetatis flore,\nUt et juventus valida,\nEbulliens calore,\n\nNon sat pudica fluxerat\nAddicta vanitati,\nSaclicque tunc scateurat\nErrore depravati;\nNam Manichaea haeresi\nMens erat illinita,\nUt gemma, quae sub sordidi\nEst luto coeni sita."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -70,13 +96,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Invenit Augustinus se longe esse a Deo in Regione dissimilitudinis, et respexit eum Dominus, et misit in mentem ejus, et lucebat in eo gratia Dei: et invisibilia Dei per ea, quae facta sunt, intellectu conspexit, et non tardavit converti ad Dominum.\n℣. Elegit eum Dominus sacerdotem sibi,\n℟. Ad sacrificandum ei hostiam laudis."
+                "la": "Invenit Augustinus se longe esse a Deo in Regione dissimilitudinis, et respexit eum Dominus, et misit in mentem ejus, et lucebat in eo gratia Dei: et invisibilia Dei per ea, quae facta sunt, intellectu conspexit, et non tardavit converti ad Dominum."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Elegit eum Dominus sacerdotem sibi,"
+                  },
+                  "r": {
+                    "la": "Ad sacrificandum ei hostiam laudis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nAdesto supplicationibus nostris Omnipotens Deus, et quibus fiduciam sperandae pietatis indulges, intercedente beato Augustino confessae misericordiae tribue benignus effectum. Per Dominum nostrum etc."
+                "la": "Adesto supplicationibus nostris Omnipotens Deus, et quibus fiduciam sperandae pietatis indulges, intercedente beato Augustino confessae misericordiae tribue benignus effectum. Per Dominum nostrum etc."
               }
             }
           ]
@@ -96,25 +141,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Sacro pregnans negotio\nSe sensit admoneri,\nFluctuque mentem vario\nDivinitus moveri;\nHinc ut vocanti cederet,\nCedit, dum provocatur,\nAc verius ut crederet,\nJam sectas detestatur.\n\nEt quidem hunc Ambrosius\nDecebat, ut doceret;\nAmbrosia quo dulcius\nSe melli commisceret."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -122,13 +180,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Vulneraverat charitas Christi cor ejus, et gestabat verba ejus in visceribus, quasi sagittas acutas. Tempore accepto exaudivit eum Dominus, et in die salutis adjuvit eum.\n℣. Tu es Sacerdos in aeternum,\n℟. Secundum ordinem Melchisedech."
+                "la": "Vulneraverat charitas Christi cor ejus, et gestabat verba ejus in visceribus, quasi sagittas acutas. Tempore accepto exaudivit eum Dominus, et in die salutis adjuvit eum."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Tu es Sacerdos in aeternum,"
+                  },
+                  "r": {
+                    "la": "Secundum ordinem Melchisedech."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus virtutum, cujus est totum, quod est optimum; infere per intercessionem S. Augustini pectoribus nostris amorem tuum, et praesta in nobis Religionis augmentum; ut quae sunt bona nutrias, ac pietatis studio, quae sunt nutrita, custodias. Per Dominum etc."
+                "la": "Deus virtutum, cujus est totum, quod est optimum; infere per intercessionem S. Augustini pectoribus nostris amorem tuum, et praesta in nobis Religionis augmentum; ut quae sunt bona nutrias, ac pietatis studio, quae sunt nutrita, custodias. Per Dominum etc."
               }
             }
           ]
@@ -148,25 +225,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Aquis perfusus lustricis\nMentem sortitur mundam,\nPatrinis gaudet Superis,\nCandore vincens undam,\n\nEt purus jam a sordibus\nCoelique Candidatus,\nPeccata tingit fletibus,\nEt abluit reatus;\n\nSic saepe poenitentia\nPlus habet sanctitatis,\nQuam signis innocentia\nIn pace puritatis."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -174,13 +264,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Conversus est ad Deum ex toto corde suo, in jejunio, in fletu et planctu. Et misertus est ejus ex alto Dominus, quoniam multus est ad ignoscendum.\n℣. Justum deduxit Dominus per vias rectas,\n℟. Et ostendit illi Regnum Dei."
+                "la": "Conversus est ad Deum ex toto corde suo, in jejunio, in fletu et planctu. Et misertus est ejus ex alto Dominus, quoniam multus est ad ignoscendum."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Justum deduxit Dominus per vias rectas,"
+                  },
+                  "r": {
+                    "la": "Et ostendit illi Regnum Dei."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nExaudi quaesumus Domine preces nostras, quas in Beati Augustini conversione deferimus, et qui tibi digne meruit famulari, ejus suffragantibus meritis, ab omnibus nos absolve peccatis. Per Dominum nostrum etc."
+                "la": "Exaudi quaesumus Domine preces nostras, quas in Beati Augustini conversione deferimus, et qui tibi digne meruit famulari, ejus suffragantibus meritis, ab omnibus nos absolve peccatis. Per Dominum nostrum etc."
               }
             }
           ]
@@ -200,25 +309,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Divini totus conflagrant\nUt ignibus amoris,\nSupemis sic exuberat\nEt imbribus favoris,\n\nQuid eligat? hinc Vulnera\nCruore purpurata?\nNum casta Matris Ubera\nLacte inebriata?\n\nQuid praestat? eligere\nAmbiguo vix datur,\nDum hic laetatur ubere,\nHic sanguine potatur."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -246,25 +368,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Praesul mirato vertice\nSupremae Sanctitatis,\nDevinxit sectas strenue,\nHostesque veritatis,\n\nPelagiana somnia\nConvellit et revellit,\nFalsa perstringit dogmata,\nEt haereses repellit,\n\nDoctoris jure laurea\nEt mista sic ornatus,\nEcclesiae fert munia\nQuaternus Doctoratus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -272,13 +407,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "In medio Ecclesiae aperuit os ejus, et implevit eum Dominus Spiritu sapientiae et intellectus, jucunditatem et exultationem thesaurizavit super eum.\n℣. Lex Dei in corde ipsius.\n℟. Et non supplantabuntur gressus ejus."
+                "la": "In medio Ecclesiae aperuit os ejus, et implevit eum Dominus Spiritu sapientiae et intellectus, jucunditatem et exultationem thesaurizavit super eum."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Lex Dei in corde ipsius."
+                  },
+                  "r": {
+                    "la": "Et non supplantabuntur gressus ejus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui per B. Augustinum Confessorem tuum atque Pontificem Ecclesiam tuam nova prole fecundasti, praesta quaesumus, ut ejus intercessione, quod ore simul et opere docuit, te adjuvante exercere valeamus. Per Dominum etc."
+                "la": "Deus, qui per B. Augustinum Confessorem tuum atque Pontificem Ecclesiam tuam nova prole fecundasti, praesta quaesumus, ut ejus intercessione, quod ore simul et opere docuit, te adjuvante exercere valeamus. Per Dominum etc."
               }
             }
           ]
@@ -298,25 +452,38 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Aetate tandem plurima,\nSed non labore lassus,\nFebri crematur ignea,\nPlus ab amore passus,\n\nSed nempe Phoeninx gratiae,\nPhoenix scientiarum,\nDierum finem clauderet\nSic decus istuarum;\n\nAmore totus conflagrans\nPetit aeternitatem,\nLucent calori socians,\nDoctrinae sanctitatem."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -324,13 +491,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "O Doctor optime, Ecclesiae sanctae lumen B. Augustine, divine legis amator, deprecare pro nobis Filium Dei.\n℣. Euge serve bone et fidelis.\n℟. Intra in gaudium Domini tui."
+                "la": "O Doctor optime, Ecclesiae sanctae lumen B. Augustine, divine legis amator, deprecare pro nobis Filium Dei."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Euge serve bone et fidelis."
+                  },
+                  "r": {
+                    "la": "Intra in gaudium Domini tui."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui per os servi tui Augustini dixisti: non potest male mori, qui bene vixit, ipsius intercessione praesta supplicibus tuis perseverantiae sanctae virtutem, ut mors temporalis sit nobis beatae immortalitatis principium. Per Dominum etc."
+                "la": "Deus, qui per os servi tui Augustini dixisti: non potest male mori, qui bene vixit, ipsius intercessione praesta supplicibus tuis perseverantiae sanctae virtutem, ut mors temporalis sit nobis beatae immortalitatis principium. Per Dominum etc."
               }
             }
           ]
@@ -350,25 +536,51 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Phoenix ad astra transit,\nNon morte, sed sopore,\nQuin imo, adhuc suppetit\nNatorum in honore!\n\nFundator ingens inclyta\nSequela alumnorum,\nProbatam per miracula\nSacrorum normam morum\n\nPer Orbis spargit ambitum,\nTrans aequor et promulgat,\nUltraque solem cognitum\nPer socios divulgat."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -376,13 +588,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Praesul sanctissime Augustine, Canon vitae Canonicae, via morum, Doctor egregie, Lux Doctorum, roga Christum pro nobis, ut nostris adsit mentibus, et in aeterna requie suis jungat agminibus.\n℣. Beati servi ejus, qui stant coram eo.\n℟. Et audiunt sapientiam ejus."
+                "la": "Praesul sanctissime Augustine, Canon vitae Canonicae, via morum, Doctor egregie, Lux Doctorum, roga Christum pro nobis, ut nostris adsit mentibus, et in aeterna requie suis jungat agminibus."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Beati servi ejus, qui stant coram eo."
+                  },
+                  "r": {
+                    "la": "Et audiunt sapientiam ejus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui nos per Evangelium Filii tui, et exhortationem B. Augustini ad salutiferae Crucis militiam congregasti: praesta quaesumus, ut ejusdem gloriosi Ducis muniti praesidiis, quod exemplo docuit, te adjuvante opere compleamus. Per Dominum etc."
+                "la": "Deus, qui nos per Evangelium Filii tui, et exhortationem B. Augustini ad salutiferae Crucis militiam congregasti: praesta quaesumus, ut ejusdem gloriosi Ducis muniti praesidiis, quod exemplo docuit, te adjuvante opere compleamus. Per Dominum etc."
               }
             }
           ]

--- a/content/practices/little-office-saint-george/flow.json
+++ b/content/practices/little-office-saint-george/flow.json
@@ -58,51 +58,72 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Martem secutus inclytum\nChristi pugil Georgius\nUt Caesaris signiferi\nExhibuit se strenuus"
+                "la": "Martem secutus inclytum\nChristi pugil Georgius\nUt Caesaris signiferi\nExhibuit se strenuus\n\nAetate Juvenili:\nSecuta mox virili\nPro milite nunc martyr sit,\nNe dubium proinde sit,\n\nSic Deo se, quae Dei sunt,\nEt Caesari, quae sua sunt,\nDedisse: ut impleret,\nQuae Christus nos doceret;\n\nLaus sit perpetua\nPatrique, Filioque,\nSpiranti ab utroque\nPar sit et gloria."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria et honore coronasti eum Domine,"
+                  },
+                  "r": {
+                    "la": "Et constituisti eum super opera manuum tuarum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Aetate Juvenili:\nSecuta mox virili\nPro milite nunc martyr sit,\nNe dubium proinde sit,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sic Deo se, quae Dei sunt,\nEt Caesari, quae sua sunt,\nDedisse: ut impleret,\nQuae Christus nos doceret;"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus sit perpetua\nPatrique, Filioque,\nSpiranti ab utroque\nPar sit et gloria."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Gloria et honore coronasti eum Domine,\n℟. Et constituisti eum super opera manuum tuarum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus qui nos beati Georgii Martyris tui meritis et intercessione laetificas, concede propitius, ut qui tua per eum beneficia poscimus, dono tuae gratiae consequamur. Per Dominum nostrum Jesum Christum etc."
+                "la": "Deus qui nos beati Georgii Martyris tui meritis et intercessione laetificas, concede propitius, ut qui tua per eum beneficia poscimus, dono tuae gratiae consequamur. Per Dominum nostrum Jesum Christum etc."
               }
             }
           ]
@@ -116,51 +137,59 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Partis trophaeis plurimis,\nCentumque fusis hostibus,\nFlorebat amplis gratiis\nEt Caesarum favoribus,"
+                "la": "Partis trophaeis plurimis,\nCentumque fusis hostibus,\nFlorebat amplis gratiis\nEt Caesarum favoribus,\n\nTam stemmate excellens,\nQuam meritis praecellens:\nAt Christiani nominis\nHaud immemor nec pectoris,\n\nChristum colebat integre,\nMultatum quamvis sanguine\nId praesciabat fore,\nFidem probat cruore;\n\nLaus sit perpetua\nPatrique, Filioque,\nSpiranti ab utroque\nPar sit et gloria."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Posuisti Domine super caput ejus"
+                  },
+                  "r": {
+                    "la": "Coronam de lapide pretioso."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Tam stemmate excellens,\nQuam meritis praecellens:\nAt Christiani nominis\nHaud immemor nec pectoris,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Christum colebat integre,\nMultatum quamvis sanguine\nId praesciabat fore,\nFidem probat cruore;"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus sit perpetua\nPatrique, Filioque,\nSpiranti ab utroque\nPar sit et gloria."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Posuisti Domine super caput ejus\n℟. Coronam de lapide pretioso."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nPresta quaesumus Omnipotens Deus, ut qui beati Georgii Martyris tui glorioso martyrio colimus, intercessione ejus in tui Nominis amore roboremur. Per Dominum nostrum etc."
+                "la": "Presta quaesumus Omnipotens Deus, ut qui beati Georgii Martyris tui glorioso martyrio colimus, intercessione ejus in tui Nominis amore roboremur. Per Dominum nostrum etc."
               }
             }
           ]
@@ -174,51 +203,59 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Spontaneae solertia\nOccasio non desuit.\nDum Caesaris saevitiae\nPavore procul restitit,"
+                "la": "Spontaneae solertia\nOccasio non desuit.\nDum Caesaris saevitiae\nPavore procul restitit,\n\nIdola contemnendo,\nSic Caesari loquendo:\nChristiadum cur sanguinem\nQuid purpuram tam nobilem\n\nImmisit ita appetis?\nCrudelis ita prodigis?\nSi sanguis est fundendus,\nAb improbis petendus.\n\nLaus sit perpetua,\nPatrique, Filioque,\nSpiranti ab utroque\nPar sit et gloria."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Magna est gloria ejus in salutari tuo,"
+                  },
+                  "r": {
+                    "la": "Gloriam et magnum decorem impones super eum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Idola contemnendo,\nSic Caesari loquendo:\nChristiadum cur sanguinem\nQuid purpuram tam nobilem"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Immisit ita appetis?\nCrudelis ita prodigis?\nSi sanguis est fundendus,\nAb improbis petendus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus sit perpetua,\nPatrique, Filioque,\nSpiranti ab utroque\nPar sit et gloria."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Magna est gloria ejus in salutari tuo,\n℟. Gloriam et magnum decorem impones super eum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nLargire, quaesumus Omnipotens Deus, ut intercedente beato Georgio Martyre tuo, et a cunctis adversitatibus liberemur in corpore, et a pravis cogitationibus mundemur in mente. Per Dominum etc."
+                "la": "Largire, quaesumus Omnipotens Deus, ut intercedente beato Georgio Martyre tuo, et a cunctis adversitatibus liberemur in corpore, et a pravis cogitationibus mundemur in mente. Per Dominum etc."
               }
             }
           ]
@@ -232,51 +269,59 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "His efferatus vocibus,\nSpumantis instar pelagi,\nCaesar jubet, Georgius\nArcto mandetur carcere,"
+                "la": "His efferatus vocibus,\nSpumantis instar pelagi,\nCaesar jubet, Georgius\nArcto mandetur carcere,\n\nSed hem! Tyranne audi,\nNon potest virtus claudi:\nEst carcer ut palatium,\nAulae sacrae compendium,\n\nNescit ligari funibus,\nCatenae sunt prae torquibus,\nAmantis in thesauro\nPlus vincula valent auro.\n\nLaus sit perpetua,\nPatrique, Filioque,\nSpiranti ab utroque\nPar sit et gloria."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Justus ut palma florebit."
+                  },
+                  "r": {
+                    "la": "Sicut cedrus Libani multiplicabitur."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Sed hem! Tyranne audi,\nNon potest virtus claudi:\nEst carcer ut palatium,\nAulae sacrae compendium,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Nescit ligari funibus,\nCatenae sunt prae torquibus,\nAmantis in thesauro\nPlus vincula valent auro."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus sit perpetua,\nPatrique, Filioque,\nSpiranti ab utroque\nPar sit et gloria."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Justus ut palma florebit.\n℟. Sicut cedrus Libani multiplicabitur."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nInfirmitatem nostram respice Omnipotens Deus; et quia pondus propriae actionis gravat, beati Georgii Martyris tui intercessio gloriosa nos protegat. Per Dominum nostrum etc."
+                "la": "Infirmitatem nostram respice Omnipotens Deus; et quia pondus propriae actionis gravat, beati Georgii Martyris tui intercessio gloriosa nos protegat. Per Dominum nostrum etc."
               }
             }
           ]
@@ -290,51 +335,59 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Isthinc famet Georgius,\nConviva coeli nobilis,\nFame fruens pro dapibus,\nSupernis satur epulis,"
+                "la": "Isthinc famet Georgius,\nConviva coeli nobilis,\nFame fruens pro dapibus,\nSupernis satur epulis,\n\nNam qui divina noscit,\nTerrena non exposcit:\nNunc nervis quoque vapulat\nQuos Miles Christi tolerat\n\nNervosus inter scuticaes\nSartagines et ungulas;\nQuin saxum et molare\nJam suscipit portare.\n\nLaus sit perpetua\nPatrique, Filioque,\nSpiranti ab utroque\nPar sit et gloria."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Justum deduxit Dominus per vias rectas,"
+                  },
+                  "r": {
+                    "la": "Et ostendit illi regnum Dei."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Nam qui divina noscit,\nTerrena non exposcit:\nNunc nervis quoque vapulat\nQuos Miles Christi tolerat"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Nervosus inter scuticaes\nSartagines et ungulas;\nQuin saxum et molare\nJam suscipit portare."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus sit perpetua\nPatrique, Filioque,\nSpiranti ab utroque\nPar sit et gloria."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Justum deduxit Dominus per vias rectas,\n℟. Et ostendit illi regnum Dei."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui beatum Georgium Martyrem tuum virtute constantiae in passione roborasti: tribue nobis, quaesumus, ejus imitatione pro amore tuo prospera mundi despicere, et nulla ejus adversa formidare. Per Dominum etc."
+                "la": "Deus, qui beatum Georgium Martyrem tuum virtute constantiae in passione roborasti: tribue nobis, quaesumus, ejus imitatione pro amore tuo prospera mundi despicere, et nulla ejus adversa formidare. Per Dominum etc."
               }
             }
           ]
@@ -348,51 +401,59 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ingens tunc surgit fabrica,\nQuae flexili vertigine\nRotunda versans machina\nCultris horrescit undique"
+                "la": "Ingens tunc surgit fabrica,\nQuae flexili vertigine\nRotunda versans machina\nCultris horrescit undique\n\nFalce novaculisque\nPlus acribus, dirisque:\nInnexus huic Georgius\nJam carne totus saucius\n\nIn frusta vix non scinditur,\nEt tamen non offenditur;\nNam Angelus curatum\nMox adest vulneratum.\n\nLaus sit perpetua\nPatrique, Filioque,\nSpiranti ab utroque\nPar sit et gloria."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Laetitia sempiterna super caput ejus,"
+                  },
+                  "r": {
+                    "la": "Gaudium et exultationem obtinebit."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Falce novaculisque\nPlus acribus, dirisque:\nInnexus huic Georgius\nJam carne totus saucius"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "In frusta vix non scinditur,\nEt tamen non offenditur;\nNam Angelus curatum\nMox adest vulneratum."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus sit perpetua\nPatrique, Filioque,\nSpiranti ab utroque\nPar sit et gloria."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Laetitia sempiterna super caput ejus,\n℟. Gaudium et exultationem obtinebit."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nDeus, qui nos in tantis periculis constitutos pro humana scis fragilitate non posse subsistere; da nobis intercedente beato Georgio Martyre tuo salutem mentis et corporis; ut ea, quae pro peccatis nostris patimur, te adjuvante vincamus. Per Dominum nostrum etc."
+                "la": "Deus, qui nos in tantis periculis constitutos pro humana scis fragilitate non posse subsistere; da nobis intercedente beato Georgio Martyre tuo salutem mentis et corporis; ut ea, quae pro peccatis nostris patimur, te adjuvante vincamus. Per Dominum nostrum etc."
               }
             }
           ]
@@ -406,51 +467,59 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Fornax ardet calcaria,\nEt saeviente Mulciber\nIgne quaecunque obvia\nDepascitur ferociter,"
+                "la": "Fornax ardet calcaria,\nEt saeviente Mulciber\nIgne quaecunque obvia\nDepascitur ferociter,\n\nGeorgio illeso,\nArdoris imperatos:\nHinc magis Caesar aestuat\nFornace quam succenderat;\n\nSed ut in igne fortius\nFit aurum, sic Georgius\nRobustior procedit,\nFornace dum excedit.\n\nLaus sit perpetua,\nPatrique, Filioque,\nSpiranti ab utroque\nPar sit et gloria."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Pretiosa in conspectu Domini"
+                  },
+                  "r": {
+                    "la": "Mors Sanctorum ejus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Georgio illeso,\nArdoris imperatos:\nHinc magis Caesar aestuat\nFornace quam succenderat;"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Sed ut in igne fortius\nFit aurum, sic Georgius\nRobustior procedit,\nFornace dum excedit."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus sit perpetua,\nPatrique, Filioque,\nSpiranti ab utroque\nPar sit et gloria."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Pretiosa in conspectu Domini\n℟. Mors Sanctorum ejus."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nPreces nostras, quaesumus, Domine clementer exaudi, ut beati Georgii Martyris tui meritis adjuvemur, cujus passione laetamur. Per Dominum nostrum etc."
+                "la": "Preces nostras, quaesumus, Domine clementer exaudi, ut beati Georgii Martyris tui meritis adjuvemur, cujus passione laetamur. Per Dominum nostrum etc."
               }
             }
           ]
@@ -464,51 +533,72 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Convertere nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Convertere nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Demum Tyrannus impotens\nNostrum jubet Georgium\nPost tantum, tamque insolens,\nCaput dare martyrium;"
+                "la": "Demum Tyrannus impotens\nNostrum jubet Georgium\nPost tantum, tamque insolens,\nCaput dare martyrium;\n\nQuod lubens Ille praebet\nChristo, cui vitam debet;\nQuo facto muri concidunt,\nIdola passim corruunt,\n\nTerra connutat motibus,\nOrbam se quasi dotibus\nGeorgii jam nosset,\nAbs quo non stare posset.\n\nLaus sit perpetua\nPatrique, Filioque,\nSpiranti ab utroque\nPar sit et gloria."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis sancte Martyr Georgi."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Quod lubens Ille praebet\nChristo, cui vitam debet;\nQuo facto muri concidunt,\nIdola passim corruunt,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Terra connutat motibus,\nOrbam se quasi dotibus\nGeorgii jam nosset,\nAbs quo non stare posset."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Laus sit perpetua\nPatrique, Filioque,\nSpiranti ab utroque\nPar sit et gloria."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis sancte Martyr Georgi.\n℟. Ut digni efficiamur promissionibus Christi."
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Oremus,\nPresta, quaesumus, Omnipotens Deus, ut beati Georgii Martyris tui fidem congrua devotione sequamur, qui pro ejusdem dilatione, martyrii palmam meruit obtinere. Per Dominum nostrum etc."
+                "la": "Presta, quaesumus, Omnipotens Deus, ut beati Georgii Martyris tui fidem congrua devotione sequamur, qui pro ejusdem dilatione, martyrii palmam meruit obtinere. Per Dominum nostrum etc."
               }
             }
           ]
@@ -547,15 +637,28 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Accipite armaturam Dei,\n℟. Ut possitis resistere in die malo."
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Accipite armaturam Dei,"
+          },
+          "r": {
+            "la": "Ut possitis resistere in die malo."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nDomine Jesu Christe, pro cujus amore et fidei confessione beatus Georgius Martyr et Miles tuus invictissimus diversa vicit tormenta, et ad mortem usque certando capitalem subiit sententiam; praesta, quaesumus, ut qui ad eum in angustiis nostris fiducialiter recurrere praesumimus, intercessionis ejus auxilio a diaboli laqueis, et ab omni mentis et corporis adversitate liberemur. Qui vivis et regnas etc.\nAmen."
+        "la": "Domine Jesu Christe, pro cujus amore et fidei confessione beatus Georgius Martyr et Miles tuus invictissimus diversa vicit tormenta, et ad mortem usque certando capitalem subiit sententiam; praesta, quaesumus, ut qui ad eum in angustiis nostris fiducialiter recurrere praesumimus, intercessionis ejus auxilio a diaboli laqueis, et ab omni mentis et corporis adversitate liberemur. Qui vivis et regnas etc.\nAmen."
       }
     }
   ]

--- a/content/practices/little-office-saint-mary-magdalene/flow.json
+++ b/content/practices/little-office-saint-mary-magdalene/flow.json
@@ -27,25 +27,64 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per gemitus et lachrymas beatae Magdalenae."
+                  },
+                  "r": {
+                    "la": "Remittat nobis Dominus peccata nostra plene."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Per gemitus et lachrymas beatae Magdalenae.\n℟. Remittat nobis Dominus peccata nostra plene.\n℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Dum Christo pedes lavera\nO pia Magdalena!\nJam abs reatu fueras\nFavore Jesu plena,\nTot ergo adhuc gemitus\nCur edis? Eequid vultus\nCum lachrymarum fluctibus\nTot exprimit singultus?"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -57,15 +96,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ora pro nobis S. M. Magdalena.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ora pro nobis S. M. Magdalena."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nBeatae Mariae Magdalenae quaesumus Domine, suffragiis adjuvemur, ut quam fides et dilectio sua salvam fecit, ejus quoque meritis ab omnibus malis salvemur in corpore, et a peccatis nostris per veram poenitentiam mundati in mente, aeternum tibi collaetemur in coelis; Qui vivis etc.\nAmen."
+                "la": "Beatae Mariae Magdalenae quaesumus Domine, suffragiis adjuvemur, ut quam fides et dilectio sua salvam fecit, ejus quoque meritis ab omnibus malis salvemur in corpore, et a peccatis nostris per veram poenitentiam mundati in mente, aeternum tibi collaetemur in coelis; Qui vivis etc.\nAmen."
               }
             }
           ]
@@ -79,25 +131,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per gemitus et lachrymas beatae Magdalenae."
+                  },
+                  "r": {
+                    "la": "Remittat nobis Dominus peccata nostra plene."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Per gemitus et lachrymas beatae Magdalenae.\n℟. Remittat nobis Dominus peccata nostra plene.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Nonne in signum gratiae\nDum Christus mox passurus\nParabat valedicere\nMatri, non rediturus,\nIs tibi quoque dixerat\nVale! o Magdalena!\nCur ergo adhuc fluiaat,\nTurgetque fletu gena?"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -125,25 +203,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per gemitus et lachrymas beatae Magdalenae."
+                  },
+                  "r": {
+                    "la": "Remittat nobis Dominus peccata nostra plene."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Per gemitus et lachrymas beatae Magdalenae.\n℟. Remittat nobis Dominus peccata nostra plene.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Quam suaviter respexerit\nIn te ex Cruce pendens,\nQuam Christus te dilexerit,\nEt brachia extendens\nVocaverit ad oscula?\nHoc Magdalena noscis!\nQuid ergo adhuc tristia,\nEt lachrymas exposcis?"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiph."
               }
@@ -171,25 +275,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per gemitus et lachrymas beatae Magdalenae."
+                  },
+                  "r": {
+                    "la": "Remittat nobis Dominus peccata nostra plene."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Per gemitus et lachrymas beatae Magdalenae.\n℟. Remittat nobis Dominus peccata nostra plene.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Tu inter primas nuntium\nLaetissimum audisti,\nResurrexisse Dominum,\nTu prima meruisti\nSub Hortulani specie\nJesum tuum videre,\nQuid ergo adhuc gemere,\nQuid movet adhuc flere?"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -217,25 +347,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per gemitus et lachrymas beatae Magdalenae."
+                  },
+                  "r": {
+                    "la": "Remittat nobis Dominus peccata nostra plene."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Per gemitus et lachrymas beatae Magdalenae.\n℟. Remittat nobis Dominus peccata nostra plene.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Sed, inquis, pia Magdala\nHaud fletuum est satis;\nPlus sunt ploranda crimina\nQuo gratia ingratis\nA Deo major data est;\nQuo laeditur plus Deus,\nAcerbior, ut dignum est,\nHoc sit et dolor meus!"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -263,25 +419,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per gemitus et lachrymas beatae Magdalenae."
+                  },
+                  "r": {
+                    "la": "Remittat nobis Dominus peccata nostra plene."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Per gemitus et lachrymas beatae Magdalenae.\n℟. Remittat nobis Dominus peccata nostra plene.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Hinc plorans solitaria\nSylvarum tesqua quaeris,\nHumana fugis otia,\nAssocians te feris;\nUt Christo, sine arbitro,\nMaria jam gaudere,\nEt planctu possis sedulo\nCommissa porro flere."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -309,25 +491,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per gemitus et lachrymas beatae Magdalenae."
+                  },
+                  "r": {
+                    "la": "Remittat nobis Dominus peccata nostra plene."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Per gemitus et lachrymas beatae Magdalenae.\n℟. Remittat nobis Dominus peccata nostra plene.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Hic lympha, crudae herbululae\nDant vitae nutrimentum,\nQuies flagra, planctus, lacrymae\nAdsunt in condimentum;\nSed dura haec, et aspera\nAligerum beata\nFrequens dulcat praesentia\nEt Musica ter grata."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -355,25 +563,51 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per gemitus et lachrymas beatae Magdalenae."
+                  },
+                  "r": {
+                    "la": "Remittat nobis Dominus peccata nostra plene."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Per gemitus et lachrymas beatae Magdalenae.\n℟. Remittat nobis Dominus peccata nostra plene.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Gloria Patri etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Tandem terdenos Magdala\nCum annos hic egisti,\nAmore Jesu saucia,\nAmplexus inter Christi,\nLaeta in coelum evolas;\nHabens, quem diligebas,\nNobis relinquens lachrymas,\nQuas prius tu fundebas."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -407,7 +641,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Antiph."
       }
@@ -419,15 +653,28 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "℣. Ora pro nobis S. M. Magdalena.\n℟. Ut digni efficiamur etc."
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ora pro nobis S. M. Magdalena."
+          },
+          "r": {
+            "la": "Ut digni efficiamur etc."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nO Benignissime Domine Jesu Christe! tutissimum poenitentium asylum, qui beatae Mariae Magdalenae Poenitentiam ita placitam tibi, gratamque habuisti, ut non solum peccata sua ei dimitteres, verum etiam Cor ejus tanta dulcedine perfunderes, ut pedes tuos ferventissimis irrigaret lachrymis, vitamque suam inter asperrima poenitentiae opera terminarer. Concede quaesumus, ut et nos peccatorum nostrorum multitudinem perfecte agnoscentes turpitudinem, tuaque offensa ingemiscere graviter tecum serio contemplemur, easque animi conversionis et spiritus contritionis actiones fideliter prosequamur illa dulcissima: Remittuntur tibi peccata tua, gratiam tuam plene consequamur, teque bonorum omnium complemento, in coelestibus quondam gaudiis aeternum perfrui mereamur. Qui vivis etc."
+        "la": "O Benignissime Domine Jesu Christe! tutissimum poenitentium asylum, qui beatae Mariae Magdalenae Poenitentiam ita placitam tibi, gratamque habuisti, ut non solum peccata sua ei dimitteres, verum etiam Cor ejus tanta dulcedine perfunderes, ut pedes tuos ferventissimis irrigaret lachrymis, vitamque suam inter asperrima poenitentiae opera terminarer. Concede quaesumus, ut et nos peccatorum nostrorum multitudinem perfecte agnoscentes turpitudinem, tuaque offensa ingemiscere graviter tecum serio contemplemur, easque animi conversionis et spiritus contritionis actiones fideliter prosequamur illa dulcissima: Remittuntur tibi peccata tua, gratiam tuam plene consequamur, teque bonorum omnium complemento, in coelestibus quondam gaudiis aeternum perfrui mereamur. Qui vivis etc."
       }
     }
   ]

--- a/content/practices/little-office-saint-sebastian/flow.json
+++ b/content/practices/little-office-saint-sebastian/flow.json
@@ -29,23 +29,55 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sagittae tuae infixae sunt mihi, et confirmasti super me manum tuam.\n℣. Domine labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Sagittae tuae infixae sunt mihi, et confirmasti super me manum tuam."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "O Sebastiane Gemma!\nQuem et virtus, quem et stemma\nLuce ornant pariili,\nTe Caesarei favores,\nTe commendat formae flores,\nTe acumen animi,\nSed quod magis te honorat,\nEst, Cor tuum quod decorat\nAmor Christi flammeus:\nIs, ut corde hunc celiabis,\nQuo afflictos plus curabis,\nTandem fiet publicus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -53,13 +85,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Cibavit illum pane vitae et intellectus, et aqua sapientiae salutaris potavit illum Dominus.\n℣. Gloria et honore coronasti eum Domine.\n℟. Et constituisti eum super opera manuum tuarum."
+                "la": "Cibavit illum pane vitae et intellectus, et aqua sapientiae salutaris potavit illum Dominus."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria et honore coronasti eum Domine."
+                  },
+                  "r": {
+                    "la": "Et constituisti eum super opera manuum tuarum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nBeati Sebastiani Martyris tui, quaesumus, Domine, intercessione nos adjuva, et ab omni peste mala tuam animam et corpus tuos praeserva, quo meritis ejus et precibus, tuam in praesentia gratiam et in futuro gloriam consequamur aeternam. Per Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit etc.\nAmen."
+                "la": "Beati Sebastiani Martyris tui, quaesumus, Domine, intercessione nos adjuva, et ab omni peste mala tuam animam et corpus tuos praeserva, quo meritis ejus et precibus, tuam in praesentia gratiam et in futuro gloriam consequamur aeternam. Per Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit etc.\nAmen."
               }
             }
           ]
@@ -75,23 +126,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sagittae tuae infixae sunt mihi, et confirmasti super me manum tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Sagittae tuae infixae sunt mihi, et confirmasti super me manum tuam."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Ecquid, inquis, ut confortem,\nJuvat, alios ad mortem\nDucam et ad lauream?\nNi et ipse hanc coronam\nTandem capiti imponam\nMeo Martyr auream;\nMarcus et Marcellianus\nHinc dum vincla tenent manus,\nPlorat dum familia,\nAdes Heros et mutantes,\nInter milites adstantes\nSuada firmas aenea."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -121,23 +191,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sagittae tuae infixae sunt mihi, et confirmasti super me manum tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Sagittae tuae infixae sunt mihi, et confirmasti super me manum tuam."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Haec dum agis, a splendore\nHeres spatium per horae\nTotus circumjiceris,\nSeptem Angelis stipatus,\nVeste nivea donatus,\nQuod sis, et praediceris,\nOmni aevo perstaturus,\nCumque Christo permansurus;\nQuae dum spectant, audiunt,\nEt Nicostratus miratur,\nJamque uxor muta fatur,\nAmbo Christum induunt!"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -167,23 +256,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sagittae tuae infixae sunt mihi, et confirmasti super me manum tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Sagittae tuae infixae sunt mihi, et confirmasti super me manum tuam."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Mille quadringenti sacro\nPost mundati sunt Lavacro\nViri atque feminae:\nSed res ista haud celata,\nQuin ad aulam fuit delata,\nPotuit perstistere;\n\nHinc dum Caesar haec rescisit,\nEt quis Ductor sit, audivit,\nIra tumens rabida,\nHuc Sebastianum dari\nVinctum jubet, et raptari\nAnte tribunalai,"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -213,23 +321,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sagittae tuae infixae sunt mihi, et confirmasti super me manum tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Sagittae tuae infixae sunt mihi, et confirmasti super me manum tuam."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Jamque ades macte heros!\nVultus Caesaris severos\nSustinens intrepide,\nSed et spernis blandimenta,\nQuae minantur, et tormenta\nDivo plenus Numine;\nChristum vocas, Christum doces;\nNihil curans, dum feroces\nMilites jam praeparant,\nJussu Caesaris damnatum\nUt ad palum religatum\nJaculis confodiant."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -259,23 +386,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sagittae tuae infixae sunt mihi, et confirmasti super me manum tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Sagittae tuae infixae sunt mihi, et confirmasti super me manum tuam."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Nec infixit tibi tanta\nMiles atrox, Christo quanta\nTu fixisti spicula:\nSpicula, sed quae Authore\nTibi cusa sunt amore,\nFolle, Patientiae,\nJamque confixum sagittis\nUt te mortuum immitis\nGens opinans abiiit,\nEn! Irene, dum sacratum\nNostru corpus est humatum,\nVivum adhuc reperit."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -305,23 +451,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sagittae tuae infixae sunt mihi, et confirmasti super me manum tuam.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Sagittae tuae infixae sunt mihi, et confirmasti super me manum tuam."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Ab Irene vix curatus\nMox Praetorium Senatus\nMetu procul repetis,\nEt Tyrannum obviantem\nMale diis immolantem\nGenerose corripis,\nHic stupore mox et ira,\nNovitate hac ex mira\nTotus ut excanduit,\nTe ad mortem virgis tergi,\nEt cnectum tunc immergi\nVolutabro praecipit."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -351,23 +516,55 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sagittae tuae infixae sunt mihi, et confirmasti super me manum tuam.\n℣. Converte nos Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus in adjutorium meum intende.\n℟. Domine ad adjuvandum me festina.\nGloria Patri etc."
+                "la": "Sagittae tuae infixae sunt mihi, et confirmasti super me manum tuam."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Sed Tyranne vah! infane,\nEn! Lucina summo mane\nDio docta Morpheo\nAdest, corpus est sacratus\nEx palude jam levatum,\nDivi parens monito,\nAd sanctorum Catacumbas\nGloriosas inter tumbas\nPia manu collocat,\nDehinc in honorem ibi\nO Sebastiane tibi\nTemplum et aedificat."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -401,7 +598,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Ant."
       }
@@ -409,13 +606,32 @@
     {
       "type": "prayer",
       "inline": {
-        "la": "In die illa, qui stat in signum populorum, ipsum Gentes deprecabuntur.\n℣. Ora pro nobis B. Martyr Sebastiane.\n℟. Ut digni efficiamur promissionibus Christi."
+        "la": "In die illa, qui stat in signum populorum, ipsum Gentes deprecabuntur."
+      }
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "la": "Ora pro nobis B. Martyr Sebastiane."
+          },
+          "r": {
+            "la": "Ut digni efficiamur promissionibus Christi."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nDeus, qui B. Sebastianum Martyrem tuum in tua fide, et dilectione tam ardenter solidasti, ut nullis carnalibus blandimentis, nullis Tyrannorum minis, nullisque carnificum plagis aut sagittis a tua cultura potuerit revocari; da nobis miseris peccatoribus, dignis ejus meritis, et intercessionibus in tribulatione auxilium, in persecutione solatium, et in omni tempore contra morbum Epidimiae praesens remedium: quatenus contra omnes diabolicas insidias viriliter dimicare discamus, mundum et ea quae in mundo sunt, despicere, nullaque ejus adversa formidare, sed a te, quae te inspirante desideramus, dona et feliciter consequi mereamur. Per Dominum nostrum Jesum Christum etc."
+        "la": "Deus, qui B. Sebastianum Martyrem tuum in tua fide, et dilectione tam ardenter solidasti, ut nullis carnalibus blandimentis, nullis Tyrannorum minis, nullisque carnificum plagis aut sagittis a tua cultura potuerit revocari; da nobis miseris peccatoribus, dignis ejus meritis, et intercessionibus in tribulatione auxilium, in persecutione solatium, et in omni tempore contra morbum Epidimiae praesens remedium: quatenus contra omnes diabolicas insidias viriliter dimicare discamus, mundum et ea quae in mundo sunt, despicere, nullaque ejus adversa formidare, sed a te, quae te inspirante desideramus, dona et feliciter consequi mereamur. Per Dominum nostrum Jesum Christum etc."
       }
     }
   ]

--- a/content/practices/little-office-serotina/flow.json
+++ b/content/practices/little-office-serotina/flow.json
@@ -19,21 +19,41 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "en-US": "℣. O Holy Banquet,\n℟. in which Christ is received, the memory of his passion is renewed, the soul is filled with grace, and there is given to us a pledge of future glory. (Alleluia)"
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "O Holy Banquet,"
+          },
+          "r": {
+            "en-US": "in which Christ is received, the memory of his passion is renewed, the soul is filled with grace, and there is given to us a pledge of future glory. (Alleluia)"
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "You have given them bread from heaven (Alleluia)"
+          },
+          "r": {
+            "en-US": "Having all sweetness within it (Alleluia)"
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "en-US": "Let us pray."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "en-US": "℣. You have given them bread from heaven (Alleluia)\n℟. Having all sweetness within it (Alleluia)"
-      }
-    },
-    {
-      "type": "prayer",
-      "inline": {
-        "en-US": "Let us pray,\nO God, who in this wonderful sacrament left us a memorial of your passion, grant, we implore you, that we may so venerate the sacred mystery of your body and blood as always to experience the fruits of your redemption. You who live and reign forever and ever."
+        "en-US": "O God, who in this wonderful sacrament left us a memorial of your passion, grant, we implore you, that we may so venerate the sacred mystery of your body and blood as always to experience the fruits of your redemption. You who live and reign forever and ever."
       }
     },
     {
@@ -67,7 +87,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Prayer for the Good of our Community"
       }
@@ -115,13 +135,20 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "en-US": "℣. Let us pray for all the brothers, sisters, parents, relatives and benefactors of our community, living and deceased.\n℟. Grant, Lord God, the reward of eternal life, to all who have been good to us in your name."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "Let us pray for all the brothers, sisters, parents, relatives and benefactors of our community, living and deceased."
+          },
+          "r": {
+            "en-US": "Grant, Lord God, the reward of eternal life, to all who have been good to us in your name."
+          }
+        }
+      ]
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm 123 – Our Trust is in the Lord"
       }
@@ -133,9 +160,22 @@
       }
     },
     {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "Lord, have mercy"
+          },
+          "r": {
+            "en-US": "Christ, have mercy"
+          }
+        }
+      ]
+    },
+    {
       "type": "prayer",
       "inline": {
-        "en-US": "℣. Lord, have mercy\n℟. Christ, have mercy\n℣. Lord, have mercy"
+        "en-US": "Lord, have mercy"
       }
     },
     {
@@ -145,15 +185,100 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "en-US": "℣. O Lord, save Your servants,\n℟. O Lord, we trust in You.\n℣. O Lord, send us help from Your holy sanctuary,\n℟. And strengthen us out of Zion.\n℣. Be for us, O Lord, a tower of strength,\n℟. Protect us from all harm.\n℣. Do not let our enemies overcome us,\n℟. Nor the son of iniquity have power to harm us.\n℣. May the name of the Lord be praised\n℟. And may He guide us on the way of salvation.\n℣. Show us, O Lord, Your paths,\n℟. And direct our hearts to keep Your precepts.\n℣. O Lord hear my prayer\n℟. And let my cry come unto You."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "O Lord, save Your servants,"
+          },
+          "r": {
+            "en-US": "O Lord, we trust in You."
+          }
+        }
+      ]
     },
     {
-      "type": "prayer",
-      "inline": {
-        "en-US": "Let us pray,"
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "O Lord, send us help from Your holy sanctuary,"
+          },
+          "r": {
+            "en-US": "And strengthen us out of Zion."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "Be for us, O Lord, a tower of strength,"
+          },
+          "r": {
+            "en-US": "Protect us from all harm."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "Do not let our enemies overcome us,"
+          },
+          "r": {
+            "en-US": "Nor the son of iniquity have power to harm us."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "May the name of the Lord be praised"
+          },
+          "r": {
+            "en-US": "And may He guide us on the way of salvation."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "Show us, O Lord, Your paths,"
+          },
+          "r": {
+            "en-US": "And direct our hearts to keep Your precepts."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "O Lord hear my prayer"
+          },
+          "r": {
+            "en-US": "And let my cry come unto You."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "en-US": "Let us pray."
       }
     },
     {
@@ -199,7 +324,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Psalm 130 – A Cry from the Depths"
       }
@@ -217,9 +342,35 @@
       }
     },
     {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "Eternal rest grant unto them, O Lord."
+          },
+          "r": {
+            "en-US": "And let perpetual light shine upon them."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "Lord have mercy"
+          },
+          "r": {
+            "en-US": "Christ have mercy"
+          }
+        }
+      ]
+    },
+    {
       "type": "prayer",
       "inline": {
-        "en-US": "℣. Eternal rest grant unto them, O Lord.\n℟. And let perpetual light shine upon them.\n℣. Lord have mercy\n℟. Christ have mercy\n℣. Lord have mercy"
+        "en-US": "Lord have mercy"
       }
     },
     {
@@ -229,15 +380,67 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "en-US": "℣. And lead us not into temptation\n℟. But deliver us from evil.\n℣. From the gates of hell\n℟. Deliver their souls, O Lord.\n℣. May they rest in peace.\n℟. Amen.\n℣. O Lord hear my prayer\n℟. And let my cry come unto you."
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "And lead us not into temptation"
+          },
+          "r": {
+            "en-US": "But deliver us from evil."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "From the gates of hell"
+          },
+          "r": {
+            "en-US": "Deliver their souls, O Lord."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "May they rest in peace."
+          },
+          "r": {
+            "en-US": "Amen."
+          }
+        }
+      ]
+    },
+    {
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "O Lord hear my prayer"
+          },
+          "r": {
+            "en-US": "And let my cry come unto you."
+          }
+        }
+      ]
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "en-US": "Let us pray."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "en-US": "Let us pray,\nGod, our Father, you grant pardon from sin and will the salvation of everyone. We beg you to be merciful and grant that all the deceased priests, brothers, sisters, relatives and benefactors of our community may come to eternal happiness through the intercession of the Blessed Virgin Mary and all your saints."
+        "en-US": "God, our Father, you grant pardon from sin and will the salvation of everyone. We beg you to be merciful and grant that all the deceased priests, brothers, sisters, relatives and benefactors of our community may come to eternal happiness through the intercession of the Blessed Virgin Mary and all your saints."
       }
     },
     {
@@ -253,28 +456,49 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "en-US": "℣. We praise the Lord our God who has brought us together to rejoice in the Spirit.\n℟. May we always be humble of heart and place our joy in the Lord. Let us not be carried away by any material success, but rather acknowledge that true happiness will be ours only when the things of this life have passed away."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "We praise the Lord our God who has brought us together to rejoice in the Spirit."
+          },
+          "r": {
+            "en-US": "May we always be humble of heart and place our joy in the Lord. Let us not be carried away by any material success, but rather acknowledge that true happiness will be ours only when the things of this life have passed away."
+          }
+        }
+      ]
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "en-US": "Hail Queen of Heaven – A Prayer for Protection"
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "en-US": "℣. Hail, Queen of Heaven\n℟. Mother of the King of Angels, O Mary, flower of virgins, Like a Rose or Lily, Pour out prayers to your Son, For the salvation of the faithful."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "Hail, Queen of Heaven"
+          },
+          "r": {
+            "en-US": "Mother of the King of Angels, O Mary, flower of virgins, Like a Rose or Lily, Pour out prayers to your Son, For the salvation of the faithful."
+          }
+        }
+      ]
     },
     {
-      "type": "prayer",
-      "inline": {
-        "en-US": "℣. Pray for us O holy Virgin of virgins,\n℟. That we may be made worthy of the promises of Christ."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "Pray for us O holy Virgin of virgins,"
+          },
+          "r": {
+            "en-US": "That we may be made worthy of the promises of Christ."
+          }
+        }
+      ]
     },
     {
       "type": "prayer",
@@ -283,7 +507,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Prayer in Honour of S. Joseph"
       }
@@ -295,7 +519,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Prayer in Honour of S. Augustine"
       }
@@ -313,10 +537,17 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "en-US": "℣. We adore you O Christ and we praise you\n℟. Because by your Holy Cross you have redeemed the world."
-      }
+      "type": "response",
+      "verses": [
+        {
+          "v": {
+            "en-US": "We adore you O Christ and we praise you"
+          },
+          "r": {
+            "en-US": "Because by your Holy Cross you have redeemed the world."
+          }
+        }
+      ]
     },
     {
       "type": "prayer",

--- a/content/practices/little-office-seven-dolours-of-the-blessed-virgin-mary/flow.json
+++ b/content/practices/little-office-seven-dolours-of-the-blessed-virgin-mary/flow.json
@@ -44,9 +44,35 @@
               }
             },
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine, labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri. Alleluia."
+                "la": "Gloria Patri. Alleluia."
               }
             },
             {
@@ -56,25 +82,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ave, dulcis Mater Christi,\nQuae cur tuum gladio\nTransfingendum audis tristi\nSenis vaticinio."
+                "la": "Ave, dulcis Mater Christi,\nQuae cur tuum gladio\nTransfingendum audis tristi\nSenis vaticinio.\n\nTanti memor fac doloris,\nMihi sis praesidio,\nUt post vallem hanc meroris\nCoeli reddar gaudio."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Tanti memor fac doloris,\nMihi sis praesidio,\nUt post vallem hanc meroris\nCoeli reddar gaudio."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -82,13 +102,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Cui comparabo te vel cui assimilabo te, filia Jerusalem? cui exaequabo te, et consolabor te, Virgo, filia Sion? magna est enim velut mare contritio tua. (Thren. 2, 13.)\n℣. Tuam ipsius animam doloris gladius pertransibit.\n℟. Ut revelentur ex multis cordibus cogitationes. (Luc. 2, 35.)"
+                "la": "Cui comparabo te vel cui assimilabo te, filia Jerusalem? cui exaequabo te, et consolabor te, Virgo, filia Sion? magna est enim velut mare contritio tua. (Thren. 2, 13.)"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Tuam ipsius animam doloris gladius pertransibit."
+                  },
+                  "r": {
+                    "la": "Ut revelentur ex multis cordibus cogitationes. (Luc. 2, 35.)"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nInterveniat pro nobis, quaesumus, Domine Jesu Christe, nunc et in hora mortis nostrae apud tuam clementiam B. Virgo Maria, Mater tua, cujus sacratissimam animam in hora tuae passionis doloris gladius pertransivit. Per te, Jesu Christe, Salvator mundi, qui cum Patre et Spiritu Sancto vivis et regnas in saecula saeculorum. Amen."
+                "la": "Interveniat pro nobis, quaesumus, Domine Jesu Christe, nunc et in hora mortis nostrae apud tuam clementiam B. Virgo Maria, Mater tua, cujus sacratissimam animam in hora tuae passionis doloris gladius pertransivit. Per te, Jesu Christe, Salvator mundi, qui cum Patre et Spiritu Sancto vivis et regnas in saecula saeculorum. Amen."
               }
             }
           ]
@@ -102,7 +141,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "II. Dolor ex Fuga in Aegyptum"
               }
@@ -110,29 +149,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ave Maria.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
+                "la": "Ave Maria."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ave, dulcis Mater Christi,\nQuae prae regis furia\nSevente, corde tristi,\nFugis exul patria."
+                "la": "Ave, dulcis Mater Christi,\nQuae prae regis furia\nSevente, corde tristi,\nFugis exul patria.\n\nPro Regina beatorum,\nNostri spes exilii,\nFac, infractus vel malorum\nFiam consors Filii."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Pro Regina beatorum,\nNostri spes exilii,\nFac, infractus vel malorum\nFiam consors Filii."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -140,13 +185,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Vide, Domine, quoniam tribulor, conturbatus est venter meus; subversus est cor meum in moerentia, quoniam amaritudine plena sum: foris interfecit gladius, et domi mors similis est. (Thren. 2.)\n℣. Domine, ante te omne desiderium meum.\n℟. Et gemitus meus a te non est absconditus."
+                "la": "Vide, Domine, quoniam tribulor, conturbatus est venter meus; subversus est cor meum in moerentia, quoniam amaritudine plena sum: foris interfecit gladius, et domi mors similis est. (Thren. 2.)"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, ante te omne desiderium meum."
+                  },
+                  "r": {
+                    "la": "Et gemitus meus a te non est absconditus."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nInterveniat pro nobis, etc. ut supra."
+                "la": "Interveniat pro nobis, etc. ut supra."
               }
             }
           ]
@@ -160,7 +224,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "III. Dolor ex amisso Duodennem Filio"
               }
@@ -168,29 +232,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ave Maria.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
+                "la": "Ave Maria."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ave, dulcis Mater Christi,\nNatum lugens inclytum:\nO quam tristis quaesivisti\nTriduo jam perditum!"
+                "la": "Ave, dulcis Mater Christi,\nNatum lugens inclytum:\nO quam tristis quaesivisti\nTriduo jam perditum!\n\nHujus memor o doloris,\nChristum fac inveniam,\nEt inventum per amoris\nNexum semper teneam."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "Hujus memor o doloris,\nChristum fac inveniam,\nEt inventum per amoris\nNexum semper teneam."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -198,13 +268,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Plorans ploravit in nocte, et lacrimae ejus in maxillis ejus: non est qui consoletur eam ex omnibus charis ejus. (Thren. 1, 2.)\n℣. Posuisti me desolatam.\n℟. Tota die merore confectam. (Thren. 1, 13.)"
+                "la": "Plorans ploravit in nocte, et lacrimae ejus in maxillis ejus: non est qui consoletur eam ex omnibus charis ejus. (Thren. 1, 2.)"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Posuisti me desolatam."
+                  },
+                  "r": {
+                    "la": "Tota die merore confectam. (Thren. 1, 13.)"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nInterveniat, etc."
+                "la": "Interveniat, etc."
               }
             }
           ]
@@ -218,7 +307,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "IV. Dolor ex Captivitate, Flagellatione, Coronatione et Bajulatione Crucis Christi"
               }
@@ -226,29 +315,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ave Maria.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
+                "la": "Ave Maria."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ave, dulcis Mater Christi,\nQuae dolorem Filium\nCapi, caedi, flens vidisti\nManibus crudeliùm:"
+                "la": "Ave, dulcis Mater Christi,\nQuae dolorem Filium\nCapi, caedi, flens vidisti\nManibus crudeliùm:\n\nO per poenas patientis,\nNobis sit impunitas!\nPer amorem condolentis\nMatris crescat charitas!"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "O per poenas patientis,\nNobis sit impunitas!\nPer amorem condolentis\nMatris crescat charitas!"
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -256,13 +351,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Videte, Domine, et considerate quoniam facta sum vilis: erectus est inimicus. Manum suam misit hostis ad omnia desiderabilia mea. (Thren. 1, 9–10.)\n℣. Quia dedit capiti meo aquam, et oculis meis fontem lacrymarum.\n℟. Et plorabo die ac nocte."
+                "la": "Videte, Domine, et considerate quoniam facta sum vilis: erectus est inimicus. Manum suam misit hostis ad omnia desiderabilia mea. (Thren. 1, 9–10.)"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Quia dedit capiti meo aquam, et oculis meis fontem lacrymarum."
+                  },
+                  "r": {
+                    "la": "Et plorabo die ac nocte."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nInterveniat, etc."
+                "la": "Interveniat, etc."
               }
             }
           ]
@@ -276,7 +390,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "V. Dolor ex Crucifixione"
               }
@@ -284,29 +398,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ave Maria.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
+                "la": "Ave Maria."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ave, dulcis Mater Christi,\nQuae sub Crucis arbore\nGemens, Natum morti tristi\nVides, heu! succumbere,"
+                "la": "Ave, dulcis Mater Christi,\nQuae sub Crucis arbore\nGemens, Natum morti tristi\nVides, heu! succumbere,\n\nO per enses hujus doloris,\nQui tunc scidit animam,\nFac me firmet vis amoris\nMortis ad victoriam."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "O per enses hujus doloris,\nQui tunc scidit animam,\nFac me firmet vis amoris\nMortis ad victoriam."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -314,13 +434,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "O vos omnes, qui transitis per viam, attendite et videte, si est dolor, sicut dolor meus. (Thren. 1, 12.)\n℣. Plauserunt super te manibus omnes transeuntes per viam.\n℟. Sibilaverunt et moverunt caput suum super filiam Jerusalem. (Thren. 2, 15.)"
+                "la": "O vos omnes, qui transitis per viam, attendite et videte, si est dolor, sicut dolor meus. (Thren. 1, 12.)"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Plauserunt super te manibus omnes transeuntes per viam."
+                  },
+                  "r": {
+                    "la": "Sibilaverunt et moverunt caput suum super filiam Jerusalem. (Thren. 2, 15.)"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nInterveniat, etc."
+                "la": "Interveniat, etc."
               }
             }
           ]
@@ -334,7 +473,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "VI. Dolor ex Corporis e Cruce Sublatione"
               }
@@ -342,29 +481,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ave Maria.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
+                "la": "Ave Maria."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ave, dulcis Mater Christi\nQuae de Cruce mortuum\nUnis Natum suscepisti,\nMadens unda fletuum."
+                "la": "Ave, dulcis Mater Christi\nQuae de Cruce mortuum\nUnis Natum suscepisti,\nMadens unda fletuum.\n\nO praetestis vir doloris,\nMater plena gratiae,\nUt supremis server horis\nGremio clementiae."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "O praetestis vir doloris,\nMater plena gratiae,\nUt supremis server horis\nGremio clementiae."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -372,13 +517,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ne vocetis me Noemi (id est pulchram), sed vocate me Mara (id est amaram), quia amaritudine valde me replevit Omnipotens. (Ruth. 1, 20.)\n℣. Fasciculus myrrhae dilectus meus mihi.\n℟. Inter ubera mea commorabitur. (Cant. 1, 12.)"
+                "la": "Ne vocetis me Noemi (id est pulchram), sed vocate me Mara (id est amaram), quia amaritudine valde me replevit Omnipotens. (Ruth. 1, 20.)"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fasciculus myrrhae dilectus meus mihi."
+                  },
+                  "r": {
+                    "la": "Inter ubera mea commorabitur. (Cant. 1, 12.)"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nInterveniat, etc."
+                "la": "Interveniat, etc."
               }
             }
           ]
@@ -392,7 +556,7 @@
           },
           "sections": [
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "VII. Dolor ex Sepultura"
               }
@@ -400,35 +564,48 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ave Maria.\n℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
+                "la": "Ave Maria."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos, Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
-                "la": "Ave, dulcis Mater Christi,\nQuae sepulchro conditum\nPlangis Natum, heu! quam tristi\nMente volvens obitum."
+                "la": "Ave, dulcis Mater Christi,\nQuae sepulchro conditum\nPlangis Natum, heu! quam tristi\nMente volvens obitum.\n\nIn virtute tot dolorum,\nQuos tulisti fortiter,\nOmnem contra vim malorum\nStare nos viriliter,\n\nDemum sorte beatorum\nFac gaudere jugiter."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "In virtute tot dolorum,\nQuos tulisti fortiter,\nOmnem contra vim malorum\nStare nos viriliter,"
-              }
-            },
-            {
-              "type": "prayer",
-              "inline": {
-                "la": "Demum sorte beatorum\nFac gaudere jugiter."
-              }
-            },
-            {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant."
               }
@@ -436,13 +613,32 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Idcirco ego plorans, et oculus meus deducens aquas: quia longe factus est a me consolator, convertens animam meam. (Thren. 1, 16.)\n℣. Defecerunt prae lacrymis oculi mei.\n℟. Conturbata sunt viscera mea. (Thren. 2, 11.)"
+                "la": "Idcirco ego plorans, et oculus meus deducens aquas: quia longe factus est a me consolator, convertens animam meam. (Thren. 1, 16.)"
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Defecerunt prae lacrymis oculi mei."
+                  },
+                  "r": {
+                    "la": "Conturbata sunt viscera mea. (Thren. 2, 11.)"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nInterveniat, etc."
+                "la": "Interveniat, etc."
               }
             }
           ]

--- a/content/practices/little-office-seven-joys-of-the-blessed-virgin-mary/flow.json
+++ b/content/practices/little-office-seven-joys-of-the-blessed-virgin-mary/flow.json
@@ -38,31 +38,51 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Eja mea labia nunc annunciate.\n℟. Sacra septem gaudia Mariae beatae."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Eja mea labia nunc annunciate."
+                  },
+                  "r": {
+                    "la": "Sacra septem gaudia Mariae beatae."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "A moerore animi clementer nos defende."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domina in adjutorium meum intende.\n℟. A moerore animi clementer nos defende.\nGloria Patri, et Filio, et Spiritui Sancto."
+                "la": "Gloria Patri, et Filio, et Spiritui Sancto."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Gaude, Virgo Mater Christi,\nQuia Jesum concepisti\nGabriele nuntio,\nFac, o Mater, ut salvemur,\nNam quod Matrem te fatemur,\nResta poscit ratio."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -74,15 +94,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Angelus Domini nunciavit Mariae, Alleluja.\n℟. Et concepit de Spiritu Sancto, Alleluja."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Angelus Domini nunciavit Mariae, Alleluja."
+                  },
+                  "r": {
+                    "la": "Et concepit de Spiritu Sancto, Alleluja."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui de beatae Mariae Virginis utero verbum tuum,\nAngelo nunciante, carnem suscipere voluisti:\npraesta supplicibus tuis, ut qui vere eam Genitricem Dei credimus,\nejus apud te intercessionibus adjuvemur.\nPer Dominum nostrum Jesum Christum."
+                "la": "Deus, qui de beatae Mariae Virginis utero verbum tuum,\nAngelo nunciante, carnem suscipere voluisti:\npraesta supplicibus tuis, ut qui vere eam Genitricem Dei credimus,\nejus apud te intercessionibus adjuvemur.\nPer Dominum nostrum Jesum Christum."
               }
             }
           ]
@@ -98,23 +131,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ave Maria, etc.\nSicut laetantium omnium, etc.\n℣. Domina in adjutorium meum intende.\n℟. A moerore animi, etc.\nGloria Patri, etc."
+                "la": "Ave Maria, etc.\nSicut laetantium omnium, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "A moerore animi, etc."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Gaude, Mater Deo plena,\nNovo gignens sine poena\nFoetum puerperio!\nEja Virgo peramena,\nCasto natum mens serena\nStringat desiderio."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -126,15 +178,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Germinavit radix Jesse, Alleluja.\n℟. Virgo peperit Salvatorem, Alleluja."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Germinavit radix Jesse, Alleluja."
+                  },
+                  "r": {
+                    "la": "Virgo peperit Salvatorem, Alleluja."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui salutis aeternae beatae Mariae virginitate fecunda\nhumano generi praemia praestitisti:\ntribue, quaesumus, ut ipsam pro nobis intercedere sentiamus,\nper quam meruimus auctorem vitae suscipere,\nDominum nostrum Jesum Christum."
+                "la": "Deus, qui salutis aeternae beatae Mariae virginitate fecunda\nhumano generi praemia praestitisti:\ntribue, quaesumus, ut ipsam pro nobis intercedere sentiamus,\nper quam meruimus auctorem vitae suscipere,\nDominum nostrum Jesum Christum."
               }
             }
           ]
@@ -150,23 +215,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ave Maria, etc.\nSicut laetantium omnium, etc.\n℣. Domina in adjutorium meum intende.\n℟. A moerore animi, etc.\nGloria Patri, etc."
+                "la": "Ave Maria, etc.\nSicut laetantium omnium, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "A moerore animi, etc."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Gaude, quod ab Oriente\nMagi stella prae lucente\nDona ferunt Filio,\nFac donerur pietate,\nFide, spe, ac charitate,\nEt pudoris lilio."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -178,15 +262,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Et intrantes domum invenerunt Puerum cum Maria matre ejus, Alleluja.\n℟. Et adorantes eum, apertis thesauris suis, obtulerunt ei munera, Alleluja."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Et intrantes domum invenerunt Puerum cum Maria matre ejus, Alleluja."
+                  },
+                  "r": {
+                    "la": "Et adorantes eum, apertis thesauris suis, obtulerunt ei munera, Alleluja."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui unigenitum tuum gentibus stella duce revelasti:\nconcede propitius, ut qui jam te ex fide cognovimus,\nper intercessionem beatae Mariae Virginis,\nusque ad contemplandam speciem tuae celsitudinis perducamur.\nPer Dominum nostrum Jesum Christum."
+                "la": "Deus, qui unigenitum tuum gentibus stella duce revelasti:\nconcede propitius, ut qui jam te ex fide cognovimus,\nper intercessionem beatae Mariae Virginis,\nusque ad contemplandam speciem tuae celsitudinis perducamur.\nPer Dominum nostrum Jesum Christum."
               }
             }
           ]
@@ -202,23 +299,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ave Maria, etc.\nSicut laetantium omnium, etc.\n℣. Domina in adjutorium meum intende.\n℟. A moerore animi, etc.\nGloria Patri, etc."
+                "la": "Ave Maria, etc.\nSicut laetantium omnium, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "A moerore animi, etc."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Gaude, quia dulcis nati,\nQuem vidisti mortem pati,\nFulget resurrectio.\nFac ab imo vitiorum\nSurgat mens, et supernorum\nGustum spiret actio."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -230,15 +346,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Gaude et laetare Virgo Maria, Alleluja.\n℟. Quia surrexit Dominus vere, Alleluja."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gaude et laetare Virgo Maria, Alleluja."
+                  },
+                  "r": {
+                    "la": "Quia surrexit Dominus vere, Alleluja."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui per resurrectionem Filii tui Domini nostri Jesu Christi\nmundum laetificare dignatus es:\npraesta quaesumus, ut per ejus Genitricem Virginem Mariam\nperpetua capiamus gaudia vitae.\nPer eundem Dominum nostrum Jesum Christum."
+                "la": "Deus, qui per resurrectionem Filii tui Domini nostri Jesu Christi\nmundum laetificare dignatus es:\npraesta quaesumus, ut per ejus Genitricem Virginem Mariam\nperpetua capiamus gaudia vitae.\nPer eundem Dominum nostrum Jesum Christum."
               }
             }
           ]
@@ -254,23 +383,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ave Maria, etc.\nSicut laetantium omnium, etc.\n℣. Domina in adjutorium meum intende.\n℟. A moerore animi, etc.\nGloria Patri, et Filio, etc."
+                "la": "Ave Maria, etc.\nSicut laetantium omnium, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "A moerore animi, etc."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, et Filio, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Gaude coelos ascendente\nNato, vides quem repente\nFerri motu proprio.\nVia vitae restituta,\nQuem post natum tu secuta,\nFac sequamur serio."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -282,15 +430,28 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Videntibus illis elevatus est, Alleluja.\n℟. Et nubes suscepit eum ab oculis eorum, Alleluja."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Videntibus illis elevatus est, Alleluja."
+                  },
+                  "r": {
+                    "la": "Et nubes suscepit eum ab oculis eorum, Alleluja."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nConcede quaesumus, Omnipotens Deus,\nut qui unigenitum tuum redemptorem nostrum\ngloriose ascendisse in coelos credimus,\nintercedente beata Maria Virgine matre ejus,\nipsi quoque in coelestibus mereamur habitare.\nPer Dominum nostrum Jesum Christum."
+                "la": "Concede quaesumus, Omnipotens Deus,\nut qui unigenitum tuum redemptorem nostrum\ngloriose ascendisse in coelos credimus,\nintercedente beata Maria Virgine matre ejus,\nipsi quoque in coelestibus mereamur habitare.\nPer Dominum nostrum Jesum Christum."
               }
             }
           ]
@@ -306,23 +467,42 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ave Maria, etc.\nSicut laetantium omnium, etc.\n℣. Domina in adjutorium meum intende.\n℟. A moerore animi, etc.\nGloria Patri, etc."
+                "la": "Ave Maria, etc.\nSicut laetantium omnium, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "A moerore animi, etc."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Gaude, quia Paraclitus\nMissus coelo novos foetus\nIgne format Entheo.\nIgne sacri nos amoris,\nFac accendi, ne laboris\nCapiamur taedio."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -336,13 +516,31 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Factus est repente de coelo sonus,\ntanquam advenientis Spiritus vehementis, Alleluja.\n℟. Et replevit totam domum, ubi erant sedentes. Alleluja."
+                "la": "Factus est repente de coelo sonus,"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui Genetrici Filii tui atque Apostolis tuis sanctum dedisti Spiritum,\nconcede plebi tuae piae petitionis effectum,\nut cui dedisti fidem, beatae Virginis intercessione eidem largiaris pacem.\nPer Dominum nostrum Jesum Christum."
+                "la": "tanquam advenientis Spiritus vehementis, Alleluja."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Et replevit totam domum, ubi erant sedentes. Alleluja."
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus, qui Genetrici Filii tui atque Apostolis tuis sanctum dedisti Spiritum,\nconcede plebi tuae piae petitionis effectum,\nut cui dedisti fidem, beatae Virginis intercessione eidem largiaris pacem.\nPer Dominum nostrum Jesum Christum."
               }
             }
           ]
@@ -362,31 +560,51 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Convertat nos Domina, tuis precibus placatus, Jesus Christus Filius tuus.\n℟. Et avertat iram suam a nobis."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Convertat nos Domina, tuis precibus placatus, Jesus Christus Filius tuus."
+                  },
+                  "r": {
+                    "la": "Et avertat iram suam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domina in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "A moerore animi, etc."
+                  }
+                }
+              ]
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domina in adjutorium meum intende.\n℟. A moerore animi, etc.\nGloria Patri, etc."
+                "la": "Gloria Patri, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Gaude, quae post Christum scandis\nAstra coeli, nuncque pandis\nAditum ad aethera,\nO fac fructu ventris tui\nPer te nobis detur frui\nIn coelesti gloria."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona"
               }
@@ -398,22 +616,42 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Exaltata est, Sancta Dei Genitrix, Alleluja.\n℟. Super choros Angelorum ad coelestia regna, Alleluja."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Exaltata est, Sancta Dei Genitrix, Alleluja."
+                  },
+                  "r": {
+                    "la": "Super choros Angelorum ad coelestia regna, Alleluja."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui beatam Mariam Virginem,\nmatrem Filii tui gloriosa assumptionis laetitia in coelos assumere dignatus es:\nconcede, ut cujus gaudia devote celebramus in terris,\neadem intercedente aeternum mereamur gaudere in coelis.\nPer Dominum nostrum Jesum Christum."
+                "la": "Deus, qui beatam Mariam Virginem,\nmatrem Filii tui gloriosa assumptionis laetitia in coelos assumere dignatus es:\nconcede, ut cujus gaudia devote celebramus in terris,\neadem intercedente aeternum mereamur gaudere in coelis.\nPer Dominum nostrum Jesum Christum."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine exaudi, etc. Benedicamus, etc.\n℟. Et Fidelium, etc."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine exaudi, etc. Benedicamus, etc."
+                  },
+                  "r": {
+                    "la": "Et Fidelium, etc."
+                  }
+                }
+              ]
             }
           ]
         }
@@ -432,7 +670,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Oratio"
       }

--- a/content/practices/little-office-sick/flow.json
+++ b/content/practices/little-office-sick/flow.json
@@ -1,7 +1,7 @@
 {
   "sections": [
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Incipit Officium unius infirmi sive plurimorum infirmorum."
       }
@@ -21,18 +21,49 @@
     {
       "type": "select",
       "on": "hour",
-      "label": { "en-US": "Hour", "pt-BR": "Hora" },
-      "map": { "0-3": "matins", "4-16": "vespers", "17-23": "vespers" },
+      "label": {
+        "en-US": "Hour",
+        "pt-BR": "Hora"
+      },
+      "map": {
+        "0-3": "matins",
+        "4-16": "vespers",
+        "17-23": "vespers"
+      },
       "options": [
         {
           "id": "vespers",
-          "label": { "en-US": "Vespers", "pt-BR": "Vésperas", "la": "Ad Vesperos" },
+          "label": {
+            "en-US": "Vespers",
+            "pt-BR": "Vésperas",
+            "la": "Ad Vesperos"
+          },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "In nomine Domini nostri Jesu Christi, lumen cum pace. ℟. Deo gratias.\n℣. Dominus sit semper vobiscum. ℟. Et cum spiritu tuo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In nomine Domini nostri Jesu Christi, lumen cum pace."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus sit semper vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -43,8 +74,21 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Dominus illuminatio mea, et salus mea, quem timebo?\n℣. Dominus sit. ℟. Et cum."
+                "la": "Dominus illuminatio mea, et salus mea, quem timebo?"
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus sit."
+                  },
+                  "r": {
+                    "la": "Et cum."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -55,11 +99,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Sana, Domine, omnes languores nostros. Alleluia. ℣. Redime de interitu vitam nostram. Alleluia, alleluia."
+                "la": "Sana, Domine, omnes languores nostros. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Redime de interitu vitam nostram. Alleluia, alleluia."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphona."
               }
@@ -67,14 +117,33 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Christe Domine, qui es medicus salutaris, Tribue languidis subsidium medicinae coelestis. ℣. O Domine salvos nos fac, o Domine bona prosperare. Tribue languidis. ℣. Gloria et honor. Tribue."
+                "la": "Christe Domine, qui es medicus salutaris, Tribue languidis subsidium medicinae coelestis."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Dominus sit. ℟. Et cum."
+                "la": "O Domine salvos nos fac, o Domine bona prosperare. Tribue languidis."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria et honor. Tribue."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus sit."
+                  },
+                  "r": {
+                    "la": "Et cum."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -85,8 +154,33 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Salvos nos faciat dextera tua. Alleluia. Exaudi nos Domine Deus noster: Alleluia, alleluia. ℣. Ut confiteamur nomini sancto tuo, et gloriamur in laude tua. Exaudi. ℣. Gloria et honor. Exaudi.\n℣. Dominus sit. ℟. Et cum."
+                "la": "Salvos nos faciat dextera tua. Alleluia. Exaudi nos Domine Deus noster: Alleluia, alleluia."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Ut confiteamur nomini sancto tuo, et gloriamur in laude tua. Exaudi."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria et honor. Exaudi."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus sit."
+                  },
+                  "r": {
+                    "la": "Et cum."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -97,17 +191,49 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Salvos nos faciat dextera tua. Alleluia. Et congrega nos de nationibus. Alleluia, alleluia. ℣. Ut confiteamur nomini sancto tuo, et gloriamur in laude tua. Et congrega nos. ℣. Gloria et honor. ℟. Alleluia, alleluia.\n℣. Dominus sit. ℟. Et cum."
+                "la": "Salvos nos faciat dextera tua. Alleluia. Et congrega nos de nationibus. Alleluia, alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Ut confiteamur nomini sancto tuo, et gloriamur in laude tua. Et congrega nos."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria et honor."
+                  },
+                  "r": {
+                    "la": "Alleluia, alleluia."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus sit."
+                  },
+                  "r": {
+                    "la": "Et cum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus."
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Christe caelestis medicina Patris,\nVerus humanae medicus salutis\nProvidae plebis precibus potenter\nPande favorem.\n\nEn ob infirmos tibi supplicamus,\nQuos nocens pestis valitudo cassat;\nUt pius morbum releves jacentum,\nQuo quatiuntur.\n\nQui potestate manifestus extans,\nMox Petri socrum febribus jacentem,\nReguli prolem, puerumque salvans\nCenturionis.\n\nFerto languenti populo vigorem;\nEfflue largam populis salutem;\nPristinis more solito reformans\nViribus aegros.\n\nCorporum morbos animaeque sana;\nVulnerum causis adhibe medelam:\nNe sine fructu cruciatus urat\nCorpora nostra.\n\nOmnis impulsus penitus recedat;\nOmnis incursus crucians liquescat;\nViror optatae foveat salutis\nMembra dolentis.\n\nIam Deus nostri miserere fletus,\nPro quibus te nunc petimus mederi;\nUt tuam omnis recubans medelam\nSentiat aeger;\n\nQuo per illata mala dum teruntur,\nEruditorum numero decori\nCompotes intrent, sociante fructu,\nRegna polorum.\n\nGloriam psallat chorus, et resultet,\nGloriam dicat, canat, et revolvat;\nNomini Trino, Deitati soli\nSidera clament. Amen."
               }
@@ -121,7 +247,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus Redemptorem mundi, Dominum nostrum Jesum Christum, cum omni supplicatione rogemus; ut vulnera famulorum suorum, omnium fidelium infirmorum, propitius curare dignetur. ℟. Praesta aeterne omnipotens Deus. Kyrie eleison. ℟. Christe eleison. Kyrie eleison."
+                "la": "Oremus Redemptorem mundi, Dominum nostrum Jesum Christum, cum omni supplicatione rogemus; ut vulnera famulorum suorum, omnium fidelium infirmorum, propitius curare dignetur."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Praesta aeterne omnipotens Deus. Kyrie eleison."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Christe eleison. Kyrie eleison."
               }
             },
             {
@@ -137,7 +275,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio Dominicalis."
               }
@@ -145,13 +283,97 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater noster, qui es in caelis. ℟. Amen.\nSanctificetur nomen tuum. ℟. Amen.\nAdveniat regnum tuum. ℟. Amen.\nFiat voluntas tua sicut in caelo et in terra. ℟. Amen.\nPanem nostrum quotidianum da nobis hodie. ℟. Quia Deus es.\nEt dimitte nobis debita nostra, sicut et nos dimittimus debitoribus nostris. ℟. Amen.\nEt ne nos inducas in tentationem. ℟. Sed libera nos a malo."
+                "la": "Pater noster, qui es in caelis."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "A malo nos libera, et in tuo timore opere bono nos confirma Trinitas, Deus noster, qui es benedictus, et vivis, et omnia regis in saecula saeculorum. ℟. Amen."
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Sanctificetur nomen tuum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Adveniat regnum tuum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Fiat voluntas tua sicut in caelo et in terra."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Panem nostrum quotidianum da nobis hodie."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Quia Deus es."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Et dimitte nobis debita nostra, sicut et nos dimittimus debitoribus nostris."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Et ne nos inducas in tentationem."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Sed libera nos a malo."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "A malo nos libera, et in tuo timore opere bono nos confirma Trinitas, Deus noster, qui es benedictus, et vivis, et omnia regis in saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
@@ -163,11 +385,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Humiliate vos ad benedictionem. Dominus sit semper vobiscum. ℟. Et cum spiritu tuo."
+                "la": "Humiliate vos ad benedictionem. Dominus sit semper vobiscum."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Et cum spiritu tuo."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Benedictio."
               }
@@ -175,7 +403,49 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Omnipotens Dominus, qui fidelissimos famulos suos omnes fideles infirmos corporali corripit vulnere, ipse illos, et nos a corporis mentisque aegritudinibus expiet. ℟. Amen.\nQuique nostram in se suscepit infirmitatem, ipse nobis, et illis tribuat tolerantiae sine fine mercedem. ℟. Amen.\nSic omnes in communi ejus pietas foveat; ut nec corrupta nostra salus desaeviat, nec desperationi infirmitas illata succumbat. ℟. Amen.\nPer misericordiam tuam Deus noster, qui es benedictus et omnia regis, in saecula saeculorum. ℟. Amen."
+                "la": "Omnipotens Dominus, qui fidelissimos famulos suos omnes fideles infirmos corporali corripit vulnere, ipse illos, et nos a corporis mentisque aegritudinibus expiet."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Quique nostram in se suscepit infirmitatem, ipse nobis, et illis tribuat tolerantiae sine fine mercedem."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Sic omnes in communi ejus pietas foveat; ut nec corrupta nostra salus desaeviat, nec desperationi infirmitas illata succumbat."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Per misericordiam tuam Deus noster, qui es benedictus et omnia regis, in saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
@@ -187,11 +457,43 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Salvos nos fac Domine Deus noster: Alleluia. Ut confiteamur nomini sancto tuo. Alleluia. ℣. Memento nostri, Domine, in beneplacito populi tui: visita nos in salutari tuo. Ut confiteamur. ℣. Gloria et honor. ℟. Ut confiteamur.\n℣. Dominus sit. ℟. Et cum."
+                "la": "Salvos nos fac Domine Deus noster: Alleluia. Ut confiteamur nomini sancto tuo. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Memento nostri, Domine, in beneplacito populi tui: visita nos in salutari tuo. Ut confiteamur."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria et honor."
+                  },
+                  "r": {
+                    "la": "Ut confiteamur."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus sit."
+                  },
+                  "r": {
+                    "la": "Et cum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -199,11 +501,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Omnipotens sempiterne Deus, inclina aurem tuam supplicationibus nostris, et famulis tuis omnibus fidelibus infirmis adversa corporis valetudine laborantibus coelestis gratiae medicinam concede. ℟. Amen."
+                "la": "Omnipotens sempiterne Deus, inclina aurem tuam supplicationibus nostris, et famulis tuis omnibus fidelibus infirmis adversa corporis valetudine laborantibus coelestis gratiae medicinam concede."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Commemorationes ad libitum."
               }
@@ -221,7 +529,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -229,8 +537,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Domine Deus omnipotens, qui vespere et mane et meridie unum diem vocari jussisti; et ut sol agnosceret occasum suum, imperasti; aperi, quaesumus, tenebras cordium nostrorum, ut, te radiante, cognoscamus te Deum verum et lumen aeternum. ℟. Amen. ℣. Per misericordiam tuam Deus noster, qui es benedictus et omnia regis, in saecula saeculorum. ℟. Amen."
+                "la": "Domine Deus omnipotens, qui vespere et mane et meridie unum diem vocari jussisti; et ut sol agnosceret occasum suum, imperasti; aperi, quaesumus, tenebras cordium nostrorum, ut, te radiante, cognoscamus te Deum verum et lumen aeternum."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per misericordiam tuam Deus noster, qui es benedictus et omnia regis, in saecula saeculorum."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -239,10 +566,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "In nomine Domini nostri Jesu Christi, perficiamus cum pace. ℟. Deo gratias."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In nomine Domini nostri Jesu Christi, perficiamus cum pace."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -260,13 +594,37 @@
         },
         {
           "id": "matins",
-          "label": { "en-US": "Matins", "pt-BR": "Matinas", "la": "Ad Matutinum" },
+          "label": {
+            "en-US": "Matins",
+            "pt-BR": "Matinas",
+            "la": "Ad Matutinum"
+          },
           "sections": [
             {
-              "type": "prayer",
-              "inline": {
-                "la": "In nomine Domini nostri Jesu Christi, lumen cum pace. ℟. Deo gratias.\n℣. Dominus sit semper vobiscum. ℟. Et cum spiritu tuo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In nomine Domini nostri Jesu Christi, lumen cum pace."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus sit semper vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -281,7 +639,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona."
               }
@@ -299,7 +657,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona."
               }
@@ -311,7 +669,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -319,11 +677,23 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ne projicias nos Domine a facie tua; nec auferas misericordiam tuam a nobis: ut quos reatus facinoris tenet obnoxios, miserationis tuae clementia faciat absolutos. ℟. Amen. Per misericordiam tuam Deus noster, qui es benedictus et omnia regis, in saecula saeculorum. ℟. Amen."
+                "la": "Ne projicias nos Domine a facie tua; nec auferas misericordiam tuam a nobis: ut quos reatus facinoris tenet obnoxios, miserationis tuae clementia faciat absolutos."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen. Per misericordiam tuam Deus noster, qui es benedictus et omnia regis, in saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphona I."
               }
@@ -331,11 +701,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Salvator noster salva nos in dilectione tua, Et indulgentia tua libera nos. ℣. Ad te levamus oculos nostros, qui habitas in coelis. Et indulgentia. ℣. Gloria et honor. ℟. Et indulgentia."
+                "la": "Salvator noster salva nos in dilectione tua, Et indulgentia tua libera nos."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Ad te levamus oculos nostros, qui habitas in coelis. Et indulgentia."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria et honor."
+                  },
+                  "r": {
+                    "la": "Et indulgentia."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -343,11 +732,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Omnipotens sempiterne Deus, inclina aurem tuam supplicationibus nostris, et famulis tuis omnibus fidelibus infirmis adversa corporis valetudine laborantibus coelestis gratiae medicinam concede. ℟. Amen. ℣. Per misericordiam tuam Deus noster, qui es benedictus et omnia regis, in saecula saeculorum. ℟. Amen."
+                "la": "Omnipotens sempiterne Deus, inclina aurem tuam supplicationibus nostris, et famulis tuis omnibus fidelibus infirmis adversa corporis valetudine laborantibus coelestis gratiae medicinam concede."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per misericordiam tuam Deus noster, qui es benedictus et omnia regis, in saecula saeculorum."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphona II."
               }
@@ -355,11 +763,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Ostende nobis Domine misericordiam tuam: Et salutare tuum da nobis. ℣. Ut confiteamur nomini sancto tuo: et gloriamur in laude tua. Et salutare. ℣. Gloria et honor. ℟. Et salutare."
+                "la": "Ostende nobis Domine misericordiam tuam: Et salutare tuum da nobis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Ut confiteamur nomini sancto tuo: et gloriamur in laude tua. Et salutare."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria et honor."
+                  },
+                  "r": {
+                    "la": "Et salutare."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -367,11 +794,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Deus, qui confitentium tibi corda purificas, et accusantem conscientiam ab omni vinculo iniquitatis absolvis: da indulgentiam famulis, et coelestis gratiae sinceram medicinam eorum tribue corporibus. ℟. Amen. ℣. Per misericordiam tuam Deus noster, qui es benedictus et omnia regis, in saecula saeculorum. ℟. Amen."
+                "la": "Deus, qui confitentium tibi corda purificas, et accusantem conscientiam ab omni vinculo iniquitatis absolvis: da indulgentiam famulis, et coelestis gratiae sinceram medicinam eorum tribue corporibus."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per misericordiam tuam Deus noster, qui es benedictus et omnia regis, in saecula saeculorum."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Antiphona III."
               }
@@ -379,11 +825,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Convertere, Domine, et eripe animas nostras: Et salvos nos fac propter misericordiam tuam. ℣. Domine, ne in furore tuo arguas nos, neque in ira tua corripias nos. Et salvos. ℣. Gloria et honor. ℟. Et salvos."
+                "la": "Convertere, Domine, et eripe animas nostras: Et salvos nos fac propter misericordiam tuam."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Domine, ne in furore tuo arguas nos, neque in ira tua corripias nos. Et salvos."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria et honor."
+                  },
+                  "r": {
+                    "la": "Et salvos."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -391,11 +856,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Adesto, quaesumus, Domine supplicibus nostris: et quibus austeritatem justae correctionis infligis, propitius adhibe auxilium misericordissimae consolationis. ℟. Amen. ℣. Per misericordiam tuam Deus noster, qui es benedictus et omnia regis, in saecula saeculorum. ℟. Amen."
+                "la": "Adesto, quaesumus, Domine supplicibus nostris: et quibus austeritatem justae correctionis infligis, propitius adhibe auxilium misericordissimae consolationis."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per misericordiam tuam Deus noster, qui es benedictus et omnia regis, in saecula saeculorum."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Responsorium."
               }
@@ -403,8 +887,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Virtus nostra, Domine, esto firmamentum infirmis. Esto refugium et liberator oppressis. ℣. Esto brachium nostrum in mane, et salus nostra in tempore tribulationis. Esto refugium. ℣. Gloria et honor. ℟. Virtus nostra."
+                "la": "Virtus nostra, Domine, esto firmamentum infirmis. Esto refugium et liberator oppressis."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Esto brachium nostrum in mane, et salus nostra in tempore tribulationis. Esto refugium."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria et honor."
+                  },
+                  "r": {
+                    "la": "Virtus nostra."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -413,13 +916,20 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Dominus sit semper vobiscum. ℟. Et cum spiritu tuo."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus sit semper vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Canticum Deuteronomij."
               }
@@ -431,7 +941,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona."
               }
@@ -449,7 +959,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Antiphona."
               }
@@ -469,8 +979,27 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Illumina, Domine, vultum tuum super nos, et miserere nobis. Ut cognoscamus in terra viam tuam. ℣. Deus misereatur nostri, et benedicat nos. Ut cognoscamus. ℣. Gloria et honor. ℟. Ut cognoscamus."
+                "la": "Illumina, Domine, vultum tuum super nos, et miserere nobis. Ut cognoscamus in terra viam tuam."
               }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Deus misereatur nostri, et benedicat nos. Ut cognoscamus."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria et honor."
+                  },
+                  "r": {
+                    "la": "Ut cognoscamus."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -481,11 +1010,30 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Laudate Dominum omnes Gentes: Alleluia, alleluia. Et collaudate eum omnes populi. ℣. Quoniam confirmata est super nos misericordia ejus: et veritas Domini manet in aeternum. Et collaudate eum. ℣. Gloria et honor. ℟. Et collaudate eum."
+                "la": "Laudate Dominum omnes Gentes: Alleluia, alleluia. Et collaudate eum omnes populi."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Quoniam confirmata est super nos misericordia ejus: et veritas Domini manet in aeternum. Et collaudate eum."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria et honor."
+                  },
+                  "r": {
+                    "la": "Et collaudate eum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Psalmus CXLVIII. Alleluia Hymnus cum Dei dictione"
               }
@@ -494,11 +1042,10 @@
               "type": "prayer",
               "inline": {
                 "la": "Laudate Dominum de caelis laudate eum in excelsis.\nLaudate eum omnes angeli ejus laudate eum omnes virtutes ejus.\nLaudate eum sol et luna laudate eum omnes stellae et lumen.\nLaudate eum caeli caelorum et aquae quae super caelos sunt, laudent nomen Domini.\nQuia ipse dixit et facta sunt ipse mandavit et creata sunt.\nStatuit ea in aeternum et in saeculum saeculi praeceptum posuit et non praeteribit.\nLaudate Dominum a terra dracones et omnes abyssi.\nIgnis grando nix glacies spiritus tempestatis qui facitis verbum ejus.\nMontes et omnes colles ligna fructifera et omnes cedri.\nBestiae et universa pecora serpentes et volucres pinnatae.\nReges terrae et omnes populi principes et judices terrae.\nJuvenes et virgines seniores cum junioribus laudent nomen Domini.\nQuia exaltatum est nomen ejus solius confessio ejus super caelum et terram.\nEt exaltavit cornu populi sui hymnus omnibus sanctis ejus filiis populo appropinquanti sibi."
-
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus CXLIX. Alleluia"
               }
@@ -510,7 +1057,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Psalmus CL. Alleluia"
               }
@@ -522,7 +1069,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Lectio libri Hieremiae Prophetae."
               }
@@ -530,17 +1077,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Cap. 29.\n℟. Deo gratias.\nHaec dicit Dominus: Ecce ego visitabo vos: et suscitabo vos, et suscitabo super vos verbum meum bonum, et reducam vos ad locum istum. Ego enim scio cogitationes, quas cogito super vos, ait Dominus, cogitationes pacis, et non afflictionis, ut dem vobis fidem, salutem, et patientiam. Et invocabitis me, et timebitis: orabitis me, et ego exaudiam vos. Quaeretis me, et invenietis: cum quaesieritis me in toto corde vestro, inveniar a vobis, ait Dominus omnipotens. ℟. Amen."
+                "la": "Cap. 29."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deo gratias."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Haec dicit Dominus: Ecce ego visitabo vos: et suscitabo vos, et suscitabo super vos verbum meum bonum, et reducam vos ad locum istum. Ego enim scio cogitationes, quas cogito super vos, ait Dominus, cogitationes pacis, et non afflictionis, ut dem vobis fidem, salutem, et patientiam. Et invocabitis me, et timebitis: orabitis me, et ego exaudiam vos. Quaeretis me, et invenietis: cum quaesieritis me in toto corde vestro, inveniar a vobis, ait Dominus omnipotens."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus."
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Christe caelestis medicina Patris,\nVerus humanae medicus salutis\nProvidae plebis precibus potenter\nPande favorem.\n\nEn ob infirmos tibi supplicamus,\nQuos nocens pestis valitudo cassat;\nUt pius morbum releves jacentum,\nQuo quatiuntur.\n\nQui potestate manifestus extans,\nMox Petri socrum febribus jacentem,\nReguli prolem, puerumque salvans\nCenturionis.\n\nFerto languenti populo vigorem;\nEfflue largam populis salutem;\nPristinis more solito reformans\nViribus aegros.\n\nCorporum morbos animaeque sana;\nVulnerum causis adhibe medelam:\nNe sine fructu cruciatus urat\nCorpora nostra.\n\nOmnis impulsus penitus recedat;\nOmnis incursus crucians liquescat;\nViror optatae foveat salutis\nMembra dolentis.\n\nIam Deus nostri miserere fletus,\nPro quibus te nunc petimus mederi;\nUt tuam omnis recubans medelam\nSentiat aeger;\n\nQuo per illata mala dum teruntur,\nEruditorum numero decori\nCompotes intrent, sociante fructu,\nRegna polorum.\n\nGloriam psallat chorus, et resultet,\nGloriam dicat, canat, et revolvat;\nNomini Trino, Deitati soli\nSidera clament. Amen."
               }
@@ -554,7 +1119,19 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus Redemptorem mundi, Dominum nostrum Jesum Christum, cum omni supplicatione rogemus; ut vulnera famulorum suorum, omnium fidelium infirmorum, propitius curare dignetur. ℟. Praesta aeterne omnipotens Deus. Kyrie eleison. ℟. Christe eleison. Kyrie eleison."
+                "la": "Oremus Redemptorem mundi, Dominum nostrum Jesum Christum, cum omni supplicatione rogemus; ut vulnera famulorum suorum, omnium fidelium infirmorum, propitius curare dignetur."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Praesta aeterne omnipotens Deus. Kyrie eleison."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Christe eleison. Kyrie eleison."
               }
             },
             {
@@ -570,7 +1147,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio Dominicalis"
               }
@@ -578,7 +1155,85 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Pater noster, qui es in caelis. ℟. Amen.\nSanctificetur nomen tuum. ℟. Amen.\nAdveniat regnum tuum. ℟. Amen.\nFiat voluntas tua sicut in caelo et in terra. ℟. Amen.\nPanem nostrum quotidianum da nobis hodie. ℟. Quia Deus es.\nEt dimitte nobis debita nostra, sicut et nos dimittimus debitoribus nostris. ℟. Amen.\nEt ne nos inducas in tentationem. ℟. Sed libera nos a malo."
+                "la": "Pater noster, qui es in caelis."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Sanctificetur nomen tuum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Adveniat regnum tuum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Fiat voluntas tua sicut in caelo et in terra."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Panem nostrum quotidianum da nobis hodie."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Quia Deus es."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Et dimitte nobis debita nostra, sicut et nos dimittimus debitoribus nostris."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Et ne nos inducas in tentationem."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Sed libera nos a malo."
               }
             },
             {
@@ -596,7 +1251,13 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Liberati a malo, confirmati semper in bono tibi servire mereamur Deo, ac Domino nostro. Pone, Domine, finem peccatis nostris: da gaudium tribulatis: praebe redemptionem captivis: sanitatem infirmis: requiemque defunctis. Concede pacem et securitatem in omnibus diebus nostris: frange audaciam inimicorum nostrorum: exaudi, Deus, orationem servorum tuorum omnium fidelium christianorum in hoc die, et in omni tempore. Per Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit, et regnat in unitate Spiritus Sancti Deus per omnia semper saecula saeculorum.\n℟. Amen."
+                "la": "Liberati a malo, confirmati semper in bono tibi servire mereamur Deo, ac Domino nostro. Pone, Domine, finem peccatis nostris: da gaudium tribulatis: praebe redemptionem captivis: sanitatem infirmis: requiemque defunctis. Concede pacem et securitatem in omnibus diebus nostris: frange audaciam inimicorum nostrorum: exaudi, Deus, orationem servorum tuorum omnium fidelium christianorum in hoc die, et in omni tempore. Per Dominum nostrum Jesum Christum Filium tuum, qui tecum vivit, et regnat in unitate Spiritus Sancti Deus per omnia semper saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
@@ -608,8 +1269,21 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Humiliate vos ad benedictionem. ℣. Dominus sit semper vobiscum. ℟. Et cum spiritu tuo."
+                "la": "Humiliate vos ad benedictionem."
               }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus sit semper vobiscum."
+                  },
+                  "r": {
+                    "la": "Et cum spiritu tuo."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",
@@ -620,11 +1294,43 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Salvos nos fac Domine Deus noster: Alleluia. Ut confiteamur nomini sancto tuo. Alleluia. ℣. Memento nostri, Domine, in beneplacito populi tui: visita nos in salutari tuo. Ut confiteamur. ℣. Gloria et honor. ℟. Ut confiteamur.\n℣. Dominus sit. ℟. Et cum."
+                "la": "Salvos nos fac Domine Deus noster: Alleluia. Ut confiteamur nomini sancto tuo. Alleluia."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Memento nostri, Domine, in beneplacito populi tui: visita nos in salutari tuo. Ut confiteamur."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Gloria et honor."
+                  },
+                  "r": {
+                    "la": "Ut confiteamur."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dominus sit."
+                  },
+                  "r": {
+                    "la": "Et cum."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Benedictio"
               }
@@ -632,11 +1338,53 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Omnipotens Dominus, qui fidelissimos famulos suos omnes fideles infirmos corporali corripit vulnere, ipse illos, et nos a corporis mentisque aegritudinibus expiet. ℟. Amen.\nQuique nostram in se suscepit infirmitatem, ipse nobis, et illis tribuat tolerantiae sine fine mercedem. ℟. Amen.\nSic omnes in communi ejus pietas foveat; ut nec corrupta nostra salus desaeviat, nec desperationi infirmitas illata succumbat. ℟. Amen.\nPer misericordiam tuam Deus noster, qui es benedictus et omnia regis, in saecula saeculorum. ℟. Amen."
+                "la": "Omnipotens Dominus, qui fidelissimos famulos suos omnes fideles infirmos corporali corripit vulnere, ipse illos, et nos a corporis mentisque aegritudinibus expiet."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Quique nostram in se suscepit infirmitatem, ipse nobis, et illis tribuat tolerantiae sine fine mercedem."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Sic omnes in communi ejus pietas foveat; ut nec corrupta nostra salus desaeviat, nec desperationi infirmitas illata succumbat."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Per misericordiam tuam Deus noster, qui es benedictus et omnia regis, in saecula saeculorum."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Commemorationes ad libitum"
               }
@@ -654,7 +1402,7 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Oratio."
               }
@@ -662,13 +1410,38 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Mane, Domine, oratio nostra perveniat ad te. Quia suscepisti confractonem fragilitatis nostrae, concede nobis diem istum jocundum, pacificum sine scandalo, sine macula: sine ulla tentatione advenientes ad vesperam, te collaudamus regem aeternum. ℟. Amen. ℣. Per misericordiam tuam Deus noster, qui es benedictus et omnia regis, in saecula saeculorum. ℟. Amen."
+                "la": "Mane, Domine, oratio nostra perveniat ad te. Quia suscepisti confractonem fragilitatis nostrae, concede nobis diem istum jocundum, pacificum sine scandalo, sine macula: sine ulla tentatione advenientes ad vesperam, te collaudamus regem aeternum."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Et fidelium animae omnium defunctorum requiescant in pace. ℟. Amen."
+                "la": "Amen."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per misericordiam tuam Deus noster, qui es benedictus et omnia regis, in saecula saeculorum."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Et fidelium animae omnium defunctorum requiescant in pace."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Amen."
               }
             },
             {
@@ -678,10 +1451,17 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "In nomine Domini nostri Jesu Christi, perficiamus cum pace. ℟. Deo gratias."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "In nomine Domini nostri Jesu Christi, perficiamus cum pace."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
             },
             {
               "type": "rubric",

--- a/content/practices/little-office-ss-joachim-and-anna/flow.json
+++ b/content/practices/little-office-ss-joachim-and-anna/flow.json
@@ -28,7 +28,39 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Benedicti sint sancti Joachim et Anna, ex quibus benedicta Virgo Maria sine originali labe concepta et nata est.\n℣. Domine, labia mea aperies.\n℟. Et os meum annuntiabit laudem tuam.\n℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina.\n℣. Gloria Patri. Alleluia."
+                "la": "Benedicti sint sancti Joachim et Anna, ex quibus benedicta Virgo Maria sine originali labe concepta et nata est."
+              }
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, labia mea aperies."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit laudem tuam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
               }
             },
             {
@@ -38,19 +70,19 @@
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "O bina conjugalis\nExempla foederis!\nO Joachim, qualis\nMariae conjugis!\nO Anna, quem nepotem,\nQuam nacta filiam!\nO Joachim, dotem\nQuis optet alteram!"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Sap. 4. 1."
               }
@@ -62,22 +94,68 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Orate pro nobis, sancti Joachim et Anna.\n℟. Ut digni efficiamur promissionibus Christi."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Orate pro nobis, sancti Joachim et Anna."
+                  },
+                  "r": {
+                    "la": "Ut digni efficiamur promissionibus Christi."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oremus."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oremus,\nDeus, qui prae omnibus Sanctis tuis beatos Joachim et Annam genitrices Filii tui parentes esse voluisti: concede, quaesumus; ut quos devoto cultu veneramur in terris, eorum quoque patrocinia sentiamus in caelis. Per eundem Dominum nostrum."
+                "la": "Deus, qui prae omnibus Sanctis tuis beatos Joachim et Annam genitrices Filii tui parentes esse voluisti: concede, quaesumus; ut quos devoto cultu veneramur in terris, eorum quoque patrocinia sentiamus in caelis. Per eundem Dominum nostrum."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Domine, exaudi orationem meam.\n℟. Et clamor meus ad te veniat.\n℣. Benedicamus Domino.\n℟. Deo gratias.\n℣. Fidelium animae per misericordiam Dei requiescant in pace.\n℟. Amen."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine, exaudi orationem meam."
+                  },
+                  "r": {
+                    "la": "Et clamor meus ad te veniat."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Benedicamus Domino."
+                  },
+                  "r": {
+                    "la": "Deo gratias."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Fidelium animae per misericordiam Dei requiescant in pace."
+                  },
+                  "r": {
+                    "la": "Amen."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -92,23 +170,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Benedicti sint sancti Joachim et Anna, ex quibus benedicta Virgo Maria sine originali labe concepta et nata est.\n℣. Deus, in adjutorium.\n℣. Gloria Patri. Alleluia."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+                "la": "Benedicti sint sancti Joachim et Anna, ex quibus benedicta Virgo Maria sine originali labe concepta et nata est."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Deus, in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Connubii quieta\nLevre tempora,\nDiems mansit usque laeta\nVel inter aspera.\nEst visa purpurae\nSed inde nidi remotum\nCor est ab aethere."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Cant 8.7"
               }
@@ -122,7 +212,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Orate pro nobis, etc.\ncum Oratione, ut supra."
+                "la": "versus Orate pro nobis, etc.\ncum Oratione, ut supra."
               }
             }
           ]
@@ -138,23 +228,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Benedicti sint sancti Joachim et Anna, ex quibus benedicta Virgo Maria sine originali labe concepta et nata est.\n℣. Deus in adjutorium.\n℣. Gloria Patri. Alleluia."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+                "la": "Benedicti sint sancti Joachim et Anna, ex quibus benedicta Virgo Maria sine originali labe concepta et nata est."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Deus in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Tandem serenoiori\nLux vexat phosphoro\nExplevit ampliiori\nUtrumque gaudio.\nConcepit Anna prolem\nStupente conjuge,\nCum vidit axe solem\nPlaudente surgere."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Prov.31. 28"
               }
@@ -168,7 +270,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Orate pro nobis, etc.\ncum Oratione, ut supra."
+                "la": "versus Orate pro nobis, etc.\ncum Oratione, ut supra."
               }
             }
           ]
@@ -184,23 +286,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Benedicti sint sancti Joachim et Anna, ex quibus benedicta Virgo Maria sine originali labe concepta et nata est.\n℣. Deus in adjutorium.\n℣. Gloria Patri. Alleluia."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+                "la": "Benedicti sint sancti Joachim et Anna, ex quibus benedicta Virgo Maria sine originali labe concepta et nata est."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Deus in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Mox numini sacratur\nVix facta trimula,\nAraque dedicatur\nTenella victima;\nEt praevolat parentum\nJam vota filia,\nEt multa se sequentum\nInvitat agmina."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Ps. 65. 12."
               }
@@ -214,7 +328,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Orate pro nobis, etc.\ncum Oratione, ut supra."
+                "la": "versus Orate pro nobis, etc.\ncum Oratione, ut supra."
               }
             }
           ]
@@ -230,23 +344,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Benedicti sint sancti Joachim et Anna, ex quibus benedicta Virgo Maria sine originali labe concepta et nata est.\n℣. Deus in adjutorium.\n℣. Gloria Patri. Alleluia."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+                "la": "Benedicti sint sancti Joachim et Anna, ex quibus benedicta Virgo Maria sine originali labe concepta et nata est."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Deus in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "Exinde quo labore\nEducta Filia!\nQuo coelitum favore\nNutrita parvula!\nIndustriae parentum\nFit axis aemulus,\nVirginumque coaetum\nServit cohortibus."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Rom 8. 28."
               }
@@ -260,7 +386,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Orate pro nobis, etc.\ncum Oratione, ut supra."
+                "la": "versus Orate pro nobis, etc.\ncum Oratione, ut supra."
               }
             }
           ]
@@ -276,23 +402,35 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Benedicti sint sancti Joachim et Anna, ex quibus benedicta Virgo Maria sine originali labe concepta et nata est.\n℣. Deus in adjutorium.\n℣. Gloria Patri. Alleluia."
-              }
-            },
-            {
-              "type": "rubric",
-              "text": {
-                "la": "Hymnus"
+                "la": "Benedicti sint sancti Joachim et Anna, ex quibus benedicta Virgo Maria sine originali labe concepta et nata est."
               }
             },
             {
               "type": "prayer",
               "inline": {
+                "la": "Deus in adjutorium."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Gloria Patri. Alleluia."
+              }
+            },
+            {
+              "type": "subheading",
+              "text": {
+                "la": "Hymnus"
+              }
+            },
+            {
+              "type": "hymn",
+              "inline": {
                 "la": "O Joachim, fidelis\nMinister aetheris!\nO Anna, nota coelis\nA Matre Numinis!\nUterque sanctitatis\nExemplar integrae:\nEt me beatitatis\nDonate lumine."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Prov. 4. 18."
               }
@@ -306,7 +444,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Orate pro nobis, etc.\ncum Oratione, ut supra."
+                "la": "versus Orate pro nobis, etc.\ncum Oratione, ut supra."
               }
             }
           ]
@@ -322,23 +460,49 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "Benedicti sint sancti Joachim et Anna, ex quibus benedicta Virgo Maria sine originali labe concepta et nata est.\n℣. Converte nos, Deus salutaris noster.\n℟. Et averte iram tuam a nobis.\n℣. Deus, in adjutorium meum intende.\n℟. Domine, ad adjuvandum me festina."
+                "la": "Benedicti sint sancti Joachim et Anna, ex quibus benedicta Virgo Maria sine originali labe concepta et nata est."
               }
             },
             {
-              "type": "rubric",
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Converte nos, Deus salutaris noster."
+                  },
+                  "r": {
+                    "la": "Et averte iram tuam a nobis."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus, in adjutorium meum intende."
+                  },
+                  "r": {
+                    "la": "Domine, ad adjuvandum me festina."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Obtutibus sacratis\nJam nata cernitur,\nComplexibus beatis\nPerenne jungitur:\nReciproce tenentur,\nTenetque undique\nDuo parva pars daretur\nEx hocce gaudio!"
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Ant. Eccl. 44. 13. 14."
               }
@@ -352,7 +516,7 @@
             {
               "type": "rubric",
               "text": {
-                "la": "℣. Orate pro nobis, etc.\ncum Oratione, ut supra."
+                "la": "versus Orate pro nobis, etc.\ncum Oratione, ut supra."
               }
             }
           ]
@@ -378,7 +542,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Oratio ad S. Joachim."
       }
@@ -390,7 +554,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Oratio ad S. Matrem Annam."
       }
@@ -402,7 +566,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Oratio ad Ambos SS. Joachim et Annam."
       }

--- a/content/practices/little-office-suffering-christ/flow.json
+++ b/content/practices/little-office-suffering-christ/flow.json
@@ -7,21 +7,39 @@
       }
     },
     {
-      "type": "prayer",
-      "inline": {
-        "la": "Oremus,\nDomine Jesu Christe, Fili Dei vivi! qui hora sexta pro redemptione mundi crucis patibulum ascendisti, et sanguinem tuum pretiosum in remissionem peccatorum nostrorum fudisti: Te humiliter deprecamur, ut post obitum nostrum, Paradisi janua nos gaudenter introire concedas. Qui vivis, et regnas cum Deo Patre, etc."
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nDeus qui in praeclara salutiferae Crucis Inventione, Passionis tuae miracula suscitasti: concede, ut vitalis ligni pretio aeternae vitae suffragia consequamur. Qui vivis, et regnas, etc."
+        "la": "Domine Jesu Christe, Fili Dei vivi! qui hora sexta pro redemptione mundi crucis patibulum ascendisti, et sanguinem tuum pretiosum in remissionem peccatorum nostrorum fudisti: Te humiliter deprecamur, ut post obitum nostrum, Paradisi janua nos gaudenter introire concedas. Qui vivis, et regnas cum Deo Patre, etc."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
       }
     },
     {
       "type": "prayer",
       "inline": {
-        "la": "Oremus,\nDeus qui nos hodierna die Exaltationis sanctae Crucis annua solemnitate laetificas: praesta, quaesumus, ut cujus mysterium in terra cognovimus, ejus redemptionis praemia in coelo mereamur. Per Dominum etc."
+        "la": "Deus qui in praeclara salutiferae Crucis Inventione, Passionis tuae miracula suscitasti: concede, ut vitalis ligni pretio aeternae vitae suffragia consequamur. Qui vivis, et regnas, etc."
+      }
+    },
+    {
+      "type": "rubric",
+      "text": {
+        "la": "Oremus."
+      }
+    },
+    {
+      "type": "prayer",
+      "inline": {
+        "la": "Deus qui nos hodierna die Exaltationis sanctae Crucis annua solemnitate laetificas: praesta, quaesumus, ut cujus mysterium in terra cognovimus, ejus redemptionis praemia in coelo mereamur. Per Dominum etc."
       }
     },
     {
@@ -50,19 +68,45 @@
           },
           "sections": [
             {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Domine labia mea aperies, etc."
+                  },
+                  "r": {
+                    "la": "Et os meum annuntiabit, etc."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Deus in adjutorium, etc."
+                  },
+                  "r": {
+                    "la": "Domine ad, etc."
+                  }
+                }
+              ]
+            },
+            {
               "type": "prayer",
               "inline": {
-                "la": "℣. Domine labia mea aperies, etc.\n℟. Et os meum annuntiabit, etc.\n℣. Deus in adjutorium, etc.\n℟. Domine ad, etc.\n℣. Gloria Patri, et Filio, etc."
+                "la": "Gloria Patri, et Filio, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus (e Psalmo 21)"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Ego autem sum vermis, et non homo:\nopprobrium hominum,\net abjectio plebis.\nOmnes videntes me, deriserunt me:\nlocuti sunt labiis, et moverunt caput."
               }
@@ -74,9 +118,22 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Contritum est cor meum in medio mei,\n℟. Contremuerunt omnia ossa mea. Jerem. 23. v. 9.\nOratio Domine Jesu Christe etc. ut supra."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Contritum est cor meum in medio mei,"
+                  },
+                  "r": {
+                    "la": "Contremuerunt omnia ossa mea. Jerem. 23. v. 9."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oratio Domine Jesu Christe etc. ut supra."
               }
             },
             {
@@ -86,9 +143,22 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Hoc signum Crucis erit in Coelo, Alleluia.\n℟. Cum Dominus ad judicandum venerit, Alleluia.\nOratio Deus! qui praeclara etc. ut supra."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Hoc signum Crucis erit in Coelo, Alleluia."
+                  },
+                  "r": {
+                    "la": "Cum Dominus ad judicandum venerit, Alleluia."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oratio Deus! qui praeclara etc. ut supra."
               }
             },
             {
@@ -98,9 +168,22 @@
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. O Crux splendidior cunctis astris!\n℟. Salva praesentem coetervam in tuis hodie laudibus congregatam.\nOratio Deus, qui nos etc. ut supra."
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "O Crux splendidior cunctis astris!"
+                  },
+                  "r": {
+                    "la": "Salva praesentem coetervam in tuis hodie laudibus congregatam."
+                  }
+                }
+              ]
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "Oratio Deus, qui nos etc. ut supra."
               }
             }
           ]
@@ -116,17 +199,17 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium etc."
+                "la": "Deus in adjutorium etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus (e Psalmo 21)"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Tribulatio proxima est:\nquoniam non est, qui adjuvet.\nCircumdederunt me vituli multi:\ntauri pingues obsederunt me."
               }
@@ -134,25 +217,61 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Pater mi! si possibile est,\ntranseat a me calix iste.\n℟. Verumtamen, non sicut ego volo,\nsed sicut Tu."
+                "la": "Pater mi! si possibile est,"
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "Oratio Domine Jesu Christe ut supra."
+                "la": "transeat a me calix iste."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Adoramus te Christe,\net benedicimus tibi, Alleluia.\n℟. Quia per crucem tuam redemisti mundum, Alleluia."
+                "la": "Verumtamen, non sicut ego volo,"
+              }
+            },
+            {
+              "type": "rubric",
+              "text": {
+                "la": "sed sicut Tu.\n\nOratio Domine Jesu Christe ut supra."
               }
             },
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. O nobile lignum exaltatur,\nChristi fides rutilat.\n℟. Dum Crux ab omnibus veneratur."
+                "la": "Adoramus te Christe,"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "et benedicimus tibi, Alleluia."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Quia per crucem tuam redemisti mundum, Alleluia."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "O nobile lignum exaltatur,"
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Christi fides rutilat."
+              }
+            },
+            {
+              "type": "prayer",
+              "inline": {
+                "la": "Dum Crux ab omnibus veneratur."
               }
             }
           ]
@@ -168,44 +287,65 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium etc."
+                "la": "Deus in adjutorium etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus (e Psalmo 21)"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Aperuerunt super me os suum,\nsicut leo rapiens et rugiens.\nSicut aqua effusus sum,\net dispersa sunt ossa mea:\nfactum est cor meum tanquam cera\nliquescens in medio ventris mei."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. O vos omnes! qui transitis per viam, attendite:\n℟. Et videte, si est dolor, sicut dolor meus. Thren. I. v. 12."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "O vos omnes! qui transitis per viam, attendite:"
+                  },
+                  "r": {
+                    "la": "Et videte, si est dolor, sicut dolor meus. Thren. I. v. 12."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oratio Domine Jesu Christe ut supra."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. O magnum pietatis opus! Alleluia.\n℟. Mors mortua tunc est, in ligno quando mortua vita fuit, Alleluia."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "O magnum pietatis opus! Alleluia."
+                  },
+                  "r": {
+                    "la": "Mors mortua tunc est, in ligno quando mortua vita fuit, Alleluia."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Tuam Crucem adoramus Domine:\n℟. Et recolimus tuam gloriosam Passionem."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Tuam Crucem adoramus Domine:"
+                  },
+                  "r": {
+                    "la": "Et recolimus tuam gloriosam Passionem."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -220,44 +360,65 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium etc."
+                "la": "Deus in adjutorium etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus (e Psalmo 21)"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Aruit tanquam testa virtus mea,\net lingua mea adhaesit faucibus meis:\net in pulverem mortis deduxisti me.\nQuoniam circumdederunt me\ncanes multi: consilium malignantium obsedit me."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Dedit percutienti se maxillam:\n℟. Saturatus est opprobiis."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Dedit percutienti se maxillam:"
+                  },
+                  "r": {
+                    "la": "Saturatus est opprobiis."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oratio Domine Jesu Christe, ut supra."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Salva nos Christe Salvator, Alleluia.\n℟. Per virtutem S. Crucis, Alleluia."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Salva nos Christe Salvator, Alleluia."
+                  },
+                  "r": {
+                    "la": "Per virtutem S. Crucis, Alleluia."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Hoc Signum Crucis erit in coelo:\n℟. Cum Dominus ad judicandum venerit."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Hoc Signum Crucis erit in coelo:"
+                  },
+                  "r": {
+                    "la": "Cum Dominus ad judicandum venerit."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -272,44 +433,65 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium etc."
+                "la": "Deus in adjutorium etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus (e Psal. 21)"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Foderunt manus meas, et pedes meos,\net dinumeraverunt omnia ossa mea,\nIpsi vero consideraverunt; et inspexerunt me:\ndiviserunt sibi vestimenta mea,\net super vestem meam miserunt sortem."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Sicut ovis ad occisionem ductus est:\n℟. Et quasi Agnus coram tondente se obmutuit. Isaiae 53. v. 7."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Sicut ovis ad occisionem ductus est:"
+                  },
+                  "r": {
+                    "la": "Et quasi Agnus coram tondente se obmutuit. Isaiae 53. v. 7."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oratio Domine Jesu Christe, etc."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ecce Crucem Domini, Alleluia.\n℟. Fugite partes adversae, Alleluia."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ecce Crucem Domini, Alleluia."
+                  },
+                  "r": {
+                    "la": "Fugite partes adversae, Alleluia."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. O Crux benedicta!\n℟. Quae sola digna fuisti portare Regem Coelorum."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "O Crux benedicta!"
+                  },
+                  "r": {
+                    "la": "Quae sola digna fuisti portare Regem Coelorum."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -324,44 +506,65 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Deus in adjutorium, etc."
+                "la": "Deus in adjutorium, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "subheading",
               "text": {
                 "la": "Hymnus (e Psal. 37)"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Qui inquirebant mala mihi,\nlocuti sunt vanitates,\net dolos tota die meditabantur,\nEgo autem tanquam surdus non audiebam,\net sicut mutus non aperiens os suum,"
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Humiliavit semetipsum:\n℟. Factus obediens usque ad mortem, mortem autem Crucis. Philip. 2. v. 8."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Humiliavit semetipsum:"
+                  },
+                  "r": {
+                    "la": "Factus obediens usque ad mortem, mortem autem Crucis. Philip. 2. v. 8."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oratio Domine Jesu Christe, ut supra."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Nos autem gloriari oportet, Alleluia.\n℟. In Cruce Domini nostri Jesu Christi. Alleluia. Gal. 6. v. 4."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Nos autem gloriari oportet, Alleluia."
+                  },
+                  "r": {
+                    "la": "In Cruce Domini nostri Jesu Christi. Alleluia. Gal. 6. v. 4."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Per lignum servi facti sumus:\n℟. Et per sanctam Crucem liberati sumus."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per lignum servi facti sumus:"
+                  },
+                  "r": {
+                    "la": "Et per sanctam Crucem liberati sumus."
+                  }
+                }
+              ]
             }
           ]
         },
@@ -376,44 +579,71 @@
             {
               "type": "prayer",
               "inline": {
-                "la": "℣. Converte nos Deus, etc.\n℣. Deus in adjutorium, etc."
+                "la": "Converte nos Deus, etc."
               }
             },
             {
-              "type": "rubric",
+              "type": "prayer",
+              "inline": {
+                "la": "Deus in adjutorium, etc."
+              }
+            },
+            {
+              "type": "subheading",
               "text": {
                 "la": "Hymnus (e Psal. 68)"
               }
             },
             {
-              "type": "prayer",
+              "type": "hymn",
               "inline": {
                 "la": "Improperium exspectavit cor meum, et miseriam,\net sustinui, qui simul contristaretur, et non fuit,\net qui consoleretur, et non inveni,\nEt dederunt in escam meam fel,\net in siti mea potaverunt me aceto."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Tradidit in mortem animam suam.\n℟. Et cum sceleratis reputatus est. Isaiae 53. 12."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Tradidit in mortem animam suam."
+                  },
+                  "r": {
+                    "la": "Et cum sceleratis reputatus est. Isaiae 53. 12."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
+              "type": "rubric",
+              "text": {
                 "la": "Oratio Domine Jesu Christe, ut supra."
               }
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Per signum Crucis, Alleluia.\n℟. De inimicis nostris libera nos Deus noster, Alleluia."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Per signum Crucis, Alleluia."
+                  },
+                  "r": {
+                    "la": "De inimicis nostris libera nos Deus noster, Alleluia."
+                  }
+                }
+              ]
             },
             {
-              "type": "prayer",
-              "inline": {
-                "la": "℣. Ad Crucis contactum resurgunt mortui:\n℟. Et Dei magnalia referantur."
-              }
+              "type": "response",
+              "verses": [
+                {
+                  "v": {
+                    "la": "Ad Crucis contactum resurgunt mortui:"
+                  },
+                  "r": {
+                    "la": "Et Dei magnalia referantur."
+                  }
+                }
+              ]
             }
           ]
         }
@@ -468,7 +698,7 @@
       }
     },
     {
-      "type": "rubric",
+      "type": "subheading",
       "text": {
         "la": "Oratio ad Deum Spiritum Sanctum"
       }


### PR DESCRIPTION
## Summary
- manually review all 85 imported little-office flows
- convert versicle/response exchanges to response sections and remove authored glyphs
- separate rubrics and structural labels from prayed text
- consolidate hymn stanzas and split absorbed hymn tails
- preserve mismatched Latin/English structures with language-scoped sections

## Verification
- per-office semantic audit: 85/85 pass
- content-engine tests: 166 passed
- corpus build: succeeded
- git diff --check: clean
- pnpm validate-flows: no little-office errors; repository retains the pre-existing unrelated baseline of 111 errors