### PR TITLE
Breviary: recognize inline-styled rubric red in iBreviary parser

### DIFF
--- a/apps/app/src/sources/ibreviary/__fixtures__/pt-ufficio_delle_letture-inline-rubric.html
+++ b/apps/app/src/sources/ibreviary/__fixtures__/pt-ufficio_delle_letture-inline-rubric.html
@@ -1,0 +1,141 @@
+	<!DOCTYPE html>
+	<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="it" lang="it">
+	<head>
+	<title>iBreviary</title>
+	<meta http-equiv="expires" content="00-00-0000" />
+	<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+	<meta name="language" content="it" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<link href="https://www.ibreviary.org/templates/ibreviary/css/bootstrap.css" rel="stylesheet" type="text/css" />
+	
+	<link href="favicon.ico" rel="icon" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-01379GYCYB"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+    
+      gtag('config', 'G-01379GYCYB');
+    </script>
+	</head>
+
+	<body style="padding: 0px; background-color: #fff; " class="">
+
+     <div class="text-center" style="padding: 10px 0px;">
+    <img src="images/header.jpg" />
+	</div>
+    <div id="menu"></div>
+	<div id="menu_bar">
+	<ul class="inline">
+        <li class=" active">
+            <a href="breviario.php">
+                <div class="text-center">
+                    <img src="images/breviary_active.png" border="0" />
+                    <div><small>Breviário</small></div>
+               </div>
+            </a>
+        </li>
+        <li class=" ">
+            <a href="letture.php">
+                <div class="text-center">
+                    <img src="images/readings.png" border="0" />
+                    <div><small>Leitura</small></div>
+               </div>
+            </a>
+        </li>
+        <li class=" ">
+            <a href="preghiere.php">
+                <div class="text-center">
+                    <img src="images/prayers.png" border="0" />
+                    <div><small>Orações</small></div>
+               </div>
+            </a>
+        </li>
+        <li class=" ">
+            <a href="messale.php">
+                <div class="text-center">
+                    <img src="images/missal.png" border="0" />
+                    <div><small>Missal</small></div>
+               </div>
+            </a>
+        </li>
+        <li class=" ">
+            <a href="opzioni.php">
+                <div class="text-center">
+                    <img src="images/settings.png" border="0" />
+                    <div><small>Outro</small></div>
+               </div>
+            </a>
+        </li>
+    <ul>
+    <div class="clearfix"></div>
+	</div>
+
+	<div id="contenuto"><div class="inner"><h1>Breviário</h1>
+<p><span class="sezione">Ofício de Leitura</span></p>
+<div class="page" title="Page 1">
+<div class="layoutArea">
+<div class="column">
+<p><span class="rubrica">V.</span>&nbsp;Abri, Senhor, os meus l&aacute;bios<br /><span class="rubrica">R.</span>&nbsp;E a minha boca anunciar&aacute; o vosso louvor.&nbsp;</p>
+</div>
+</div>
+</div>
+<p><span class="rubrica">Ant.</span>&nbsp;Vinde, exultemos de alegria, ao som de c&acirc;nticos aclamemos o Senhor.&nbsp;</p>
+<p class="rubrica" style="text-align: center;"><strong>Salmo 94 (95)</strong><br />Convite ao louvor de Deus</p>
+<p style="text-align: center;"><em>Exortai-vos cada dia uns aos outros,</em><br /><em>at&eacute; ao dia que se chama &laquo;Hoje&raquo;</em>&nbsp;(Hebr 3, 13).</p>
+<p>Vinde, exultemos de alegria no Senhor,<br />&nbsp; &nbsp;aclamemos a Deus, nosso Salvador.<br />Vamos &agrave; sua presen&ccedil;a e d&ecirc;mos gra&ccedil;as,&nbsp;<br />&nbsp; &nbsp;ao som de c&acirc;nticos aclamemos o Senhor.&nbsp;<span class="rubrica">(Ant.)</span></p>
+<p>Pois grande Deus &eacute; o Senhor,<br />&nbsp; &nbsp;Rei maior que todos os deuses.<br />Em sua m&atilde;o est&atilde;o as profundezas da terra<br />&nbsp; &nbsp;e pertencem-Lhe os cimos das montanhas.<br />D&rsquo;Ele &eacute; o mar, foi Ele quem o fez,<br />&nbsp; &nbsp;d&rsquo;Ele &eacute; a terra firme, que suas m&atilde;os formaram.&nbsp;<span class="rubrica">(Ant.)</span></p>
+<p>Vinde, prostremo-nos em terra,<br />&nbsp; &nbsp;adoremos o Senhor que nos criou.<br />Pois Ele &eacute; o nosso Deus<br />&nbsp; &nbsp;e n&oacute;s o seu povo, ovelhas do seu rebanho.&nbsp;<span class="rubrica">(Ant.)</span></p>
+<p>Quem dera ouv&iacute;sseis hoje a sua voz:<br />&nbsp; &nbsp;&laquo;N&atilde;o endure&ccedil;ais os vossos cora&ccedil;&otilde;es,<br />como em Meriba, como no dia de Massa no deserto,<br />&nbsp; &nbsp;onde vossos pais Me tentaram e provocaram,<br />&nbsp; &nbsp;apesar de terem visto as minhas obras.&nbsp;<span class="rubrica">(Ant.)</span></p>
+<p>Durante quarenta anos essa gera&ccedil;&atilde;o Me desgostou,<br />&nbsp; &nbsp;e Eu disse: &Eacute; um povo de cora&ccedil;&atilde;o transviado,<br />&nbsp; &nbsp;que n&atilde;o atinou com os meus caminhos.<br />Por isso jurei na minha ira:<br />&nbsp; &nbsp;N&atilde;o entrar&atilde;o no meu repouso&raquo;.&nbsp;<span class="rubrica">(Ant.)</span></p>
+<p>Gl&oacute;ria ao Pai e ao Filho<br />&nbsp; &nbsp;e ao Esp&iacute;rito Santo,<br />como era no princ&iacute;pio,<br />&nbsp; &nbsp;agora e sempre. Amen.&nbsp;<span class="rubrica">(Ant.)</span></p>
+<p class="rubrica">HINO</p>
+<p>Que salmos ou que versos cantaremos&nbsp;<br />Em teu louvor, &oacute; Luz imensa e pura,&nbsp;<br />Luz de quem o Sol claro e quanto vemos&nbsp;<br />Recebe luz e gra&ccedil;a e formosura?&nbsp;<br />Que louvores t&atilde;o novos Te daremos,&nbsp;<br />&Oacute; Criador de toda a criatura,&nbsp;<br />Que nunca ouvidos fossem, nunca ditos&nbsp;<br />Em palavras, em cantos, em escritos?</p>
+<p>Falta o sentido, fica a l&iacute;ngua muda,&nbsp;<br />Se tratar teus louvores imagina;&nbsp;<br />Ent&atilde;o diz menos quanto mais estuda,&nbsp;<br />E quanto mais se alteia mais declina.&nbsp;<br />A ci&ecirc;ncia humana mais aguda&nbsp;<br />&Eacute; ignor&acirc;ncia cega ante a divina;&nbsp;<br />S&oacute; o amor Te louva, s&oacute; Te obriga,&nbsp;<br />&Oacute; beleza t&atilde;o nova e t&atilde;o antiga.</p>
+<p>Beleza donde nasce e se deriva&nbsp;<br />Quanta beleza t&ecirc;m as coisas belas:&nbsp;<br />&Oacute; beleza incriada, eterna, altiva,&nbsp;<br />Invis&iacute;vel em Ti, vis&iacute;vel nelas,&nbsp;<br />A Ti s&oacute; louve toda a coisa viva,&nbsp;<br />A Terra, o C&eacute;u, o Sol, Lua, e estrelas:&nbsp;<br />E quem Te quiser dar maior louvor,&nbsp;<br />Maior parte Te d&ecirc;&nbsp;do seu amor.</p><p><span class="rubrica">SALMODIA</span></p>
+<p><span class="rubrica">Ant. 1</span>&nbsp;Como Deus &eacute; bom para Israel, para os homens de cora&ccedil;&atilde;o puro!&nbsp;</p>
+<p style="text-align: center;"><strong><span class="rubrica">Salmo 72 (73)</span></strong><br /><span class="rubrica">O problema do mal</span></p>
+<p style="text-align: center;"><em>Feliz aquele que n&atilde;o se escandalizar por minha causa</em>&nbsp;<br />(Mt 11, 6).</p>
+<p class="rubrica" style="text-align: center;">I</p>
+<p>Como Deus &eacute; bom para os justos, *&nbsp;<br />&nbsp; &nbsp;para os homens de cora&ccedil;&atilde;o puro!</p>
+<p>A mim, por&eacute;m, quase me falharam os p&eacute;s, *&nbsp;<br />&nbsp; &nbsp;por pouco n&atilde;o escorreguei,&nbsp;<br />quando tive inveja dos &iacute;mpios, *&nbsp;<br />&nbsp; &nbsp;ao ver o bem-estar dos pecadores.</p>
+<p>Para eles n&atilde;o h&aacute; sofrimento, *&nbsp;<br />&nbsp; &nbsp;seu corpo &eacute; saud&aacute;vel e robusto.&nbsp;<br />N&atilde;o t&ecirc;m contrariedades na vida, *&nbsp;<br />&nbsp; &nbsp;n&atilde;o s&atilde;o atormentados como os outros homens.</p>
+<p>Por isso a soberba &eacute; o seu adorno *&nbsp;<br />&nbsp; &nbsp;e a arrog&acirc;ncia o seu manto.&nbsp;<br />Da dureza do cora&ccedil;&atilde;o lhes brota a iniquidade, *&nbsp;<br />&nbsp; &nbsp;da sua mente transbordam maquina&ccedil;&otilde;es.</p>
+<p>Zombam e falam com mal&iacute;cia, *&nbsp;<br />&nbsp; &nbsp;falam de alto, com arrog&acirc;ncia.&nbsp;<br />Com a boca afrontam o c&eacute;u *&nbsp;<br />&nbsp; &nbsp;e a sua l&iacute;ngua atordoa a terra.</p>
+<p>Por isso se julgam em seguran&ccedil;a, *&nbsp;<br />&nbsp; &nbsp;ao abrigo de todas as calamidades.&nbsp;<br />E dizem: &laquo;Porventura Deus o saber&aacute;? *&nbsp;<br />&nbsp; &nbsp;Ter&aacute; conhecimento disto o Alt&iacute;ssimo?&raquo;.</p>
+<p>Assim s&atilde;o os pecadores: *&nbsp;<br />&nbsp; &nbsp;sempre tranquilos e a amontoar riquezas.</p>
+<p><span class="rubrica">Ant.&nbsp;</span>Como Deus &eacute; bom para Israel, para os homens de cora&ccedil;&atilde;o puro!</p>
+<p><span class="rubrica" data-mce-mark="1">Ant. 2</span>&nbsp;O seu riso h&aacute;-de converter-se em luto e a sua alegria em tristeza.&nbsp;</p>
+<p class="rubrica" style="text-align: center;">II</p>
+<p>Ter&aacute; sido em v&atilde;o que guardei puro o meu cora&ccedil;&atilde;o *&nbsp;<br />&nbsp; &nbsp;e conservei as minhas m&atilde;os inocentes?</p>
+<p>Todos os dias tenho sido atribulado, *&nbsp;<br />&nbsp; &nbsp;todas as manh&atilde;s recome&ccedil;a a minha pena.&nbsp;<br />Se eu dissesse: &laquo;Vou falar como eles&raquo;, *&nbsp;<br />&nbsp; &nbsp;seria infiel &agrave; gera&ccedil;&atilde;o dos vossos filhos.</p>
+<p>Reflectia sobre estas coisas, para as entender *&nbsp;<br />&nbsp; &nbsp;&ndash; problema dif&iacute;cil para mim &ndash;&nbsp;<br />at&eacute; ao dia em que entrei no santu&aacute;rio de Deus *&nbsp;<br />&nbsp; &nbsp;e compreendi a sorte que os espera.</p>
+<p>Na verdade, V&oacute;s os colocais em terreno escorregadio *&nbsp;<br />&nbsp; &nbsp;e os precipitais na ru&iacute;na.&nbsp;<br />Como ca&iacute;ram de repente na desola&ccedil;&atilde;o *&nbsp;<br />&nbsp; &nbsp;e acabaram transidos de pavor!</p>
+<p>Como quem desperta de um sonho, Senhor,&nbsp;*<br />&nbsp; &nbsp;V&oacute;s, ao levantar-Vos, desprezais a sua imagem.</p>
+<p><span class="rubrica" data-mce-mark="1">Ant.&nbsp;</span>O seu riso h&aacute;-de converter-se em luto e a sua alegria em tristeza.&nbsp;</p>
+<p><span class="rubrica">Ant. 3</span>&nbsp;Acabam mal os que est&atilde;o longe de V&oacute;s. Para mim, a felicidade &eacute; estar junto de Deus.&nbsp;</p>
+<p class="rubrica" style="text-align: center;">III</p>
+<p>Quando meu cora&ccedil;&atilde;o se exasperava *&nbsp;<br />&nbsp; &nbsp;e as minhas entranhas se consumiam,&nbsp;<br />eu era um louco, sem entendimento, *&nbsp;<br />&nbsp; &nbsp;como um irracional diante de V&oacute;s.</p>
+<p>Eu, por&eacute;m, estarei sempre convosco: *&nbsp;<br />&nbsp; &nbsp;V&oacute;s me tomastes pela m&atilde;o direita,&nbsp;<br />guiais-me com o vosso conselho *&nbsp;<br />&nbsp; &nbsp;e por fim me recebereis na gl&oacute;ria.</p>
+<p>Quem, fora de V&oacute;s, h&aacute; para mim no c&eacute;u? *&nbsp;<br />&nbsp; &nbsp;Nem na terra outra coisa desejo.&nbsp;<br />Podem desfalecer a minha carne e o meu cora&ccedil;&atilde;o, *&nbsp;<br />&nbsp; &nbsp;Deus ser&aacute; sempre o meu ref&uacute;gio e a minha heran&ccedil;a.</p>
+<p>Acabam mal os que est&atilde;o longe de V&oacute;s, *&nbsp;<br />&nbsp; &nbsp;aniquilais os que Vos abandonam.</p>
+<p>Para mim, a felicidade &eacute; estar junto de Deus, *&nbsp;<br />&nbsp; &nbsp;buscar no Senhor o meu ref&uacute;gio,&nbsp;<br />para poder contar todas as suas obras, *&nbsp;<br />&nbsp; &nbsp;&agrave;s portas da filha de Si&atilde;o.</p>
+<p><span class="rubrica">Ant.&nbsp;</span>Acabam mal os que est&atilde;o longe de V&oacute;s. Para mim, a felicidade &eacute; estar junto de Deus.&nbsp;</p>
+<p><span class="rubrica" data-mce-mark="1">V.</span>&nbsp;Como s&atilde;o doces ao meu paladar as vossas palavras, Senhor,<br /><span class="rubrica" data-mce-mark="1">R.</span>&nbsp;Mais que o mel para a minha boca!</p>
+<p><span class="rubrica" data-mce-mark="1">PRIMEIRA LEITURA</span></p>
+<p class="estilos">Do Primeiro Livro de Samuel&nbsp;<span class="rubrica">17, 1-10.32.38-51</span></p>
+<p class="rubrica" style="text-align: center;"><em>David trava combate com Golias</em></p>
+<p style="text-align: justify;">&nbsp; &nbsp;Naqueles dias, os filisteus convocaram as suas hostes para a guerra, concentraram-se em Soco de Jud&aacute; e acamparam entre Soco e Azeca, em Ef&eacute;s-Damim. Por seu lado, Saul e os israelitas concentraram-se e acamparam no Vale do Terebinto, e dispuseram-se em ordem de batalha contra os filisteus. Os filisteus ocupavam um monte e os israelitas outro monte em frente, ficando o vale a separ&aacute;-los. <br />&nbsp; &nbsp;Saiu ent&atilde;o do acampamento dos filisteus um campe&atilde;o chamado Golias. Era de Get e tinha seis c&ocirc;vados e um palmo de altura. Trazia na cabe&ccedil;a um capacete de bronze e vestia coura&ccedil;a de escamas que pesava cinco mil siclos de bronze. Usava nas&nbsp;pernas caneleiras de bronze e aos ombros uma azagaia tamb&eacute;m de bronze. A haste da sua lan&ccedil;a era grossa como um &oacute;rg&atilde;o de tear, e a ponta de ferro da lan&ccedil;a pesava seiscentos siclos. &Agrave; sua frente caminhava o escudeiro. Golias postou-se diante das fileiras de Israel e gritou: &laquo;Porque sa&iacute;stes e vos dispusestes em ordem de batalha? N&atilde;o sou eu o filisteu e v&oacute;s os servos de Saul? Escolhei um homem que venha ao meu encontro. Se me vencer e me matar, ficaremos vossos escravos; mas se for eu a venc&ecirc;-lo e a mat&aacute;-lo, ficareis v&oacute;s nossos escravos e nos servireis&raquo;. O filisteu disse ainda: &laquo;Eu desafio hoje as hostes de Israel. Dai-me um homem e bater‑nos‑emos em combate singular&raquo;.<br />&nbsp; &nbsp;Ent&atilde;o David foi levado &agrave; presen&ccedil;a de Saul e disse-lhe: &laquo;Ningu&eacute;m desanime por causa desse filisteu. O teu servo ir&aacute; lutar contra ele&raquo;. Saul revestiu David com a sua armadura, p&ocirc;s-lhe na cabe&ccedil;a um capacete de bronze e armou-o com uma coura&ccedil;a.<br />&nbsp; &nbsp;David cingiu a espada por cima das vestes e tentou caminhar com aquela equipagem a que n&atilde;o estava habituado. E disse a Saul: &laquo;N&atilde;o posso caminhar com esta armadura, porque n&atilde;o estou habituado&raquo;. E tirou a armadura.<br />&nbsp; &nbsp;Tomou o seu cajado nas m&atilde;os, escolheu na torrente cinco pedras bem lisas e meteu-as no seu surr&atilde;o de pastor, que lhe servia de bolsa. Depois, com a funda na m&atilde;o, avan&ccedil;ou contra o filisteu.<br />&nbsp; &nbsp;O filisteu foi-se aproximando pouco a pouco de David, levando &agrave; frente o seu escudeiro. Quando olhou e viu David, desprezou-o, porque era um rapaz novo, ruivo e de bela apar&ecirc;ncia. Disse ent&atilde;o a David: &laquo;Sou porventura algum c&atilde;o, para vires contra mim de pau na m&atilde;o?&raquo;. E amaldi&ccedil;oou David em nome dos seus deuses. E acrescentou: &laquo;Vem ao meu encontro, e eu darei a tua carne &agrave;s aves do c&eacute;u e aos animais do campo&raquo;.<br />&nbsp; &nbsp;Mas David respondeu ao filisteu: &laquo;Tu vens contra mim armado de espada, lan&ccedil;a e azagaia, e eu vou contra ti em nome do Senhor do Universo, o Deus dos ex&eacute;rcitos de Israel, que tu desafiaste. O Senhor vai entregar-te hoje mesmo nas minhas m&atilde;os. Eu te matarei e te cortarei a cabe&ccedil;a, e darei hoje&nbsp;o teu cad&aacute;ver e os cad&aacute;veres dos filisteus &agrave;s aves do c&eacute;u e aos animais selvagens. Ent&atilde;o saber&aacute; toda terra que h&aacute; um Deus em Israel e toda a gente h&aacute;-de ver que n&atilde;o &eacute; pela espada ou pela lan&ccedil;a que o Senhor concede a salva&ccedil;&atilde;o. Porque esta guerra &eacute; do Senhor e Ele vos entregar&aacute; em nossas m&atilde;os&raquo;.<br />&nbsp; &nbsp;Quando o filisteu se levantou e veio ao encontro de David, tamb&eacute;m este correu velozmente contra o filisteu. Meteu a m&atilde;o no surr&atilde;o, tirou uma pedra, arremessou-a com a funda e atingiu o filisteu na fronte. A pedra cravou-se-lhe na testa, e ele caiu de bru&ccedil;os no ch&atilde;o. Foi assim, com uma funda e uma pedra, que David triunfou do filisteu e o feriu mortalmente, sem ter uma espada na m&atilde;o. David correu para o filisteu e, quando chegou junto dele, tirou-lhe a espada da bainha e acabou de o matar, cortando-lhe a cabe&ccedil;a.</p>
+<p style="text-align: justify;"><span class="rubrica" data-mce-mark="1">RESPONS&Oacute;RIO&nbsp; &nbsp;cf. 1 Sam 17, 37;&nbsp; Salmo 56 (57), 4c.5a</span><br /><span class="rubrica" data-mce-mark="1">R.&nbsp;</span><span data-mce-mark="1">O Senhor salvou-me da boca do le&atilde;o e do urso:</span>&nbsp;<span class="rubrica" data-mce-mark="1">*</span>&nbsp;Ele me livrar&aacute; dos meus inimigos.<br /><span class="rubrica" data-mce-mark="1">V.</span>&nbsp;Deus enviou-me a sua bondade e fidelidade, e libertou-me do meio dos le&otilde;es.&nbsp;<span class="rubrica" data-mce-mark="1">*</span>&nbsp;Ele me livrar&aacute; dos meus inimigos.</p><p><span style="color: #dc2300;">SEGUNDA LEITURA</span></p>
+<p>Do tratado de S&atilde;o Greg&oacute;rio de Nissa, bispo, sobre a perfei&ccedil;&atilde;o da vida crist&atilde;<br /><span class="rubrica">(PG 46, 254-255) (Sec. IV)</span></p>
+<p class="rubrica" style="text-align: center;"><em>O crist&atilde;o &eacute; outro Cristo</em></p>
+<p style="text-align: justify;">&nbsp; &nbsp;Paulo conheceu a Cristo melhor que ningu&eacute;m, e ensinou, com as suas obras, como devem ser os que d&rsquo;Ele receberam o nome de crist&atilde;os. Imitou-o de modo t&atilde;o perfeito que reflectia em si mesmo a imagem do Senhor, e de tal modo transformou os sentimentos do seu cora&ccedil;&atilde;o nos do cora&ccedil;&atilde;o de Cristo, que n&atilde;o parecia ser Paulo quem falava, mas Cristo. Consciente desta sua prerrogativa, ele mesmo diz: <em>Quereis a prova de Cristo que fala em mim</em>.<br />&nbsp; &nbsp;E tamb&eacute;m: <em>Eu vivo, mas j&aacute; n&atilde;o sou eu que vivo, &eacute; Cristo que vive em mim</em>. Paulo revelou-nos tamb&eacute;m qual a for&ccedil;a que tem o nome de Cristo, quando chama a <em>Cristo poder e sabedoria de Deus,&nbsp;paz e luz inacess&iacute;vel em que habita Deus; expia&ccedil;&atilde;o e reden&ccedil;&atilde;o, sumo sacerdote, P&aacute;scoa, propicia&ccedil;&atilde;o das almas; esplendor da gl&oacute;ria e imagem da ess&ecirc;ncia de Deus e criador dos s&eacute;culos; alimento e bebida espiritual, rochedo e &aacute;gua, fundamento da f&eacute; e pedra angular; imagem de Deus invis&iacute;vel, grande Deus, Cabe&ccedil;a do corpo que &eacute; a Igreja; Primog&eacute;nito da nova criatura, Prim&iacute;cias dos que morreram, Primog&eacute;nito de entre os mortos, Primog&eacute;nito entre muitos irm&atilde;os, Mediador entre Deus e os homens; </em>Filho unig&eacute;nito<em> coroado de gl&oacute;ria e honra, Senhor da gl&oacute;ria e origem das coisas, Rei de justi&ccedil;a e Rei de paz, </em>Rei universal, cujo reino n&atilde;o tem limites<em>.<br /> </em>&nbsp; &nbsp;S&atilde;o estes e outros nomes semelhantes que Paulo d&aacute; a Cristo e s&atilde;o tantos que dificilmente se poderiam contar. Mas se compararmos e relacionarmos entre si o significado de todos estes nomes, podemos descobrir, na medida em que o nosso entendimento &eacute; capaz, a for&ccedil;a admir&aacute;vel do nome de Cristo e da sua inef&aacute;vel majestade.<br />&nbsp; &nbsp;Por isso, uma vez que a bondade do Senhor nos concedeu uma participa&ccedil;&atilde;o no maior, no mais divino e no primeiro de todos os nomes, ao honrar-nos com o nome de &laquo;crist&atilde;os&raquo;, que deriva do de Cristo, &eacute; necess&aacute;rio que todos aqueles nomes que exprimem o significado desta palavra se vejam tamb&eacute;m reflectidos em n&oacute;s, para que n&atilde;o sejamos falsamente chamados &laquo;crist&atilde;os&raquo;, mas d&ecirc;mos testemunho com a nossa vida.</p>
+<p style="text-align: justify;"><span class="rubrica">RESPONS&Oacute;RIO&nbsp; &nbsp;Salmo 5, 12; 88 (89), 16-17a<br /><span class="rubrica">R.</span></span>&nbsp;Alegrem-se e rejubilem para sempre todos os que em V&oacute;s confiam.&nbsp;<span class="rubrica">*</span>&nbsp;V&oacute;s protegeis e alegrais os que amam o vosso nome.<span class="rubrica"><br /><span class="rubrica">V.</span>&nbsp;</span>Caminhar&atilde;o, Senhor, &agrave; luz do vosso rosto e todos os dias aclamar&atilde;o o vosso nome.<span class="rubrica">&nbsp;</span><span class="rubrica"><span class="rubrica">*</span>&nbsp;</span>V&oacute;s protegeis e alegrais os que amam o vosso nome.</p>
+<p class="rubrica" style="text-align: center;">Ora&ccedil;&atilde;o</p>
+<p style="text-align: justify;">&nbsp; &nbsp;Senhor, fazei-nos viver a cada instante no temor e no amor do vosso santo nome, porque nunca a vossa provid&ecirc;ncia abandona aqueles que formais solidamente no vosso amor. Por Nosso Senhor.</p>
+<p><span class="rubrica" data-mce-mark="1">V.</span>&nbsp;Bendigamos o Senhor.&nbsp;<br /><span class="rubrica" data-mce-mark="1">R.</span>&nbsp;D&ecirc;mos gra&ccedil;as a Deus.</p>
+<p><a href="#menu">- Menu -</a></p>
+</div><script type="text/javascript" src="http://www.santiebeati.it/santidioggicss.txt"></script>    </div>
+
+    </body>
+    </html>

