### PR TITLE
Books: collapsible tree Sumário on the book page + reliable reader TOC close

### DIFF
--- a/apps/app/src/app/(tabs)/(today,explore,library,you,search)/browse/book/[bookId]/index.tsx
+++ b/apps/app/src/app/(tabs)/(today,explore,library,you,search)/browse/book/[bookId]/index.tsx
@@ -117,6 +117,10 @@ export default function BookDetailScreen() {
     return total > 0 ? total : undefined
   }, [chapterMinutes, leaves, completed])
 
+  const cursor = getCursor(bookRef)
+  const position = cursor ? parseReaderPosition(cursor.position) : undefined
+  const resumeChapterId = position?.chapterId
+
   // Collapsible-tree state for the inline Sumário. Seeded once the manifest
   // loads: small trees open fully (the familiar outline); huge trees stay
   // collapsed to the top level, with the resume chapter's ancestors opened so
@@ -126,14 +130,10 @@ export default function BookDetailScreen() {
   useEffect(() => {
     if (seededExpand.current || !book?.toc) return
     seededExpand.current = true
-    if (tocTooLarge) {
-      const cur = getCursor(bookRef)
-      const resume = cur ? parseReaderPosition(cur.position)?.chapterId : undefined
-      setExpandedIds(ancestorGroupIds(book.toc, resume))
-    } else {
-      setExpandedIds(collectAllSectionIds(book.toc))
-    }
-  }, [book?.toc, tocTooLarge, bookRef])
+    setExpandedIds(
+      tocTooLarge ? ancestorGroupIds(book.toc, resumeChapterId) : collectAllSectionIds(book.toc),
+    )
+  }, [book?.toc, tocTooLarge, resumeChapterId])
 
   const flatToc = useMemo(
     () => (book?.toc ? flattenToc(book.toc, expandedIds) : []),
@@ -183,9 +183,6 @@ export default function BookDetailScreen() {
   const author = authorSrc ? localizeContent(authorSrc as never) : undefined
   const description = book?.description ? localizeContent(book.description) : undefined
 
-  const cursor = getCursor(bookRef)
-  const position = cursor ? parseReaderPosition(cursor.position) : undefined
-  const resumeChapterId = position?.chapterId
   const ctaLabel = resumeChapterId ? t('book.continue') : t('book.startReading')
 
   const currentLeafIndex = position ? leaves.findIndex((l) => l.id === position.chapterId) : -1
@@ -371,9 +368,8 @@ function SumarioHeading({
               </XStack>
             </Pressable>
           ) : null}
-          <YStack flex={1} />
           {showExpandControls ? (
-            <XStack gap="$md">
+            <XStack gap="$md" marginLeft="auto">
               <Pressable onPress={onExpandAll} hitSlop={8} accessibilityRole="button">
                 <Typography variant="interface" fontSize="$1" color="$accent">
                   {t('books.expandAll', { defaultValue: 'Expand all' })}

--- a/apps/app/src/app/(tabs)/(today,explore,library,you,search)/browse/book/[bookId]/index.tsx
+++ b/apps/app/src/app/(tabs)/(today,explore,library,you,search)/browse/book/[bookId]/index.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { type Href, useLocalSearchParams, useRouter } from 'expo-router'
-import { Check, ChevronRight } from 'lucide-react-native'
-import { useMemo, useState } from 'react'
+import { Check, ChevronDown, ChevronRight, Search } from 'lucide-react-native'
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Pressable } from 'react-native'
 import Animated, { useAnimatedScrollHandler, useSharedValue } from 'react-native-reanimated'
@@ -14,10 +14,16 @@ import type { BookEntry, TocNode } from '@/content/manifestTypes'
 import { getCursor } from '@/db/repositories'
 import { BookHero } from '@/features/books/BookHero'
 import {
+  ancestorGroupIds,
+  buildCompletedLeafIndex,
+  buildLeafCountIndex,
   buildTitleLookup,
-  countLeavesUnder,
+  collectAllSectionIds,
   countTocNodes,
-  firstLeafId,
+  type FlatTocItem,
+  flattenToc,
+  hasNestedSections,
+  localizedTitle,
 } from '@/features/books/reader/bookContent'
 import { listCompletedChapters } from '@/features/books/reader/chapterCompletions'
 import { loadChapterMinutes } from '@/features/books/reader/chapterTimings'
@@ -111,6 +117,57 @@ export default function BookDetailScreen() {
     return total > 0 ? total : undefined
   }, [chapterMinutes, leaves, completed])
 
+  // Collapsible-tree state for the inline Sumário. Seeded once the manifest
+  // loads: small trees open fully (the familiar outline); huge trees stay
+  // collapsed to the top level, with the resume chapter's ancestors opened so
+  // it's reachable.
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
+  const seededExpand = useRef(false)
+  useEffect(() => {
+    if (seededExpand.current || !book?.toc) return
+    seededExpand.current = true
+    if (tocTooLarge) {
+      const cur = getCursor(bookRef)
+      const resume = cur ? parseReaderPosition(cur.position)?.chapterId : undefined
+      setExpandedIds(ancestorGroupIds(book.toc, resume))
+    } else {
+      setExpandedIds(collectAllSectionIds(book.toc))
+    }
+  }, [book?.toc, tocTooLarge, bookRef])
+
+  const flatToc = useMemo(
+    () => (book?.toc ? flattenToc(book.toc, expandedIds) : []),
+    [book?.toc, expandedIds],
+  )
+  const toggleTocExpand = useCallback((id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+  const expandAllToc = useCallback(() => {
+    if (book?.toc) setExpandedIds(collectAllSectionIds(book.toc))
+  }, [book?.toc])
+  const collapseAllToc = useCallback(() => setExpandedIds(new Set()), [])
+  const showTocExpandControls = useMemo(
+    () => (book?.toc ? hasNestedSections(book.toc) || tocTooLarge : false),
+    [book?.toc, tocTooLarge],
+  )
+
+  // Leaf totals (and finished counts) for every group row, walked once instead
+  // of recursing per row on each scroll frame — the Encyclopedia's letters span
+  // ~1,300 chapters each.
+  const tocLeafCounts = useMemo(
+    () => (book?.toc ? buildLeafCountIndex(book.toc) : new Map<string, number>()),
+    [book?.toc],
+  )
+  const tocCompletedCounts = useMemo(
+    () => (book?.toc ? buildCompletedLeafIndex(book.toc, completed) : new Map<string, number>()),
+    [book?.toc, completed],
+  )
+
   if (!entry) {
     return (
       <YStack flex={1} backgroundColor="$background" alignItems="center" justifyContent="center">
@@ -142,9 +199,29 @@ export default function BookDetailScreen() {
     params: chapter ? { bookId, chapter } : { bookId },
   })
 
+  const hasToc = !!book?.toc && book.toc.length > 0
+
   return (
     <>
-      <Animated.ScrollView
+      {/* One virtualized list for the whole screen: the hero + meta live in the
+          header so the collapsible Sumário can virtualize (a list can't nest in
+          a ScrollView). onScroll still feeds the hero's parallax. */}
+      <Animated.FlatList
+        data={flatToc}
+        keyExtractor={tocKeyExtractor}
+        getItemLayout={tocGetItemLayout}
+        renderItem={({ item }) => (
+          <TocTreeRow
+            item={item}
+            lang={lang}
+            currentChapterId={resumeChapterId}
+            completed={completed}
+            leafCounts={tocLeafCounts}
+            completedCounts={tocCompletedCounts}
+            buildHref={readerHref}
+            onToggle={toggleTocExpand}
+          />
+        )}
         onScroll={onScroll}
         scrollEventThrottle={16}
         style={{ flex: 1, backgroundColor: background }}
@@ -152,63 +229,65 @@ export default function BookDetailScreen() {
           paddingBottom: insets.bottom + nativeTabBarClearance + nowPlaying,
         }}
         contentInsetAdjustmentBehavior="never"
-      >
-        <BookHero
-          name={name}
-          author={author}
-          ctaLabel={ctaLabel}
-          tone={toneByIndex(toneIndexForId(bookRef))}
-          scrollY={scrollY}
-          readHref={readerHref()}
-        />
-
-        {/* Opaque column over the hero's lower bleed; paddingTop clears the
-            floating capsule that straddles the seam. */}
-        <YStack
-          width="100%"
-          maxWidth={640}
-          alignSelf="center"
-          paddingHorizontal="$lg"
-          paddingTop={40}
-          gap="$lg"
-          backgroundColor="$background"
-        >
-          <LibraryActionRow
-            itemId={bookRef}
-            kind="book"
-            onAddToCollection={() => setAddingToCollection(true)}
-          />
-
-          {progressFraction > 0 && (
-            <BookProgressLine
-              fraction={progressFraction}
-              currentLeafIndex={currentLeafIndex}
-              totalLeaves={leaves.length}
-              completedCount={completed.size}
-              minutesRemaining={minutesRemaining}
-              minutesRead={readingTimeMs > 60_000 ? Math.round(readingTimeMs / 60_000) : undefined}
-              streakDays={streakDays > 1 ? streakDays : undefined}
-              updatedAt={position?.updatedAt}
-              label={resumeChapterId ? titleLookup.get(resumeChapterId) : undefined}
+        ListHeaderComponent={
+          <>
+            <BookHero
+              name={name}
+              author={author}
+              ctaLabel={ctaLabel}
+              tone={toneByIndex(toneIndexForId(bookRef))}
+              scrollY={scrollY}
+              readHref={readerHref()}
             />
-          )}
 
-          {description && <PrologueProse text={description} />}
+            {/* Opaque column over the hero's lower bleed; paddingTop clears the
+                floating capsule that straddles the seam. */}
+            <YStack
+              width="100%"
+              maxWidth={640}
+              alignSelf="center"
+              paddingHorizontal="$lg"
+              paddingTop={40}
+              gap="$lg"
+              backgroundColor="$background"
+            >
+              <LibraryActionRow
+                itemId={bookRef}
+                kind="book"
+                onAddToCollection={() => setAddingToCollection(true)}
+              />
 
-          {book?.toc && book.toc.length > 0 && (
-            <Contents
-              toc={book.toc}
-              lang={lang}
-              compact={tocTooLarge}
-              currentChapterId={resumeChapterId}
-              completed={completed}
-              totalLeaves={leaves.length}
-              buildHref={readerHref}
-              onBrowseAll={() => setBrowsingToc(true)}
-            />
-          )}
-        </YStack>
-      </Animated.ScrollView>
+              {progressFraction > 0 && (
+                <BookProgressLine
+                  fraction={progressFraction}
+                  currentLeafIndex={currentLeafIndex}
+                  totalLeaves={leaves.length}
+                  completedCount={completed.size}
+                  minutesRemaining={minutesRemaining}
+                  minutesRead={
+                    readingTimeMs > 60_000 ? Math.round(readingTimeMs / 60_000) : undefined
+                  }
+                  streakDays={streakDays > 1 ? streakDays : undefined}
+                  updatedAt={position?.updatedAt}
+                  label={resumeChapterId ? titleLookup.get(resumeChapterId) : undefined}
+                />
+              )}
+
+              {description && <PrologueProse text={description} />}
+
+              {hasToc ? (
+                <SumarioHeading
+                  showExpandControls={showTocExpandControls}
+                  showSearch={tocTooLarge}
+                  onExpandAll={expandAllToc}
+                  onCollapseAll={collapseAllToc}
+                  onSearch={() => setBrowsingToc(true)}
+                />
+              ) : null}
+            </YStack>
+          </>
+        }
+      />
 
       <AddToCollectionSheet
         itemRef={bookRef}
@@ -236,187 +315,167 @@ export default function BookDetailScreen() {
   )
 }
 
-/** The table of contents — an illuminated marker + a tappable chapter list. */
-function Contents({
-  toc,
-  lang,
-  compact,
-  currentChapterId,
-  completed,
-  totalLeaves,
-  buildHref,
-  onBrowseAll,
+const tocRowHeight = 56
+
+function tocKeyExtractor(item: FlatTocItem) {
+  return item.node.id
+}
+
+function tocGetItemLayout(_: unknown, index: number) {
+  return { length: tocRowHeight, offset: tocRowHeight * index, index }
+}
+
+function tocTitle(node: TocNode, lang: string): string {
+  return localizedTitle(node.title, lang) ?? node.id
+}
+
+/** The ✦ Sumário marker, plus expand/collapse + search controls for big trees. */
+function SumarioHeading({
+  showExpandControls,
+  showSearch,
+  onExpandAll,
+  onCollapseAll,
+  onSearch,
 }: {
-  toc: TocNode[]
-  lang: string
-  /** True for huge TOCs: render only top-level sections + a "Browse all" button. */
-  compact: boolean
-  currentChapterId?: string
-  completed: Set<string>
-  totalLeaves: number
-  buildHref: (chapterId: string) => Href
-  onBrowseAll: () => void
+  showExpandControls: boolean
+  showSearch: boolean
+  onExpandAll: () => void
+  onCollapseAll: () => void
+  onSearch: () => void
 }) {
   const { t } = useTranslation()
+  const theme = useTheme()
   return (
-    <YStack gap="$md">
-      <XStack alignItems="center" gap="$sm" paddingTop="$sm">
+    <YStack gap="$sm" paddingTop="$sm">
+      <XStack alignItems="center" gap="$sm">
         <Typography fontSize="$1">✦</Typography>
         <Typography variant="screen-title" fontSize="$4" textAlign="left">
           {t('book.contents')}
         </Typography>
         <YStack flex={1} height={1} backgroundColor="$accentSubtle" />
       </XStack>
-      <YStack>
-        {compact
-          ? toc.map((node) => (
-              <CompactSectionRow
-                key={node.id}
-                node={node}
-                lang={lang}
-                completed={completed}
-                buildHref={buildHref}
-              />
-            ))
-          : toc.map((node) => (
-              <TocNodeRow
-                key={node.id}
-                node={node}
-                lang={lang}
-                depth={0}
-                currentChapterId={currentChapterId}
-                completed={completed}
-                buildHref={buildHref}
-              />
-            ))}
-      </YStack>
-      {compact ? (
-        <Pressable onPress={onBrowseAll} accessibilityRole="button">
-          <XStack
-            alignItems="center"
-            justifyContent="center"
-            paddingVertical="$md"
-            borderRadius="$md"
-            backgroundColor="$accentSubtle"
-          >
-            <Typography variant="interface" fontSize="$2" color="$accent">
-              {t('book.browseAllChapters', {
-                defaultValue: 'Browse all {{count}} chapters',
-                count: totalLeaves,
-              })}
-            </Typography>
-          </XStack>
-        </Pressable>
+      {showExpandControls || showSearch ? (
+        <XStack alignItems="center" gap="$md">
+          {showSearch ? (
+            <Pressable
+              onPress={onSearch}
+              hitSlop={8}
+              accessibilityRole="button"
+              accessibilityLabel={t('books.searchChapters', { defaultValue: 'Search chapters' })}
+            >
+              <XStack alignItems="center" gap="$xs">
+                <Search size={14} color={theme.accent?.val} />
+                <Typography variant="interface" fontSize="$1" color="$accent">
+                  {t('books.searchChapters', { defaultValue: 'Search chapters' })}
+                </Typography>
+              </XStack>
+            </Pressable>
+          ) : null}
+          <YStack flex={1} />
+          {showExpandControls ? (
+            <XStack gap="$md">
+              <Pressable onPress={onExpandAll} hitSlop={8} accessibilityRole="button">
+                <Typography variant="interface" fontSize="$1" color="$accent">
+                  {t('books.expandAll', { defaultValue: 'Expand all' })}
+                </Typography>
+              </Pressable>
+              <Pressable onPress={onCollapseAll} hitSlop={8} accessibilityRole="button">
+                <Typography variant="interface" fontSize="$1" color="$accent">
+                  {t('books.collapseAll', { defaultValue: 'Collapse all' })}
+                </Typography>
+              </Pressable>
+            </XStack>
+          ) : null}
+        </XStack>
       ) : null}
     </YStack>
   )
 }
 
-/**
- * Top-level section row for huge TOCs (Catholic Encyclopedia etc.). Renders
- * the section title + leaf count + completion fraction; tap opens the reader
- * at the section's first leaf.
- */
-function CompactSectionRow({
-  node,
-  lang,
-  completed,
-  buildHref,
-}: {
-  node: TocNode
-  lang: string
-  completed: Set<string>
-  buildHref: (chapterId: string) => Href
-}) {
-  const theme = useTheme()
-  const router = useRouter()
-  const title =
-    (node.title as Record<string, string>)[lang] ?? Object.values(node.title)[0] ?? node.id
-  const totalLeavesUnder = countLeavesUnder(node)
-  const completedUnder = useMemo(() => {
-    let n = 0
-    function walk(n2: TocNode) {
-      if (!n2.children?.length) {
-        if (completed.has(n2.id)) n++
-        return
-      }
-      for (const c of n2.children) walk(c)
-    }
-    walk(node)
-    return n
-  }, [node, completed])
-  const target = firstLeafId(node)
-
-  // Plain router.push (see TocNodeRow comment) — AppleZoom from inside a
-  // scrollable list left a ghost view that blocked taps on the frontispiece.
+/** Constrains a TOC row to the same centered column the header meta uses. */
+function TocRowFrame({ children }: { children: ReactNode }) {
   return (
-    <Pressable
-      onPress={() => router.push(buildHref(target))}
-      accessibilityRole="link"
-      accessibilityLabel={title}
-      style={{ width: '100%' }}
+    <YStack
+      width="100%"
+      maxWidth={640}
+      alignSelf="center"
+      paddingHorizontal="$lg"
+      backgroundColor="$background"
     >
-      <XStack
-        alignItems="center"
-        gap="$sm"
-        paddingVertical="$md"
-        borderBottomWidth={0.5}
-        borderColor="$accentSubtle"
-      >
-        <YStack flex={1} gap="$xs">
-          <Typography variant="interface" fontSize="$3" numberOfLines={2}>
-            {title}
-          </Typography>
-          <Typography variant="label" fontSize="$1" color="$colorSecondary" opacity={0.75}>
-            {completedUnder > 0
-              ? `${completedUnder} / ${totalLeavesUnder}`
-              : `${totalLeavesUnder} chapters`}
-          </Typography>
-        </YStack>
-        <ChevronRight size={16} color={theme.colorSecondary?.val} />
-      </XStack>
-    </Pressable>
+      {children}
+    </YStack>
   )
 }
 
-function TocNodeRow({
-  node,
+/**
+ * One row of the collapsible Sumário. Group nodes (with children) toggle
+ * expand/collapse in place; leaf nodes open the reader. Fixed height so the
+ * list virtualizes via getItemLayout — the 12k-chapter Encyclopedia stays smooth.
+ */
+function TocTreeRow({
+  item,
   lang,
-  depth,
   currentChapterId,
   completed,
+  leafCounts,
+  completedCounts,
   buildHref,
+  onToggle,
 }: {
-  node: TocNode
+  item: FlatTocItem
   lang: string
-  depth: number
   currentChapterId?: string
   completed: Set<string>
+  leafCounts: Map<string, number>
+  completedCounts: Map<string, number>
   buildHref: (chapterId: string) => Href
+  onToggle: (id: string) => void
 }) {
+  const { t } = useTranslation()
   const theme = useTheme()
   const router = useRouter()
-  const title =
-    (node.title as Record<string, string>)[lang] ?? Object.values(node.title)[0] ?? node.id
+  const { node, depth, isLeaf, isExpanded } = item
+  const title = tocTitle(node, lang)
+  const indent = depth * 16
 
-  if (node.children?.length) {
+  if (!isLeaf) {
+    const total = leafCounts.get(node.id) ?? 0
+    const done = completedCounts.get(node.id) ?? 0
     return (
-      <YStack gap="$xs" paddingTop="$sm">
-        <Typography variant="label" fontSize="$1" paddingLeft={depth * 16}>
-          {title}
-        </Typography>
-        {node.children.map((child) => (
-          <TocNodeRow
-            key={child.id}
-            node={child}
-            lang={lang}
-            depth={depth + 1}
-            currentChapterId={currentChapterId}
-            completed={completed}
-            buildHref={buildHref}
-          />
-        ))}
-      </YStack>
+      <TocRowFrame>
+        <Pressable
+          onPress={() => onToggle(node.id)}
+          accessibilityRole="button"
+          accessibilityLabel={title}
+          accessibilityState={{ expanded: isExpanded }}
+          style={{ width: '100%' }}
+        >
+          <XStack
+            height={tocRowHeight}
+            alignItems="center"
+            gap="$sm"
+            paddingLeft={indent}
+            borderBottomWidth={0.5}
+            borderColor="$accentSubtle"
+          >
+            {isExpanded ? (
+              <ChevronDown size={16} color={theme.colorSecondary?.val} />
+            ) : (
+              <ChevronRight size={16} color={theme.colorSecondary?.val} />
+            )}
+            <YStack flex={1} gap="$xs">
+              <Typography variant="interface" fontSize="$3" numberOfLines={1}>
+                {title}
+              </Typography>
+              <Typography variant="label" fontSize="$1" color="$colorSecondary" opacity={0.75}>
+                {done > 0
+                  ? `${done} / ${total}`
+                  : t('book.sectionChapters', { defaultValue: '{{count}} chapters', count: total })}
+              </Typography>
+            </YStack>
+          </XStack>
+        </Pressable>
+      </TocRowFrame>
     )
   }
 
@@ -425,45 +484,49 @@ function TocNodeRow({
 
   // Plain router.push instead of ZoomLink. AppleZoom triggered from a row
   // inside a scrollable list appears to leave a snapshot view that blocks
-  // taps on the frontispiece after the modal dismisses (the bug doesn't
-  // recur when the user opens the reader from the BookHero CTA, which is
-  // outside the ScrollView). The Hero keeps its zoom morph.
+  // taps on the frontispiece after the modal dismisses. The Hero keeps its
+  // zoom morph.
   return (
-    <Pressable
-      onPress={() => router.push(buildHref(node.id))}
-      accessibilityRole="link"
-      accessibilityLabel={title}
-      style={{ width: '100%' }}
-    >
-      <XStack
-        alignItems="center"
-        gap="$sm"
-        paddingVertical="$sm"
-        paddingLeft={depth * 16}
-        borderBottomWidth={0.5}
-        borderColor="$accentSubtle"
+    <TocRowFrame>
+      <Pressable
+        onPress={() => router.push(buildHref(node.id))}
+        accessibilityRole="link"
+        accessibilityLabel={title}
+        style={{ width: '100%' }}
       >
-        <Typography
-          variant="interface"
-          fontSize="$3"
-          flex={1}
-          numberOfLines={2}
-          color={isCurrent ? '$accent' : '$color'}
-          opacity={isCompleted && !isCurrent ? 0.6 : 1}
+        <XStack
+          height={tocRowHeight}
+          alignItems="center"
+          gap="$sm"
+          paddingLeft={indent}
+          borderBottomWidth={0.5}
+          borderColor="$accentSubtle"
         >
-          {title}
-        </Typography>
-        {node.pointRange ? (
-          <Typography variant="label" fontSize="$1" color="$colorSecondary" opacity={0.8}>
-            {`${node.pointRange.from}–${node.pointRange.to}`}
+          <Typography
+            variant="interface"
+            fontSize="$3"
+            flex={1}
+            numberOfLines={2}
+            color={isCurrent ? '$accent' : '$color'}
+            opacity={isCompleted && !isCurrent ? 0.6 : 1}
+          >
+            {title}
           </Typography>
-        ) : null}
-        {isCompleted ? (
-          <Check size={14} color={theme.accent?.val ?? theme.colorSecondary?.val} />
-        ) : null}
-        <ChevronRight size={16} color={isCurrent ? theme.accent?.val : theme.colorSecondary?.val} />
-      </XStack>
-    </Pressable>
+          {node.pointRange ? (
+            <Typography variant="label" fontSize="$1" color="$colorSecondary" opacity={0.8}>
+              {`${node.pointRange.from}–${node.pointRange.to}`}
+            </Typography>
+          ) : null}
+          {isCompleted ? (
+            <Check size={14} color={theme.accent?.val ?? theme.colorSecondary?.val} />
+          ) : null}
+          <ChevronRight
+            size={16}
+            color={isCurrent ? theme.accent?.val : theme.colorSecondary?.val}
+          />
+        </XStack>
+      </Pressable>
+    </TocRowFrame>
   )
 }
 

--- a/apps/app/src/features/books/reader/BookReader.tsx
+++ b/apps/app/src/features/books/reader/BookReader.tsx
@@ -628,9 +628,10 @@ export function BookReader({ bookId, chapter }: Props) {
 
   const handleSelectChapter = useCallback(
     (id: string) => {
+      // The TOC sheet owns its own dismissal (closes before this fires); we
+      // only navigate. See ReaderTocSheet's close-first tap handler.
       const idx = leaves.findIndex((l) => l.id === id)
       if (idx >= 0) foliateRef.current?.goTo(idx, 0)
-      setSheet(null)
     },
     [leaves],
   )

--- a/apps/app/src/features/books/reader/ReaderTocSheet.tsx
+++ b/apps/app/src/features/books/reader/ReaderTocSheet.tsx
@@ -9,7 +9,13 @@ import { Text, useTheme, XStack, YStack } from 'tamagui'
 import type { TocNode } from '@/content/resolver'
 import { localizeContent } from '@/lib/i18n'
 import { useDebounced } from '@/lib/useDebounced'
-import { collectAllSectionIds, hasNestedSections } from './bookContent'
+import {
+  ancestorGroupIds,
+  collectAllSectionIds,
+  type FlatTocItem,
+  flattenToc,
+  hasNestedSections,
+} from './bookContent'
 import type { ChapterTiming } from './chapterTimings'
 
 type Props = {
@@ -27,51 +33,18 @@ type Props = {
   onSelect: (chapterId: string) => void
 }
 
-type FlatTocItem = {
-  node: TocNode
-  depth: number
-  isLeaf: boolean
-  isExpanded: boolean
-}
-
 const itemHeight = 48
 const sheetFraction = 0.85
 
-function flattenToc(nodes: TocNode[], expandedIds: Set<string>, depth = 0): FlatTocItem[] {
-  const result: FlatTocItem[] = []
-  for (const node of nodes) {
-    const isLeaf = !node.children?.length
-    const isExpanded = !isLeaf && expandedIds.has(node.id)
-    result.push({ node, depth, isLeaf, isExpanded })
-    if (isExpanded && node.children) {
-      result.push(...flattenToc(node.children, expandedIds, depth + 1))
-    }
-  }
-  return result
-}
-
-// Auto-expand the ancestor chain of the current chapter so the user opens the
-// TOC and immediately sees where they are.
+// Auto-expand the top-level groups plus the ancestor chain of the current
+// chapter so the user opens the TOC and immediately sees where they are. The
+// sheet is virtualized, so expanding every top-level group up front is cheap.
 function collectInitialExpanded(toc: TocNode[], currentChapterId?: string): Set<string> {
   const ids = new Set<string>()
   for (const node of toc) {
     if (node.children?.length) ids.add(node.id)
   }
-  if (!currentChapterId) return ids
-  function findAncestors(nodes: TocNode[], path: string[]): boolean {
-    for (const node of nodes) {
-      if (node.id === currentChapterId) return true
-      if (node.children?.length) {
-        path.push(node.id)
-        if (findAncestors(node.children, path)) return true
-        path.pop()
-      }
-    }
-    return false
-  }
-  const path: string[] = []
-  findAncestors(toc, path)
-  for (const id of path) ids.add(id)
+  for (const id of ancestorGroupIds(toc, currentChapterId)) ids.add(id)
   return ids
 }
 
@@ -214,8 +187,11 @@ export function ReaderTocSheet({
               return (
                 <Pressable
                   onPress={() => {
-                    onSelect(node.id)
+                    // Close first, then navigate on the next frame: a synchronous
+                    // foliate goTo (injectJavaScript) in the same tick interrupts
+                    // the native sheet's dismiss animation and leaves it open.
                     onClose()
+                    requestAnimationFrame(() => onSelect(node.id))
                   }}
                   accessibilityRole="link"
                   accessibilityLabel={title}
@@ -294,8 +270,8 @@ export function ReaderTocSheet({
                     // Readable group → navigate + close the tray (like leaves);
                     // a body-less group just expands and the tray stays open.
                     if (isReadableGroup) {
-                      onSelect(node.id)
                       onClose()
+                      requestAnimationFrame(() => onSelect(node.id))
                     } else {
                       toggleExpand(node.id)
                     }

--- a/apps/app/src/features/books/reader/__tests__/bookContent.test.ts
+++ b/apps/app/src/features/books/reader/__tests__/bookContent.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import type { BookEntry, TocNode } from '@/content/manifestTypes'
-import { buildTitleLookup, flattenReadingFlow, promoteFirstHeading } from '../bookContent'
+import {
+  ancestorGroupIds,
+  buildTitleLookup,
+  flattenReadingFlow,
+  flattenToc,
+  promoteFirstHeading,
+} from '../bookContent'
 
 const sample: TocNode[] = [
   { id: 'preface', title: { 'en-US': 'Preface', 'pt-BR': 'Prefácio' } },
@@ -53,6 +59,54 @@ describe('flattenReadingFlow', () => {
   it('honors an explicit role override', () => {
     const toc: TocNode[] = [{ id: 'intro', title: { 'en-US': 'Intro' }, role: 'section' }]
     expect(flattenReadingFlow(toc, manifest([]), 'en-US')[0].role).toBe('section')
+  })
+})
+
+describe('flattenToc', () => {
+  it('hides children of collapsed groups, showing only top-level rows', () => {
+    const rows = flattenToc(sample, new Set())
+    expect(rows.map((r) => r.node.id)).toEqual(['preface', 'book-1', 'epilogue'])
+    expect(rows.map((r) => r.isLeaf)).toEqual([true, false, true])
+    expect(rows.find((r) => r.node.id === 'book-1')?.isExpanded).toBe(false)
+  })
+
+  it('reveals a group’s children only while it is expanded, with depth', () => {
+    const rows = flattenToc(sample, new Set(['book-1']))
+    expect(rows.map((r) => [r.node.id, r.depth])).toEqual([
+      ['preface', 0],
+      ['book-1', 0],
+      ['ch-1', 1],
+      ['ch-2', 1],
+      ['epilogue', 0],
+    ])
+    // ch-2 is itself a collapsed group → its children stay hidden.
+    expect(rows.some((r) => r.node.id === 'ch-2-a')).toBe(false)
+  })
+
+  it('expands nested groups when both ancestors are open', () => {
+    const rows = flattenToc(sample, new Set(['book-1', 'ch-2']))
+    expect(rows.map((r) => r.node.id)).toEqual([
+      'preface',
+      'book-1',
+      'ch-1',
+      'ch-2',
+      'ch-2-a',
+      'ch-2-b',
+      'epilogue',
+    ])
+    expect(rows.find((r) => r.node.id === 'ch-2-a')?.depth).toBe(2)
+  })
+})
+
+describe('ancestorGroupIds', () => {
+  it('returns the group path down to a deep leaf, excluding the leaf', () => {
+    expect([...ancestorGroupIds(sample, 'ch-2-a')]).toEqual(['book-1', 'ch-2'])
+  })
+
+  it('is empty for a top-level node or an unknown / missing target', () => {
+    expect(ancestorGroupIds(sample, 'preface').size).toBe(0)
+    expect(ancestorGroupIds(sample, 'nope').size).toBe(0)
+    expect(ancestorGroupIds(sample, undefined).size).toBe(0)
   })
 })
 

--- a/apps/app/src/features/books/reader/bookContent.ts
+++ b/apps/app/src/features/books/reader/bookContent.ts
@@ -184,28 +184,16 @@ export function countTocNodes(toc: TocNode[]): number {
   return n
 }
 
-export function firstLeafId(node: TocNode): string {
-  if (!node.children?.length) return node.id
-  for (const child of node.children) return firstLeafId(child)
-  return node.id
-}
-
-export function countLeavesUnder(node: TocNode): number {
-  if (!node.children?.length) return 1
-  let n = 0
-  for (const child of node.children) n += countLeavesUnder(child)
-  return n
-}
-
 /**
- * groupId → number of leaf chapters beneath it, for every group node, built in
- * one bottom-up pass. Lets a TOC row read its leaf count by id instead of
- * re-walking its subtree on each render.
+ * groupId → summed leaf value beneath it, for every group node, in one
+ * bottom-up pass — `leafValue` scores each leaf (1 to count all, 0/1 to count a
+ * subset). Lets a TOC row read its subtree total by id instead of re-walking on
+ * each render.
  */
-export function buildLeafCountIndex(toc: TocNode[]): Map<string, number> {
+function buildLeafIndex(toc: TocNode[], leafValue: (node: TocNode) => number): Map<string, number> {
   const counts = new Map<string, number>()
   function walk(node: TocNode): number {
-    if (!node.children?.length) return 1
+    if (!node.children?.length) return leafValue(node)
     let n = 0
     for (const child of node.children) n += walk(child)
     counts.set(node.id, n)
@@ -215,21 +203,17 @@ export function buildLeafCountIndex(toc: TocNode[]): Map<string, number> {
   return counts
 }
 
-/** Same as buildLeafCountIndex, but counts only leaves present in `completed`. */
+/** groupId → number of leaf chapters beneath it. */
+export function buildLeafCountIndex(toc: TocNode[]): Map<string, number> {
+  return buildLeafIndex(toc, () => 1)
+}
+
+/** groupId → number of leaves beneath it present in `completed`. */
 export function buildCompletedLeafIndex(
   toc: TocNode[],
   completed: Set<string>,
 ): Map<string, number> {
-  const counts = new Map<string, number>()
-  function walk(node: TocNode): number {
-    if (!node.children?.length) return completed.has(node.id) ? 1 : 0
-    let n = 0
-    for (const child of node.children) n += walk(child)
-    counts.set(node.id, n)
-    return n
-  }
-  for (const node of toc) walk(node)
-  return counts
+  return buildLeafIndex(toc, (node) => (completed.has(node.id) ? 1 : 0))
 }
 
 export function collectAllSectionIds(toc: TocNode[]): Set<string> {

--- a/apps/app/src/features/books/reader/bookContent.ts
+++ b/apps/app/src/features/books/reader/bookContent.ts
@@ -154,7 +154,8 @@ export function flattenReadingFlow(
   return flow
 }
 
-function localizedTitle(title: TocNode['title'], lang: string): string | undefined {
+/** A node's title in `lang`, falling back to the first language present. */
+export function localizedTitle(title: TocNode['title'], lang: string): string | undefined {
   return (title as Record<string, string>)[lang] ?? Object.values(title)[0]
 }
 
@@ -196,6 +197,41 @@ export function countLeavesUnder(node: TocNode): number {
   return n
 }
 
+/**
+ * groupId → number of leaf chapters beneath it, for every group node, built in
+ * one bottom-up pass. Lets a TOC row read its leaf count by id instead of
+ * re-walking its subtree on each render.
+ */
+export function buildLeafCountIndex(toc: TocNode[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  function walk(node: TocNode): number {
+    if (!node.children?.length) return 1
+    let n = 0
+    for (const child of node.children) n += walk(child)
+    counts.set(node.id, n)
+    return n
+  }
+  for (const node of toc) walk(node)
+  return counts
+}
+
+/** Same as buildLeafCountIndex, but counts only leaves present in `completed`. */
+export function buildCompletedLeafIndex(
+  toc: TocNode[],
+  completed: Set<string>,
+): Map<string, number> {
+  const counts = new Map<string, number>()
+  function walk(node: TocNode): number {
+    if (!node.children?.length) return completed.has(node.id) ? 1 : 0
+    let n = 0
+    for (const child of node.children) n += walk(child)
+    counts.set(node.id, n)
+    return n
+  }
+  for (const node of toc) walk(node)
+  return counts
+}
+
 export function collectAllSectionIds(toc: TocNode[]): Set<string> {
   const ids = new Set<string>()
   function walk(nodes: TocNode[]) {
@@ -219,6 +255,57 @@ export function hasNestedSections(toc: TocNode[]): boolean {
     return false
   }
   return walk(toc)
+}
+
+/** A TOC node placed in a flat, render-ready list (the collapsible-tree row). */
+export type FlatTocItem = {
+  node: TocNode
+  depth: number
+  isLeaf: boolean
+  isExpanded: boolean
+}
+
+/**
+ * Flatten the TOC tree into the rows currently visible given `expandedIds`:
+ * a group's children are emitted only while the group is expanded. Shared by
+ * the in-reader TOC sheet and the book-detail Sumário so both collapse alike.
+ */
+export function flattenToc(nodes: TocNode[], expandedIds: Set<string>, depth = 0): FlatTocItem[] {
+  const result: FlatTocItem[] = []
+  for (const node of nodes) {
+    const isLeaf = !node.children?.length
+    const isExpanded = !isLeaf && expandedIds.has(node.id)
+    result.push({ node, depth, isLeaf, isExpanded })
+    if (isExpanded && node.children) {
+      result.push(...flattenToc(node.children, expandedIds, depth + 1))
+    }
+  }
+  return result
+}
+
+/**
+ * The set of group ids on the path from the roots down to `targetId` (excluding
+ * the target itself). Expanding these reveals the target's row. Empty when the
+ * target is absent or undefined.
+ */
+export function ancestorGroupIds(toc: TocNode[], targetId?: string): Set<string> {
+  const ids = new Set<string>()
+  if (!targetId) return ids
+  function find(nodes: TocNode[], path: string[]): boolean {
+    for (const node of nodes) {
+      if (node.id === targetId) return true
+      if (node.children?.length) {
+        path.push(node.id)
+        if (find(node.children, path)) return true
+        path.pop()
+      }
+    }
+    return false
+  }
+  const path: string[] = []
+  find(toc, path)
+  for (const id of path) ids.add(id)
+  return ids
 }
 
 /**


### PR DESCRIPTION
## Why

The book-detail **Sumário** couldn't be drilled into. Small TOCs rendered as an always-expanded outline; huge ones (the 12,364-chapter **Catholic Encyclopedia**) showed flat top-level letter rows that *jumped to the first chapter* on tap — there was no way to expand/collapse a node in place. Separately, the in-reader Sumário sheet didn't auto-close when you tapped a chapter.

## What

**Inline collapsible, virtualized tree on the book page**
- The screen is now one `Animated.FlatList` (hero + meta live in the list header) so the tree can virtualize without nesting a list inside a `ScrollView`. Hero parallax preserved via the same scroll handler.
- Group rows toggle **expand/collapse in place** (chevron); leaf rows navigate. Small trees open fully (the familiar outline); huge trees start collapsed to the top level with the resume chapter's ancestors opened. **Expand all / Collapse all** + a **Search chapters** entry appear for big trees.
- Extracted `flattenToc` / `FlatTocItem` + new `ancestorGroupIds` into `bookContent.ts`, now shared with the in-reader `ReaderTocSheet`.
- Leaf/finished counts are precomputed once per TOC instead of re-walking each group subtree on every scroll frame.

**Reader Sumário sheet auto-close**
- The synchronous foliate `goTo` fired in the same tick as the sheet's dismissal interrupted the bottom-sheet close animation. Now: **close first, navigate on the next frame**; removed the redundant `setSheet(null)` so the sheet owns its dismissal.

## Test plan
- [ ] Encyclopedia → Sumário shows collapsed letters; tapping a letter expands its chapters inline, tap again collapses; scrolling an expanded letter stays smooth; tapping a chapter opens the reader.
- [ ] A small tree book (e.g. Pius X Greater Catechism) → outline shows expanded as before, still collapsible.
- [ ] Reader → menu → Sumário → tap a chapter → sheet auto-closes and the chapter opens.

## Checks
- biome ✓, `tsc --noEmit` ✓ (touched files), `vitest` ✓ — added `flattenToc` collapse + `ancestorGroupIds` coverage in `bookContent.test.ts`.