--- a/apps/app/src/sources/ibreviary/office-of-readings-reading.test.ts
+++ b/apps/app/src/sources/ibreviary/office-of-readings-reading.test.ts
@@ -61,6 +61,25 @@ describe('extractSecondReading — all editions', () => {
   })
 })
 
+describe('extractSecondReading — markup variants', () => {
+  // Some hand-edited days inline the rubric red on a bare <span> instead of
+  // class="rubrica" (e.g. June 22 2026 pt: SEGUNDA LEITURA → São Gregório de
+  // Nissa). The parser must still treat that label as a rubric so the anchor is
+  // found. Regression for "ibreviary: Office of Readings second reading not found".
+  it('handles an inline-styled (no class="rubrica") SEGUNDA LEITURA label', () => {
+    const reading = extractSecondReading(
+      parseHour(load('pt-ufficio_delle_letture-inline-rubric.html')),
+      'pt-BR',
+    )
+    const text = allText(reading)
+    expect(text).toContain('São Gregório de Nissa')
+    expect(text).not.toContain('SEGUNDA LEITURA')
+    expect(text).not.toContain('PRIMEIRA LEITURA')
+    expect(text).not.toContain('Golias') // first reading (Samuel/David)
+    expect(text).not.toContain('RESPONSÓRIO')
+  })
+})
+
 describe('extractSecondReading — failure contract', () => {
   it('throws when the second reading is absent (so nothing junk caches)', () => {
     const stub: Primitive[] = [{ type: 'rubric', text: { primary: 'FIRST READING' } }]

--- a/apps/app/src/sources/ibreviary/parse.ts
+++ b/apps/app/src/sources/ibreviary/parse.ts
@@ -53,12 +53,19 @@ function endBlock(c: Collector) {
   c.block = []
 }
 
+// iBreviary's rubric red. Rubrics normally carry class="rubrica", but a few
+// hand-edited days inline the colour on a bare <span> instead (no class) — e.g.
+// some "SEGUNDA LEITURA" labels. Treat that exact red as a rubric too, so the
+// label anchors second-reading extraction and renders red like every other day.
+const rubricRed = /color:\s*#dc2300/i
+
 // `rubrica` and `capolettera_piccolo` (EN section labels) both render red;
 // `citazione`/<em> are italic. `sezione` is the page title — the practice UI
 // already names the hour, so it's dropped.
 function spanStyle(el: Element, inherited: RunStyle): RunStyle | 'skip' {
   if (hasClass(el, 'sezione')) return 'skip'
   if (hasClass(el, 'rubrica') || hasClass(el, 'capolettera_piccolo')) return 'rubric'
+  if (rubricRed.test(el.attribs.style ?? '')) return 'rubric'
   if (hasClass(el, 'citazione')) return 'italic'
   return inherited
 }


### PR DESCRIPTION
## Problem

The **Patristic Reading** practice ("Leitura Patrística") failed on **June 22, 2026 (pt-BR)** with the retryable error card:

> Não foi possível carregar esta seção. Reabra para tentar novamente.
> ibreviary: Office of Readings second reading not found

## Root cause

`extractSecondReading` locates the second reading by finding a **rubric** primitive matching `/^SEGUNDA LEITURA/i`. A span only becomes a rubric when it carries `class="rubrica"`. That day's office was hand-edited in iBreviary's TinyMCE (`data-mce-mark="1"` throughout) and the label was written as:

```html
<p><span style="color: #dc2300;">SEGUNDA LEITURA</span></p>
```

— the rubric red **inlined as a style with no `rubrica` class**. The parser treated it as plain text, the anchor was never found, and extraction threw. (Same cause made the label render white instead of red in the full Breviary view.)

Verified against the live HTML: the entire office had exactly **one** inline-color span (`#dc2300`), wrapping "SEGUNDA LEITURA" — so treating that red as a rubric is precise and over-classifies nothing.

## Fix

`spanStyle()` in `parse.ts` now also treats iBreviary's rubric red (`#dc2300`) inlined on a bare span as a rubric. This fixes both extraction **and** the full-office rendering, and leaves `extractSecondReading` untouched.

Adds the captured June 22 office as a regression fixture + a test that reproduces the failure (throws without the fix, passes with it).

## Verification

- `pnpm --filter app test src/sources/ibreviary` — 59 tests pass; confirmed the new test fails ("second reading not found") with the parser fix reverted.
- `pnpm biome check` clean.